### PR TITLE
Add RTL8811AU support via RF_TYPE_ID autodetect

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -8,7 +8,15 @@
 #include "WiFiDriver.h"
 
 #define USB_VENDOR_ID 0x0bda
-#define USB_PRODUCT_ID 0x8812
+
+/* Known USB product IDs for RTL8812AU (2T2R) and RTL8811AU (1T1R, 1x1 cut of
+ * the same Jaguar silicon). Both are driven by this library. */
+static constexpr uint16_t kRealtekProductIds[] = {
+    0x8812, /* RTL8812AU (also seen on some 8811AU boards) */
+    0x0811, /* RTL8811AU */
+    0xa811, /* RTL8811AU */
+    0xb811, /* RTL8811AU/8821AU variants */
+};
 
 static void packetProcessor(const Packet &packet) {}
 
@@ -25,11 +33,17 @@ int main() {
 
   libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_DEBUG);
 
-  libusb_device_handle *dev_handle =
-      libusb_open_device_with_vid_pid(ctx, USB_VENDOR_ID, USB_PRODUCT_ID);
+  libusb_device_handle *dev_handle = nullptr;
+  for (uint16_t pid : kRealtekProductIds) {
+    dev_handle = libusb_open_device_with_vid_pid(ctx, USB_VENDOR_ID, pid);
+    if (dev_handle != NULL) {
+      logger->info("Opened Realtek device {:04x}:{:04x}", USB_VENDOR_ID, pid);
+      break;
+    }
+  }
   if (dev_handle == NULL) {
-    logger->error("Cannot find device {:04x}:{:04x}", USB_VENDOR_ID,
-                  USB_PRODUCT_ID);
+    logger->error("Cannot find any supported Realtek device under VID {:04x}",
+                  USB_VENDOR_ID);
     libusb_exit(ctx);
     return 1;
   }

--- a/src/EepromManager.cpp
+++ b/src/EepromManager.cpp
@@ -47,11 +47,15 @@ void EepromManager::read_chip_version_8812a(RtlUsbAdapter device) {
       .ICType = CHIP_8812,
       .ChipType = (value32 & RTL_ID) ? TEST_CHIP : NORMAL_CHIP,
       .VendorType = (value32 & VENDOR_ID) ? CHIP_VENDOR_UMC : CHIP_VENDOR_TSMC,
-      .RFType = RF_TYPE_2T2R, /* RF_2T2R; */
+      /* SYS_CFG bit 27 (RF_TYPE_ID): set on 1T1R cuts (RTL8811AU),
+       * clear on 2T2R cuts (RTL8812AU). */
+      .RFType = (value32 & RF_TYPE_ID) ? RF_TYPE_1T1R : RF_TYPE_2T2R,
   };
 
+  /* Manual override: force 1T1R even when SYS_CFG reports 2T2R
+   * (useful if EFUSE/strap is mis-burnt on a 1T1R board). */
   if (registry_priv::special_rf_path == 1) {
-    version_id.RFType = RF_TYPE_1T1R; /* RF_1T1R; */
+    version_id.RFType = RF_TYPE_1T1R;
   }
 
   version_id.CUTVersion = (HAL_CUT_VERSION_E)(((value32 & CHIP_VER_RTL_MASK) >>


### PR DESCRIPTION
## Summary

- **Root cause:** `EepromManager::read_chip_version_8812a` hardcoded `RFType = RF_TYPE_2T2R`, so the existing 1T1R code paths (`PHY_BB8812_Config_1T`, the `numTotalRfPath` loops in `PHY_RF6052_Config_8812` / TX power, per-BW `L1pkVal` branches, 2.4 GHz eLNA threshold) were unreachable on RTL8811AU dongles even though the driver could otherwise drive the chip.
- **Fix:** derive `RFType` from `REG_SYS_CFG` bit 27 (`RF_TYPE_ID`) the same way Realtek's upstream rtl8812au driver does — set → 1T1R (RTL8811AU), clear → 2T2R (RTL8812AU). Same firmware, same power sequence, same EFUSE layout; only the chain count and a handful of BB constants differ, all of which are already conditionalised.
- **Manual override preserved:** `registry_priv::special_rf_path == 1` still forces 1T1R after autodetect, in case a board's EFUSE/strap is mis-burnt.
- **Demo PID widening:** `demo/main.cpp` now tries `0x8812 → 0x0811 → 0xa811 → 0xb811` before giving up. `0xc811` is intentionally excluded — it is shared with the unrelated **RTL8811CU** chipset, which uses a different driver family entirely and is not supported by this code.

## Test plan

Need hardware verification before merge:

- [ ] **8812AU regression:** plug a known RTL8812AU dongle, run `WiFiDriverDemo`, confirm log shows `RF_Type is 2 TotalTxPath is 2` and beacon RX still works on ch36/20 MHz.
- [ ] **8811AU positive:** plug a known RTL8811AU dongle (verified via `lsusb` — VID `0bda`, PID one of `0811`/`a811`/`b811`/`8812`, **not** `c811`), run `WiFiDriverDemo`, confirm log shows `RF_Type is 0 TotalTxPath is 1` and beacons are received.
- [ ] **TX smoke test:** `WiFiDriverTxDemo` on the 8811AU and confirm the hardcoded beacon is seen by a separate sniffer.
- [ ] **macOS / Android builds:** verify the demo's `kRealtekProductIds` table still links under `_MSC_VER`, `__ANDROID__`, `__APPLE__` paths (compile-tested on macOS; the table is `static constexpr`, no platform-specific behaviour).

## Open questions for the reporter (#20)

1. What does `lsusb` show for your dongle? We need the exact VID:PID to confirm it's an AU and not a CU (which we can't support — separate silicon, separate driver).
2. Does the dongle associate / scan on 5 GHz under aircrack-ng's rtl8812au today? Several upstream issues (e.g. aircrack-ng/rtl8812au#793) point to RFE-Type / antenna-byte EFUSE mis-reads on 1T1R variants; if you're affected, the `registry_priv::RFE_Type = 64` and `AmplifierType_*` defaults may need adjusting based on what `Hal_ReadRFEType_8812A` reports from your EFUSE.
3. Any TX power / link-budget anomalies vs. a 2T2R dongle on the same channel? `TxBBSwing_*` defaults are EFUSE-driven; calibration on 1T1R SKUs may surface tuning needs.

Refs #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)