### PR TITLE
RTL8814AU: match TX descriptor to kernel-driver field-for-field

### DIFF
--- a/src/RtlJaguarDevice.cpp
+++ b/src/RtlJaguarDevice.cpp
@@ -137,12 +137,8 @@ bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
 
   SET_TX_DESC_DATA_BW_8812(usb_frame, BWSettingOfDesc);
 
-  /* Upstream rtl8814a_xmit.c sets ONLY LAST_SEG=1 (not FIRST_SEG) for a
-   * single-fragment frame, and MACID = bmc_camid which is 0 for the
-   * broadcast/default CAM entry. Our previous values (FIRST_SEG=1, MACID=1)
-   * caused the chip to silently reject every bulk-OUT — verified by
-   * usbmon trace comparing the OOT-driver's working TX descriptor to
-   * ours at byte offsets 3 (flags) and 4 (MACID). */
+  /* Single-fragment frame: LAST_SEG=1 (no FIRST_SEG); OWN=1 so chip
+   * processes the descriptor. */
   SET_TX_DESC_LAST_SEG_8812(usb_frame, 1);
   SET_TX_DESC_OWN_8812(usb_frame, 1);
 
@@ -152,40 +148,45 @@ bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
   SET_TX_DESC_OFFSET_8812(usb_frame,
                           static_cast<uint8_t>(TXDESC_SIZE + OFFSET_SZ));
 
-  SET_TX_DESC_MACID_8812(usb_frame, static_cast<uint8_t>(0x00));
+  /* Match the kernel-driver TX descriptor field-for-field. usbmon
+   * capture of kernel-driver TX in monitor mode (8814AU, channel 6)
+   * shows these exact values; previous comments in this file proposed
+   * different values based on speculative reasoning that didn't hold
+   * up under empirical comparison:
+   *
+   *   MACID = 1                 (broadcast/default CAM, not 0)
+   *   RATE_ID = 8 (non-VHT)     (kernel uses 8, not 7)
+   *   GID = 63 (= 0x3F)         (no-group default; previously left 0)
+   *   SW_DEFINE = 1             (DriverFixedRate flag; previously 0)
+   *   RETRY_LIMIT_ENABLE = 1, DATA_RETRY_LIMIT = 12
+   *                             (mgmt-frame defaults from upstream
+   *                              rtl8814au_xmit.c:267; previously
+   *                              both 0)
+   *   SPE_RPT = 0               (kernel does NOT set this; previously 1)
+   *   DISABLE_FB = 0            (kernel does NOT set this; previously 1)
+   *   HWSEQ_EN = 1              (chip auto-fills 802.11 SEQ; unchanged)
+   */
+  SET_TX_DESC_MACID_8812(usb_frame, static_cast<uint8_t>(0x01));
 
   if (!vht) {
-    rate_id = 7;
+    rate_id = 8;
   } else {
     rate_id = 9;
   }
 
   SET_TX_DESC_BMC_8812(usb_frame, 1);
-  SET_TX_DESC_RATE_ID_8812(
-      usb_frame,
-      static_cast<uint8_t>(rate_id));
+  SET_TX_DESC_RATE_ID_8812(usb_frame, static_cast<uint8_t>(rate_id));
 
   SET_TX_DESC_QUEUE_SEL_8812(usb_frame, 0x12);
-  /* Upstream 8814 uses HWSEQ_EN=1 (chip auto-fills the 802.11 SEQ number)
-   * with the descriptor SEQ field zero. Verified by usbmon trace: OOT
-   * driver sets bit 15 of word 8 (byte 33 = 0x80). Our previous path set
-   * HWSEQ_EN=0 + SEQ field manually — the chip's HWSEQ-disabled path may
-   * require additional driver-side sequence handling we don't have. */
   SET_TX_DESC_HWSEQ_EN_8812(usb_frame, static_cast<uint8_t>(1));
-  /* OOT-driver descriptor has SPE_RPT=1 (bit 19 of word 2 = byte 10 bit 3).
-   * Special TX report — chip may use this to signal TX-complete back to the
-   * driver. Without it, the TX queue may stall waiting for a status ack we
-   * never enable. */
-  SET_TX_DESC_SPE_RPT_8812(usb_frame, static_cast<uint8_t>(1));
-  /* OOT-driver descriptor has RETRY_LIMIT_ENABLE=0 (let chip use its
-   * default retry policy). Setting RETRY_LIMIT_ENABLE=1 with
-   * DATA_RETRY_LIMIT=0 means "give up after 0 retries" — the chip drops
-   * the frame and never even attempts to TX. */
+  SET_TX_DESC_GID_8812(usb_frame, static_cast<uint8_t>(0x3F));
+  SET_TX_DESC_SW_DEFINE_8812(usb_frame, static_cast<uint16_t>(0x001));
+  SET_TX_DESC_RETRY_LIMIT_ENABLE_8812(usb_frame, 1);
+  SET_TX_DESC_DATA_RETRY_LIMIT_8812(usb_frame, 12);
   if (sgi) {
     _logger->info("short gi enabled,set sgi");
     SET_TX_DESC_DATA_SHORT_8812(usb_frame, 1);
   }
-  SET_TX_DESC_DISABLE_FB_8812(usb_frame, 1);
   SET_TX_DESC_USE_RATE_8812(usb_frame, 1);
   SET_TX_DESC_TX_RATE_8812(usb_frame,
                            static_cast<uint8_t>(MRateToHwRate(


### PR DESCRIPTION
## Summary

Usbmon capture of the working morrownr/aircrack-ng kernel driver injecting a probe-request on the 8814 (channel 6, monitor mode) was diffed against devourer's TX descriptor, both 140-byte single-fragment frames. The first 32-byte descriptor block differed in seven fields. Update devourer's `send_packet` so the descriptor is byte-identical to the kernel-driver's.

| Field | Was | Now | Rationale |
|---|---|---|---|
| `MACID` | 0 | 1 | broadcast/default CAM |
| `RATE_ID` (non-VHT) | 7 | 8 | rate-table index |
| `GID` | 0 | 63 (`0x3F`) | no-group default |
| `SW_DEFINE` | 0 | 1 | `DriverFixedRate` flag |
| `RETRY_LIMIT_ENABLE` | 0 | 1 | mgmt-frame default |
| `DATA_RETRY_LIMIT` | 0 | 12 | per upstream `rtl8814au_xmit.c:267` |
| `SPE_RPT` | 1 | 0 | kernel does not set |
| `DISABLE_FB` | 1 | 0 | kernel does not set |

## Background

The previous values came from earlier WIP comments speculating about chip behavior. Live usbmon diff against the working kernel driver shows the actual field set the chip expects.

## Verification

- Devourer's first TX bulk-OUT now reads:
  `64002885 01120800 0000003f 00010000 00003200 00000000 01000000 76a90000` — byte-identical to kernel-driver's TX descriptor.
- With chip primed by the kernel driver (`insmod 8814au.ko`, monitor, ch6, `rmmod`) and devourer started with `DEVOURER_SKIP_INIT=1`: **781 of 781 bulk-OUT URBs complete with status=0**. With the previous descriptor, URBs also completed status=0 but on-air TX never happened (the chip silently dropped frames whose descriptor field values it didn't accept).
- 8814 RX still works end-to-end (10+ packets in demo window).

## What this does NOT fix

End-to-end 8814 TX without `DEVOURER_SKIP_INIT`. Devourer's HAL init still leaves the chip in a state where EP `0x02` times out URBs (a separate gate, tracked in task #21). With this PR, when the chip-init gate is fixed, the descriptor will already be correct.

## Test plan

- [x] Build green on macOS + Arch Linux 6.18
- [x] RX regression: 10+ packets on `0bda:8813` ch6
- [x] TX descriptor byte-equality with kernel-driver verified via usbmon
- [x] `DEVOURER_SKIP_INIT=1` path: 781/781 bulk-OUT URB completions status=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)