### PR TITLE
RtlJaguarDevice: validate radiotap header length and read it_len as le16

### DIFF
--- a/src/RtlJaguarDevice.cpp
+++ b/src/RtlJaguarDevice.cpp
@@ -28,8 +28,11 @@ bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
   u8 fixed_rate = MGN_1M, sgi = 0, bwidth = 0, ldpc = 0, stbc = 0;
   u16 txflags = 0;
   int rate_id = 0;
-  radiotap_length = int(packet[2]);
-  if (radiotap_length <= 0 || (size_t)radiotap_length >= length) {
+  if (length < sizeof(struct ieee80211_radiotap_header)) {
+    return false;
+  }
+  radiotap_length = get_unaligned_le16(packet + 2);
+  if (radiotap_length == 0 || (size_t)radiotap_length >= length) {
     return false;
   }
   real_packet_length = length - radiotap_length;


### PR DESCRIPTION
## Summary

Follow-up hardening on top of PR #31. Two concerns the PR #31 guard didn't cover:

1. `packet[2]` was dereferenced with no check that `length` is large enough to hold the radiotap header. Bail early if `length < sizeof(struct ieee80211_radiotap_header)`.
2. The radiotap `it_len` field is `__le16` at bytes 2-3, not a single byte. Use `get_unaligned_le16()` to match `Radiotap.c:215` and the `IEEE80211_RADIOTAP_TX_FLAGS` reader four lines down in the same function.

Threat model: the only caller of `send_packet` is `txdemo` with a hardcoded local beacon, so this is defensive hardening, not a deployed-system bug.

## Test plan

- [x] cmake build clean (WiFiDriver + WiFiDriverDemo + WiFiDriverTxDemo)
- [ ] txdemo smoke run on RTL8812AU still emits the beacon (no behavioural change expected — the normal beacon path has `length` well above `sizeof(ieee80211_radiotap_header)` and `it_len = 0x0d`)