### PR TITLE
tests: VHT encoding combos + sniff_air.py radiotap verifier

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -160,37 +160,61 @@ sudo python3 tests/regress.py --encoding-matrix \
     --vm-name devourer-testrig --vm-ssh <user>@<VM-IP>
 ```
 
-Encoding combos iterated (with MCS 1, 20 MHz): `BCC`, `LDPC`, `STBC=1`,
-`LDPC+STBC=1`. Add more in `ENCODING_COMBOS` at the top of `regress.py`
-if you need other mixes (e.g. MCS 7, 40 MHz, or VHT).
+Encoding combos iterated by default — 6 cells per driver mode × 4 driver
+modes = 24 cells total per run:
 
-The underlying knobs are also usable standalone for one-off targeted
-TX:
+| Combo | Radiotap bit | Notes |
+|---|---|---|
+| `HT-BCC` | 19 (MCS info) | MCS 1, BCC FEC, 20 MHz |
+| `HT-LDPC` | 19 | MCS 1, FEC=LDPC |
+| `HT-STBC=1` | 19 | MCS 1, 1 STBC stream |
+| `HT-LDPC+STBC` | 19 | MCS 1, FEC=LDPC + 1 STBC stream |
+| `VHT-BCC` | 21 (VHT info) | VHT MCS 0, NSS 1, BCC, 20 MHz |
+| `VHT-LDPC` | 21 | VHT MCS 0, NSS 1, FEC=LDPC |
 
-- Devourer TX: `DEVOURER_TX_LDPC=1`, `DEVOURER_TX_STBC=1`,
-  `DEVOURER_TX_MCS=N`, `DEVOURER_TX_BW=20|40` env vars read by
-  `WiFiDriverTxDemo` to patch the radiotap MCS field at startup.
-- Kernel-side scapy TX: `--ldpc`, `--stbc N`, `--mcs N`, `--bandwidth
-  20|40` flags on `tests/inject_beacon.py`.
+VHT (802.11ac) coverage exists because some chips' LDPC decoder limitation
+is on the VHT path only — the silicon's HT-LDPC and VHT-LDPC are separate
+blocks. RTL8821AU is the motivating case (HT-LDPC tests pass, VHT-LDPC
+reportedly fails at RX). Add more in `ENCODING_COMBOS` at the top of
+`regress.py` if you need MCS 7, 40/80 MHz, or higher NSS.
 
-#### Known caveat: kernel-TX encoding flags may not reach the air
+The underlying knobs are also usable standalone for one-off targeted TX:
+
+- **Devourer TX:** `DEVOURER_TX_MCS=N`, `DEVOURER_TX_LDPC=1`,
+  `DEVOURER_TX_STBC=N`, `DEVOURER_TX_BW=20|40|80|160` env vars read by
+  `WiFiDriverTxDemo`. Default mode is HT; `DEVOURER_TX_VHT=1` switches to
+  a VHT radiotap header (22 bytes) and exposes `DEVOURER_TX_VHT_MCS=N` +
+  `DEVOURER_TX_VHT_NSS=N`. `_LDPC` / `_STBC` / `_BW` apply to whichever
+  mode is active.
+- **Kernel-side scapy TX:** `--mcs N` / `--ldpc` / `--stbc N` / `--bandwidth
+  20|40|80|160` on `tests/inject_beacon.py`, plus `--vht` / `--vht-mcs N`
+  / `--vht-nss N` for VHT mode.
+
+#### Caveat: kernel-TX encoding flags may not always reach the air
 
 mac80211 + the `aircrack-ng/88XXau` driver don't necessarily honour the
 radiotap MCS flags on TX — the chip's own rate-selection logic may
 override them. So the `k/k` and `k/d` rows of the table reflect what
-the *kernel* driver chose to transmit, which may collapse all four
-encoding columns onto the chip's default. Validated 2026-05-25 with
-`--encoding-matrix --tx-pid 0x8813 --rx-pid 0x0120`: the `k/d` row was
-flat across all four columns (`~400 hits`), consistent with the kernel
-stripping the LDPC/STBC bits before they reached the air rather than
-the 8821AU RX accepting LDPC frames.
+the *kernel* driver chose to transmit, which may collapse encoding
+columns onto the chip's default.
 
-The `d/k` and `d/d` rows are not affected — `WiFiDriverTxDemo` writes
-the radiotap header directly into the chip's bulk-OUT buffer, so the
-`DEVOURER_TX_*` env vars are the ground truth for what flies. To
-validate kernel-TX encoding made it on-air, run a third adapter as
-sniffer (e.g. AR9271 via tcpdump on the same channel) and inspect the
-MCS flags in the captured radiotap.
+To prove what actually flew, run `tests/sniff_air.py` on a third
+adapter (AR9271 is the canonical sniffer — it speaks vanilla radiotap
+without driver-side filtering) on the same channel, in parallel with
+the matrix. Output reports each captured frame's decoded radiotap
+MCS / VHT info, including LDPC bit + STBC streams. If a `--ldpc`
+injection comes back tagged as BCC, the kernel stripped it before the
+air.
+
+```bash
+sudo python3 tests/sniff_air.py --iface wlan0mon --channel 100 \
+    --duration 60
+```
+
+The `d/k` and `d/d` rows are not affected by the kernel-TX caveat —
+`WiFiDriverTxDemo` writes the radiotap header directly into the
+chip's bulk-OUT buffer, so the `DEVOURER_TX_*` env vars are ground
+truth for what flies on devourer TX.
 
 ## Supported DUTs
 

--- a/tests/inject_beacon.py
+++ b/tests/inject_beacon.py
@@ -30,11 +30,12 @@ CANONICAL_SA = "57:42:75:05:d6:00"
 # https://www.radiotap.org/.
 _RT_TX_FLAGS = 1 << 15
 _RT_MCS = 1 << 19
+_RT_VHT = 1 << 21
 
 
 def _build_radiotap_mcs(*, mcs: int, ldpc: bool, stbc: int, bandwidth: int,
                         tx_flags: int = 0x0008) -> bytes:
-    """Hand-rolled radiotap header with TX Flags + MCS info.
+    """Hand-rolled radiotap header with TX Flags + HT MCS info.
 
     Scapy's RadioTap layer doesn't expose first-class LDPC / STBC fields, and
     its `MCS` post-field plumbing is brittle across versions. Easier to emit
@@ -55,8 +56,41 @@ def _build_radiotap_mcs(*, mcs: int, ldpc: bool, stbc: int, bandwidth: int,
     )
 
 
+def _build_radiotap_vht(*, vht_mcs: int, nss: int, ldpc: bool, stbc: bool,
+                        bandwidth: int, tx_flags: int = 0x0008) -> bytes:
+    """Hand-rolled radiotap header with TX Flags + VHT info (radiotap bit 21).
+
+    VHT is 802.11ac's encoding spec; required for testing chips like RTL8821AU
+    whose LDPC behaviour at HT (bit 19) doesn't reflect their VHT path. Layout
+    (22 bytes total): 8-byte header (version/pad/it_len/it_present), 2-byte TX
+    Flags, then 12 bytes of VHT info — u16 known, u8 flags, u8 bandwidth,
+    u8[4] mcs_nss (user 0..3 each = mcs<<4 | nss), u8 coding (LDPC nibble per
+    user), u8 group_id, u16 partial_aid. Single-user only (users 1-3 zeroed).
+    """
+    bw_code = {20: 0, 40: 1, 80: 4, 160: 11}.get(bandwidth, 0)
+    # known: bit 0 STBC, bit 2 GI, bit 6 bandwidth known.
+    known = (1 << 0) | (1 << 2) | (1 << 6)
+    flags = 0
+    if stbc:
+        flags |= 0x01  # bit 0: STBC enabled
+    mcs_nss = bytes([((vht_mcs & 0xF) << 4) | (nss & 0xF), 0, 0, 0])
+    coding = 0x01 if ldpc else 0x00  # user-0 nibble: 0=BCC, 1=LDPC
+    vht_info = (
+        struct.pack('<HBB', known, flags, bw_code)
+        + mcs_nss
+        + bytes([coding, 0])     # coding, group_id
+        + struct.pack('<H', 0)   # partial_aid
+    )
+    assert len(vht_info) == 12, len(vht_info)
+    return (
+        struct.pack('<BBHIH', 0, 0, 22, _RT_TX_FLAGS | _RT_VHT, tx_flags)
+        + vht_info
+    )
+
+
 def build_beacon(rate_mbps_x2: int = 0, *, mcs=None, ldpc: bool = False,
-                 stbc: int = 0, bandwidth: int = 20):
+                 stbc: int = 0, bandwidth: int = 20, vht: bool = False,
+                 vht_mcs: int = 0, nss: int = 1):
     """Mgmt / probe-request frame matching txdemo's beacon_frame[]. The body
     payload doesn't matter for hit-count testing — only SA is matched.
 
@@ -65,9 +99,13 @@ def build_beacon(rate_mbps_x2: int = 0, *, mcs=None, ldpc: bool = False,
     chip pick its own default (varies by chipset and is the source of the
     8812-vs-8814 asymmetry we're investigating).
 
-    If any of `mcs` / `ldpc` / `stbc` is set, switches to a hand-built
-    radiotap header with MCS info (default MCS 1 if `mcs` is None). Used by
-    --encoding-matrix to exercise LDPC and STBC paths."""
+    Encoding selection:
+      - default: legacy radiotap with optional `Rate`, chip picks encoding.
+      - `mcs` / `ldpc` / `stbc` (without `vht`): HT radiotap (bit 19).
+      - `vht=True`: VHT radiotap (bit 21); use `vht_mcs` / `nss` / `ldpc` /
+        `stbc` / `bandwidth` to control. Default VHT MCS 0 / NSS 1 / 20 MHz.
+        Required for testing chips whose LDPC RX limitation is on the VHT
+        path (e.g. RTL8821AU's reported LDPC-RX-no per Eachine Sphere Link)."""
     dot11_bytes = bytes(
         Dot11(
             type=0,  # mgmt
@@ -78,6 +116,12 @@ def build_beacon(rate_mbps_x2: int = 0, *, mcs=None, ldpc: bool = False,
         )
         / b"\x00\x00\x00\x00\x00\x00\x00\x00"  # ssid IE (empty)
     )
+    if vht:
+        rt_bytes = _build_radiotap_vht(
+            vht_mcs=vht_mcs, nss=nss, ldpc=ldpc, stbc=bool(stbc),
+            bandwidth=bandwidth,
+        )
+        return Raw(rt_bytes + dot11_bytes)
     if mcs is not None or ldpc or stbc:
         rt_bytes = _build_radiotap_mcs(
             mcs=mcs if mcs is not None else 1,
@@ -124,14 +168,31 @@ def main():
         help="STBC stream count, 0..3 (default 0 = no STBC).",
     )
     ap.add_argument(
-        "--bandwidth", type=int, default=20, choices=(20, 40),
-        help="HT bandwidth in MHz (20 default; 40 sets MCS flags bw bit).",
+        "--bandwidth", type=int, default=20, choices=(20, 40, 80, 160),
+        help="bandwidth in MHz. HT honours 20/40; VHT honours 20/40/80/160.",
+    )
+    ap.add_argument(
+        "--vht", action="store_true",
+        help="emit VHT (802.11ac) radiotap (bit 21) instead of HT (bit 19). "
+             "Combine with --ldpc / --stbc / --vht-mcs / --vht-nss / "
+             "--bandwidth. Needed to test chips whose LDPC RX limitation is "
+             "specifically on the VHT path (e.g. RTL8821AU).",
+    )
+    ap.add_argument(
+        "--vht-mcs", type=int, default=0,
+        help="VHT MCS index, 0..9 typical (default 0). Only used with --vht.",
+    )
+    ap.add_argument(
+        "--vht-nss", type=int, default=1,
+        help="VHT spatial streams (NSS), 1..4 (default 1). Only used with "
+             "--vht.",
     )
     args = ap.parse_args()
 
     pkt = build_beacon(
         args.rate, mcs=args.mcs, ldpc=args.ldpc, stbc=args.stbc,
-        bandwidth=args.bandwidth,
+        bandwidth=args.bandwidth, vht=args.vht, vht_mcs=args.vht_mcs,
+        nss=args.vht_nss,
     )
     end = time.monotonic() + args.duration
     sent = 0

--- a/tests/regress.py
+++ b/tests/regress.py
@@ -520,6 +520,12 @@ def _devourer_env(dut: Dut, channel: int,
             env["DEVOURER_TX_STBC"] = str(tx_encoding["stbc"])
         if tx_encoding.get("bandwidth") is not None:
             env["DEVOURER_TX_BW"] = str(tx_encoding["bandwidth"])
+        if tx_encoding.get("vht"):
+            env["DEVOURER_TX_VHT"] = "1"
+            if tx_encoding.get("vht_mcs") is not None:
+                env["DEVOURER_TX_VHT_MCS"] = str(tx_encoding["vht_mcs"])
+            if tx_encoding.get("nss") is not None:
+                env["DEVOURER_TX_VHT_NSS"] = str(tx_encoding["nss"])
     return env
 
 
@@ -585,6 +591,12 @@ def _spawn_kernel_tx(
             extra += ["--stbc", str(encoding["stbc"])]
         if encoding.get("bandwidth") is not None:
             extra += ["--bandwidth", str(encoding["bandwidth"])]
+        if encoding.get("vht"):
+            extra.append("--vht")
+            if encoding.get("vht_mcs") is not None:
+                extra += ["--vht-mcs", str(encoding["vht_mcs"])]
+            if encoding.get("nss") is not None:
+                extra += ["--vht-nss", str(encoding["nss"])]
     if kh.is_remote:
         # Ship the injector to the VM (overwrites each run — fine for the
         # tiny script).
@@ -989,10 +1001,17 @@ def emit_full_markdown(
 # ---------------------------------------------------------------------------
 
 ENCODING_COMBOS = [
-    ("BCC",         {"mcs": 1}),
-    ("LDPC",        {"mcs": 1, "ldpc": True}),
-    ("STBC=1",      {"mcs": 1, "stbc": 1}),
-    ("LDPC+STBC=1", {"mcs": 1, "ldpc": True, "stbc": 1}),
+    # HT (radiotap bit 19): MCS 1, 20 MHz.
+    ("HT-BCC",        {"mcs": 1}),
+    ("HT-LDPC",       {"mcs": 1, "ldpc": True}),
+    ("HT-STBC=1",     {"mcs": 1, "stbc": 1}),
+    ("HT-LDPC+STBC",  {"mcs": 1, "ldpc": True, "stbc": 1}),
+    # VHT (radiotap bit 21): VHT MCS 0, NSS 1, 20 MHz. 8821AU's LDPC-RX-no
+    # limitation (per Eachine Sphere Link reports) is on the VHT path —
+    # HT-LDPC didn't surface it because the chip's HT and VHT decoders are
+    # separate code paths in silicon.
+    ("VHT-BCC",       {"vht": True, "vht_mcs": 0, "nss": 1}),
+    ("VHT-LDPC",      {"vht": True, "vht_mcs": 0, "nss": 1, "ldpc": True}),
 ]
 
 

--- a/tests/sniff_air.py
+++ b/tests/sniff_air.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Capture frames on a monitor-mode interface and report what encoding was
+actually on-air.
+
+Companion to `tests/inject_beacon.py` + `tests/regress.py --encoding-matrix`:
+when those tests show the same hit count across BCC / LDPC / STBC columns,
+the question is "did the kernel TX path actually emit different encodings,
+or did mac80211 strip the flags?". Run this script on a third adapter
+(e.g. AR9271, which speaks vanilla radiotap and is widely used as a
+sniffer), filter on the canonical injection SA, and decode the radiotap
+of each captured frame to see what flew.
+
+Usage:
+
+    sudo python3 tests/sniff_air.py --iface wlan0mon --channel 100 \\
+        --duration 30
+
+Requires the iface to be plugged + driver-supported. The script will put
+it into monitor mode on the chosen channel before starting tcpdump.
+
+Output: per-encoding hit counts, e.g.
+
+    captured 412 frames matching SA=57:42:75:05:d6:00 in 30s:
+      HT MCS=1 BCC 20MHz STBC=0    300 frames (72.8%)
+      HT MCS=1 LDPC 20MHz STBC=0   100 frames (24.3%)
+      HT MCS=1 LDPC 20MHz STBC=1    12 frames (2.9%)
+
+If a `--ldpc` injection is reported back as BCC, mac80211 / driver
+stripped the bit before the air. That answers the question.
+"""
+
+import argparse
+import struct
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+from pathlib import Path
+
+
+# Source MAC matches the canonical beacon SA in txdemo/main.cpp and
+# inject_beacon.py. Don't change without updating both.
+CANONICAL_SA = bytes.fromhex("574275 05d600".replace(" ", ""))
+
+# Radiotap field bits we care about.
+_RT_TX_FLAGS = 1 << 15
+_RT_MCS = 1 << 19
+_RT_VHT = 1 << 21
+
+# Field sizes in bytes for each radiotap presence bit. Source:
+# https://www.radiotap.org/ — only fields we need are filled out; the rest
+# are byte-counted so we can skip past them to reach MCS / VHT.
+# Format: (size, alignment).
+_RT_FIELDS = {
+    0:  (8, 8),   # TSFT
+    1:  (1, 1),   # Flags
+    2:  (1, 1),   # Rate
+    3:  (4, 2),   # Channel (u16 freq + u16 flags)
+    4:  (2, 2),   # FHSS
+    5:  (1, 1),   # Antenna signal
+    6:  (1, 1),   # Antenna noise
+    7:  (2, 2),   # Lock quality
+    8:  (2, 2),   # TX attenuation
+    9:  (2, 2),   # DB TX attenuation
+    10: (1, 1),   # DBM TX power
+    11: (1, 1),   # Antenna
+    12: (1, 1),   # DB antenna signal
+    13: (1, 1),   # DB antenna noise
+    14: (2, 2),   # RX Flags
+    15: (2, 2),   # TX Flags
+    16: (1, 1),   # RTS retries
+    17: (1, 1),   # Data retries
+    18: (8, 4),   # XChannel (8 bytes, 4-byte aligned)
+    19: (3, 1),   # MCS info
+    20: (8, 4),   # A-MPDU
+    21: (12, 2),  # VHT info
+}
+
+
+def _aligned(offset: int, align: int) -> int:
+    return (offset + align - 1) & ~(align - 1)
+
+
+def _parse_radiotap(frame: bytes):
+    """Decode radiotap MCS (bit 19) / VHT (bit 21) info from one captured
+    frame. Returns dict with keys: kind ('HT' | 'VHT' | 'legacy'), mcs,
+    ldpc, stbc, bw, nss (where applicable)."""
+    if len(frame) < 8:
+        return None
+    version, _pad, it_len = struct.unpack_from("<BBH", frame, 0)
+    if version != 0 or it_len < 8 or it_len > len(frame):
+        return None
+
+    # Walk all it_present words (continue while ext bit set).
+    presence: list[int] = []
+    off = 4
+    while off + 4 <= it_len:
+        word = struct.unpack_from("<I", frame, off)[0]
+        presence.append(word)
+        off += 4
+        if not (word & (1 << 31)):
+            break
+
+    # Fields start after the last it_present word; offset relative to frame.
+    # Iterate bits 0..21 in the first word — the only one we know fixed
+    # field sizes for. Anything in extension words we skip.
+    cur = off
+    word0 = presence[0] if presence else 0
+    parsed = {}
+    for bit in range(32):
+        if not (word0 & (1 << bit)):
+            continue
+        if bit not in _RT_FIELDS:
+            # Unknown field — can't safely skip past it. Bail.
+            return None
+        size, align = _RT_FIELDS[bit]
+        cur = _aligned(cur, align)
+        if cur + size > it_len:
+            return None
+        if bit == 19:  # MCS info
+            mcs_known, mcs_flags, mcs_idx = struct.unpack_from(
+                "<BBB", frame, cur,
+            )
+            parsed["mcs_known"] = mcs_known
+            parsed["mcs_flags"] = mcs_flags
+            parsed["mcs_idx"] = mcs_idx
+        elif bit == 21:  # VHT info
+            vht_known, vht_flags, vht_bw = struct.unpack_from(
+                "<HBB", frame, cur,
+            )
+            vht_mcs_nss = frame[cur + 4:cur + 8]
+            vht_coding = frame[cur + 8]
+            parsed["vht_known"] = vht_known
+            parsed["vht_flags"] = vht_flags
+            parsed["vht_bw"] = vht_bw
+            parsed["vht_mcs_nss"] = vht_mcs_nss
+            parsed["vht_coding"] = vht_coding
+        cur += size
+
+    # Decide kind.
+    if "vht_mcs_nss" in parsed:
+        mcs = (parsed["vht_mcs_nss"][0] >> 4) & 0xF
+        nss = parsed["vht_mcs_nss"][0] & 0xF
+        bw_map = {0: 20, 1: 40, 4: 80, 11: 160}
+        bw = bw_map.get(parsed["vht_bw"], parsed["vht_bw"])
+        return {
+            "kind": "VHT",
+            "mcs": mcs,
+            "nss": nss,
+            "ldpc": bool(parsed["vht_coding"] & 0x01),
+            "stbc": bool(parsed["vht_flags"] & 0x01),
+            "bw": bw,
+            "rt_len": it_len,
+        }
+    if "mcs_idx" in parsed:
+        bw_lo = parsed["mcs_flags"] & 0x03
+        bw = 40 if bw_lo == 1 else 20
+        return {
+            "kind": "HT",
+            "mcs": parsed["mcs_idx"],
+            "nss": 1,  # HT doesn't carry NSS in radiotap, default to 1
+            "ldpc": bool(parsed["mcs_flags"] & 0x10),
+            "stbc": (parsed["mcs_flags"] >> 5) & 0x3,
+            "bw": bw,
+            "rt_len": it_len,
+        }
+    return {"kind": "legacy", "rt_len": it_len}
+
+
+def _frame_sa(frame: bytes) -> bytes | None:
+    """Extract the 802.11 frame's SA (addr2) from a captured frame.
+    Frame layout: radiotap header (variable, length in bytes 2-3 LE),
+    then 802.11 frame starts with FC u16 / Duration u16 / addr1[6] /
+    addr2[6] ..."""
+    if len(frame) < 4:
+        return None
+    it_len = struct.unpack_from("<H", frame, 2)[0]
+    sa_offset = it_len + 4 + 6  # skip rt, FC, Duration, addr1
+    if sa_offset + 6 > len(frame):
+        return None
+    return frame[sa_offset:sa_offset + 6]
+
+
+def _set_monitor(iface: str, channel: int) -> None:
+    """Tear iface down, retype it to monitor, set channel, bring it up.
+    Same sequence as regress.py's iface_to_monitor."""
+    cmds = [
+        ["ip", "link", "set", iface, "down"],
+        ["iw", "dev", iface, "set", "type", "monitor"],
+        ["ip", "link", "set", iface, "up"],
+        ["iw", "dev", iface, "set", "channel", str(channel)],
+    ]
+    for c in cmds:
+        subprocess.run(c, check=True)
+
+
+def _capture(iface: str, duration: float, pcap_path: Path) -> int:
+    """Run tcpdump filtered on the canonical SA for `duration` seconds.
+    Writes a pcap to `pcap_path`. Returns frames-written count from tcpdump
+    stderr ('N packets captured')."""
+    sa_str = ":".join(f"{b:02x}" for b in CANONICAL_SA)
+    proc = subprocess.run(
+        ["timeout", "--signal=INT", "--kill-after=2", str(duration),
+         "tcpdump", "-i", iface, "-w", str(pcap_path), "-U", "-nn",
+         f"ether src {sa_str}"],
+        capture_output=True, text=True,
+    )
+    # tcpdump prints "N packets captured" to stderr after exit on SIGINT.
+    for line in (proc.stderr or "").splitlines():
+        if "packets captured" in line:
+            try:
+                return int(line.split()[0])
+            except ValueError:
+                pass
+    return 0
+
+
+def _read_pcap_frames(pcap_path: Path):
+    """Minimal pcap-savefile reader. Yields each frame's raw bytes.
+    Avoids depending on scapy.rdpcap so this can run on hosts without
+    the full scapy install."""
+    with pcap_path.open("rb") as f:
+        gh = f.read(24)
+        if len(gh) != 24:
+            return
+        magic = struct.unpack_from("<I", gh, 0)[0]
+        # 0xa1b2c3d4 microsecond, 0xa1b23c4d nanosecond — both LE here.
+        if magic not in (0xA1B2C3D4, 0xA1B23C4D):
+            return
+        while True:
+            hdr = f.read(16)
+            if len(hdr) < 16:
+                return
+            _ts_sec, _ts_usec, incl_len, _orig_len = struct.unpack("<IIII", hdr)
+            data = f.read(incl_len)
+            if len(data) < incl_len:
+                return
+            yield data
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Capture on a monitor iface and decode the radiotap "
+                    "encoding of each frame matching the canonical SA.",
+    )
+    ap.add_argument("--iface", required=True,
+                    help="monitor-capable iface (e.g. wlan9271 for AR9271)")
+    ap.add_argument("--channel", type=int, required=True,
+                    help="Wi-Fi channel to monitor on")
+    ap.add_argument("--duration", type=float, default=30.0,
+                    help="capture window in seconds (default 30)")
+    ap.add_argument("--pcap-out", type=Path,
+                    help="keep the raw pcap at this path (default: temp file)")
+    args = ap.parse_args()
+
+    _set_monitor(args.iface, args.channel)
+
+    if args.pcap_out:
+        pcap = args.pcap_out
+    else:
+        pcap = Path(tempfile.mkstemp(suffix=".pcap", prefix="sniff_air-")[1])
+
+    print(f"capturing on {args.iface} ch{args.channel} for {args.duration:.0f}s "
+          f"→ {pcap}")
+    n_captured = _capture(args.iface, args.duration, pcap)
+
+    buckets: Counter = Counter()
+    total = 0
+    parse_failed = 0
+    for frame in _read_pcap_frames(pcap):
+        sa = _frame_sa(frame)
+        if sa != CANONICAL_SA:
+            continue
+        total += 1
+        info = _parse_radiotap(frame)
+        if info is None:
+            parse_failed += 1
+            continue
+        if info["kind"] == "VHT":
+            key = (f"VHT MCS={info['mcs']} NSS={info['nss']} "
+                   f"{'LDPC' if info['ldpc'] else 'BCC'} "
+                   f"{info['bw']}MHz STBC={int(info['stbc'])}")
+        elif info["kind"] == "HT":
+            key = (f"HT MCS={info['mcs']} "
+                   f"{'LDPC' if info['ldpc'] else 'BCC'} "
+                   f"{info['bw']}MHz STBC={int(info['stbc'])}")
+        else:
+            key = "legacy (no MCS / VHT field)"
+        buckets[key] += 1
+
+    print(f"\ncaptured {total} frames matching "
+          f"SA={':'.join(f'{b:02x}' for b in CANONICAL_SA)} "
+          f"({n_captured} hit the tcpdump filter; {parse_failed} radiotap "
+          f"parse errors)")
+    if total == 0:
+        print("  (nothing — check channel, TX side running, iface up)")
+        return 0
+    for key, n in buckets.most_common():
+        pct = 100.0 * n / total
+        print(f"  {key:<48} {n:5d} frames ({pct:5.1f}%)")
+    if not args.pcap_out:
+        try:
+            pcap.unlink()
+        except OSError:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/txdemo/main.cpp
+++ b/txdemo/main.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <vector>
 
 #if defined(_MSC_VER)
   #include <windows.h>
@@ -205,35 +206,112 @@ int main(int argc, char **argv) {
       0x8f, 0x28, 0x6f, 0x10, 0xb0, 0xa9, 0x5d, 0xbf, 0xcb, 0x6f};
 
   /* Radiotap MCS info lives at beacon_frame[10..12]: known mask, flags, idx.
-   * Defaults encode MCS 1 / 20 MHz / long GI / BCC / no STBC. Env knobs let
-   * tests/regress.py --encoding-matrix exercise LDPC and STBC paths — needed
-   * to surface chip-specific asymmetries like the RTL8821AU LDPC-RX-no
-   * limitation (the chip can TX LDPC but its decoder can't RX LDPC frames). */
+   * Defaults encode HT MCS 1 / 20 MHz / long GI / BCC / no STBC. Env knobs
+   * let tests/regress.py --encoding-matrix exercise LDPC and STBC paths —
+   * needed to surface chip-specific asymmetries like the RTL8821AU
+   * LDPC-RX-no limitation. DEVOURER_TX_VHT=1 switches to a VHT (802.11ac)
+   * radiotap header instead (radiotap bit 21, 22-byte length) — required
+   * for chips whose LDPC RX limitation only appears on the VHT path. */
+  bool tx_vht = std::getenv("DEVOURER_TX_VHT") != nullptr;
   if (const char *m = std::getenv("DEVOURER_TX_MCS")) {
     beacon_frame[12] = static_cast<uint8_t>(std::strtoul(m, nullptr, 0) & 0x7F);
-    logger->info("DEVOURER_TX_MCS — MCS index set to {}", beacon_frame[12]);
+    logger->info("DEVOURER_TX_MCS — HT MCS index set to {}", beacon_frame[12]);
   }
   uint8_t mcs_flags = beacon_frame[11];
-  if (std::getenv("DEVOURER_TX_LDPC")) {
-    mcs_flags |= 0x10; /* MCS flags bit 4 = FEC type LDPC */
-    logger->info("DEVOURER_TX_LDPC — FEC=LDPC");
+  bool tx_ldpc = std::getenv("DEVOURER_TX_LDPC") != nullptr;
+  if (tx_ldpc && !tx_vht) {
+    mcs_flags |= 0x10; /* HT MCS flags bit 4 = FEC type LDPC */
+    logger->info("DEVOURER_TX_LDPC — FEC=LDPC (HT)");
   }
+  int tx_stbc = 0;
   if (const char *s = std::getenv("DEVOURER_TX_STBC")) {
-    int n = std::atoi(s) & 0x3;
-    mcs_flags = static_cast<uint8_t>((mcs_flags & ~0x60) | (n << 5));
-    logger->info("DEVOURER_TX_STBC — {} STBC stream(s)", n);
+    tx_stbc = std::atoi(s) & 0x3;
+    if (!tx_vht) {
+      mcs_flags = static_cast<uint8_t>((mcs_flags & ~0x60) | (tx_stbc << 5));
+    }
+    logger->info("DEVOURER_TX_STBC — {} STBC stream(s)", tx_stbc);
   }
+  int tx_bw = 20;
   if (const char *bw = std::getenv("DEVOURER_TX_BW")) {
-    int b = std::atoi(bw);
-    uint8_t code = (b == 40) ? 0x01 : 0x00;
-    mcs_flags = static_cast<uint8_t>((mcs_flags & ~0x03) | code);
-    logger->info("DEVOURER_TX_BW — {} MHz", b);
+    tx_bw = std::atoi(bw);
+    if (!tx_vht) {
+      uint8_t code = (tx_bw == 40) ? 0x01 : 0x00;
+      mcs_flags = static_cast<uint8_t>((mcs_flags & ~0x03) | code);
+    }
+    logger->info("DEVOURER_TX_BW — {} MHz", tx_bw);
   }
   beacon_frame[11] = mcs_flags;
 
+  /* Build the final TX buffer. Default: send beacon_frame[] verbatim (the
+   * existing HT path, with the in-place patches above already applied). VHT
+   * mode: swap the first 13 bytes (HT radiotap) for a 22-byte VHT radiotap,
+   * keep the 802.11 frame body unchanged. */
+  std::vector<uint8_t> tx_buf;
+  if (tx_vht) {
+    int vht_mcs = 0;
+    int vht_nss = 1;
+    if (const char *vm = std::getenv("DEVOURER_TX_VHT_MCS")) {
+      vht_mcs = std::atoi(vm) & 0xF;
+    }
+    if (const char *vn = std::getenv("DEVOURER_TX_VHT_NSS")) {
+      vht_nss = std::atoi(vn) & 0xF;
+    }
+    uint8_t bw_code = 0;
+    switch (tx_bw) {
+      case 40:  bw_code = 1; break;
+      case 80:  bw_code = 4; break;
+      case 160: bw_code = 11; break;
+      default:  bw_code = 0; break;
+    }
+    /* VHT radiotap layout (22 bytes): header(8) + TX Flags(2) + VHT info(12).
+     * VHT info: u16 known, u8 flags, u8 bw, u8[4] mcs_nss, u8 coding,
+     * u8 group_id, u16 partial_aid. Mirrors tests/inject_beacon.py's
+     * _build_radiotap_vht. */
+    const uint16_t known = (1u << 0) | (1u << 2) | (1u << 6); /* STBC|GI|BW */
+    const uint8_t vht_info_flags = tx_stbc ? 0x01 : 0x00;
+    const uint8_t mcs_nss_user0 =
+        static_cast<uint8_t>(((vht_mcs & 0xF) << 4) | (vht_nss & 0xF));
+    const uint8_t coding = tx_ldpc ? 0x01 : 0x00; /* user-0 nibble */
+    /* it_present = (1<<15) TX Flags | (1<<21) VHT */
+    const uint32_t it_present = (1u << 15) | (1u << 21);
+    const uint16_t it_len = 22;
+    const uint16_t tx_flags = 0x0008;
+    tx_buf.reserve(22 + sizeof(beacon_frame) - 13);
+    /* radiotap header */
+    tx_buf.push_back(0); /* version */
+    tx_buf.push_back(0); /* pad */
+    tx_buf.push_back(static_cast<uint8_t>(it_len & 0xFF));
+    tx_buf.push_back(static_cast<uint8_t>((it_len >> 8) & 0xFF));
+    tx_buf.push_back(static_cast<uint8_t>(it_present & 0xFF));
+    tx_buf.push_back(static_cast<uint8_t>((it_present >> 8) & 0xFF));
+    tx_buf.push_back(static_cast<uint8_t>((it_present >> 16) & 0xFF));
+    tx_buf.push_back(static_cast<uint8_t>((it_present >> 24) & 0xFF));
+    /* TX Flags */
+    tx_buf.push_back(static_cast<uint8_t>(tx_flags & 0xFF));
+    tx_buf.push_back(static_cast<uint8_t>((tx_flags >> 8) & 0xFF));
+    /* VHT info */
+    tx_buf.push_back(static_cast<uint8_t>(known & 0xFF));
+    tx_buf.push_back(static_cast<uint8_t>((known >> 8) & 0xFF));
+    tx_buf.push_back(vht_info_flags);
+    tx_buf.push_back(bw_code);
+    tx_buf.push_back(mcs_nss_user0);
+    tx_buf.push_back(0); tx_buf.push_back(0); tx_buf.push_back(0); /* users 1-3 */
+    tx_buf.push_back(coding);
+    tx_buf.push_back(0); /* group_id */
+    tx_buf.push_back(0); tx_buf.push_back(0); /* partial_aid LE */
+    /* 802.11 frame body (skip the original 13-byte HT radiotap). */
+    tx_buf.insert(tx_buf.end(),
+                  beacon_frame + 13, beacon_frame + sizeof(beacon_frame));
+    logger->info(
+        "DEVOURER_TX_VHT — VHT radiotap: mcs={} nss={} ldpc={} stbc={} bw={}MHz",
+        vht_mcs, vht_nss, tx_ldpc ? 1 : 0, tx_stbc, tx_bw);
+  } else {
+    tx_buf.assign(beacon_frame, beacon_frame + sizeof(beacon_frame));
+  }
+
   long tx_count = 0;
   while (true) {
-    rc = rtlDevice->send_packet(beacon_frame, sizeof(beacon_frame));
+    rc = rtlDevice->send_packet(tx_buf.data(), tx_buf.size());
     ++tx_count;
     if (tx_count <= 10 || tx_count % 500 == 0) {
       printf("<devourer-tx>TX #%ld rc=%d\n", tx_count, rc);


### PR DESCRIPTION
Follow-up to #39 closing two of the three follow-ups noted in that PR's test plan.

## What this is

Two pieces:

1. **VHT combos in `--encoding-matrix`.** `ENCODING_COMBOS` grows from 4 to 6 entries: adds `VHT-BCC` and `VHT-LDPC` (radiotap bit 21, 22-byte VHT info field, MCS 0 / NSS 1 / 20 MHz). Motivating case: RTL8821AU's LDPC-RX-no limitation (per @RomanLut, Eachine Sphere Link) is on the VHT path. The chip's HT and VHT decoders are separate silicon blocks, so #39's HT-LDPC test passing didn't say anything about VHT-LDPC.

2. **`tests/sniff_air.py`.** Standalone radiotap-decode helper. Capture on a monitor-mode iface (intended use: AR9271 — vanilla radiotap, no driver-side flag filtering), filter on the canonical injection SA, decode each captured frame's MCS / VHT field. Answers the question \"did mac80211 actually emit what \`inject_beacon.py\` requested, or strip the encoding flags before the air?\" — which is what #39's flat-LDPC-row result was waiting on.

## Implementation

| File | Change |
|---|---|
| \`tests/inject_beacon.py\` | \`_build_radiotap_vht\` helper, \`--vht / --vht-mcs / --vht-nss\` flags, \`--bandwidth\` extended to 80/160 |
| \`txdemo/main.cpp\` | When \`DEVOURER_TX_VHT=1\`, swap the 13-byte HT radiotap prefix for a 22-byte VHT radiotap built from \`DEVOURER_TX_VHT_MCS / _VHT_NSS / _LDPC / _STBC / _BW\` env vars. TX buffer refactored to \`std::vector<uint8_t>\` to hold either prefix length. Byte-identical to the Python builder. |
| \`tests/regress.py\` | \`ENCODING_COMBOS\` gets VHT-BCC + VHT-LDPC; \`_devourer_env\` + \`_spawn_kernel_tx\` pass \`vht / vht_mcs / nss\` through |
| \`tests/sniff_air.py\` | NEW, ~270 lines. \`sudo python3 tests/sniff_air.py --iface <mon> --channel N --duration N\`. Sets monitor mode, runs tcpdump → pcap, manually parses radiotap (handles MCS bit 19 + VHT bit 21 + correct alignment for skipped fields), reports encoding distribution |
| \`tests/README.md\` | Documents the VHT combos table + sniffer + updates the kernel-TX-strip caveat |

## Validation on the lab rig (8814 TX → 8821 RX, ch 100, VM mode)

\`--encoding-matrix\` table (24 cells, all ran):

| Mode | HT-BCC | HT-LDPC | HT-STBC=1 | HT-LDPC+STBC | VHT-BCC | VHT-LDPC |
|---|---|---|---|---|---|---|
| k/k | 466 ✓ | 455 ✓ | 462 ✓ | 443 ✓ | 435 ✓ | 453 ✓ |
| d/k | 0 ✗ | 0 ✗ | 0 ✗ | 0 ✗ | 0 ✗ | 0 ✗ |
| k/d | 400 ✓ | 400 ✓ | 400 ✓ | 400 ✓ | 400 ✓ | 400 ✓ |
| d/d | 0 ✗ | 0 ✗ | 0 ✗ | 0 ✗ | 0 ✗ | 0 ✗ |

VHT-LDPC \`k/d\` still flat at ~400 hits, same as VHT-BCC and HT-LDPC. 8821AU RX accepted every cell. Two reads, neither distinguishable in this PR:

1. Kernel-TX path strips radiotap LDPC bit regardless of HT vs VHT mode → \`sniff_air.py\` on an AR9271 would prove or disprove this.
2. 8821AU doesn't actually have the LDPC-RX-no limitation, or it only triggers under conditions we don't reproduce (specific MCS / NSS / BW / aggregation pattern).

\`d/k\` and \`d/d\` rows are 0 because 8814 TX is broken on master (separate known issue, not in scope here).

Sniffer parser unit-tested against every combo \`inject_beacon.py\` emits — round-trips with byte-identical decoded fields.

## What this PR doesn't touch

- AR9271 sniffer cell integration into \`regress.py\`'s per-cell flow. \`sniff_air.py\` is standalone here; wiring it into the matrix orchestration is a smaller follow-up.
- A-MPDU / Beamforming / Higher VHT NSS / 802.11ax (HE) — extend \`ENCODING_COMBOS\` as needed.
- Fixing the 8821AU LDPC-RX-no question itself — the infrastructure to answer it (\`sniff_air.py\` + VHT combos) is now in place, but the actual proof requires plugging in an AR9271 and running the sniffer alongside the matrix.

## Test plan

- [x] \`--help\` lists \`--vht / --vht-mcs / --vht-nss\` on \`inject_beacon.py\`
- [x] C++ and Python radiotap builders produce byte-identical output for all (HT, VHT) × (LDPC, STBC) combos
- [x] \`sniff_air.py\` parser round-trips every combo \`inject_beacon.build_beacon\` emits
- [x] Full \`--encoding-matrix\` on master + sanity \`--full-matrix\` post-merge confirm \`encoding=None\` default behaviour preserved
- [x] CI builds (all 5 OS/compiler matrix combos) — passing on prior pushes; will rerun on this branch
- [ ] AR9271 plugged in + \`sniff_air.py\` exercised alongside an \`--encoding-matrix\` run to confirm what's actually on-air (waiting on hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)