### PR TITLE
RTL8821AU: 8821-specific init flow (replaces trace-derived parity)

### DIFF
--- a/src/HalModule.cpp
+++ b/src/HalModule.cpp
@@ -109,11 +109,14 @@ bool HalModule::rtl8812au_hal_init() {
    * both chips — these write to chip-version-agnostic registers and the
    * functions that do diverge dispatch internally on ICType. */
   const bool is_8814a = _eepromManager->version_id.ICType == CHIP_8814A;
+  const bool is_8821 = _eepromManager->version_id.ICType == CHIP_8821;
   if (!is_8814a) {
-    _device.rtw_write8(REG_RF_CTRL, 5);
-    _device.rtw_write8(REG_RF_CTRL, 7);
-    _device.rtw_write8(REG_RF_B_CTRL_8812, 5);
-    _device.rtw_write8(REG_RF_B_CTRL_8812, 7);
+    if (!is_8821) {
+      _device.rtw_write8(REG_RF_CTRL, 5);
+      _device.rtw_write8(REG_RF_CTRL, 7);
+      _device.rtw_write8(REG_RF_B_CTRL_8812, 5);
+      _device.rtw_write8(REG_RF_B_CTRL_8812, 7);
+    }
 
     // If HW didn't go through a complete de-initial procedure,
     // it probably occurs some problem for double initial procedure.
@@ -130,7 +133,9 @@ bool HalModule::rtl8812au_hal_init() {
    * runs LLT init AFTER fw boot, and doing it pre-fw on 8814 breaks the
    * beacon-queue fwdl path (the chip silently rejects bulk OUT writes). */
   if (_eepromManager->version_id.ICType != CHIP_8814A) {
-    if (!InitLLTTable8812A(TX_PAGE_BOUNDARY_8812)) {
+    const uint8_t txpktbuf_bndy =
+        is_8821 ? TX_PAGE_BOUNDARY_8821 : TX_PAGE_BOUNDARY_8812;
+    if (!InitLLTTable8812A(txpktbuf_bndy)) {
       _logger->error("InitLLTTable8812A failed");
       return false;
     }
@@ -198,11 +203,18 @@ bool HalModule::rtl8812au_hal_init() {
           llt);
     }
   } else {
-    _InitQueueReservedPage_8812AUsb();
-    _InitTxBufferBoundary_8812AUsb();
+    if (is_8821) {
+      _InitQueueReservedPage_8821AUsb();
+      _InitTxBufferBoundary_8821AUsb();
+    } else {
+      _InitQueueReservedPage_8812AUsb();
+      _InitTxBufferBoundary_8812AUsb();
+    }
     _InitQueuePriority_8812AUsb();
     _InitPageBoundary_8812AUsb();
-    _InitTransferPageSize_8812AUsb();
+    if (!is_8821) {
+      _InitTransferPageSize_8812AUsb();
+    }
   }
 
   // Get Rx PHY status in order to report RSSI and others.
@@ -227,6 +239,13 @@ bool HalModule::rtl8812au_hal_init() {
   // than the real Rx buffer size in 88E. 2011.08.05. by tynli.
   value8 = _device.rtw_read8(REG_CR);
   _device.rtw_write8(REG_CR, (uint8_t)(value8 | MACTXEN | MACRXEN));
+
+  if (is_8821) {
+    uint8_t sysCfg3 = _device.rtw_read8(REG_SYS_CFG + 3);
+    if ((sysCfg3 & BIT0) != 0) {
+      _device.rtw_write8(0x7c, (uint8_t)(_device.rtw_read8(0x7c) | BIT6));
+    }
+  }
 
   _device.rtw_write16(REG_PKT_VO_VI_LIFE_TIME, 0x0400); /* unit: 256us. 256ms */
   _device.rtw_write16(REG_PKT_BE_BK_LIFE_TIME, 0x0400); /* unit: 256us. 256ms */
@@ -779,6 +798,20 @@ bool HalModule::HalPwrSeqCmdParsing(WLAN_PWR_CFG *PwrSeqCmd) {
       AryIdx++;
       continue;
     }
+    uint8_t cutMask = PWR_CUT_ALL_MSK;
+    if (_eepromManager->version_id.ICType == CHIP_8821) {
+      cutMask = _eepromManager->version_id.ChipType == NORMAL_CHIP
+                    ? PWR_CUT_A_MSK
+                    : PWR_CUT_TESTCHIP_MSK;
+    }
+    if (!(GET_PWR_CFG_CUT_MASK(PwrCfgCmd) & cutMask)) {
+      AryIdx++;
+      continue;
+    }
+    if (!(GET_PWR_CFG_FAB_MASK(PwrCfgCmd) & PWR_FAB_ALL_MSK)) {
+      AryIdx++;
+      continue;
+    }
     switch (PwrCfgCmd.cmd) {
     case PWR_CMD_READ:
       break;
@@ -1232,6 +1265,51 @@ void HalModule::_InitTxBufferBoundary_8812AUsb() {
   _device.rtw_write8(REG_WMAC_LBK_BF_HD, txPageBoundary8812);
   _device.rtw_write8(REG_TRXFF_BNDY, txPageBoundary8812);
   _device.rtw_write8(REG_TDECTRL + 1, txPageBoundary8812);
+}
+
+void HalModule::_InitQueueReservedPage_8821AUsb() {
+  uint32_t numHQ = 0;
+  uint32_t numLQ = 0;
+  uint32_t numNQ = 0;
+
+  if (registry_priv::wifi_spec) {
+    if (_device.OutEpQueueSel & TxSele::TX_SELE_HQ) {
+      numHQ = WMM_NORMAL_PAGE_NUM_HPQ_8821;
+    }
+    if (_device.OutEpQueueSel & TxSele::TX_SELE_LQ) {
+      numLQ = WMM_NORMAL_PAGE_NUM_LPQ_8821;
+    }
+    if (_device.OutEpQueueSel & TxSele::TX_SELE_NQ) {
+      numNQ = WMM_NORMAL_PAGE_NUM_NPQ_8821;
+    }
+  } else {
+    if (_device.OutEpQueueSel & TxSele::TX_SELE_HQ) {
+      numHQ = NORMAL_PAGE_NUM_HPQ_8821;
+    }
+    if (_device.OutEpQueueSel & TxSele::TX_SELE_LQ) {
+      numLQ = NORMAL_PAGE_NUM_LPQ_8821;
+    }
+    if (_device.OutEpQueueSel & TxSele::TX_SELE_NQ) {
+      numNQ = NORMAL_PAGE_NUM_NPQ_8821;
+    }
+  }
+
+  const uint32_t numPubQ = TX_TOTAL_PAGE_NUMBER_8821 - numHQ - numLQ - numNQ;
+  _device.rtw_write8(REG_RQPN_NPQ, (uint8_t)_NPQ(numNQ));
+  _device.rtw_write32(REG_RQPN,
+                      _HPQ(numHQ) | _LPQ(numLQ) | _PUBQ(numPubQ) | LD_RQPN);
+}
+
+void HalModule::_InitTxBufferBoundary_8821AUsb() {
+  const uint8_t txpktbuf_bndy = registry_priv::wifi_spec
+                                    ? WMM_NORMAL_TX_PAGE_BOUNDARY_8821
+                                    : TX_PAGE_BOUNDARY_8821;
+
+  _device.rtw_write8(REG_BCNQ_BDNY, txpktbuf_bndy);
+  _device.rtw_write8(REG_MGQ_BDNY, txpktbuf_bndy);
+  _device.rtw_write8(REG_WMAC_LBK_BF_HD, txpktbuf_bndy);
+  _device.rtw_write8(REG_TRXFF_BNDY, txpktbuf_bndy);
+  _device.rtw_write8(REG_TDECTRL + 1, txpktbuf_bndy);
 }
 
 void HalModule::_InitQueuePriority_8812AUsb() {
@@ -1711,6 +1789,7 @@ void HalModule::_InitBeaconMaxError_8812A() {
 
 void HalModule::_InitBurstPktLen() {
   uint8_t speedvalue, provalue, temp;
+  const bool is_8821 = _eepromManager->version_id.ICType == CHIP_8821;
 
   _device.rtw_write8(0xf050, 0x01); /* usb3 rx interval */
   _device.rtw_write16(
@@ -1719,7 +1798,7 @@ void HalModule::_InitBurstPktLen() {
   _device.rtw_write8(0x289, 0xf5); /* for rxdma control */
 
   /* 0x456 = 0x70, sugguested by Zhilin */
-  _device.rtw_write8(REG_AMPDU_MAX_TIME_8812, 0x70);
+  _device.rtw_write8(REG_AMPDU_MAX_TIME_8812, is_8821 ? 0x5e : 0x70);
 
   _device.rtw_write32(REG_AMPDU_MAX_LENGTH_8812, 0xffffffff);
   _device.rtw_write8(REG_USTIME_TSF, 0x50);
@@ -1727,6 +1806,9 @@ void HalModule::_InitBurstPktLen() {
 
   speedvalue =
       _device.rtw_read8(0xff); /* check device operation speed: SS 0xff bit7 */
+  if (is_8821) {
+    speedvalue = BIT7;
+  }
 
   if ((speedvalue & BIT7) != 0) {
     /* USB2/1.1 Mode */
@@ -1768,6 +1850,10 @@ void HalModule::_InitBurstPktLen() {
   _device.rtw_write16(REG_MAX_AGGR_NUM, 0x1f1f);
   _device.rtw_write8(REG_FWHW_TXQ_CTRL,
                      (uint8_t)(_device.rtw_read8(REG_FWHW_TXQ_CTRL) & (~BIT7)));
+  if (is_8821 && !registry_priv::wifi_spec) {
+    _device.rtw_write8(REG_FWHW_TXQ_CTRL, 0x80);
+    _device.rtw_write32(REG_FAST_EDCA_CTRL, 0x03087777);
+  }
 
   // AMPDUBurstMode is always false
   // if (pHalData.AMPDUBurstMode)

--- a/src/HalModule.h
+++ b/src/HalModule.h
@@ -82,7 +82,9 @@ private:
   bool check_positive(int32_t condition1, int32_t condition2,
                       int32_t condition4);
   void _InitQueueReservedPage_8812AUsb();
+  void _InitQueueReservedPage_8821AUsb();
   void _InitTxBufferBoundary_8812AUsb();
+  void _InitTxBufferBoundary_8821AUsb();
   void _InitQueuePriority_8812AUsb();
   void _InitNormalChipTwoOutEpPriority_8812AUsb();
   void _InitNormalChipRegPriority_8812AUsb(uint16_t beQ, uint16_t bkQ,


### PR DESCRIPTION
Cherry-picks the HalModule-only delta from @RomanLut's #22 minimal-fix commit (`caa46d92` on `RomanLut/devourer:rtl8811au_support`), which isolates his original wholesale-svpcom port down to **just the 8821 init-flow changes** — same `_eepromManager->version_id.ICType == CHIP_8821` dispatch points, but using the proper rtl8812au-derived init sequence instead of master's trace-replay approach from #37.

Supersedes #22 (which is now functionally a superset of this PR plus already-reverted noise). Same fix, isolated.

## Motivating bug

@RomanLut [reported](https://github.com/OpenIPC/devourer/pull/22#issuecomment-4528955230) that master's 8821AU works for cold init but fails on hotplug: after unplug/replug, PixelPilot stops receiving until the app is restarted. Independently reproduced in his hx-esp32cam-fpv Android GS builds.

He [confirmed](https://github.com/OpenIPC/devourer/pull/22#issuecomment-4536175...) the Android path goes through `libusb_wrap_sys_device()` with an fd from `UsbDeviceConnection.getFileDescriptor()`, not the traditional `libusb_open_device_with_vid_pid`.

Linux-side reproduction with sysfs unbind/rebind never showed the failure mode (see #22 comment chain — three forms of "hotplug" tested, master passes all). The diagnosis that makes both observations consistent:

Master's #37 8821 init is a **trace-derived register-poke replay** that works on first init (because that's the chip state the trace was captured from) but doesn't necessarily produce a valid chip state from arbitrary starting conditions. A freshly-wrapped Android fd may present such a condition; this PR's **proper init flow** re-initializes from any starting state.

## What this changes

`HalModule::rtl8812au_hal_init` dispatch points where 8821 currently falls through 8812's path, switched to 8821-specific:

- `REG_RF_CTRL = 5/7` + `REG_RF_B_CTRL_8812 = 5/7` writes skipped for 8821
- LLT init uses `TX_PAGE_BOUNDARY_8821` (vs `_8812`)
- Queue/buffer init dispatches to new `_InitQueueReservedPage_8821AUsb` and `_InitTxBufferBoundary_8821AUsb` (added below); `_InitTransferPageSize_8812AUsb` skipped for 8821
- Post-MACTXEN/MACRXEN: `if (REG_SYS_CFG+3 & BIT0) → 0x7C |= BIT6`
- `HalPwrSeqCmdParsing` gains `GET_PWR_CFG_CUT_MASK` + `GET_PWR_CFG_FAB_MASK` filtering; for 8821, `cutMask = NORMAL_CHIP ? PWR_CUT_A_MSK : PWR_CUT_TESTCHIP_MSK`
- `_InitBurstPktLen` for 8821: `REG_AMPDU_MAX_TIME_8812 = 0x5e` (vs 0x70), force `speedvalue = BIT7`, `REG_FWHW_TXQ_CTRL = 0x80` + `REG_FAST_EDCA_CTRL = 0x03087777` when `!wifi_spec`

New helpers in `HalModule`:

- `_InitQueueReservedPage_8821AUsb`: uses `NORMAL_PAGE_NUM_{HPQ,LPQ,NPQ}_8821` (or `WMM_NORMAL_PAGE_NUM_*` under `wifi_spec`) and `TX_TOTAL_PAGE_NUMBER_8821`
- `_InitTxBufferBoundary_8821AUsb`: writes `TX_PAGE_BOUNDARY_8821` to `BCNQ_BDNY` / `MGQ_BDNY` / `WMAC_LBK_BF_HD` / `TRXFF_BNDY` / `TDECTRL+1`

All constants already exist in `hal/rtl8812a_hal.h` and `hal/HalPwrSeqCmd.h`.

## Linux-side validation on lab rig

`tests/regress.py --full-matrix --channel 100` on 8814AU + 8821AU T2U Plus, VM mode (`devourer-testrig` + `aircrack-ng/88XXau`). No regressions vs #34 baseline; 8821 cells uniformly improved:

| TX → RX | #34 baseline | with this patch |
|---|---|---|
| 8814 kernel → 8821 kernel | 271 ✓ | **430 ✓** |
| 8814 kernel → 8821 devourer | 200 ✓ | **400 ✓** |
| 8821 kernel → 8814 kernel | 260 ✓ | **365 ✓** |
| 8821 devourer → 8814 kernel | 4341 ✓ | **5865 ✓** |

8814-TX cells still 0 (known broken, separate issue). 8814-RX cells still 0 (known broken, separate issue).

## What this doesn't validate

The Android hotplug end-to-end. That requires @RomanLut building PixelPilot against this branch and exercising the unplug/replug flow on an actual Android device — which we can't do from the Linux lab.

**@RomanLut: could you build PixelPilot / hx-esp32cam-fpv against this branch (`feat/pr22-minimal-hotplug-fix`) and confirm that the hotplug failure mode goes away?** If yes, this is ready to merge and supersedes #22.

## What this doesn't touch

- `RtlUsbAdapter.cpp` (rxagg thresholds, `infinite_read` early-return) — your minimal-fix commit reverted those, so they're not in scope here. We can revisit separately if you find they're needed.
- `EepromManager.cpp` (`IsRtl8821A` vs `is_rtl8821a_pid` allow-list) — both work, master's allow-list is intentional, you've already reverted.
- The trace-derived register pokes from #37 — this PR doesn't remove them yet. They still apply on the post-fwdl path and may now be redundant; cleaning that up is a follow-up.

## Test plan

- [x] CMake build clean on master
- [x] `--full-matrix` no regressions; 8821 cells improved
- [x] CI builds on push
- [ ] @RomanLut confirms PixelPilot hotplug fix on Android
- [ ] If confirmed, follow-up to remove now-redundant #37 trace pokes

Co-authored with @RomanLut (`Co-Authored-By` trailer in commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)