### PR TITLE
RTL8821AU: remove redundant PR #37 trace-derived post-fwdl pokes

### DIFF
--- a/src/HalModule.cpp
+++ b/src/HalModule.cpp
@@ -441,119 +441,17 @@ bool HalModule::rtl8812au_hal_init() {
     }
   }
 
-  if (_eepromManager->version_id.ICType == CHIP_8821) {
-    /* Program MAC address to REG_MACID (0x0610). usbmon-trace diff vs
-     * aircrack-ng/88XXau on the same T2U Plus (2357:0120) shows the kernel
-     * writes 6 individual bytes at 0x0610..0x0615 during monitor-mode
-     * bring-up — devourer never writes REG_MACID, leaving it zero. With
-     * REG_MACID unprogrammed the chip's MAC RX engine drops frames from
-     * TX peers whose framing matches certain patterns even with RCR_AAP
-     * set (the kernel-TX-8812 → devourer-RX-8821 cell got 0 hits while
-     * kernel-TX-8812 → kernel-RX-8821 got 258 hits — same chip, same
-     * peer, only difference was this register being programmed).
-     *
-     * Hardcoded to the actual T2U Plus MAC observed in the usbmon trace.
-     * Proper fix: read from EFUSE via Hal_EfuseParseMACAddr_8821A path
-     * (mirrors 8812's GetHwReg path, but devourer doesn't currently
-     * expose the MAC bytes from EepromManager's efuse_eeprom_data shadow
-     * for non-8814 chips). */
-    static const uint8_t k8821Mac[6] = {0xe0, 0xd3, 0x62, 0x97, 0xa9, 0x72};
-    for (uint16_t i = 0; i < 6; ++i) {
-      _device.rtw_write8(0x0610 + i, k8821Mac[i]);
-    }
-
-    /* Trace-derived 8821 post-fwdl writes. Captured from
-     * aircrack-ng/88XXau on the T2U Plus (2357:0120) during monitor-mode
-     * bring-up; the usbmon-diff vs devourer surfaced these. Values are
-     * LITTLE-ENDIAN u32 (usbmon shows wire bytes in transmission order;
-     * to write the same value via rtw_write32 on a LE host, bytes need
-     * to be reversed from the usbmon text):
-     *
-     *   addr   usbmon wire bytes   →  u32 to write
-     *   0x004c 82 82 40 01            0x01408282
-     *   0x004e 40                     0x40 (1 byte)
-     *   0x0040 00                     0x00 (1 byte)
-     *   0x0208 60 f8 00 00            0x0000f860
-     *   0x0520 0f 3f 00 00            0x00003f0f
-     *   0x0670 00 00 00 c0            0xc0000000
-     *   0x0a0a 40                     0x40 (1 byte)
-     *   0x1874 22 2f f8 e6            0xe6f82f22
-     *   0x1878 fe ed f4 5e            0x5ef4edfe
-     *   0x187c..0x187f                22 00 6c 90 (4 individual bytes)
-     */
-    _device.rtw_write32(0x004c, 0x01408282u);
-    _device.rtw_write8(0x004e, 0x40);
-    _device.rtw_write8(0x0040, 0x00);
-    _device.rtw_write32(0x0208, 0x0000f860u);
-    _device.rtw_write32(0x0520, 0x00003f0fu);
-    _device.rtw_write32(0x0670, 0xc0000000u);
-    _device.rtw_write8(0x0a0a, 0x40);
-    _device.rtw_write32(0x1874, 0xe6f82f22u);
-    _device.rtw_write32(0x1878, 0x5ef4edfeu);
-    _device.rtw_write8(0x187c, 0x22);
-    _device.rtw_write8(0x187d, 0x00);
-    _device.rtw_write8(0x187e, 0x6c);
-    _device.rtw_write8(0x187f, 0x90);
-
-    /* BB / AGC value overrides. The 8821 BB table imported in PR #30
-     * (svpcom/rtl8812au v5.2.20) sets initial values that DIFFER from
-     * what aircrack-ng/88XXau's chip ends up with after runtime phydm
-     * AGC adjustments. The trace-vs-devourer value diff shows 92
-     * registers where both write but with different final values; the
-     * cluster at 0x0c20-0x0c44 + 0x0830/0834/8a4/8b0/c50/c54/c90/cb4/e90
-     * are the AGC + power-detect-threshold + BW-indication settings.
-     *
-     * Devourer doesn't run phydm at all (no runtime AGC). Best we can
-     * do without porting phydm is force the chip to the kernel's
-     * post-init values — picks up the AGC tuning kernel does without
-     * needing the dynamic feedback loop. */
-    _device.rtw_write32(0x0830, 0x2aaaf1a8u);  /* PWED_TH (RX power det) */
-    _device.rtw_write32(0x0834, 0x0437a706u);  /* BW indication */
-    _device.rtw_write32(0x08a4, 0x7f7f2028u);
-    _device.rtw_write32(0x08b0, 0x00000042u);
-    _device.rtw_write32(0x0c20, 0x29292929u);  /* AGC table */
-    _device.rtw_write32(0x0c24, 0x1d1d1d1du);
-    _device.rtw_write32(0x0c28, 0x1d1d1d1du);
-    _device.rtw_write32(0x0c2c, 0x1f1f1f1fu);
-    _device.rtw_write32(0x0c30, 0x1f1f1f1fu);
-    _device.rtw_write32(0x0c3c, 0x1f1f1f1fu);
-    _device.rtw_write32(0x0c40, 0x1f1f1f1fu);
-    _device.rtw_write32(0x0c44, 0x2a2a1f1fu);
-    _device.rtw_write32(0x0c50, 0x0000001eu);
-    _device.rtw_write32(0x0c54, 0x00070d15u);
-    _device.rtw_write32(0x0c90, 0x04238508u);
-    _device.rtw_write32(0x0cb4, 0x20000077u);
-    _device.rtw_write32(0x0e90, 0x01800c00u);
-    _logger->info("8821 trace-derived BB/AGC value overrides applied");
-
-    /* Trace-derived 8814 post-fwdl init writes. usbmon diff vs
-     * kernel-driver (cold-init → monitor → inject) revealed these are
-     * present in the kernel path and absent from devourer. Applied as a
-     * batch to bring devourer's chip state into MAC-TX-ready shape.
-     *
-     *   REG_RRSR (0x0440)        = 0xff0f0000  Response Rate Set
-     *   0x04bc                   = 0x00        TX queue gate
-     *   REG_QUEUE_CTRL (0x04c6)  = 0x04        Queue control
-     *   REG_TX_PTCL_CTRL (0x520) = 0x0f2f0000  TX protocol control
-     *   REG_RD_CTRL (0x0524)     = 0x0f4fff00  RD control
-     *   0x0670                   = 0x000000c0  NAV-related
-     *   RA-table init at 0x0990-0x09a4
-     */
-    _device.rtw_write32(0x0440, 0xff0f0000u);   /* REG_RRSR */
-    _device.rtw_write8(0x04bc, 0x00);
-    _device.rtw_write8(0x04c6, 0x04);           /* REG_QUEUE_CTRL */
-    _device.rtw_write32(0x0520, 0x0f2f0000u);   /* REG_TX_PTCL_CTRL */
-    _device.rtw_write32(0x0524, 0x0f4fff00u);   /* REG_RD_CTRL */
-    _device.rtw_write32(0x0670, 0x000000c0u);
-    /* Rate-adaptation table init (final values from trace). */
-    _device.rtw_write32(0x0990, 0xffff1027u);
-    _device.rtw_write32(0x0994, 0x0001484cu);
-    _device.rtw_write32(0x0998, 0x24282c30u);
-    _device.rtw_write32(0x099c, 0x34383c40u);
-    _device.rtw_write32(0x09a0, 0x44000000u);
-    _device.rtw_write32(0x09a4, 0x80000800u);
-    _logger->info("8814A: REG_MACID + trace-derived post-fwdl writes applied");
-  }
+  /* Historic 8821 trace-derived post-fwdl block (hardcoded T2U Plus MAC at
+   * 0x0610, ~13 trace-derived register pokes, BB/AGC value overrides,
+   * RRSR/queue/RA-table writes — captured from aircrack-ng/88XXau on one
+   * specific cold-init session) was removed here. PR #42 replaced the
+   * 8821 init with a proper init-flow dispatch in HalModule (around line
+   * 100-200), which sets up the chip from any starting state. Master had
+   * been applying BOTH the proper init AND the trace replay; the trace
+   * replay was load-bearing only before #42 landed, and its hard-coded
+   * MAC + double-writes to 0x0520/0x0670 (different values per write)
+   * make it actively harmful in the long run. Removed pending matrix +
+   * Android-hotplug re-validation. */
 
   if (is_8814a) {
     /* TX-validation diagnostic. Read back the registers that gate USB→TX


### PR DESCRIPTION
Cleanup follow-up to #42. Drops 113 lines from `HalModule::rtl8812au_hal_init`'s `if (CHIP_8821)` post-fwdl block — the trace-replay parity originally added in #37, now made redundant by #42's proper 8821-specific init flow.

## What's removed

Inside the `if (CHIP_8821)` branch:

- Hardcoded T2U Plus MAC at 0x0610..0x0615 (k8821Mac static)
- ~13 trace-captured register pokes (0x004c, 0x004e, 0x0040, 0x0208, 0x0520, 0x0670, 0x0a0a, 0x1874-0x187f)
- BB/AGC value overrides (0x0830/0834/8a4/8b0, 0x0c20-0x0c44 cluster, 0x0c50/0c54/0c90/0cb4/0e90)
- Mislabeled "8814 post-fwdl init" RRSR/queue-ctrl/RA-table block — actually inside the 8821 branch, wrong comment header. Writes 0x0440, 0x04bc, 0x04c6, 0x0520, 0x0524, 0x0670, 0x0990-0x09a4.

The double-writes to 0x0520 and 0x0670 (different values per write within the same `if (CHIP_8821)` block) were the smell — the trace replay had never been fully reasoned through. PR #42's proper init lands the chip in MAC-RX-ready state from any starting condition, making the replay unnecessary.

## Linux validation

`tests/regress.py --full-matrix --channel 100` on 8814 + 8821 T2U Plus, VM mode. No regressions; 8821 cells preserved within RF variance:

| TX → RX | post-#42 (with trace pokes) | this PR |
|---|---|---|
| 8814 kernel → 8821 kernel | 430 ✓ | **435 ✓** |
| 8814 kernel → 8821 devourer | 400 ✓ | **400 ✓** |
| 8821 kernel → 8814 kernel | 365 ✓ | **372 ✓** |
| 8821 devourer → 8814 kernel | 5865 ✓ | **5933 ✓** |

8814-TX cells (2, 4) and 8814-RX cells (7, 8) unchanged at 0 — known separate issues.

## What this doesn't validate

Android-side hotplug end-to-end. PR #42 was confirmed by @RomanLut to fix hotplug on PixelPilot + hx-esp32cam-fpv **with the trace pokes still in place**. This PR removes them. Proper init flow alone *should* be sufficient (that's the whole point of #42 — driving the chip from any starting state without relying on pre-captured pokes that matched one specific state) — but it deserves re-validation.

@RomanLut — when you have a moment, could you re-build PixelPilot / hx-esp32cam-fpv against this branch and confirm hotplug still works on 8821AU? Single replug cycle is enough. If it regresses, the trace pokes were load-bearing for hotplug specifically (unlikely IMO but possible) and we revert.

## What this PR doesn't touch

- 8814AU branch — the `if (is_8814a)` block at the top of the same area still programs the hardcoded MAC and the `DEVOURER_OOT_REPLAY=1`-gated path; unchanged.
- The 8821-specific init flow added in #42 — that's what makes this removal safe; not modified.

## Test plan

- [x] Build clean
- [x] CI matrix (all 5 OS/compiler combos)
- [x] `--full-matrix` no regressions on Linux
- [ ] @RomanLut confirms 8821AU hotplug still works on Android against this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)