### PR TITLE
tests: fix radiotap parser + per-cell pcap collision in --encoding-matrix

### DIFF
--- a/tests/regress.py
+++ b/tests/regress.py
@@ -806,6 +806,7 @@ def run_cell(
     kh: KernelHost,
     encoding: Optional[dict] = None,
     sniffer_iface: Optional[str] = None,
+    cell_tag: str = "",
 ) -> CellResult:
     """Run one matrix cell. State contract: always restore DUTs to a clean
     baseline (host kernel-bound) on exit via try/finally.
@@ -819,7 +820,14 @@ def run_cell(
     via sniff_air's radiotap decoder and a one-line summary appended to
     the CellResult.notes. Lets the matrix prove what encoding actually
     flew, vs what inject_beacon.py / txdemo *requested*."""
+    # Per-cell filename stem. `cell_tag` is appended by callers that run
+    # multiple cells with the same (tx_side, rx_side) but different
+    # encodings (--encoding-matrix) — without it the pcap from cell N
+    # gets overwritten by cell N+1, so --keep-logs only preserves the
+    # last encoding combo per driver-mode.
     cell_id = f"tx-{tx_side}_rx-{rx_side}"
+    if cell_tag:
+        cell_id = f"{cell_id}_{cell_tag}"
     tx_log = tmpdir / f"{cell_id}.tx.log"
     rx_log = tmpdir / f"{cell_id}.rx.log"
     sniffer_pcap = tmpdir / f"{cell_id}.sniffer.pcap" if sniffer_iface else None
@@ -1152,11 +1160,13 @@ def run_encoding_matrix(
                 f"RX={rx_dut.chipset} ({rx_side})  enc=[{enc_label}]"
             )
             print(cell_hdr + " ...", flush=True)
+            # Sanitize encoding label for use in a filename.
+            tag = enc_label.lower().replace("+", "-").replace("=", "")
             try:
                 r = run_cell(
                     devourer_root, tx_dut, rx_dut, tx_side, rx_side,
                     channel, duration, tmpdir, kh, encoding=enc,
-                    sniffer_iface=sniffer_iface,
+                    sniffer_iface=sniffer_iface, cell_tag=tag,
                 )
             except Exception as e:
                 print(f"  ✗ cell crashed: {e}", flush=True)

--- a/tests/sniff_air.py
+++ b/tests/sniff_air.py
@@ -84,7 +84,12 @@ def _aligned(offset: int, align: int) -> int:
 def _parse_radiotap(frame: bytes):
     """Decode radiotap MCS (bit 19) / VHT (bit 21) info from one captured
     frame. Returns dict with keys: kind ('HT' | 'VHT' | 'legacy'), mcs,
-    ldpc, stbc, bw, nss (where applicable)."""
+    ldpc, stbc, bw, nss (where applicable), or None on malformed header.
+
+    Handles multi-word it_present chains and the radiotap control bits
+    (29 RADIOTAP_NS, 30 VENDOR_NS, 31 EXT). Real mac80211 captures from
+    ath9k_htc routinely use multiple presence words + bit 29, so a parser
+    that only walks word0 fails on every frame."""
     if len(frame) < 8:
         return None
     version, _pad, it_len = struct.unpack_from("<BBH", frame, 0)
@@ -101,41 +106,74 @@ def _parse_radiotap(frame: bytes):
         if not (word & (1 << 31)):
             break
 
-    # Fields start after the last it_present word; offset relative to frame.
-    # Iterate bits 0..21 in the first word — the only one we know fixed
-    # field sizes for. Anything in extension words we skip.
     cur = off
-    word0 = presence[0] if presence else 0
-    parsed = {}
-    for bit in range(32):
-        if not (word0 & (1 << bit)):
-            continue
-        if bit not in _RT_FIELDS:
-            # Unknown field — can't safely skip past it. Bail.
-            return None
-        size, align = _RT_FIELDS[bit]
-        cur = _aligned(cur, align)
-        if cur + size > it_len:
-            return None
-        if bit == 19:  # MCS info
-            mcs_known, mcs_flags, mcs_idx = struct.unpack_from(
-                "<BBB", frame, cur,
-            )
-            parsed["mcs_known"] = mcs_known
-            parsed["mcs_flags"] = mcs_flags
-            parsed["mcs_idx"] = mcs_idx
-        elif bit == 21:  # VHT info
-            vht_known, vht_flags, vht_bw = struct.unpack_from(
-                "<HBB", frame, cur,
-            )
-            vht_mcs_nss = frame[cur + 4:cur + 8]
-            vht_coding = frame[cur + 8]
-            parsed["vht_known"] = vht_known
-            parsed["vht_flags"] = vht_flags
-            parsed["vht_bw"] = vht_bw
-            parsed["vht_mcs_nss"] = vht_mcs_nss
-            parsed["vht_coding"] = vht_coding
-        cur += size
+    parsed: dict = {}
+
+    # Iterate bits across ALL presence words in transmission order.
+    # Bits 29-31 are control bits, not data:
+    #   29 RADIOTAP_NS  — namespace restart marker, no data consumed
+    #   30 VENDOR_NS    — 6-byte vendor namespace header (OUI 3 + sub-NS 1
+    #                     + skip-len 2). Subsequent bits in the same
+    #                     namespace use a vendor-defined mapping we don't
+    #                     know — give up after consuming the header.
+    #   31 EXT          — another presence word follows; no data
+    in_vendor_ns = False
+    for word in presence:
+        for bit in range(32):
+            if not (word & (1 << bit)):
+                continue
+            if bit == 31:  # EXT — handled by outer loop
+                continue
+            if bit == 29:  # RADIOTAP_NS — restart to default namespace
+                in_vendor_ns = False
+                continue
+            if bit == 30:  # VENDOR_NS — skip 6-byte header, then stop
+                cur = _aligned(cur, 2)
+                if cur + 6 > it_len:
+                    return None
+                cur += 6
+                in_vendor_ns = True
+                # Continue iterating bits, but any further field bits in
+                # this word are in vendor namespace — we can't size them.
+                continue
+            if in_vendor_ns:
+                # Vendor field, unknown size — bail out of further parsing
+                # but keep what we already extracted.
+                return parsed_to_result(parsed, it_len)
+            if bit not in _RT_FIELDS:
+                # Unknown radiotap field — can't safely advance cur. Return
+                # what we parsed so far rather than discarding.
+                return parsed_to_result(parsed, it_len)
+            size, align = _RT_FIELDS[bit]
+            cur = _aligned(cur, align)
+            if cur + size > it_len:
+                return parsed_to_result(parsed, it_len)
+            if bit == 19:  # MCS info
+                mcs_known, mcs_flags, mcs_idx = struct.unpack_from(
+                    "<BBB", frame, cur,
+                )
+                parsed["mcs_known"] = mcs_known
+                parsed["mcs_flags"] = mcs_flags
+                parsed["mcs_idx"] = mcs_idx
+            elif bit == 21:  # VHT info
+                vht_known, vht_flags, vht_bw = struct.unpack_from(
+                    "<HBB", frame, cur,
+                )
+                vht_mcs_nss = frame[cur + 4:cur + 8]
+                vht_coding = frame[cur + 8]
+                parsed["vht_known"] = vht_known
+                parsed["vht_flags"] = vht_flags
+                parsed["vht_bw"] = vht_bw
+                parsed["vht_mcs_nss"] = vht_mcs_nss
+                parsed["vht_coding"] = vht_coding
+            cur += size
+    return parsed_to_result(parsed, it_len)
+
+
+def parsed_to_result(parsed: dict, it_len: int):
+    """Convert the raw parsed-field dict into the public result shape.
+    Returned by _parse_radiotap once iteration completes OR bails early
+    on an unknown / out-of-bounds field."""
 
     # Decide kind.
     if "vht_mcs_nss" in parsed:


### PR DESCRIPTION
Two bugs in the sniffer integration from #40 / #41 that together hid the real finding about what kernel TX actually emits on-air. Fixing them surfaces a definitive answer to the open LDPC question.

## Bug 1: `_parse_radiotap` returned None on every real-world frame

The parser only iterated `it_present[0]` and bailed when it hit a bit not in `_RT_FIELDS`. Every captured frame from `ath9k_htc` has presence `0xa000402f` with bits `[0,1,2,3,5,14,29,31]` — bits 29 (`RADIOTAP_NS` marker) and 31 (`EXT` — continuation word) are control bits, not data fields. The parser hit bit 29 on every frame → `408 parse-errors / 408 frames` on the first AR9271 sniffer run.

Fix: iterate bits across ALL presence words; recognise the three control bits (29 RADIOTAP_NS, 30 VENDOR_NS, 31 EXT) and skip them with the right data consumption (6 bytes for VENDOR_NS, none for the others); when hitting an unknown radiotap field, return the parsed-so-far dict rather than discarding the whole frame.

Round-trip against `inject_beacon.build_beacon` for every `(HT, VHT) × (BCC, LDPC, STBC)` combo: byte-identical decoded fields. Real AR9271-captured beacon: parses cleanly as `kind=legacy`.

## Bug 2: cell pcap filename collision in `--encoding-matrix`

`cell_id = f"tx-{tx_side}_rx-{rx_side}"` doesn't include the encoding label, so six encoding cells per driver-mode wrote to the same `/tmp/devourer-regress-*/tx-{tx}_rx-{rx}.sniffer.pcap`. The last cell overwrote the first five — so `--keep-logs` retained only the LAST encoding combo per mode (typically VHT-LDPC, where AR9271 captures 0 frames since it's n-only). Made post-hoc debugging impossible.

Fix: optional `cell_tag` parameter on `run_cell`, set by `run_encoding_matrix` to the sanitised encoding label (`ht-bcc`, `ht-ldpc`, `vht-ldpcstbc`, …). Other matrix modes (`run_matrix`, `run_full_matrix`) leave it empty — they only run one cell per `(tx_side, rx_side)` pair.

## What this surfaces

Encoding matrix re-run on the rig (8814 TX → 8821 RX, ch6, AR9271 sniffer):

| Mode | Encoding requested | Sniffer decoded |
|---|---|---|
| k/k | HT-BCC | `HT MCS1 BCC 20MHz STBC=0` (412) |
| k/k | HT-LDPC | `HT MCS1 **BCC** 20MHz STBC=0` (386) |
| k/k | HT-STBC=1 | `HT MCS1 BCC 20MHz **STBC=0**` (418) |
| k/k | HT-LDPC+STBC=1 | `HT MCS1 **BCC** **STBC=0**` (422) |
| k/k | VHT-BCC | 0 frames (AR9271 is n-only) |
| k/k | VHT-LDPC | 0 frames |

Same in the `k/d` row.

**`aircrack-ng/88XXau` (or mac80211 in its TX path) strips the radiotap LDPC bit and STBC stream count.** MCS index (1) and the HT-vs-VHT distinction DO survive. So every "LDPC" kernel-TX cell in #40 and #41 was actually emitting BCC on-air — the flat `k/d` row in those PRs' results never disproved @RomanLut's 8821AU LDPC-RX-no claim, it just meant we never tested the chip with an actual LDPC frame.

VHT cells show 0 to AR9271 (n-only) but >0 to the 8821 RX (AC chip), so the HT/VHT distinction IS honoured. We still can't see whether mac80211 strips the VHT-LDPC bit specifically — would need an AC-capable sniffer (or to capture on the 8821 RX itself in monitor mode).

## Implications

- The `--encoding-matrix` mode is most useful for chip-side asymmetries reachable through MCS-index and HT-vs-VHT; it can't validate LDPC- or STBC-specific RX behaviour through the kernel TX path as currently wired.
- A proper LDPC-RX validation needs a userspace TX path that writes the radiotap directly to the chip — devourer's txdemo does this (`DEVOURER_TX_LDPC=1` env var is ground-truth). 8814 TX being broken on master is the blocker for using this from the d/k cells.
- The AR9271 sniffer integration is functional; the data it produces is now reliable. Future hotplug / encoding investigations can rely on it.

## Test plan

- [x] Parser round-trips every encoding combo `inject_beacon.build_beacon` emits
- [x] Parser handles real AR9271 capture (multi-word presence, bits 29/31 set)
- [x] `--encoding-matrix` produces distinct pcap-per-cell with `--keep-logs`
- [x] Re-ran end-to-end on the rig — all 24 cells emit reliable sniffer summaries
- [x] CI builds — no C++ changes here, Python-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)