### PR TITLE
RTL8814AU: drop REG_CR=0 post-fwdl write that wedges bulk-OUT

### DIFF
--- a/src/FirmwareManager.cpp
+++ b/src/FirmwareManager.cpp
@@ -531,7 +531,16 @@ void FirmwareManager::FirmwareDownload_8814A() {
    * byte-for-byte after the last fwdl IDDMA program. */
   _device.rtw_write8(REG_MCUFWDL, 0x79);    /* declare init ready */
   _device.rtw_write8(0x010d, 0x00);         /* REG_RD_CTRL+1 */
-  _device.rtw_write8(0x0100, 0x00);         /* REG_CR byte 0 = 0 */
+  /* DO NOT write 0x0100 (REG_CR) = 0 here. Bisect 2026-05-26 of #36 wedge:
+   * zeroing REG_CR disables byte 0's DMA-enable bits (HCI_TXDMA_EN/
+   * HCI_RXDMA_EN/TXDMA_EN/RXDMA_EN/PROTOCOL_EN/SCHEDULE_EN). The later
+   * `REG_CR |= MACTXEN | MACRXEN` at HalModule.cpp:241 sets bits 6,7 but
+   * leaves bits 0..5 zero, so the chip's TX/RX DMA engines never come up
+   * — bulk-OUT URBs queue at EP 0x02 but the FIFO never drains. URBs sit
+   * until libusb's 500 ms async timeout cancels them (-ENOENT), giving
+   * the 95%+ submit-failure pattern reported in #36. Kernel rtw88_8814au
+   * never writes this address with this value. With this single write
+   * removed, devourer-TX on 8814AU goes from 0.4% completion to 100%. */
   _device.rtw_write32(0x1330, 0x80000000);  /* REG_3081_DCDC_CTRL */
   _device.rtw_write16(0x0230, 0x0000);      /* REG_PCIE_CTRL_REG word */
   _device.rtw_write32(0x022c, 0x80000000);  /* REG_BIST_CTRL */


### PR DESCRIPTION
## Summary
- `FirmwareDownload_8814A` was writing `REG_CR (0x0100) = 0` immediately after `MCUFWDL=0x79`. This clears all 8 enable bits in byte 0 — including the DMA-enable bits (0..5).
- The later `REG_CR |= MACTXEN | MACRXEN` at `HalModule.cpp:241` is a 2-bit OR; it sets bits 6+7 but leaves bits 0..5 at zero. So the chip's TX/RX DMA engines never come up: bulk-OUT URBs queue at EP `0x02` but the FIFO has no drain path. URBs sit at the chip until libusb's 500 ms async timeout cancels them (`-ENOENT`), giving the catastrophic submit-failure pattern reported in #36.
- Kernel `rtw88_8814au` never writes `REG_CR=0` during post-fwdl. The "byte-for-byte rtw88-mirror" comment block above this code is wrong on this specific address.
- Bisected by gating each of the 7 divergent post-fwdl writes (`0x010d`, `0x0100`, `0x1330`, `0x0230`, `0x022c`, `REG_BCN_CTRL`, `0x0210`) behind env vars; only `0x0100` reproduces the wedge.
- See [#36 comment with the full bisect ladder + per-write data](https://github.com/OpenIPC/devourer/issues/36#issuecomment-4544760338).

## Scope
- This resolves #36 (catastrophic `LIBUSB_TRANSFER_TIMED_OUT` submit failures on devourer-TX 8814AU after USB cycling).
- It does **not** restore 8814AU on-air emission — URBs complete cleanly now but no frames hit the air. That is a separate gate (likely TX-descriptor / rate-config) and out of scope here; will track separately.
- `RTL8814AU devourer-RX` in matrix is also still broken (cells 11/12/19/20/23/24 = 0 hits) — pre-existing, unrelated.

## Test plan
- [x] Local `WiFiDriverTxDemo` 12 s on `0bda:8813`: **2203/2203 OK, 0 fail** (was 815 submits / 575 fail = 0.4% completion on master).
- [x] `RTL8812AU` `WiFiDriverTxDemo` sanity: 796/796/0 unchanged (different code path).
- [x] `RTL8821AU` `WiFiDriverTxDemo` sanity: 991/991/0 unchanged (different code path).
- [x] `sudo python3 tests/regress.py --full-matrix --channel 100 --vm-name devourer-testrig --vm-ssh josephnef@...` (the original #36 repro): 8814 devourer-TX cells `[2,4,6,8]` now show `0 hits / 4500 TX` (no `(N fail)` annotation, indicating `tx_failures == 0` per `regress.py:494-495`). Before fix: each cell showed `(4700+ fail)`. 8812/8821 devourer-TX cells unchanged (5927–6884 hits, identical to pre-fix).
- [ ] CI matrix builds (GCC/Clang/MSVC on Ubuntu/macOS/Windows) — should be unaffected since this is a single-line removal in a 8814-only code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)