### PR TITLE
RTL8814AU: iterate HT_MCS24-31 + VHT_4SS in per-path TX power apply

### DIFF
--- a/src/RadioManagementModule.cpp
+++ b/src/RadioManagementModule.cpp
@@ -1202,14 +1202,24 @@ void RadioManagementModule::phy_set_tx_power_level_by_path(uint8_t channel,
     phy_set_tx_power_index_by_rate_section(path, channel,
                                            RATE_SECTION::VHT_2SSMCS0_2SSMCS9);
   }
-  /* 8814A 3-stream rate sections — must be programmed so the chip's TXAGC
-   * table is fully populated even though the USB-2 link can't sustain 3-SS
-   * data rates. Upstream PHY_SetTxPowerLevel8814 iterates all sections. */
+  /* 8814A 3-stream + 4-stream rate sections — must be programmed so the
+   * chip's TXAGC table at BB 0x1998 is fully populated even though the
+   * USB-2 link can't sustain 3-SS or 4-SS data rates. Upstream
+   * PHY_SetTxPowerLevel8814 iterates ALL sections including 4SS. The
+   * earlier 3SS-only stop was a port-incomplete bug: a kernel-vs-devourer
+   * cold-init usbmon diff (2026-05-28, devourer-testrig VM) showed BB
+   * 0x1998 had ~248 fewer writes in devourer than kernel — a count
+   * proportional to the missing (8 HT_MCS24_MCS31 + 10 VHT_4SS) × 4 paths
+   * = 72 writes per `PHY_SetTxPowerLevel8812` apply. */
   if (_eepromManager->version_id.ICType == CHIP_8814A) {
     phy_set_tx_power_index_by_rate_section(path, channel,
                                            RATE_SECTION::HT_MCS16_MCS23);
     phy_set_tx_power_index_by_rate_section(path, channel,
                                            RATE_SECTION::VHT_3SSMCS0_3SSMCS9);
+    phy_set_tx_power_index_by_rate_section(path, channel,
+                                           RATE_SECTION::HT_MCS24_MCS31);
+    phy_set_tx_power_index_by_rate_section(path, channel,
+                                           RATE_SECTION::VHT_4SSMCS0_4SSMCS9);
   }
 }
 


### PR DESCRIPTION
## Summary

`phy_set_tx_power_level_by_path` was stopping at 3SS for 8814AU, but upstream `PHY_SetTxPowerLevel8814` iterates all sections including 4SS — even though USB-2 can't sustain 4-SS data rates, the chip's TXAGC table at BB 0x1998 still needs the full per-(path, rate) population to read correct gains for the rates that DO go on air. The existing comment in `phy_set_tx_power_level_by_path` (\"upstream PHY_SetTxPowerLevel8814 iterates all sections\") documented the intent but the patch stopped at 3SS.

Found via the new pcapng diff from #55. Cold-init usbmon diff against `aircrack-ng/88XXau` in the `devourer-testrig` VM (2026-05-28):

| BB reg 0x1998 writes (cold init) | count |
|---|---|
| Kernel `88XXau` | 1029 |
| Devourer pre-patch | 781 |
| Devourer post-patch | **925** |

The +144 delta matches (8 HT_MCS24-31 + 10 VHT_4SS) × 4 RF paths × 2 `PHY_SetTxPowerLevel8812` applies per cold init = 144.

## Caveat

Empirically does NOT close the on-air TX gate on 8814AU on its own — sniffer-attached AR9271 run on ch6 with this patch + `DEVOURER_DRAIN_BULK_IN=1` (from #55) still shows 0 frames matching CANONICAL_SA. The remaining 104-write gap on 0x1998 plus new divergence signal at 0x0994 (kernel 55 / devourer 1), 0x0838 (devourer 49 / kernel 1), 0x08b0 (devourer 27 / kernel 1) suggests devourer and the kernel driver take different IQK / calibration paths — separate investigation.

This is a clean port-completion fix worth landing on its own.

## Test plan

- [x] `cmake --build build -j` clean on Linux gcc / clang (CI will exercise macos + msvc)
- [x] `WiFiDriverTxDemo` with `DEVOURER_PID=0x8813 DEVOURER_CHANNEL=6` runs through init + TX loop, no regressions
- [x] Cold-init pcapng diff confirms +144 writes to BB 0x1998 land on the wire as expected
- [ ] Followup: chase 0x0994 / 0x0838 / 0x08b0 IQK-path divergence

🤖 Generated with [Claude Code](https://claude.com/claude-code)