### PR TITLE
docs: split README 5GHz chip status into UNII-1 vs UNII-2/3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 The Realtek 11ac driver that simply devours its competitors.
 
 Devourer is a userspace re-implementation of Realtek's RTL88xxAU Wi-Fi
-driver (Jaguar family: RTL8812AU shipping on both bands, RTL8821AU
-shipping at 2.4 GHz, RTL8811AU supported via the 8812 code path,
-RTL8814AU RX-only), speaking to the chip directly through libusb. No
-kernel module, no `rtl8812au` DKMS tree — just a C++20 static library
-(`WiFiDriver`) plus two demo executables for RX and TX. It is the
-OpenIPC project's driver of choice for long-range video links built on
-top of cheap Realtek 11ac USB radios.
+driver (Jaguar family: RTL8812AU shipping on every band/channel,
+RTL8821AU shipping at 2.4 GHz and 5 GHz UNII-1 RX, RTL8811AU supported
+via the 8812 code path, RTL8814AU RX-only), speaking to the chip
+directly through libusb. No kernel module, no `rtl8812au` DKMS tree —
+just a C++20 static library (`WiFiDriver`) plus two demo executables
+for RX and TX. It is the OpenIPC project's driver of choice for
+long-range video links built on top of cheap Realtek 11ac USB radios.
 
 ## Hardware landscape
 
@@ -21,12 +21,12 @@ register-table layout, firmware-download plumbing, and
 family; chip-specific EEPROM handling, firmware blobs, and RF tables are
 layered on top.
 
-| Part           | RF / streams    | 2.4 GHz       | 5 GHz         | Notes                                       |
-| -------------- | --------------- | ------------- | ------------- | ------------------------------------------- |
-| **RTL8812AU**  | 2T2R            | TX + RX       | TX + RX       | VID/PID `0bda:8812`; reference part         |
-| **RTL8811AU**  | 1T1R            | TX + RX       | TX + RX       | 1T1R cut of 8812 silicon; rides 8812 code path with `RFType=RF_TYPE_1T1R` selected from `REG_SYS_CFG` bit 27 |
-| **RTL8814AU**  | 4T4R, 3-SS max  | RX only       | RX only       | VID/PID `0bda:8813`; 2-SS effective on USB-2. TX submits succeed on the bulk pipe but nothing reaches the air at any band — see issue #36 |
-| **RTL8821AU**  | 1T1R AC + BT    | TX + RX       | RX only       | OEM-rebadged as TP-Link Archer T2U Plus (`2357:0120`) etc; Android hotplug works end-to-end. 5 GHz TX needs the per-channel IQK calibration ported from upstream `halrf_iqk_8821a_ce.c` — see issue #59 |
+| Part           | RF / streams    | 2.4 GHz       | 5 GHz UNII-1 (ch36-48) | 5 GHz UNII-2/3 (ch52+) | Notes                                       |
+| -------------- | --------------- | ------------- | ---------------------- | ---------------------- | ------------------------------------------- |
+| **RTL8812AU**  | 2T2R            | TX + RX       | TX + RX                | TX + RX                | VID/PID `0bda:8812`; reference part — works on every channel/band combo |
+| **RTL8811AU**  | 1T1R            | TX + RX       | TX + RX                | TX + RX                | 1T1R cut of 8812 silicon; rides 8812 code path with `RFType=RF_TYPE_1T1R` selected from `REG_SYS_CFG` bit 27. Status mirrored from 8812 — no 8811AU DUT in the test rig |
+| **RTL8814AU**  | 4T4R, 3-SS max  | RX only       | RX only                | RX only                | VID/PID `0bda:8813`; 2-SS effective on USB-2. TX submits succeed on the bulk pipe but nothing reaches the air at any band — see issue #36 |
+| **RTL8821AU**  | 1T1R AC + BT    | TX + RX       | RX only                | none                   | OEM-rebadged as TP-Link Archer T2U Plus (`2357:0120`) etc; Android hotplug works end-to-end. 5 GHz UNII-1 RX works on this chip but TX is silently gated — sweep `--channel 36/40/44/48` to verify on your hardware. UNII-2 / UNII-3 (ch100, 149, 161, …) are completely broken — both TX and RX. Five hypotheses tested + refuted to date (IQK port, BB-divergence overrides, missing init writes, post-channel-set delay, TX power cap) — see issue #59 |
 
 Successor families (`Jaguar2` / `Jaguar+` — 8812BU, 8822BU/BE, etc., and
 the later `Kestrel` 11ax generation) are **out of scope**: they share


### PR DESCRIPTION
## Summary

The previous \"5 GHz\" column in the hardware-landscape table oversimplified per-chip status. A channel sweep across all three plugged DUTs (8812AU, 8821AU, 8814AU) on 2026-06-01 surfaced a real cutoff at the UNII-1 boundary specifically for 8821AU. This PR splits the \"5 GHz\" column into \"5 GHz UNII-1 (ch36-48)\" and \"5 GHz UNII-2/3 (ch52+)\" so the chip × band cells read directly.

## Measurement data

8821AU on TP-Link Archer T2U Plus (`2357:0120`), devourer TX → 8812AU kernel RX in VM:

| Channel | Band | hits / 4500 TX |
|---|---|---|
| ch1 / 6 / 11 | 2.4 G | 4397 – 4426 ✓ |
| ch36 / 40 / 44 / 48 | 5 G UNII-1 | 0 ✗ |
| ch100 | 5 G UNII-2 DFS | 0 ✗ |
| ch149 / 161 | 5 G UNII-3 non-DFS | 0 ✗ |

8821AU RX side (kernel TX → 8821AU devourer RX):
- 2.4 G: works ✓
- UNII-1 (ch36 / 48): 100 hits each ✓
- UNII-2 / UNII-3: 0 ✗

So 8821AU has a sharper boundary than the previous \"5 GHz = RX only\" captured: UNII-1 RX works, but UNII-2 / UNII-3 are completely dark in both directions.

For reference, 8812AU works on every channel both bands (4300 – 4676 hits at every channel tested), and 8814AU TX is broken everywhere as long known (issue #36).

## What this PR doesn't change

8821AU 5 GHz TX gate investigation is still open. Five hypotheses tested and refuted to date (IQK port from upstream `halrf_iqk_8821a_ce.c`, BB-divergence value overrides, missing init writes like `REG_DWBCN1_CTRL_8812`, post-channel-set settle delay, TX power cap). The 8821 cell in the updated table now lists these so the next investigator doesn't retry them. See issue #59.

## Test plan

- [x] Local edit + diff reviewed
- [ ] CI green (docs-only, build matrix is the only gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)