### PR TITLE
T1: gate PowerTracking8812a to CHIP_8812 (fix wrong pwrtrk on 8821/8814)

### DIFF
--- a/src/HalModule.cpp
+++ b/src/HalModule.cpp
@@ -294,8 +294,12 @@ bool HalModule::rtl8812au_hal_init() {
   /* Initialise phydm thermal-meter pwrtrk state now that BB+RF tables
    * have been applied. Mirrors phydm's `phydm_rf_init` ->
    * `odm_txpowertracking_init`. The watchdog ticks themselves run from
-   * the channel-set path + RtlJaguarDevice background thread. */
-  _radioManagementModule->InitPwrTrack();
+   * the channel-set path + RtlJaguarDevice background thread.
+   * 8812A-only — see RadioManagementModule::phy_SwChnlAndSetBwMode8812
+   * for the gate rationale. */
+  if (_eepromManager->version_id.ICType == CHIP_8812) {
+    _radioManagementModule->InitPwrTrack();
+  }
 
   /* Arm I/Q calibration so the initial channel-set runs a full IQK
    * (TX-tone + RX-tone, ~50-100 ms). Mirrors upstream where

--- a/src/RadioManagementModule.cpp
+++ b/src/RadioManagementModule.cpp
@@ -276,8 +276,19 @@ void RadioManagementModule::phy_SwChnlAndSetBwMode8812() {
    * upstream watchdog tick — reads RF[A][0x42], folds into the
    * thermal-value rolling average, walks the delta-swing table for
    * the (band, channel) bucket, and writes the resulting BB-swing
-   * index to 0xc1c[31:21] / 0xe1c[31:21]. */
-  _pwrTrk.TickThermalMeter(current_band_type, _currentChannel);
+   * index to 0xc1c[31:21] / 0xe1c[31:21].
+   *
+   * 8812A-only. The delta-swing tables + `PowerTracking8812a` logic
+   * came from `aircrack-ng/rtl8812au/hal/phydm/halrf/rtl8812a/
+   * halrf_8812a_ce.c`. The 8821AU has its own `halrf_8821a_ce.c`
+   * variant with different per-band tables and 1T1R-specific math —
+   * running 8812A code on 8821A produced wrong values at ch6 BB
+   * 0xc1c[31:21] (T1 8821 canary diff caught it as kern 0x200/0dB vs
+   * dev 0x1C8/-1dB). Until the 8821 pwrtrk is ported, skip the tick
+   * on non-8812 chips. */
+  if (_eepromManager->version_id.ICType == CHIP_8812) {
+    _pwrTrk.TickThermalMeter(current_band_type, _currentChannel);
+  }
 
   /* T1 cross-validation oracle (TODO.md): when DEVOURER_DUMP_CANARY=1
    * is set, dump the canary BB/MAC/RF registers after channel-set is


### PR DESCRIPTION
## Summary

The 8821AU canary diff (T1 follow-on) caught this bug: `PowerTracking8812a::TickThermalMeter` was firing on every Jaguar chip (8812 / 8821 / 8814), but its delta-swing tables + math are 8812-specific. Upstream maintains a parallel `halrf_8821a_ce.c` for 8821 with different per-band tables and 1T1R-specific logic — the 8812 code produces wrong values on 8821.

## Findings

**8821 ch6 canary divergences (pre-gate):**

| Register | Kernel | Devourer | Notes |
|---|---|---|---|
| BB 0xc1c[31:21] | 0x200 (0 dB) | 0x1C8 (-1 dB) | devourer's wrong pwrtrk write |
| BB 0x8b0 | 0x18 | 0x42 | AGC-state side effect |

**Post-gate:** both divergences disappear — pwrtrk no longer fires on 8821, BB stays at band-init values matching kernel's not-yet-converged state.

## Fix

Gate the trigger at both call sites with `_eepromManager->version_id.ICType == CHIP_8812`:
- `RadioManagementModule::phy_SwChnlAndSetBwMode8812` (per channel-set tick)
- `HalModule::rtl8812au_hal_init` (cold-init seed)

Matches the same chip-gating pattern already used for IQK (`Iqk8812a`).

8814AU also benefits — pwrtrk was firing on it with the same 8812 tables. No matrix run for 8814 because 8814 TX is gated by issue #36, but canary correctness improves.

## Future work

8821AU pwrtrk port — separate change. Needs `halrf_8821a_ce.c` translation + 1T1R-specific table simplification.

## Test plan

- [x] 8821 ch6 canary: BB 0xc1c + BB 0x8b0 divergences gone (verified post-build).
- [x] Build clean.
- [ ] Full matrix at ch6/ch36/ch100 with all 3 adapters — 8812 dongle was off USB during this work; verification pending re-plug. Expected: 8821 + 8814 unchanged from PR #67 baseline (which is currently stacked under this); 8812 unchanged (still runs pwrtrk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)