### PR TITLE
T1: extend canary oracle with 8814AU path-C/D BB regs

### DIFF
--- a/src/RadioManagementModule.cpp
+++ b/src/RadioManagementModule.cpp
@@ -337,6 +337,30 @@ void RadioManagementModule::phy_SwChnlAndSetBwMode8812() {
     for (uint32_t a : rf_canary)
       _logger->info("RF[B] 0x{:02x} = 0x{:05X}", a,
                     phy_query_rf_reg(RfPath::RF_PATH_B, a, 0xfffffu));
+
+    /* 8814AU extension: dump path-C/D BB-AGC + IGI + BB-swing. Paths C/D
+     * exist at BB-register-table level (0x18xx for path C, 0x1Axx for
+     * path D, see hal/Hal8814PhyReg.h). NB: the corresponding RF
+     * registers for paths C/D are write-only by HW design on 8814AU
+     * (see kaeru cite "RTL8814AU RF read mechanism — paths C/D
+     * write-only by HW design") — read attempts return undefined
+     * data, so we skip RF[C]/RF[D]. The BB-table state IS readable
+     * and is the canary surface for path-C/D init drift. */
+    if (_eepromManager->version_id.ICType == CHIP_8814A) {
+      static const uint16_t bb_canary_8814_pathCD[] = {
+          /* Path-C TX-AGC table */
+          0x1820, 0x1824, 0x1828, 0x182c, 0x1830, 0x1834, 0x1838, 0x183c,
+          0x1840,
+          /* Path-C BB-swing + IGI */
+          0x181c, 0x1850,
+          /* Path-D TX-AGC table */
+          0x1a20, 0x1a24, 0x1a28, 0x1a2c, 0x1a30, 0x1a34, 0x1a38, 0x1a3c,
+          0x1a40,
+          /* Path-D BB-swing + IGI */
+          0x1a1c, 0x1a50};
+      for (uint16_t a : bb_canary_8814_pathCD)
+        _logger->info("BB 0x{:04x} = 0x{:08X}", a, _device.rtw_read32(a));
+    }
     _logger->info("=== END DEVOURER_DUMP_CANARY ===");
   }
 

--- a/tools/canary_kernel_dump.sh
+++ b/tools/canary_kernel_dump.sh
@@ -38,12 +38,14 @@
 set -euo pipefail
 
 if [[ $# -lt 2 ]]; then
-  echo "Usage: $0 <iface> <channel>" >&2
+  echo "Usage: $0 <iface> <channel> [chip]" >&2
+  echo "  chip: 8812 (default) | 8814" >&2
   exit 1
 fi
 
 IFACE="$1"
 CHANNEL="$2"
+CHIP="${3:-8812}"
 
 if ! ip -o link show "$IFACE" >/dev/null 2>&1; then
   echo "iface '$IFACE' not found — did you modprobe 88XXau?" >&2
@@ -92,5 +94,17 @@ for PATH_IDX in 0 1; do
     printf "RF[%s] %s = %s\n" "$PATH_LBL" "$RF" "$(rfread $PATH_IDX $RF)"
   done
 done
+
+# 8814AU extension: path-C/D BB-AGC + IGI + BB-swing. RF[C]/RF[D]
+# are write-only by HW design on 8814AU (read attempts return undefined
+# data), so we only dump BB-table state for paths C/D.
+if [[ "$CHIP" = "8814" ]]; then
+  for ADDR in 0x1820 0x1824 0x1828 0x182c 0x1830 0x1834 0x1838 0x183c \
+              0x1840 0x181c 0x1850 \
+              0x1a20 0x1a24 0x1a28 0x1a2c 0x1a30 0x1a34 0x1a38 0x1a3c \
+              0x1a40 0x1a1c 0x1a50; do
+    printf "BB %s = %s\n" "$ADDR" "$(readreg $ADDR)"
+  done
+fi
 
 echo "=== END DEVOURER_DUMP_CANARY ==="


### PR DESCRIPTION
## Summary

The original `DEVOURER_DUMP_CANARY` set was 8812AU-specific — covered path A/B BB regs (`0xc**`, `0xe**`) plus shared MAC/RF regs. 8814AU has additional path-C/D BB-table state at `0x18xx` (path C) and `0x1Axx` (path D); the existing oracle silently skipped these on 8814AU, so any init drift in path-C/D programming was invisible.

## Extension

- `RadioManagementModule::phy_SwChnlAndSetBwMode8812` now appends the 8814AU path-C/D registers when `version_id.ICType == CHIP_8814A`. Covers TX-AGC (`0x1820-0x1840` / `0x1a20-0x1a40`), BB-swing (`0x181c` / `0x1a1c`), and IGI (`0x1850` / `0x1a50`).
- RF[C] / RF[D] are intentionally skipped — paths C/D RF are write-only by HW design on 8814AU. Read attempts return undefined data so there's no useful canary surface there.
- `tools/canary_kernel_dump.sh` takes an optional third `chip` argument (default `8812`). With `chip=8814`, dumps the same path-C/D set so the kernel + devourer captures are comparable line-by-line.

## Divergences this oracle surfaces (8814AU, ch6, fresh capture vs aircrack-ng/88XXau)

8 BB-AGC anchor regs (`0x80c`, `0x82c`, `0x830`, `0x834`, `0x8ac`, `0x8b0`, `0x8c4`, `0xe90`), 7 MAC anchor regs (`0x040`, `0x100`, `0x420`, `0x4c8`, `0x522`, `0x610`, `0x614`), and 4 path-C/D BB regs (`0x181c`, `0x1a1c`, `0x1850`, `0x1a50`). At 5G additionally: BB-swing on path-C/D doesn't get the band-set write (devourer leaves BB-init default; kernel writes `0x2D400053`). REG_MACID at `0x610` is zero on devourer (the EFUSE port from prior T1 work fires for 8812/8821 but not 8814 — different EFUSE offset).

## Test plan

- [x] `DEVOURER_DUMP_CANARY=1` on 8814AU outputs the path-C/D extension after the standard set.
- [x] `tools/canary_kernel_dump.sh wlx... 6 8814` outputs the symmetric kernel-side dump.
- [x] Diff is structurally aligned (same register addresses on both sides → line-by-line comparison works).
- [x] No functional behaviour change — the dump is purely diagnostic, only fires when `DEVOURER_DUMP_CANARY=1` is set.

## Follow-on

Each surfaced divergence is a separate fix candidate (REG_MACID for 8814, path-C/D BB-swing band-set, etc.). This PR just lays the ground truth so those fixes can be verified against a working oracle instead of blind reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)