### PR TITLE
TUN ⇄ stream-link bridge: full-duplex IP-over-precoder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,3 +112,12 @@ add_executable(StreamTxDemo
     txdemo/stream_tx_demo/main.cpp
 )
 target_link_libraries(StreamTxDemo PUBLIC WiFiDriver PRIVATE PkgConfig::libusb)
+
+# Stream-link DUPLEX: one binary, one chip, both directions. Combines the RX
+# loop from WiFiDriverDemo and the stdin-driven TX from StreamTxDemo —
+# stdin = length-prefixed PSDU bodies, stdout = <devourer-stream> lines.
+# tools/precoder/tun_p2p.py spawns this for --mode=duplex.
+add_executable(StreamDuplexDemo
+    txdemo/stream_duplex_demo/main.cpp
+)
+target_link_libraries(StreamDuplexDemo PUBLIC WiFiDriver PRIVATE PkgConfig::libusb)

--- a/tools/precoder/tun_p2p.py
+++ b/tools/precoder/tun_p2p.py
@@ -60,6 +60,7 @@ proving per-subcarrier IQ at the antenna.
 from __future__ import annotations
 
 import argparse
+import collections
 import fcntl
 import os
 import re
@@ -218,9 +219,33 @@ def tx_thread(stop: StopBit, tun_fd: int, tx_stdin, body_bytes: int,
         stop.stop = True
 
 
+class SeqWindow:
+    """Sliding-window seq dedup. `size` keeps the last K seqs seen; the K+1'th
+    pushes out the oldest. Wrap-aware in the sense that re-using a u16 seq
+    after `size` other seqs have been seen is treated as a fresh packet (the
+    old entry has aged out), so the window must be sized large enough to
+    cover the worst-case TX-side --repeat fan-out at the expected packet
+    rate but small enough that legitimate seq reuse after wrap is allowed.
+    """
+
+    def __init__(self, size: int) -> None:
+        self.size = max(1, size)
+        self._set: set[int] = set()
+        self._order: collections.deque[int] = collections.deque()
+
+    def seen_or_add(self, seq: int) -> bool:
+        if seq in self._set:
+            return True
+        self._set.add(seq)
+        self._order.append(seq)
+        if len(self._order) > self.size:
+            self._set.discard(self._order.popleft())
+        return False
+
+
 def rx_thread(stop: StopBit, rx_stdout, tun_fd: int,
               shape: Optional[dict], seed: int, offset: int, entry_state: int,
-              counters: dict) -> None:
+              dedup: Optional[SeqWindow], counters: dict) -> None:
     try:
         for line in rx_stdout:
             if stop.stop:
@@ -237,6 +262,11 @@ def rx_thread(stop: StopBit, rx_stdout, tun_fd: int,
             )
             if frame is None:
                 counters["malformed"] += 1
+                continue
+            if dedup is not None and dedup.seen_or_add(frame.seq):
+                # Duplicate from --repeat fan-out (or a real radio repeat).
+                # Drop before it ever touches the IP stack.
+                counters["dedup_dropped"] += 1
                 continue
             try:
                 os.write(tun_fd, frame.payload)
@@ -284,9 +314,19 @@ def main(argv: Optional[list[str]] = None) -> int:
                     default=str(repo / "build" / "StreamDuplexDemo"))
     ap.add_argument("--interval-ms", type=int, default=2)
     ap.add_argument("--repeat", type=int, default=1,
-                    help="blind per-frame replication (RX has no dedup in this "
-                         "v1, so >1 will send duplicate IP packets up the "
-                         "stack; default 1)")
+                    help="blind per-frame replication (combine with the "
+                         "default --dedup to collapse the fan-out at RX so "
+                         "the IP stack sees one packet per source packet)")
+    ap.add_argument("--no-dedup", dest="dedup", action="store_false",
+                    default=True,
+                    help="disable RX-side seq dedup (default: on). With "
+                         "--repeat>1 OR a real radio retransmission, leaving "
+                         "this on prevents duplicate IP packets reaching the "
+                         "kernel.")
+    ap.add_argument("--dedup-window", type=int, default=4096,
+                    help="dedup window size in distinct seqs (default 4096). "
+                         "Bigger = tolerates higher --repeat at higher packet "
+                         "rates; smaller = allows seq reuse sooner")
     ap.add_argument("--tun-name", default="dvr0")
     ap.add_argument("--tun-addr", default=None,
                     help="address/CIDR to assign to the TUN, e.g. "
@@ -356,7 +396,9 @@ def main(argv: Optional[list[str]] = None) -> int:
     counters = {
         "tx_pkts": 0, "tx_bytes": 0, "tun_oversize": 0,
         "rx_pkts": 0, "rx_bytes": 0, "malformed": 0, "rate_mismatch": 0,
+        "dedup_dropped": 0,
     }
+    dedup = SeqWindow(args.dedup_window) if args.dedup else None
 
     if single_binary:
         duplex_proc = launch_duplex(args)
@@ -388,7 +430,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         t = threading.Thread(
             target=rx_thread, daemon=True,
             args=(stop, rx_stdout, tun_fd, shape,
-                  args.seed, args.offset, args.entry_state, counters),
+                  args.seed, args.offset, args.entry_state, dedup, counters),
         )
         t.start()
         threads.append(t)
@@ -409,6 +451,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                     f"tun_p2p: tx={counters['tx_pkts']}pkt/"
                     f"{counters['tx_bytes']}B "
                     f"rx={counters['rx_pkts']}pkt/{counters['rx_bytes']}B "
+                    f"dedup-drop={counters['dedup_dropped']} "
                     f"mal={counters['malformed']} "
                     f"rate-mismatch={counters['rate_mismatch']} "
                     f"tun-oversize={counters['tun_oversize']}\n"

--- a/tools/precoder/tun_p2p.py
+++ b/tools/precoder/tun_p2p.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""TUN ⇄ stream-link bridge — IP-over-precoder for one P2P peer.
+
+First-cut "real-world P2P" demo built on the stream layer. Opens a Linux TUN
+device, spawns StreamTxDemo and/or WiFiDriverDemo as subprocesses, and runs
+two threads:
+
+    tun fd ──read──► encode_body ─length-prefix─► StreamTxDemo (libusb TX)
+    WiFiDriverDemo (libusb RX) ─<devourer-stream>─► decode_body ──write──► tun fd
+
+ONE IP PACKET = ONE STREAM FRAME (seq increments per packet, total=0 = unbounded
+stream). body_bytes defaults to 1500 so a 1490-byte tun MTU fits cleanly with
+the 10-byte envelope; tweak with --body-bytes if you want to trade airtime
+per packet for throughput per packet.
+
+NOT IN THIS V1 (deliberately, documented):
+
+* No reliability. Probe-request has no MAC ACK and we add no ARQ or FEC. Lost
+  packets are lost; out-of-order packets are written to TUN in arrival order
+  (the kernel's IP/TCP stack tolerates that). Use --repeat N to blindly
+  duplicate every TX body — rough loss insurance at N× the airtime cost.
+* No dedup across the wire. If TX peer uses --repeat>1 the RX peer writes
+  every duplicate to TUN. TCP/IP at the endpoints filters them out; UDP may
+  see them. For a clean demo, run with --repeat 1.
+* No congestion control or flow control. TUN reads are blocking; if the link
+  is slow the upstream socket back-pressures naturally via the TUN's queue.
+* Single-pair-of-peers. The body has no per-peer address field; the canonical
+  SA carries every frame. Multiple bridges on the same channel will hear each
+  other's traffic.
+
+USAGE — duplex on one host with two adapters (requires CAP_NET_ADMIN):
+
+    sudo python3 tools/precoder/tun_p2p.py \\
+        --tx-pid 0x8812 \\
+        --rx-pid 0x0120 --rx-vid 0x2357 \\
+        --tun-name dvr0 --tun-addr 10.99.0.1/24 \\
+        --channel 6
+
+Pair this with a peer running the same command but with --tx-pid / --rx-pid
+swapped and --tun-addr 10.99.0.2/24. ping between 10.99.0.1 and 10.99.0.2
+once both sides are up.
+
+ONE-WAY DEMO (also useful as a hardware smoke):
+
+    # Sender (peer A):
+    sudo python3 tools/precoder/tun_p2p.py --mode tx-only \\
+        --tx-pid 0x8812 --tun-name dvr0 --tun-addr 10.99.0.1/30 --channel 6
+
+    # Receiver (peer B):
+    sudo python3 tools/precoder/tun_p2p.py --mode rx-only \\
+        --rx-pid 0x0120 --rx-vid 0x2357 --tun-name dvr0 --tun-addr 10.99.0.5/30 \\
+        --channel 6
+
+Shape mode: pass --shape '0:+1,8:-1,16:+1' to both peers; same caveat as
+stream_tx.py — offset/entry_state default to 0 so the shape is model-bound,
+not on-air-honoured. Useful for "the bytes encode a shape" demos, not for
+proving per-subcarrier IQ at the antenna.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import os
+import re
+import shutil
+import signal
+import struct
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Optional
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+import stream  # noqa: E402
+
+# Linux TUN/TAP constants. See <linux/if_tun.h>.
+TUNSETIFF = 0x400454CA
+IFF_TUN = 0x0001
+IFF_NO_PI = 0x1000
+
+_STREAM_RE = re.compile(
+    r"<devourer-stream>rate=(?P<rate>\d+) len=(?P<len>\d+) body=(?P<hex>[0-9a-fA-F]*)"
+)
+
+
+# --------------------------------------------------------------------------- #
+# Shape spec — same parser as stream_tx.py / stream_rx.py
+# --------------------------------------------------------------------------- #
+def parse_shape(s: Optional[str]) -> Optional[dict]:
+    if not s:
+        return None
+    out: dict[int, int] = {}
+    for tok in s.split(","):
+        tok = tok.strip()
+        if not tok or ":" not in tok:
+            continue
+        k, v = tok.split(":", 1)
+        v = v.strip()
+        sign = +1 if v in ("+1", "+", "1") else -1 if v in ("-1", "-") else 0
+        if sign == 0:
+            raise ValueError(f"bad shape value {v!r}; want ±1")
+        out[int(k.strip(), 0)] = sign
+    return out or None
+
+
+# --------------------------------------------------------------------------- #
+# TUN device
+# --------------------------------------------------------------------------- #
+def open_tun(name: str, mtu: int, addr_cidr: Optional[str]) -> int:
+    """Open /dev/net/tun, attach the named interface in TUN mode (L3, no PI),
+    set MTU, optionally assign an IP, bring up. Returns the fd."""
+    fd = os.open("/dev/net/tun", os.O_RDWR)
+    ifr = struct.pack("16sH", name.encode().ljust(16, b"\x00")[:16],
+                      IFF_TUN | IFF_NO_PI)
+    fcntl.ioctl(fd, TUNSETIFF, ifr)
+    ip = shutil.which("ip") or "/sbin/ip"
+    subprocess.run([ip, "link", "set", name, "mtu", str(mtu)], check=True)
+    if addr_cidr:
+        # `replace` instead of `add` so a re-run after a crash doesn't EEXIST.
+        subprocess.run([ip, "addr", "replace", addr_cidr, "dev", name],
+                       check=True)
+    subprocess.run([ip, "link", "set", name, "up"], check=True)
+    return fd
+
+
+# --------------------------------------------------------------------------- #
+# Subprocess launchers — mirrors precoder_stream_roundtrip.py's setup but
+# without log-collection threads (we read live).
+# --------------------------------------------------------------------------- #
+def launch_tx(args) -> subprocess.Popen:
+    env = dict(os.environ, DEVOURER_PID=args.tx_pid, DEVOURER_VID=args.tx_vid,
+               DEVOURER_CHANNEL=str(args.channel), DEVOURER_USB_QUIET="1")
+    cmd = [args.tx_bin, "--interval-ms", str(args.interval_ms),
+           "--max-psdu", str(args.body_bytes * 4 + 256)]
+    return subprocess.Popen(cmd, env=env, stdin=subprocess.PIPE,
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                            bufsize=0)
+
+
+def launch_rx(args) -> subprocess.Popen:
+    env = dict(os.environ, DEVOURER_PID=args.rx_pid, DEVOURER_VID=args.rx_vid,
+               DEVOURER_CHANNEL=str(args.channel),
+               DEVOURER_STREAM_OUT="1", DEVOURER_USB_QUIET="1")
+    return subprocess.Popen([args.rx_bin], env=env,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.DEVNULL,
+                            text=True, bufsize=1)
+
+
+def launch_duplex(args) -> subprocess.Popen:
+    """Single binary, one chip, both directions. stdin = length-prefixed
+    PSDU bodies (TX side), stdout = `<devourer-stream>` lines (RX side)."""
+    env = dict(os.environ, DEVOURER_PID=args.duplex_pid,
+               DEVOURER_VID=args.duplex_vid,
+               DEVOURER_CHANNEL=str(args.channel), DEVOURER_USB_QUIET="1")
+    cmd = [args.duplex_bin, "--interval-ms", str(args.interval_ms),
+           "--max-psdu", str(args.body_bytes * 4 + 256)]
+    # stdout text-mode so the RX thread reads lines; stdin binary (default
+    # for Popen.stdin handle obtained via PIPE).
+    return subprocess.Popen(cmd, env=env, stdin=subprocess.PIPE,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.DEVNULL,
+                            text=False, bufsize=0)
+
+
+# --------------------------------------------------------------------------- #
+# Worker threads
+# --------------------------------------------------------------------------- #
+class StopBit:
+    """Tiny shared flag for clean shutdown. We never need full Event semantics
+    so a single attribute is enough."""
+
+    def __init__(self) -> None:
+        self.stop = False
+
+
+def tx_thread(stop: StopBit, tun_fd: int, tx_stdin, body_bytes: int,
+              shape: Optional[dict], seed: int, offset: int, entry_state: int,
+              repeat: int, counters: dict) -> None:
+    seq = 0
+    try:
+        while not stop.stop:
+            try:
+                pkt = os.read(tun_fd, body_bytes)
+            except OSError as e:
+                if stop.stop:
+                    return
+                sys.stderr.write(f"tun read: {e}\n")
+                return
+            if not pkt:
+                return
+            if len(pkt) > body_bytes - stream.ENVELOPE_LEN:
+                # Should never happen with --tun-mtu sized correctly.
+                counters["tun_oversize"] += 1
+                continue
+            frame = stream.StreamFrame(seq=seq, total=0, payload=pkt)
+            seq = (seq + 1) & 0xFFFF
+            body, _ = stream.encode_body(
+                frame, shape=shape, body_bytes=body_bytes,
+                seed=seed, offset=offset, entry_state=entry_state,
+            )
+            chunk = struct.pack("<I", len(body)) + body
+            try:
+                for _ in range(repeat):
+                    tx_stdin.write(chunk)
+                tx_stdin.flush()
+            except (BrokenPipeError, ValueError):
+                return
+            counters["tx_pkts"] += 1
+            counters["tx_bytes"] += len(pkt)
+    finally:
+        stop.stop = True
+
+
+def rx_thread(stop: StopBit, rx_stdout, tun_fd: int,
+              shape: Optional[dict], seed: int, offset: int, entry_state: int,
+              counters: dict) -> None:
+    try:
+        for line in rx_stdout:
+            if stop.stop:
+                return
+            m = _STREAM_RE.search(line)
+            if not m:
+                continue
+            if int(m.group("rate")) != 0x04:
+                counters["rate_mismatch"] += 1
+            body = bytes.fromhex(m.group("hex"))
+            frame = stream.decode_body(
+                body, shape=shape,
+                seed=seed, offset=offset, entry_state=entry_state,
+            )
+            if frame is None:
+                counters["malformed"] += 1
+                continue
+            try:
+                os.write(tun_fd, frame.payload)
+            except OSError as e:
+                sys.stderr.write(f"tun write: {e}\n")
+                return
+            counters["rx_pkts"] += 1
+            counters["rx_bytes"] += len(frame.payload)
+    finally:
+        stop.stop = True
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+def main(argv: Optional[list[str]] = None) -> int:
+    repo = _HERE.parent.parent
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--mode", choices=("duplex", "tx-only", "rx-only",
+                                       "duplex-split"),
+                    default="duplex",
+                    help="duplex (default) = one chip both directions via "
+                         "StreamDuplexDemo (needs --duplex-pid); "
+                         "duplex-split = two chips, --tx-pid + --rx-pid "
+                         "(the pre-duplex layout); "
+                         "tx-only / rx-only drop the unused subprocess")
+    ap.add_argument("--duplex-pid", default=None,
+                    help="DEVOURER_PID for the single chip in duplex mode")
+    ap.add_argument("--duplex-vid", default="0x0bda")
+    ap.add_argument("--tx-pid", default=None,
+                    help="DEVOURER_PID for the TX adapter "
+                         "(tx-only / duplex-split)")
+    ap.add_argument("--rx-pid", default=None,
+                    help="DEVOURER_PID for the RX adapter "
+                         "(rx-only / duplex-split)")
+    ap.add_argument("--tx-vid", default="0x0bda")
+    ap.add_argument("--rx-vid", default="0x0bda")
+    ap.add_argument("--channel", type=int, default=6)
+    ap.add_argument("--tx-bin", default=str(repo / "build" / "StreamTxDemo"))
+    ap.add_argument("--rx-bin", default=str(repo / "build" / "WiFiDriverDemo"))
+    ap.add_argument("--duplex-bin",
+                    default=str(repo / "build" / "StreamDuplexDemo"))
+    ap.add_argument("--interval-ms", type=int, default=2)
+    ap.add_argument("--repeat", type=int, default=1,
+                    help="blind per-frame replication (RX has no dedup in this "
+                         "v1, so >1 will send duplicate IP packets up the "
+                         "stack; default 1)")
+    ap.add_argument("--tun-name", default="dvr0")
+    ap.add_argument("--tun-addr", default=None,
+                    help="address/CIDR to assign to the TUN, e.g. "
+                         "'10.99.0.1/24'. Omit to leave addressing to the "
+                         "caller (e.g. `ip addr add` after we open).")
+    ap.add_argument("--tun-mtu", type=int, default=None,
+                    help="MTU for the TUN interface; default = body_bytes - "
+                         "envelope (10 B). One IP packet fits in one stream "
+                         "frame as long as this stays at or below that limit.")
+    ap.add_argument("--body-bytes", type=int, default=1500,
+                    help="stream body size (default 1500). Larger = fewer "
+                         "frames per IP packet at the cost of longer airtime "
+                         "per frame; smaller = the opposite.")
+    ap.add_argument("--shape", default=None,
+                    help="shape spec (e.g. '0:+1,8:-1,16:+1'); same caveat as "
+                         "stream_tx.py — model-bound, not on-air-honoured at "
+                         "the default offset/entry_state.")
+    ap.add_argument("--seed", type=lambda s: int(s, 0),
+                    default=stream.DEFAULT_SEED)
+    ap.add_argument("--offset", type=int, default=0)
+    ap.add_argument("--entry-state", type=lambda s: int(s, 0), default=0)
+    ap.add_argument("--report-interval", type=float, default=5.0,
+                    help="seconds between stderr counter prints; 0 = silent")
+    args = ap.parse_args(argv)
+
+    do_tx = args.mode in ("duplex", "duplex-split", "tx-only")
+    do_rx = args.mode in ("duplex", "duplex-split", "rx-only")
+    single_binary = args.mode == "duplex"
+    if single_binary:
+        if not args.duplex_pid:
+            ap.error("--duplex-pid is required for --mode=duplex")
+    else:
+        if do_tx and not args.tx_pid:
+            ap.error("--tx-pid is required unless --mode=rx-only")
+        if do_rx and not args.rx_pid:
+            ap.error("--rx-pid is required unless --mode=tx-only")
+    if args.body_bytes < stream.ENVELOPE_LEN + 1:
+        ap.error(f"--body-bytes must be >= {stream.ENVELOPE_LEN + 1}")
+    # Byte mode requires body_bytes to be a whole-symbol count
+    # (legacy 6M = 24 info bits/symbol = 3 bytes/symbol). Round up rather
+    # than erroring so a hand-picked --body-bytes doesn't trip on first packet.
+    bytes_per_sym = stream._LEGACY_BPSK.n_dbps // 8
+    if args.body_bytes % bytes_per_sym != 0:
+        rounded = ((args.body_bytes + bytes_per_sym - 1) // bytes_per_sym
+                   * bytes_per_sym)
+        sys.stderr.write(
+            f"tun_p2p: --body-bytes {args.body_bytes} not a multiple of "
+            f"{bytes_per_sym} (one OFDM symbol); rounding up to {rounded}\n"
+        )
+        args.body_bytes = rounded
+    tun_mtu = args.tun_mtu if args.tun_mtu is not None else (
+        args.body_bytes - stream.ENVELOPE_LEN)
+    if tun_mtu > args.body_bytes - stream.ENVELOPE_LEN:
+        ap.error(f"--tun-mtu {tun_mtu} exceeds payload capacity "
+                 f"{args.body_bytes - stream.ENVELOPE_LEN} for body "
+                 f"{args.body_bytes}B")
+
+    shape = parse_shape(args.shape)
+    sys.stderr.write(
+        f"tun_p2p: mode={args.mode} tun={args.tun_name} "
+        f"mtu={tun_mtu} body={args.body_bytes}B "
+        f"shape={'on' if shape else 'off'}\n"
+    )
+
+    tun_fd = open_tun(args.tun_name, tun_mtu, args.tun_addr)
+    stop = StopBit()
+    counters = {
+        "tx_pkts": 0, "tx_bytes": 0, "tun_oversize": 0,
+        "rx_pkts": 0, "rx_bytes": 0, "malformed": 0, "rate_mismatch": 0,
+    }
+
+    if single_binary:
+        duplex_proc = launch_duplex(args)
+        tx_proc = duplex_proc
+        rx_proc = duplex_proc
+        # Wrap the binary stdout in a text-mode reader for the existing
+        # rx_thread's `for line in rx_stdout:` loop.
+        import io
+        rx_stdout = io.TextIOWrapper(duplex_proc.stdout, encoding="ascii",
+                                     errors="replace", newline="\n")
+    else:
+        tx_proc = launch_tx(args) if do_tx else None
+        rx_proc = launch_rx(args) if do_rx else None
+        rx_stdout = rx_proc.stdout if rx_proc is not None else None
+
+    threads: list[threading.Thread] = []
+    if do_tx:
+        assert tx_proc is not None and tx_proc.stdin is not None
+        t = threading.Thread(
+            target=tx_thread, daemon=True,
+            args=(stop, tun_fd, tx_proc.stdin, args.body_bytes, shape,
+                  args.seed, args.offset, args.entry_state, args.repeat,
+                  counters),
+        )
+        t.start()
+        threads.append(t)
+    if do_rx:
+        assert rx_stdout is not None
+        t = threading.Thread(
+            target=rx_thread, daemon=True,
+            args=(stop, rx_stdout, tun_fd, shape,
+                  args.seed, args.offset, args.entry_state, counters),
+        )
+        t.start()
+        threads.append(t)
+
+    def shutdown(*_):
+        stop.stop = True
+    signal.signal(signal.SIGINT, shutdown)
+    signal.signal(signal.SIGTERM, shutdown)
+
+    last_print = 0.0
+    import time
+    try:
+        while not stop.stop:
+            time.sleep(0.5)
+            if args.report_interval and (time.monotonic() - last_print) >= args.report_interval:
+                last_print = time.monotonic()
+                sys.stderr.write(
+                    f"tun_p2p: tx={counters['tx_pkts']}pkt/"
+                    f"{counters['tx_bytes']}B "
+                    f"rx={counters['rx_pkts']}pkt/{counters['rx_bytes']}B "
+                    f"mal={counters['malformed']} "
+                    f"rate-mismatch={counters['rate_mismatch']} "
+                    f"tun-oversize={counters['tun_oversize']}\n"
+                )
+    finally:
+        stop.stop = True
+        seen_procs: set[int] = set()
+        for p in (tx_proc, rx_proc):
+            if p is None or id(p) in seen_procs:
+                continue
+            seen_procs.add(id(p))
+            try:
+                p.terminate()
+                p.wait(timeout=3)
+            except (subprocess.TimeoutExpired, ProcessLookupError):
+                try:
+                    p.kill()
+                except ProcessLookupError:
+                    pass
+        try:
+            os.close(tun_fd)
+        except OSError:
+            pass
+        for t in threads:
+            t.join(timeout=2)
+
+    sys.stderr.write(
+        f"tun_p2p: shutdown. final tx={counters['tx_pkts']}pkt/"
+        f"{counters['tx_bytes']}B rx={counters['rx_pkts']}pkt/"
+        f"{counters['rx_bytes']}B\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/txdemo/stream_duplex_demo/main.cpp
+++ b/txdemo/stream_duplex_demo/main.cpp
@@ -1,0 +1,298 @@
+// StreamDuplexDemo — single-chip full-duplex for the precoder stream link.
+//
+// Combines WiFiDriverDemo's RX loop (Init → infinite_read → packet callback)
+// with StreamTxDemo's stdin-driven TX (read length-prefixed PSDU body →
+// send_packet) on ONE claimed interface. RX runs in the main thread; TX in a
+// worker thread reads stdin and calls send_packet concurrently. libusb is
+// thread-safe; the two bulk endpoints (_bulk_in_ep, _bulk_out_ep) don't share
+// transfer state.
+//
+// Used by tools/precoder/tun_p2p.py in --mode=duplex with a single PID per
+// peer. Replaces the StreamTxDemo + WiFiDriverDemo pair (one adapter per
+// direction) with a single binary per peer (one adapter per peer, ergo two
+// adapters total for a P2P link instead of four).
+//
+// On-wire wire format on stdin is identical to StreamTxDemo:
+//     <u32_le length><length bytes of descrambled PSDU body>
+// EOF on stdin closes the TX side cleanly; RX keeps running until the process
+// terminates.
+//
+// RX emission on stdout mirrors demo/main.cpp's DEVOURER_STREAM_OUT path —
+// `<devourer-stream>rate=R len=L body=HEX` for every frame matching the
+// canonical SA. Other stdout output is suppressed; stderr carries logger and
+// counters.
+
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#if defined(_MSC_VER)
+  #include <io.h>
+  #include <fcntl.h>
+  #include <windows.h>
+  typedef int pid_t;
+  #define sleep(seconds) Sleep((seconds)*1000)
+#elif defined(__ANDROID__)
+  #include <libusb.h>
+  #include <unistd.h>
+#elif defined(__APPLE__)
+  #include <unistd.h>
+  #include <libusb.h>
+#else
+  #include <unistd.h>
+  #include <libusb-1.0/libusb.h>
+#endif
+
+#include "FrameParser.h"
+#include "RtlUsbAdapter.h"
+#include "WiFiDriver.h"
+#include "logger.h"
+
+#define USB_VENDOR_ID 0x0bda
+
+static constexpr uint16_t kRealtekProductIds[] = {
+    0x8812, 0x0811, 0xa811, 0xb811, 0x8813,
+};
+
+// Same radiotap + probe-request header as StreamTxDemo / PrecoderDemo. The
+// canonical SA matcher in the packet processor below is identical to
+// demo/main.cpp's, so any tooling that already grep'd <devourer-stream>
+// lines keeps working unchanged.
+static const uint8_t kRadiotapLegacy6M[13] = {
+    0x00, 0x00, 0x0d, 0x00, 0x04, 0x80, 0x00,
+    0x00, 0x0c, 0x00, 0x08, 0x00, 0x00};
+static const uint8_t kCanonicalSa[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
+
+static std::vector<uint8_t> build_dot11_probe_req() {
+  std::vector<uint8_t> h = {
+      0x40, 0x00, 0x00, 0x00,
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+  };
+  h.insert(h.end(), kCanonicalSa, kCanonicalSa + 6);
+  h.insert(h.end(), kCanonicalSa, kCanonicalSa + 6);
+  h.push_back(0x80);
+  h.push_back(0x00);
+  return h;
+}
+
+static bool read_exact(FILE *f, void *buf, size_t n) {
+  size_t got = 0;
+  auto *p = static_cast<uint8_t *>(buf);
+  while (got < n) {
+    size_t r = std::fread(p + got, 1, n - got, f);
+    if (r == 0) {
+      if (got == 0 && std::feof(f)) return false;
+      std::fprintf(stderr,
+                   "stream_duplex_demo: short stdin read (%zu/%zu)\n", got, n);
+      return false;
+    }
+    got += r;
+  }
+  return true;
+}
+
+// RX callback — emits `<devourer-stream>` on canonical-SA matches. Wrapped in
+// a mutex against the TX thread's printf calls so the two log streams don't
+// interleave mid-line. (The TX thread only writes to stderr, RX to stdout, so
+// in practice they don't collide, but keeping the mutex is cheap.)
+static std::mutex g_print_mu;
+static std::atomic<long> g_rx_hits{0};
+
+static void packet_processor(const Packet &packet) {
+  if (packet.Data.size() < 16) return;
+  if (std::memcmp(packet.Data.data() + 10, kCanonicalSa, 6) != 0) return;
+  long hits = ++g_rx_hits;
+  std::lock_guard<std::mutex> lk(g_print_mu);
+  std::printf("<devourer-stream>rate=%u len=%zu body=",
+              packet.RxAtrib.data_rate, packet.Data.size());
+  for (size_t i = 24; i < packet.Data.size(); ++i)
+    std::printf("%02x", packet.Data[i]);
+  std::printf("\n");
+  std::fflush(stdout);
+  if (hits <= 5 || hits % 500 == 0) {
+    std::fprintf(stderr, "<stream-duplex>rx hits=%ld\n", hits);
+    std::fflush(stderr);
+  }
+}
+
+struct TxArgs {
+  class RtlJaguarDevice *rtl;  // unique_ptr lives in main(); raw ptr OK while
+                                // we join() before that unique_ptr goes away
+  int interval_ms;
+  size_t max_psdu;
+  std::atomic<bool> *should_stop;
+  std::shared_ptr<Logger> logger;
+};
+
+static void tx_thread(TxArgs args) {
+  auto dot11 = build_dot11_probe_req();
+  std::vector<uint8_t> tx_buf;
+  tx_buf.reserve(sizeof(kRadiotapLegacy6M) + dot11.size() + args.max_psdu);
+  long tx_count = 0;
+
+  while (!args.should_stop->load()) {
+    uint8_t len_bytes[4];
+    if (!read_exact(stdin, len_bytes, sizeof(len_bytes))) {
+      // Clean EOF or short read — TX side done. RX keeps running.
+      std::fprintf(stderr, "<stream-duplex>tx EOF after %ld PSDUs\n", tx_count);
+      break;
+    }
+    uint32_t len = static_cast<uint32_t>(len_bytes[0])
+                 | (static_cast<uint32_t>(len_bytes[1]) << 8)
+                 | (static_cast<uint32_t>(len_bytes[2]) << 16)
+                 | (static_cast<uint32_t>(len_bytes[3]) << 24);
+    if (len == 0 || len > args.max_psdu) {
+      std::fprintf(stderr,
+                   "<stream-duplex>tx PSDU len %u out of range (max %zu)\n",
+                   len, args.max_psdu);
+      break;
+    }
+    std::vector<uint8_t> psdu(len);
+    if (!read_exact(stdin, psdu.data(), len)) {
+      std::fprintf(stderr, "<stream-duplex>tx EOF mid-PSDU (%u bytes)\n", len);
+      break;
+    }
+    tx_buf.clear();
+    tx_buf.insert(tx_buf.end(), kRadiotapLegacy6M,
+                  kRadiotapLegacy6M + sizeof(kRadiotapLegacy6M));
+    tx_buf.insert(tx_buf.end(), dot11.begin(), dot11.end());
+    tx_buf.insert(tx_buf.end(), psdu.begin(), psdu.end());
+    bool ok = args.rtl->send_packet(tx_buf.data(), tx_buf.size());
+    ++tx_count;
+    if (tx_count <= 5 || tx_count % 500 == 0) {
+      std::fprintf(stderr,
+                   "<stream-duplex>tx #%ld ok=%d psdu=%u\n",
+                   tx_count, ok ? 1 : 0, len);
+      std::fflush(stderr);
+    }
+    if (args.interval_ms > 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(args.interval_ms));
+    }
+  }
+}
+
+int main(int argc, char **argv) {
+  auto logger = std::make_shared<Logger>();
+
+  int interval_ms = 2;
+  size_t max_psdu = 4096;
+  long termux_fd = 0;
+  for (int i = 1; i < argc; ++i) {
+    std::string a = argv[i];
+    if (a == "--interval-ms" && i + 1 < argc) {
+      interval_ms = std::atoi(argv[++i]);
+    } else if (a == "--max-psdu" && i + 1 < argc) {
+      max_psdu = static_cast<size_t>(std::strtoul(argv[++i], nullptr, 0));
+    } else {
+      char *end = nullptr;
+      long v = std::strtol(a.c_str(), &end, 0);
+      if (end && *end == '\0' && v > 0) termux_fd = v;
+    }
+  }
+
+#if defined(_MSC_VER)
+  _setmode(_fileno(stdin), _O_BINARY);
+#endif
+
+  libusb_context *context = nullptr;
+  libusb_device_handle *handle = nullptr;
+  int rc;
+
+  if (termux_fd > 0) {
+    libusb_set_option(NULL, LIBUSB_OPTION_NO_DEVICE_DISCOVERY);
+    libusb_set_option(NULL, LIBUSB_OPTION_WEAK_AUTHORITY);
+    libusb_init(&context);
+    rc = libusb_wrap_sys_device(context, (intptr_t)termux_fd, &handle);
+    if (rc < 0) {
+      logger->error("libusb_wrap_sys_device: {}", rc);
+      return 1;
+    }
+  } else {
+    rc = libusb_init(&context);
+    if (rc < 0) return rc;
+    /* Match WiFiDriverDemo's libusb log level convention — DEVOURER_USB_QUIET
+     * drops to WARNING so a long-running duplex doesn't flood the harness. */
+    libusb_set_option(context, LIBUSB_OPTION_LOG_LEVEL,
+                      std::getenv("DEVOURER_USB_QUIET")
+                          ? LIBUSB_LOG_LEVEL_WARNING
+                          : LIBUSB_LOG_LEVEL_INFO);
+    uint16_t target_pid = 0;
+    if (const char *pid_env = std::getenv("DEVOURER_PID")) {
+      target_pid = static_cast<uint16_t>(std::strtoul(pid_env, nullptr, 0));
+    }
+    uint16_t target_vid = USB_VENDOR_ID;
+    if (const char *vid_env = std::getenv("DEVOURER_VID")) {
+      target_vid = static_cast<uint16_t>(std::strtoul(vid_env, nullptr, 0));
+    }
+    for (uint16_t pid : kRealtekProductIds) {
+      if (target_pid != 0 && pid != target_pid) continue;
+      handle = libusb_open_device_with_vid_pid(context, target_vid, pid);
+      if (handle != NULL) {
+        logger->info("Opened device {:04x}:{:04x}", target_vid, pid);
+        break;
+      }
+    }
+    if (handle == NULL && target_pid != 0) {
+      handle = libusb_open_device_with_vid_pid(context, target_vid, target_pid);
+    }
+    if (handle == NULL) {
+      logger->error("No supported device found under VID {:04x}", target_vid);
+      libusb_exit(context);
+      return 1;
+    }
+  }
+
+  if (libusb_kernel_driver_active(handle, 0)) {
+    libusb_detach_kernel_driver(handle, 0);
+  }
+  if (termux_fd == 0 && !std::getenv("DEVOURER_SKIP_RESET")) {
+    libusb_reset_device(handle);
+  }
+  rc = libusb_claim_interface(handle, 0);
+  assert(rc == 0);
+
+  WiFiDriver wifi_driver{logger};
+  auto rtlDevice = wifi_driver.CreateRtlDevice(handle);
+
+  int channel = 6;
+  if (const char *ch_env = std::getenv("DEVOURER_CHANNEL")) {
+    channel = std::atoi(ch_env);
+  }
+  rtlDevice->SetTxPower(40);
+
+  std::atomic<bool> should_stop{false};
+
+  // Spawn TX thread first; it'll block on stdin until our peer pushes a
+  // length-prefixed PSDU. Then drop into Init() (the RX loop) in the main
+  // thread.
+  TxArgs txa{rtlDevice.get(), interval_ms, max_psdu, &should_stop, logger};
+  std::thread tx{tx_thread, std::move(txa)};
+
+  logger->info("StreamDuplexDemo entering RX loop on ch {} — TX thread ready",
+               channel);
+  // RX loop. Same Init() path as WiFiDriverDemo; SelectedChannel sets up the
+  // shared monitor-mode bring-up (StartWithMonitorMode + SetMonitorChannel).
+  rtlDevice->Init(packet_processor,
+                  SelectedChannel{.Channel = static_cast<uint8_t>(channel),
+                                  .ChannelOffset = 0,
+                                  .ChannelWidth = CHANNEL_WIDTH_20});
+
+  // Init() returns only on should_stop (set by signal handler in the future
+  // — none wired here, so Ctrl-C ends the process abruptly and the OS reaps
+  // the TX thread).
+  should_stop = true;
+  if (tx.joinable()) tx.join();
+  libusb_release_interface(handle, 0);
+  libusb_close(handle);
+  libusb_exit(context);
+  return 0;
+}


### PR DESCRIPTION
## Summary

Builds a real-world P2P IP link on top of the stream layer (#81). Linux TUN device on each peer, one IP packet = one stream frame, single Realtek adapter per peer carries both directions via a new `StreamDuplexDemo` binary.

## Single-chip full-duplex

`txdemo/stream_duplex_demo/main.cpp` runs the RX loop (`Init` + `infinite_read` + packet callback) and the stdin-driven TX (`send_packet`) on ONE `libusb_claim_interface(0)`, with TX in a worker thread and RX in main. No mutex needed: libusb's synchronous bulk transfers on the two separate endpoints don't share state, and the chip's `StartWithMonitorMode` configures both directions regardless of entry point. **Two adapters total for a P2P, not four.**

## Bridge: `tools/precoder/tun_p2p.py`

Opens `/dev/net/tun` (IFF_TUN | IFF_NO_PI, MTU 1490 by default, optional `--tun-addr`), spawns the C++ binary(ies), runs two threads:

```
tun fd ──read──► encode_body ─length-prefix─► binary stdin
binary stdout ─<devourer-stream>─► decode_body ──write──► tun fd
```

Modes:
- `duplex` (default) — one binary, one chip, `--duplex-pid` required.
- `duplex-split` — two binaries, two chips per peer (the pre-duplex layout, kept as a fallback).
- `tx-only` / `rx-only` — half-bridges for one-way demos.

Defaults: `body_bytes=1500`, one IP packet per stream frame, seq increments per packet, total=0. `--repeat N` replicates every encoded body N times for blind redundancy.

## RX-side dedup (added in this PR)

Without dedup the kernel saw N copies of every duplicated request and generated N replies, which the peer's bridge then fan-out replicated again → **multiplicative DUP explosion** at the sender. Now `rx_thread` runs decoded frames through a `SeqWindow` (default 4096-entry sliding window) before writing to TUN: duplicate seqs are counted (`dedup_dropped`) and dropped. `--no-dedup` restores the v1 behaviour for diagnostics.

## Hardware validation

RTL8812AU `0bda:8812` and RTL8821AU / TP-Link Archer T2U Plus `2357:0120`, channel 6, two Linux netns on one host, no SDR.

**Short ping (5 packets):**

| Mode               | Result                                      |
|--------------------|---------------------------------------------|
| `--repeat 4` no dedup (old) | 5/5, 0% loss, **+25 DUPs**, RTT 7.3/18.9/34.7 ms |
| `--repeat 4` + dedup        | 5/5, 0% loss, **0 DUPs**,  RTT 8.0/10.8/12.6 ms |
| `--repeat 1`                | 4/5, 20% loss, no DUPs,    RTT 5.6/6.2/6.8 ms   |

**60 s soak, dedup on, 1 Hz pings:**

| Mode             | Loss     | RTT avg | RTT max | dedup-drop | Notes                                |
|------------------|---------:|--------:|--------:|-----------:|--------------------------------------|
| `--repeat 4`     | **0%**   | **9.9 ms**  | 17.1 ms | 100 / 95  | one packet per source, IP-clean      |
| `--repeat 1`     | **10%**  | **6.9 ms**  | 10.0 ms | 0 / 0     | raw radio loss; clean RTT, no flood  |

**10-min soak (600 pings, --repeat 4, no dedup — the run that motivated the dedup):**

```
600 packets transmitted, 595 received, +5041 duplicates,
0.833% packet loss, time 599819ms
rtt min/avg/max/mdev = 6.4 / 24.3 / 52.9 / 9.2 ms
```

Bridges held steady throughout 10 minutes: `send_packet` and `infinite_read` coexisted continuously, counters incremented smoothly, no hangs. The high avg RTT (24 ms) and DUP storm motivated the dedup fix — with dedup the same `--repeat 4` traffic now reports ~10 ms avg, no DUPs.

## What this v1 deliberately doesn't do (documented in-script)

- **No reliability** — no ARQ, no FEC. The 10% raw loss at `--repeat 1` is what an unmodified probe-request looks like over the air; `--repeat 4` + dedup is the brute-force defence. Next step is a proper in-band ARQ or FEC layer (and surfacing corrupted frames from the chip — see follow-up).
- **No flow control** — TUN reads block; OS back-pressure does the rest.
- **Single P2P pair** — every body carries the canonical SA, so multiple bridges on the same channel hear each other. No addr multiplex.

## Test plan

- [x] `cmake --build build -j` clean (new target `StreamDuplexDemo` compiles)
- [x] `tun_p2p.py --help` parses (incl. `--no-dedup` / `--dedup-window`)
- [x] `--mode tx-only` + `--mode rx-only`: ICMP from ns_a appears on tun_b (one-way validation)
- [x] `--mode duplex` on both peers, single chip each: bidirectional ping at 0% loss with `--repeat 4`
- [x] `--mode duplex` 10-min soak, 0.83% loss, no bridge hangs
- [x] `--mode duplex` 60s soak `--repeat 4` + dedup: 0% loss, 0 DUPs
- [x] `--mode duplex` 60s soak `--repeat 1`: 10% loss, 0 DUPs, clean RTT
- [ ] Reviewer to rerun with their own pair of 8812/8821 adapters

Builds on #81 (precoder stream link), which is already on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)