### PR TITLE
Phy-level soft metrics on stream lines + BER-vs-SNR analyser

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -80,10 +80,21 @@ static void packetProcessor(const Packet &packet) {
           std::getenv("DEVOURER_RX_KEEP_CORRUPTED") != nullptr;
       const bool corrupted = packet.RxAtrib.crc_err || packet.RxAtrib.icv_err;
       if (stream_out && (!corrupted || keep_corrupted)) {
-        printf("<devourer-stream>rate=%u len=%zu crc_err=%u icv_err=%u body=",
+        /* Per-stream phy soft metrics (RSSI / EVM / SNR for paths A,B; on
+         * 8814AU paths C,D would also be non-zero but we surface only A,B
+         * here to stay aligned with <devourer-body>'s format). These are
+         * link-quality measurements at the PHY before decoding — same
+         * source as the Tier-2 diagnostics — so a consumer like
+         * corruption_analysis.py can correlate BER with link quality on a
+         * per-frame basis instead of relying on aggregated statistics. */
+        printf("<devourer-stream>rate=%u len=%zu crc_err=%u icv_err=%u "
+               "rssi=%d,%d evm=%d,%d snr=%d,%d body=",
                packet.RxAtrib.data_rate, packet.Data.size(),
                packet.RxAtrib.crc_err ? 1u : 0u,
-               packet.RxAtrib.icv_err ? 1u : 0u);
+               packet.RxAtrib.icv_err ? 1u : 0u,
+               packet.RxAtrib.rssi[0], packet.RxAtrib.rssi[1],
+               packet.RxAtrib.evm[0], packet.RxAtrib.evm[1],
+               packet.RxAtrib.snr[0], packet.RxAtrib.snr[1]);
         for (size_t i = 24; i < packet.Data.size(); ++i)
           printf("%02x", packet.Data[i]);
         printf("\n");

--- a/tests/precoder_stream_roundtrip.py
+++ b/tests/precoder_stream_roundtrip.py
@@ -54,6 +54,9 @@ _STREAM_RE = re.compile(
     r"<devourer-stream>rate=(?P<rate>\d+)\s+len=(?P<len>\d+)"
     r"(?:\s+crc_err=(?P<crc_err>\d+))?"
     r"(?:\s+icv_err=(?P<icv_err>\d+))?"
+    r"(?:\s+rssi=(?P<rssi>-?\d+,-?\d+))?"
+    r"(?:\s+evm=(?P<evm>-?\d+,-?\d+))?"
+    r"(?:\s+snr=(?P<snr>-?\d+,-?\d+))?"
     r"\s+body=(?P<hex>[0-9a-fA-F]*)"
 )
 

--- a/tools/precoder/corruption_analysis.py
+++ b/tools/precoder/corruption_analysis.py
@@ -62,8 +62,43 @@ _STREAM_RE = re.compile(
     r"<devourer-stream>rate=(?P<rate>\d+)\s+len=(?P<len>\d+)"
     r"(?:\s+crc_err=(?P<crc_err>\d+))?"
     r"(?:\s+icv_err=(?P<icv_err>\d+))?"
+    r"(?:\s+rssi=(?P<rssi>-?\d+,-?\d+))?"
+    r"(?:\s+evm=(?P<evm>-?\d+,-?\d+))?"
+    r"(?:\s+snr=(?P<snr>-?\d+,-?\d+))?"
     r"\s+body=(?P<hex>[0-9a-fA-F]*)"
 )
+
+
+def _parse_pair(s: Optional[str]) -> Optional[tuple[int, int]]:
+    if not s:
+        return None
+    a, b = s.split(",")
+    return int(a), int(b)
+
+
+def _effective_snr(snr: Optional[tuple[int, int]]) -> Optional[int]:
+    """Pick the SNR value that actually drove decode quality.
+
+    The two-path field carries SNR for paths A and B; on single-antenna
+    USB sticks path B reads 0 (no signal, not "0 dB SNR"), so a naive
+    min(A,B) would always report 0 and the BER-vs-SNR view collapses.
+    `max(A,B)` works for both 1T1R (B is 0, A drives) and 2T2R single-
+    stream operation (the chip picks the stronger path for the only
+    stream). For an honest 2T2R two-stream analysis a finer model
+    would be needed; this is a single-stream PoC.
+    """
+    if snr is None:
+        return None
+    return max(snr)
+
+
+def _snr_bucket(snr: Optional[tuple[int, int]]) -> str:
+    """Group SNR into 5-dB buckets. Returns 'no-snr' when absent."""
+    eff = _effective_snr(snr)
+    if eff is None:
+        return "no-snr"
+    base = (eff // 5) * 5
+    return f"{base:>3d}-{base + 5} dB"
 
 
 def _expected_bodies(source: bytes, mtu: int, body_bytes: int,
@@ -116,6 +151,13 @@ def main(argv: Optional[list[str]] = None) -> int:
     byte_pos_examined = collections.Counter()
     per_frame_byte_errs: list[int] = []
     per_frame_bit_errs: list[int] = []
+    # Per-frame phy metrics (parsed but only used when present).
+    snr_clean: list[int] = []
+    snr_corrupt: list[int] = []
+    # (snr_bucket, corrupted_or_not) -> count; for the BER-vs-SNR table.
+    bucket_frames: collections.Counter = collections.Counter()
+    bucket_bit_errors: collections.Counter = collections.Counter()
+    bucket_bits_compared: collections.Counter = collections.Counter()
 
     for line in sys.stdin:
         m = _STREAM_RE.search(line)
@@ -124,6 +166,10 @@ def main(argv: Optional[list[str]] = None) -> int:
         total_captured += 1
         crc_err = int(m.group("crc_err") or 0)
         icv_err = int(m.group("icv_err") or 0)
+        snr = _parse_pair(m.group("snr"))
+        eff = _effective_snr(snr)
+        if eff is not None:
+            (snr_corrupt if crc_err or icv_err else snr_clean).append(eff)
         if crc_err or icv_err:
             total_corrupted += 1
         else:
@@ -156,6 +202,10 @@ def main(argv: Optional[list[str]] = None) -> int:
         bit_errors += frame_bit_errs
         per_frame_byte_errs.append(frame_byte_errs)
         per_frame_bit_errs.append(frame_bit_errs)
+        bucket = _snr_bucket(snr)
+        bucket_frames[bucket] += 1
+        bucket_bit_errors[bucket] += frame_bit_errs
+        bucket_bits_compared[bucket] += compare_len * 8
 
     if not matched_seq:
         sys.stderr.write(
@@ -196,6 +246,31 @@ def main(argv: Optional[list[str]] = None) -> int:
             exam = byte_pos_examined[pos]
             pct = 100.0 * count / max(1, exam)
             print(f"  {pos:3d}   {count:5d}/{exam:5d}   {pct:5.1f}%")
+
+    # Phy-metrics correlation. Two views: distribution of weakest-path SNR
+    # for chip-clean vs chip-corrupt frames, and per-SNR-bucket BER.
+    if snr_clean or snr_corrupt:
+        def _stat(xs: list[int]) -> str:
+            if not xs:
+                return "n=0"
+            xs = sorted(xs)
+            n = len(xs)
+            return (f"n={n} min={xs[0]} p25={xs[n // 4]} "
+                    f"med={xs[n // 2]} p75={xs[(3 * n) // 4]} max={xs[-1]}")
+        print(f"\nphy SNR (stronger path, dB):")
+        print(f"  chip-clean    : {_stat(snr_clean)}")
+        print(f"  chip-corrupt  : {_stat(snr_corrupt)}")
+
+    if bucket_frames and any(b != "no-snr" for b in bucket_frames):
+        print(f"\nBER by SNR bucket (stronger path, 5-dB buckets):")
+        print(f"  bucket       frames   bits-cmp   bit-err    BER")
+        for bucket in sorted(bucket_frames):
+            n = bucket_frames[bucket]
+            bits = bucket_bits_compared[bucket]
+            errs = bucket_bit_errors[bucket]
+            ber = errs / max(1, bits)
+            print(f"  {bucket:>11s}   {n:6d}   {bits:8d}   {errs:6d}   "
+                  f"{ber:.3e}")
 
     return 0
 

--- a/tools/precoder/stream_rx.py
+++ b/tools/precoder/stream_rx.py
@@ -46,6 +46,9 @@ _STREAM_RE = re.compile(
     r"<devourer-stream>rate=(?P<rate>\d+)\s+len=(?P<len>\d+)"
     r"(?:\s+crc_err=(?P<crc_err>\d+))?"
     r"(?:\s+icv_err=(?P<icv_err>\d+))?"
+    r"(?:\s+rssi=(?P<rssi>-?\d+,-?\d+))?"
+    r"(?:\s+evm=(?P<evm>-?\d+,-?\d+))?"
+    r"(?:\s+snr=(?P<snr>-?\d+,-?\d+))?"
     r"\s+body=(?P<hex>[0-9a-fA-F]*)"
 )
 

--- a/tools/precoder/tun_p2p.py
+++ b/tools/precoder/tun_p2p.py
@@ -88,6 +88,9 @@ _STREAM_RE = re.compile(
     r"<devourer-stream>rate=(?P<rate>\d+)\s+len=(?P<len>\d+)"
     r"(?:\s+crc_err=(?P<crc_err>\d+))?"
     r"(?:\s+icv_err=(?P<icv_err>\d+))?"
+    r"(?:\s+rssi=(?P<rssi>-?\d+,-?\d+))?"
+    r"(?:\s+evm=(?P<evm>-?\d+,-?\d+))?"
+    r"(?:\s+snr=(?P<snr>-?\d+,-?\d+))?"
     r"\s+body=(?P<hex>[0-9a-fA-F]*)"
 )
 


### PR DESCRIPTION
## Summary

Follow-up A from #83. Adds per-path RSSI / EVM / SNR to every `<devourer-stream>` line so `corruption_analysis.py` can correlate BER with link quality on a per-frame basis instead of aggregated-only statistics.

## Changes

- **`demo/main.cpp`** — `<devourer-stream>rate=R len=L crc_err=X icv_err=Y rssi=A,B evm=A,B snr=A,B body=HEX`. Same source as the Tier-2 diagnostics in `<devourer-body>`; no new RX-status fields, just surfacing what `FrameParser` already populates on `RxAtrib`.
- **`tools/precoder/corruption_analysis.py`** — parses the new fields, reports two new sections:
  - SNR distribution (min/p25/med/p75/max) for chip-clean vs chip-corrupt populations
  - BER per 5-dB SNR bucket  
  Uses `max(snr_A, snr_B)` as the "effective" SNR — on single-antenna 1T1R sticks path B reads 0 (no signal, not "0 dB"), so a naive `min` would collapse the bucket view; `max` picks the active path on 1T1R and the stronger path on 2T2R single-stream operation.
- **`stream_rx.py` / `tun_p2p.py` / `precoder_stream_roundtrip.py`** — regex updated to tolerate the new optional `rssi=`/`evm=`/`snr=` fields. None of them use the metrics yet (pass-through compatibility).

## Hardware verification

500 frames at default TX power, RTL8812AU → T2U Plus RTL8821AU, ch 6:

```
phy SNR (stronger path, dB):
  chip-clean    : n=467 min=0 p25=30 med=33 p75=38 max=51
  chip-corrupt  : n=0

BER by SNR bucket (stronger path, 5-dB buckets):
  bucket       frames   bits-cmp   bit-err    BER
       0-5 dB        1        192        0   0.000e+00
     20-25 dB       11       2112        0   0.000e+00
     25-30 dB       76      14592        0   0.000e+00
     30-35 dB      178      34176        0   0.000e+00
     35-40 dB      122      23424        0   0.000e+00
     40-45 dB       55      10560        0   0.000e+00
     45-50 dB       19       3648        0   0.000e+00
     50-55 dB        5        960        0   0.000e+00
```

Bench link is too clean for chip-corrupt events even at the SNR tails — same finding as the post-PR-investigation in #83 (loss is at PHY sync, not FCS). The analyser is ready for noisier deployments / range-extended captures (follow-up B).

## Offline analyser smoke

Synthetic 5-clean@28dB + 5-corrupt@5dB injection. Analyser correctly buckets:

```
BER by SNR bucket (stronger path, 5-dB buckets):
  bucket       frames   bits-cmp   bit-err    BER
      5-10 dB        5        960       10   1.042e-02
     25-30 dB        5        960        0   0.000e+00
```

The per-bucket correlation works as designed — corrupted samples land in the 5-10 dB bucket at 1.04×10⁻² BER, clean samples land at high SNR with BER 0.

Builds on #83 (merged). Next: follow-up B — characterise real-world background corruption patterns (burst-length distribution, byte-position distribution) to inform stream-layer FEC design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)