### PR TITLE
F1: Honour HT-MCS in send_packet (gated by DEVOURER_TX_HT_MCS)

### DIFF
--- a/src/RtlJaguarDevice.cpp
+++ b/src/RtlJaguarDevice.cpp
@@ -71,6 +71,7 @@ bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
       break;
 
     case IEEE80211_RADIOTAP_MCS: {
+      u8 mcs_known = iterator.this_arg[0];
       u8 mcs_flags = iterator.this_arg[1];
 
       uint8_t mcs_bw_field = mcs_flags & IEEE80211_RADIOTAP_MCS_BW_MASK;
@@ -86,6 +87,23 @@ bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
         sgi = 1;
       } else {
         sgi = 0;
+      }
+
+      /* DEVOURER_TX_HT_MCS=1: honour the HT MCS index from radiotap byte 2
+       * and set fixed_rate accordingly. Without this knob the historic
+       * behaviour kicks in — fixed_rate stays at the MGN_1M default and the
+       * chip transmits 1 Mbps CCK regardless of the HT-MCS field (see PR
+       * #80's README: "send_packet only wires fixed_rate from the radiotap
+       * RATE/VHT fields — never the HT MCS index"). Gated because flipping
+       * this unconditionally would silently change the regression matrix's
+       * rate sweeps and the precoder PoC's locked-in 6 Mbps OFDM carrier. */
+      static const bool ht_mcs_enabled =
+          std::getenv("DEVOURER_TX_HT_MCS") != nullptr;
+      if (ht_mcs_enabled && (mcs_known & IEEE80211_RADIOTAP_MCS_HAVE_MCS)) {
+        uint8_t mcs_index = iterator.this_arg[2];
+        if (mcs_index <= 31) {
+          fixed_rate = MGN_MCS0 + mcs_index;
+        }
       }
     } break;
 


### PR DESCRIPTION
## Summary

`RtlJaguarDevice::send_packet`'s IEEE80211_RADIOTAP_MCS branch parsed BW and SGI from the radiotap MCS field but **never set `fixed_rate`**. An HT-MCS-only radiotap header fell through to the function-top `MGN_1M` default, so the chip transmitted 1 Mbps CCK regardless of the MCS index. PR #80's README documented this as the "HT MCS 0 doesn't reach the air" decisive correction that locked the precoder PoC to legacy 6 Mbps OFDM.

The VHT branch already does the right thing (line 119: `fixed_rate = MGN_VHT1SS_MCS0 + ((nss-1)*10 + mcs)`); the HT case just needed the equivalent: `fixed_rate = MGN_MCS0 + radiotap_byte_2` when HAVE_MCS is set. `MGN_MCS0..MGN_MCS31 = 0x80..0x9F` map cleanly through `MRateToHwRate` to `DESC_RATEMCS0..MCS31`. No translation layer needed.

## Why gated

Flipping this unconditionally would silently change the regression matrix's rate sweeps (currently expecting 1 Mbps CCK on HT-MCS frames) and would break PR #80's PoC plan that explicitly locks to legacy 6M OFDM as the precoder's on-air carrier. Gated behind `DEVOURER_TX_HT_MCS=1`. Defaults are unchanged.

## Patch

```cpp
case IEEE80211_RADIOTAP_MCS: {
  u8 mcs_known = iterator.this_arg[0];   // new
  u8 mcs_flags = iterator.this_arg[1];
  /* existing BW + SGI handling unchanged */
+ static const bool ht_mcs_enabled =
+     std::getenv("DEVOURER_TX_HT_MCS") != nullptr;
+ if (ht_mcs_enabled && (mcs_known & IEEE80211_RADIOTAP_MCS_HAVE_MCS)) {
+   uint8_t mcs_index = iterator.this_arg[2];
+   if (mcs_index <= 31) {
+     fixed_rate = MGN_MCS0 + mcs_index;
+   }
+ }
} break;
```

## Unlocked

* 6.5 Mbps → 150 Mbps OFDM (1 stream, MCS 0..7) and SGI/40 MHz variants
* 5–10× the airtime budget per frame for the JSCC/FEC client
* Foundation for the F3 stream-carrier rate switch (planned follow-up)

## Test plan

- [x] `cmake --build build -j` clean
- [x] Default behaviour (`DEVOURER_TX_HT_MCS` unset): code path is `if (false && ...)` → no observable change. Existing tests pass.
- [ ] Hardware (depends on F3 for the CLI to drive it): set `DEVOURER_TX_HT_MCS=1`, transmit a probe request with an HT-MCS radiotap header, assert the RX-side `data_rate` is in the HT range (`0x0c..0x2b`) rather than `0x00` (1M CCK).

First in a series of five small C++ features for the precoder stream link. Followed by:
- F4 — surface RX seq + tsfl on `<devourer-stream>`
- F3 — selectable stream-carrier rate/BW (uses F1's HT-MCS unlock)
- F5 — C2H TX-RPT parser + REG_FIFOPAGE_INFO queue-depth poll
- F2 — BB-dbgport per-subcarrier IQ spike (research)

🤖 Generated with [Claude Code](https://claude.com/claude-code)