### PR TITLE
F4: Surface RX seq_num + TSF low on <devourer-stream>

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -107,14 +107,20 @@ static void packetProcessor(const Packet &packet) {
          * source as the Tier-2 diagnostics — so a consumer like
          * corruption_analysis.py can correlate BER with link quality on a
          * per-frame basis instead of relying on aggregated statistics. */
+        /* seq + tsfl: chip-side sequence number (12-bit u16) and TSF low
+         * (full 32-bit u32). Consumers can dedup by seq and measure
+         * one-way latency by diffing TSF against the host clock. Optional
+         * fields — pre-#84 regex consumers tolerate them via the same
+         * pass-through pattern. */
         printf("<devourer-stream>rate=%u len=%zu crc_err=%u icv_err=%u "
-               "rssi=%d,%d evm=%d,%d snr=%d,%d body=",
+               "rssi=%d,%d evm=%d,%d snr=%d,%d seq=%u tsfl=%u body=",
                packet.RxAtrib.data_rate, packet.Data.size(),
                packet.RxAtrib.crc_err ? 1u : 0u,
                packet.RxAtrib.icv_err ? 1u : 0u,
                packet.RxAtrib.rssi[0], packet.RxAtrib.rssi[1],
                packet.RxAtrib.evm[0], packet.RxAtrib.evm[1],
-               packet.RxAtrib.snr[0], packet.RxAtrib.snr[1]);
+               packet.RxAtrib.snr[0], packet.RxAtrib.snr[1],
+               packet.RxAtrib.seq_num, packet.RxAtrib.tsfl);
         for (size_t i = 24; i < packet.Data.size(); ++i)
           printf("%02x", packet.Data[i]);
         printf("\n");

--- a/src/FrameParser.cpp
+++ b/src/FrameParser.cpp
@@ -125,8 +125,12 @@ static rx_pkt_attrib rtl8812_query_rx_desc_status(uint8_t *pdesc) {
    * tools/precoder/seed_probe.py is the reliable path. */
   pattrib.scrambler = (uint8_t)LE_BITS_TO_4BYTE(pdesc + 16, 9, 7);
 
-  /* Offset 20 */
-  /* pattrib.tsfl=(byte)GET_RX_STATUS_DESC_TSFL_8812(pdesc); */
+  /* Offset 20 — chip-side TSF low (32 bits). Surfaced via RxAtrib.tsfl
+   * for downstream latency measurement and dup-detection (see
+   * demo/main.cpp's <devourer-stream> line). The macro reads bits 0..31
+   * of pdesc+20 (full 4-byte u32), not a byte — the original commented
+   * `(byte)` cast in master was a copy-paste from another field. */
+  pattrib.tsfl = GET_RX_STATUS_DESC_TSFL_8812(pdesc);
 
   return pattrib;
 }

--- a/src/FrameParser.h
+++ b/src/FrameParser.h
@@ -285,6 +285,12 @@ struct rx_pkt_attrib
                         encrypt algorith */
     bool crc_err;
     bool icv_err;
+    /* TSF low (4 bytes at RX-descriptor offset 20) — chip-side timestamp
+     * for the frame. With the seq_num just above it, a downstream layer
+     * can drop duplicates by seq and measure one-way latency by diffing
+     * the chip's TSF against its own wall clock. Populated by
+     * FrameParser; surfaced through demo/main.cpp's <devourer-stream>. */
+    uint32_t tsfl;
     uint8_t data_rate;
     uint8_t bw;
     uint8_t stbc;


### PR DESCRIPTION
## Summary

Both fields are already on the RX descriptor: `seq_num` is parsed at `FrameParser.cpp:98`, `tsfl` was one commented-out line at line 129. The FEC layer (#86 / #87) and any latency-measurement consumer want both visible; this PR surfaces what the chip already gives us.

## Changes

- **`src/FrameParser.h`** — add `uint32_t tsfl` to `rx_pkt_attrib` alongside the existing `seq_num`.
- **`src/FrameParser.cpp`** — uncomment the TSFL parser and drop the bogus `(byte)` cast (the macro reads all 32 bits of `pdesc+20` as a u32, not a byte — verified against `rtl8812a_recv.h`):
  ```diff
  - /* pattrib.tsfl=(byte)GET_RX_STATUS_DESC_TSFL_8812(pdesc); */
  + pattrib.tsfl = GET_RX_STATUS_DESC_TSFL_8812(pdesc);
  ```
- **`demo/main.cpp`** — extend the `<devourer-stream>` printf with `seq=%u tsfl=%u`. Optional fields; PR #84's regex pattern in `stream_rx.py` / `tun_p2p.py` / `corruption_analysis.py` already tolerates them via the same pass-through approach used for rssi/evm/snr.

## What this enables (out of scope for this PR — just data surfacing)

- FEC RX side can dedup by chip-side seq before feeding the codec, so air-level retransmissions stop double-counting at the codec.
- One-way latency measurement by diffing TSF against the host clock at TX time — a building block for the F5 TX-RPT goodput numbers and any adaptive `--fec-overhead` loop.

## Test plan

- [x] `cmake --build build -j` clean
- [x] `<devourer-stream>` lines on master now carry `seq` + `tsfl` fields; existing Python consumers tolerate the additions via their existing regex pass-through (no Python-side change required).
- [ ] Reviewer to run an existing tun_p2p bench and confirm the new fields appear without disturbing throughput / loss numbers.

Second in the five-feature C++ series. Followed by:
- F3 — selectable stream-carrier rate/BW (uses F1's HT-MCS unlock + this PR's seq/tsfl plumbing for dup detection)
- F5 — C2H TX-RPT parser + REG_FIFOPAGE_INFO queue-depth poll
- F2 — BB-dbgport per-subcarrier IQ spike (research)

Predecessor: F1 (#88).

🤖 Generated with [Claude Code](https://claude.com/claude-code)