### PR TITLE
8814: clamp CCK TX rate to OFDM on 5GHz channels (fixes 5GHz TX, #50)

### DIFF
--- a/src/RtlJaguarDevice.cpp
+++ b/src/RtlJaguarDevice.cpp
@@ -151,6 +151,19 @@ bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
     }
   }
 
+  /* CCK rates (1/2/5.5/11M) do not exist at 5GHz. The RTL8814AU silently
+   * drops a CCK-rated frame on a 5GHz channel — the bulk-OUT completes but
+   * nothing goes on-air (verified on hardware: default MGN_1M beacon = 0
+   * frames at ch36/ch100, but ~14k on-air once the rate is OFDM). 2.4GHz
+   * CCK is fine. So on a 5GHz channel, clamp a CCK rate to the lowest OFDM
+   * rate. (The 8812 chip happens to auto-fall-back CCK->OFDM at 5G; the
+   * 8814 does not, so we must do it in software.) */
+  if (_channel.Channel > 14 &&
+      (fixed_rate == MGN_1M || fixed_rate == MGN_2M ||
+       fixed_rate == MGN_5_5M || fixed_rate == MGN_11M)) {
+    fixed_rate = MGN_6M;
+  }
+
   usb_frame = new uint8_t[usb_frame_length]();
 
   ptxdesc = (struct tx_desc *)usb_frame;


### PR DESCRIPTION
## What

8814 devourer-TX produced **0 on-air frames at 5 GHz** (the 5GHz half of #50) despite 100% URB completion. 2.4 GHz TX worked fine.

## Root cause

`send_packet` defaults `fixed_rate` to `MGN_1M` (1 Mbps **CCK**) and only overrides it from the radiotap RATE/VHT fields (or HT-MCS under `DEVOURER_TX_HT_MCS`). **CCK rates (1/2/5.5/11M) do not exist at 5 GHz** — the RTL8814AU silently drops a CCK-rated frame on a 5 GHz channel: the bulk-OUT completes (rc ok), but nothing goes on-air. The 8812 chip happens to auto-fall-back CCK→OFDM at 5 GHz; the 8814 does not.

## Fix

On a 5 GHz channel (`_channel.Channel > 14`), clamp a CCK `fixed_rate` to the lowest OFDM rate (`MGN_6M`).

## Validation — real hardware (RTL8814AU `0bda:8813`, RTL8821AU kernel-monitor witness)

- 8814 TX at **ch100**, default rate: **0 → ~13,770 on-air frames** (6 M OFDM, 11a).
- Confirmed the (chip-agnostic) clamp path at **ch36 (UNII-1)** via the 8812 on the same `send_packet` — OFDM on-air.
- **ch6 (2.4 GHz CCK)** unaffected.

Together with the merged 5GHz-RX fix (#93), this brings the 8814 to TX+RX on 2.4 GHz and 5 GHz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
