### PR TITLE
StreamTxDemo: fix mingw/Windows-GCC build and binary stdin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.15)
 
-# Set the toolchain file for vcpkg on Windows.
-if(WIN32)
+# Set the toolchain file for vcpkg on Windows (only if VCPKG_ROOT is set;
+# on mingw we get libusb from pkg-config directly).
+if(WIN32 AND NOT "$ENV{VCPKG_ROOT}" STREQUAL "")
     set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
 endif()
 

--- a/txdemo/stream_duplex_demo/main.cpp
+++ b/txdemo/stream_duplex_demo/main.cpp
@@ -41,6 +41,12 @@
   #include <windows.h>
   typedef int pid_t;
   #define sleep(seconds) Sleep((seconds)*1000)
+#elif defined(__MINGW32__) || defined(__MINGW64__)
+  // mingw builds: POSIX libusb/unistd PLUS io.h/fcntl.h for binary stdin.
+  #include <io.h>
+  #include <fcntl.h>
+  #include <unistd.h>
+  #include <libusb-1.0/libusb.h>
 #elif defined(__ANDROID__)
   #include <libusb.h>
   #include <unistd.h>
@@ -233,7 +239,9 @@ int main(int argc, char **argv) {
     }
   }
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
+  // mingw/GCC defines _WIN32 but not _MSC_VER, yet still has _setmode — make
+  // stdin binary so a 0x1A/CRLF doesn't corrupt the length-prefixed PSDU stream.
   _setmode(_fileno(stdin), _O_BINARY);
 #endif
 

--- a/txdemo/stream_tx_demo/main.cpp
+++ b/txdemo/stream_tx_demo/main.cpp
@@ -46,6 +46,12 @@
   #include <process.h>
   typedef int pid_t;
   #define sleep(seconds) Sleep((seconds)*1000)
+#elif defined(__MINGW32__) || defined(__MINGW64__)
+  // mingw builds: POSIX libusb/unistd PLUS io.h/fcntl.h for binary stdin.
+  #include <io.h>
+  #include <fcntl.h>
+  #include <unistd.h>
+  #include <libusb-1.0/libusb.h>
 #elif defined(__ANDROID__)
   #include <libusb.h>
   #include <unistd.h>
@@ -134,8 +140,9 @@ int main(int argc, char **argv) {
     }
   }
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
   // Make stdin binary so a 0x1A or CRLF doesn't corrupt PSDU bytes.
+  // (mingw/GCC defines _WIN32 but not _MSC_VER, yet still has _setmode.)
   _setmode(_fileno(stdin), _O_BINARY);
 #endif
 


### PR DESCRIPTION
## Problem

Building `StreamTxDemo` (the stream-link TX demo) with **mingw-w64 (GCC on Windows)** is broken in two independent ways. Both are mingw-only and do not affect the MSVC/vcpkg build.

### 1. Binary stdin not set on mingw → first frame truncated

`txdemo/stream_tx_demo/main.cpp` gates both the Windows includes (`io.h`/`fcntl.h`) and the `_setmode(_fileno(stdin), _O_BINARY)` call on `#if defined(_MSC_VER)`. mingw/GCC defines `_WIN32` but **not** `_MSC_VER`, so it falls into the POSIX `#else` branch and leaves stdin in **text mode**. A `0x1A` (or CRLF) byte in the binary `<u32_le len><PSDU>` stream then triggers:

```
stream_tx_demo: short read on stdin (76/269); record truncated mid-PSDU
```

and the demo exits before transmitting a single frame.

### 2. CMake aborts under mingw (no vcpkg)

`CMakeLists.txt` unconditionally sets `CMAKE_TOOLCHAIN_FILE` to `"$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"` on `WIN32`. With `VCPKG_ROOT` unset (the normal mingw / pkg-config case) this expands to the bogus `/scripts/buildsystems/vcpkg.cmake` and configuration fails with *"Could not find toolchain file"*.

## Fix

- Add a `__MINGW32__ || __MINGW64__` include branch (io.h + fcntl.h + unistd.h + libusb) and gate `_setmode` on `_WIN32` — identical behavior on MSVC, now also correct on mingw.
- Only set the vcpkg toolchain file when `VCPKG_ROOT` is non-empty.

## Verification

mingw-w64, libusb 1.0.28 via pkg-config, real RTL8812AU. After the fix `StreamTxDemo.exe` reads the full binary stream and radiates every frame:

```
<stream-tx>TX #1 ok=1 psdu=269 total=306
...
<stream-tx>done; sent 512 PSDUs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
