### PR TITLE
demo: surface decoded RX PHY (bw/stbc/ldpc/sgi) in <devourer-stream>

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -256,15 +256,26 @@ static void packetProcessor(const Packet &packet) {
          * one-way latency by diffing TSF against the host clock. Optional
          * fields — pre-#84 regex consumers tolerate them via the same
          * pass-through pattern. */
+        /* Decoded PHY descriptor fields (bw/stbc/ldpc/sgi) alongside the rate
+         * index: these let an SDR-as-TX completeness harness assert that the
+         * frame devourer received carries the bandwidth / STBC / FEC / guard
+         * interval the transmitter encoded. Valid on 8812/8821; on 8814AU the
+         * RX descriptor doesn't expose these at this offset (FrameParser.cpp),
+         * so they read as the chip's defaults there. Inserted before body= so
+         * the trailing hex-dump pattern downstream regex consumers key on is
+         * unchanged. */
         printf("<devourer-stream>rate=%u len=%zu crc_err=%u icv_err=%u "
-               "rssi=%d,%d evm=%d,%d snr=%d,%d seq=%u tsfl=%u body=",
+               "rssi=%d,%d evm=%d,%d snr=%d,%d seq=%u tsfl=%u "
+               "bw=%u stbc=%u ldpc=%u sgi=%u body=",
                packet.RxAtrib.data_rate, packet.Data.size(),
                packet.RxAtrib.crc_err ? 1u : 0u,
                packet.RxAtrib.icv_err ? 1u : 0u,
                packet.RxAtrib.rssi[0], packet.RxAtrib.rssi[1],
                packet.RxAtrib.evm[0], packet.RxAtrib.evm[1],
                packet.RxAtrib.snr[0], packet.RxAtrib.snr[1],
-               packet.RxAtrib.seq_num, packet.RxAtrib.tsfl);
+               packet.RxAtrib.seq_num, packet.RxAtrib.tsfl,
+               packet.RxAtrib.bw, packet.RxAtrib.stbc,
+               packet.RxAtrib.ldpc, packet.RxAtrib.sgi);
         for (size_t i = 24; i < packet.Data.size(); ++i)
           printf("%02x", packet.Data[i]);
         printf("\n");

--- a/tests/verify_stream_fields.sh
+++ b/tests/verify_stream_fields.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# M0 verification: confirm the <devourer-stream> RX line now carries the decoded
+# PHY descriptor fields (bw/stbc/ldpc/sgi) added in demo/main.cpp.
+#
+# Two-adapter loopback, NO SDR: an 8821AU transmits the canonical-SA beacon
+# (WiFiDriverTxDemo) while an 8812AU receives with DEVOURER_STREAM_OUT=1. The
+# stream line only fires on canonical-SA frames, so a devourer TX is required.
+#
+#   TX: RTL8821AU (TP-Link Archer T2U Plus, 2357:0120)  --ch6-->  air
+#   RX: RTL8812AU (0bda:8812), DEVOURER_STREAM_OUT=1
+#
+# Usage: sudo tests/verify_stream_fields.sh   (run from repo root, after a build)
+set -u
+CH=6
+BIN=./build
+TXPID=0x0120 ; TXVID=0x2357
+RXPID=0x8812
+OUT=$(mktemp /tmp/devourer-stream-verify.XXXXXX)
+TXLOG=$(mktemp /tmp/devourer-tx-verify.XXXXXX)
+
+cleanup() {
+  # exact-comm kills so we never reap an unrelated process
+  pkill -f "WiFiDriverTxDemo" 2>/dev/null
+  pkill -f "WiFiDriverDemo"   2>/dev/null
+  rm -f "$OUT" "$TXLOG"
+}
+trap cleanup EXIT INT TERM
+
+echo "[verify] starting 8821AU canonical-SA TX on ch$CH ..."
+DEVOURER_VID=$TXVID DEVOURER_PID=$TXPID DEVOURER_CHANNEL=$CH \
+  "$BIN/WiFiDriverTxDemo" >"$TXLOG" 2>&1 &
+sleep 8   # let the TX adapter init + start injecting
+
+echo "[verify] starting 8812AU RX (STREAM_OUT) for 30s ..."
+timeout 30 env DEVOURER_PID=$RXPID DEVOURER_CHANNEL=$CH DEVOURER_STREAM_OUT=1 \
+  "$BIN/WiFiDriverDemo" 2>/dev/null >"$OUT"
+
+N=$(grep -c devourer-stream "$OUT")
+echo "[verify] <devourer-stream> lines: $N"
+if [ "$N" -gt 0 ]; then
+  echo "[verify] sample (body truncated):"
+  grep -m2 devourer-stream "$OUT" | sed 's/body=.*/body=.../'
+  if grep -q "bw=.*stbc=.*ldpc=.*sgi=" "$OUT"; then
+    echo "[verify] RESULT: PASS — bw/stbc/ldpc/sgi present in stream line"
+    exit 0
+  fi
+  echo "[verify] RESULT: FAIL — stream line present but new fields missing"
+  exit 1
+fi
+echo "[verify] RESULT: no canonical-SA frames RX'd. Check both adapters are"
+echo "         plugged, on ch$CH, and the TX log below:"
+tail -15 "$TXLOG"
+exit 1


### PR DESCRIPTION
The `<devourer-stream>` RX line emitted only the rate index. This adds the **bandwidth, STBC, LDPC (FEC) and short-GI** fields (already in `RxAtrib`) so an external reference — e.g. an SDR-as-TX completeness harness — can assert that a received frame carries the PHY the transmitter actually encoded.

- Fields are inserted **before** `body=`, so the trailing hex-dump pattern downstream regex consumers key on is unchanged (same pass-through convention as the pre-#84 optional fields).
- Valid on RTL8812AU / 8821AU. On 8814AU the RX descriptor doesn't expose these at this offset, so they read as chip defaults there (noted in the comment).
- `tests/verify_stream_fields.sh`: two-adapter loopback (no SDR) confirming the new fields appear on canonical-SA frames.

Enables the SDR completeness work (josephnef/sdr2wifi) to validate the RX direction.

Generated with Claude Code