### PR TITLE
demo/send_packet: env-gated 40 MHz RX + HT STBC/LDPC TX radiotap

### DIFF
--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -166,11 +166,13 @@ static void packetProcessor(const Packet &packet) {
   static const bool dump_all = std::getenv("DEVOURER_RX_DUMP_ALL") != nullptr;
   if (dump_all) {
     printf("<devourer-corrupt-any>len=%zu crc_err=%u icv_err=%u "
-           "rate=%u rssi=%d,%d evm=%d,%d snr=%d,%d\n",
+           "rate=%u bw=%u stbc=%u ldpc=%u sgi=%u rssi=%d,%d evm=%d,%d snr=%d,%d\n",
            packet.Data.size(),
            packet.RxAtrib.crc_err ? 1u : 0u,
            packet.RxAtrib.icv_err ? 1u : 0u,
            packet.RxAtrib.data_rate,
+           packet.RxAtrib.bw, packet.RxAtrib.stbc,
+           packet.RxAtrib.ldpc, packet.RxAtrib.sgi,
            packet.RxAtrib.rssi[0], packet.RxAtrib.rssi[1],
            packet.RxAtrib.evm[0], packet.RxAtrib.evm[1],
            packet.RxAtrib.snr[0], packet.RxAtrib.snr[1]);
@@ -444,10 +446,24 @@ int main() {
     channel = std::atoi(ch_env);
     logger->info("DEVOURER_CHANNEL set — tuning to channel {}", channel);
   }
+  /* RX bandwidth: 20 MHz by default. DEVOURER_BW=40 selects a 40 MHz monitor
+   * channel (for receiving HT40 frames); DEVOURER_CHOFFSET picks the secondary
+   * half (1 = secondary above the primary, 2 = secondary below). */
+  ChannelWidth_t width = CHANNEL_WIDTH_20;
+  uint8_t ch_offset = 0;
+  if (const char *bw_env = std::getenv("DEVOURER_BW")) {
+    if (std::atoi(bw_env) == 40) {
+      width = CHANNEL_WIDTH_40;
+      ch_offset = 1; // default: secondary channel above the primary
+      if (const char *off_env = std::getenv("DEVOURER_CHOFFSET"))
+        ch_offset = static_cast<uint8_t>(std::atoi(off_env));
+      logger->info("DEVOURER_BW=40 — 40 MHz RX, channel-offset {}", ch_offset);
+    }
+  }
   rtlDevice->Init(packetProcessor, SelectedChannel{
                                        .Channel = static_cast<uint8_t>(channel),
-                                       .ChannelOffset = 0,
-                                       .ChannelWidth = CHANNEL_WIDTH_20,
+                                       .ChannelOffset = ch_offset,
+                                       .ChannelWidth = width,
                                    });
 
   rc = libusb_release_interface(dev_handle, 0);

--- a/src/RtlJaguarDevice.cpp
+++ b/src/RtlJaguarDevice.cpp
@@ -97,6 +97,19 @@ bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
         sgi = 0;
       }
 
+      /* STBC (radiotap MCS known bit5 / flags bits5-6) and FEC=LDPC (known bit4 /
+       * flags bit4). The HT branch previously read neither, so an HT frame tagged
+       * STBC/LDPC in radiotap silently transmitted as BCC SISO -- only the VHT
+       * branch honoured them. Reading them here lets WiFiDriverTxDemo emit a real
+       * HT STBC / HT LDPC frame (needed as a chip reference for the gr-ieee802-11
+       * fork's modern-format TX). */
+      if (mcs_known & 0x20) {
+        stbc = (mcs_flags >> 5) & 0x3;
+      }
+      if ((mcs_known & 0x10) && (mcs_flags & 0x10)) {
+        ldpc = 1;
+      }
+
       /* DEVOURER_TX_HT_MCS=1: honour the HT MCS index from radiotap byte 2
        * and set fixed_rate accordingly. Without this knob the historic
        * behaviour kicks in — fixed_rate stays at the MGN_1M default and the


### PR DESCRIPTION
Two small, independent additions that let `WiFiDriverTxDemo`/`WiFiDriverDemo` exercise
modern HT formats (used to validate an external userspace TX against the chip):

1. **`demo`: env-gated 40 MHz RX (`DEVOURER_BW=40`)** + the bw/stbc/ldpc/sgi PHY flags
   on the `<devourer-corrupt-any>` DUMP_ALL line (matching `<devourer-stream>`), so an
   HT40 frame can be received and a decoded-but-CRC-failed frame inspected for its PHY
   params.
2. **`send_packet`: honour STBC and FEC=LDPC on the HT radiotap path.** The HT-MCS
   radiotap branch read bandwidth/short-GI but never STBC or FEC, so an HT frame tagged
   STBC/LDPC transmitted as plain BCC SISO — only the VHT branch honoured them. Reading
   them here (with `DEVOURER_TX_HT_MCS=1`) makes `WiFiDriverTxDemo` emit a real HT STBC /
   HT LDPC frame. Verified at the TX descriptor: `fixed rate:128 (MGN_MCS0) ... stbc:1`.

Builds clean (WiFiDriverDemo + WiFiDriverTxDemo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)