### PR TITLE
RX: keep multiple bulk-IN URBs in flight (mirror kernel's always-posted model)

### DIFF
--- a/src/RtlJaguarDevice.cpp
+++ b/src/RtlJaguarDevice.cpp
@@ -4,6 +4,9 @@
 
 #include <chrono>
 #include <cstdlib>
+#include <mutex>
+#include <thread>
+#include <vector>
 
 /* Per-queue free-page registers (8814A only — 0x0230..0x0240 don't decode
  * the same way on 8812/8821). Cross-checked against hal/rtl8814a_spec.h
@@ -329,12 +332,41 @@ void RtlJaguarDevice::Init(Action_ParsedRadioPacket packetProcessor,
   SetMonitorChannel(channel);
 
   _logger->info("Listening air...");
-  while (!should_stop) {
-    auto packets = _device.infinite_read();
-    for (auto &p : packets) {
-      _packetProcessor(p);
-    }
+  /* Keep several bulk-IN transfers in flight at once (mirrors the kernel's ~4
+   * always-posted RX URBs — confirmed via usbmon: rtw88 re-submits each URB
+   * ~20us after completion and cycles 4 of them). With a single synchronous
+   * transfer there is a window between transfers where NO URB is posted; the
+   * 8814's RX-DMA ring pauses in that gap and, under sparse traffic,
+   * intermittently wedges after a short burst — the "RX stalls at ~10 frames"
+   * bug (8812/8821 tolerate it, the 8814 does not). infinite_read() is
+   * reentrant (local buffer + local FrameParser; libusb is thread-safe), so a
+   * small worker pool restores the always-posted behaviour. Frame order across
+   * workers is not preserved, which is fine for monitor-mode RX. Set
+   * DEVOURER_RX_URBS=1 to restore the old single-transfer behaviour. */
+  int rx_workers = 4;
+  if (const char *e = std::getenv("DEVOURER_RX_URBS")) {
+    rx_workers = std::atoi(e);
+    if (rx_workers < 1) rx_workers = 1;
   }
+  std::mutex proc_mu;
+  std::vector<std::thread> workers;
+  for (int i = 0; i < rx_workers; ++i) {
+    workers.emplace_back([this, &proc_mu]() {
+      while (!should_stop) {
+        auto packets = _device.infinite_read();
+        if (packets.empty())
+          continue;
+        std::lock_guard<std::mutex> lk(proc_mu);
+        for (auto &p : packets) {
+          if (should_stop)
+            break;
+          _packetProcessor(p);
+        }
+      }
+    });
+  }
+  for (auto &t : workers)
+    t.join();
 
 #if 0
   _device.UsbDevice.SetBulkDataHandler(BulkDataHandler);


### PR DESCRIPTION
## What

The monitor-mode RX loop did **one synchronous `libusb_bulk_transfer` at a time**, leaving a window between transfers where **no URB is posted**. usbmon ground-truth on the same hardware shows the kernel (`rtw88`) instead keeps **4 bulk-IN URBs always posted**, re-submitting each ~20 µs after completion.

With a single posted URB, the RTL8814AU's RX-DMA ring pauses in the parse gap and, under sparse traffic, intermittently wedges after a short burst — the **"8814 RX stalls after ~10 frames"** symptom (the 8812/8821 tolerate it; the 8814 does not).

## Change

Run `infinite_read()` from a small worker pool (default **4**) instead of a single loop. `infinite_read()` is already reentrant — local 32 KB buffer + local `FrameParser`, and libusb is thread-safe — so the workers simply restore the always-posted behaviour the kernel has. `packetProcessor` is serialised under a mutex. Frame order across workers isn't preserved, which is fine for monitor-mode RX.

`DEVOURER_RX_URBS` overrides the worker count (`1` restores the old single-transfer behaviour).

## Validation

- **usbmon-confirmed**: the pool keeps 4 bulk-IN URBs in flight (matching the kernel).
- **Regression-clean**: RTL8812AU and RTL8821AU RX 300+ frames; RTL8814AU healthy. `ctest` green.
- Diagnosed against a known-good kernel reference (`88XXau`/`rtw88_8814au`) which receives thousands of frames where devourer's single-URB path stalled — confirming the 8814 RX **hardware is healthy** and the stall was a host-side single-URB issue, not RF/rig degradation.

## Honest caveat

The intermittent 8814 stall this targets is timing-dependent and was **dormant at commit time**, so this hardens the RX path to match the kernel's proven always-posted model rather than being confirmed against a live reproduction. It is low-risk (reentrant call, mutex-serialised delivery, env escape hatch) and regression-validated on all three Jaguar chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)