### PR TITLE
tests: fade-SLA on-air validation harness (measure-only)

### DIFF
--- a/tests/fade_sla_onair.sh
+++ b/tests/fade_sla_onair.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Fade-SLA validation — does devourer's adaptive controller hold the delivery SLA
+# under time-correlated fading?
+#
+# Runs the closed loop (8812 VTX <-> 8821 VRX, both StreamDuplexDemo driven by
+# adaptive_link.py) TWICE under a B210 interferer at the SAME gain: once STATIC,
+# once FADING (--fade-coherence). It then compares the VRX's post-seq delivery
+# (the `deliv=` field of <adaptive-vrx>). The hypothesis, from the linklab sim, is
+# that the controller's fixed margin can't cover deep fades, so the FADING run's
+# worst-window delivery drops below the SLA while the STATIC run holds it.
+#
+# This ONLY MEASURES — no controller code is changed. It is the precondition for
+# deciding whether a variance-aware fade margin is worth adding to the controller.
+#
+#   sudo bash tests/fade_sla_onair.sh                  # default ch6, 30 s/phase
+#   IGAIN=80 FADE_DEPTH=14 SECS=45 sudo bash tests/fade_sla_onair.sh
+# SKIP_RAIL=1 after a clean boot (skips the control-adapter rail re-check).
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PREC="$ROOT/tools/precoder"
+
+VTX_PID=${VTX_PID:-0x8812}; VTX_VID=${VTX_VID:-0x0bda}; VTX=${VTX_SYSFS:-9-2}
+VRX_PID=${VRX_PID:-0x0120}; VRX_VID=${VRX_VID:-0x2357}; VRX=${VRX_SYSFS:-9-1.4}
+CH=${CH:-6}; SECS=${SECS:-30}; VTX_ID=${VTX_ID:-0xABCD}
+IGAIN=${IGAIN:-78}; FADE_COH=${FADE_COH:-0.3}; FADE_DEPTH=${FADE_DEPTH:-12}
+SLA=${SLA:-0.99}
+
+VIDEO=/tmp/fade_sla_video.bin
+declare -A VRX_LOG=( [static]=/tmp/fade_sla_vrx_static.log [fading]=/tmp/fade_sla_vrx_fading.log )
+declare -A VTX_LOG=( [static]=/tmp/fade_sla_vtx_static.log [fading]=/tmp/fade_sla_vtx_fading.log )
+INTF_LOG=/tmp/fade_sla_intf.log
+
+KILL(){ sudo pkill -9 -f adaptive_link 2>/dev/null
+        sudo pkill -9 StreamDuplexD 2>/dev/null
+        sudo pkill -9 -f sdr_interferer 2>/dev/null; }
+trap KILL EXIT
+
+# free both Wi-Fi adapters (B210 is UHD-accessed)
+for D in "$VTX" "$VRX"; do
+  for i in /sys/bus/usb/devices/$D/$D:*; do
+    ifc=$(basename "$i"); drv=$(readlink -f "$i/driver" 2>/dev/null)
+    [ -n "$drv" ] && echo "$ifc" | sudo tee "$drv/unbind" >/dev/null 2>&1
+  done
+done; sleep 1
+
+head -c 4000000 /dev/urandom > "$VIDEO"   # synthetic video bytes
+
+run_phase(){               # $1=label  $2..=extra sdr_interferer args
+  local label="$1"; shift
+  echo "=== PHASE $label: interferer ch$CH gain=$IGAIN $* ==="
+  sudo python3 "$ROOT/tests/sdr_interferer.py" --channel "$CH" --tx-gain "$IGAIN" \
+       --rate 20e6 --mode noise --secs $((SECS + 12)) "$@" >"$INTF_LOG" 2>&1 &
+  sleep 8
+  sudo env DEVOURER_VID=$VRX_VID DEVOURER_PID=$VRX_PID PYTHONPATH="$PREC" \
+       python3 "$PREC/adaptive_link.py" --role vrx --pid $VRX_PID --channel $CH \
+       --vtx-id $VTX_ID --duplex "$ROOT/build/StreamDuplexDemo" >"${VRX_LOG[$label]}" 2>&1 &
+  sleep 5
+  sudo env DEVOURER_VID=$VTX_VID DEVOURER_PID=$VTX_PID PYTHONPATH="$PREC" \
+       python3 "$PREC/adaptive_link.py" --role vtx --pid $VTX_PID --channel $CH \
+       --vtx-id $VTX_ID --video "$VIDEO" --duplex "$ROOT/build/StreamDuplexDemo" \
+       >"${VTX_LOG[$label]}" 2>&1 &
+  sleep "$SECS"; KILL; sleep 2
+}
+
+# delivery stats from a VRX log's <adaptive-vrx> deliv= field
+stats(){ grep -oP '<adaptive-vrx>.*?deliv=\K[0-9.]+' "$1" | python3 -c '
+import sys
+v=[float(x) for x in sys.stdin if x.strip()]
+if not v: print("n=0 (no samples)"); sys.exit()
+v.sort(); n=len(v)
+mean=sum(v)/n; mn=v[0]; p10=v[max(0,int(0.10*n))]
+print(f"n={n} mean={mean:.3f} p10={p10:.3f} min={mn:.3f}")'; }
+
+run_phase static
+run_phase fading --fade-coherence "$FADE_COH" --fade-depth-db "$FADE_DEPTH"
+
+echo
+echo "=== RESULT (SLA target deliv >= $SLA) ==="
+echo "[static] $(stats "${VRX_LOG[static]}")"
+echo "[fading] $(stats "${VRX_LOG[fading]}")"
+echo "interferer fade envelope samples: $(grep -c '<interferer-fade>' "$INTF_LOG")"
+echo "trajectories:"
+echo "  static: $(grep -c '<adaptive-vrx>' "${VRX_LOG[static]}") samples -> ${VRX_LOG[static]}"
+echo "  fading: $(grep -c '<adaptive-vrx>' "${VRX_LOG[fading]}") samples -> ${VRX_LOG[fading]}"
+echo
+echo "Interpretation: if [fading] min/p10 deliv drops below $SLA while [static]"
+echo "holds it (at the same interferer gain), the fixed-margin controller is"
+echo "confirmed to under-deliver under fading — the precondition for adding a"
+echo "variance-aware fade margin."

--- a/tests/sdr_interferer.py
+++ b/tests/sdr_interferer.py
@@ -56,6 +56,13 @@ def main(argv=None) -> int:
                     help="RNG seed — fixes the noise so runs are reproducible")
     ap.add_argument("--secs", type=float, default=0.0,
                     help="run time; 0 = until SIGINT/SIGTERM")
+    ap.add_argument("--fade-coherence", type=float, default=0.0,
+                    help="if >0, modulate interference power with a time-correlated "
+                         "(AR1) envelope of this coherence time (s) -> the victim "
+                         "link sees correlated SNR fades (for fade-SLA validation)")
+    ap.add_argument("--fade-depth-db", type=float, default=12.0,
+                    help="peak-to-floor interference power swing (dB) of the fade "
+                         "envelope; deeper = harder fades")
     args = ap.parse_args(argv)
 
     if args.freq is None:
@@ -105,20 +112,44 @@ def main(argv=None) -> int:
     signal.signal(signal.SIGINT, lambda *_: stop.update(flag=True))
     signal.signal(signal.SIGTERM, lambda *_: stop.update(flag=True))
 
+    # Time-correlated fading envelope: an AR(1) process modulates the interference
+    # power, so the victim link sees correlated SNR fades. Base amplitude is
+    # auto-scaled so the loudest (~3-sigma) fade peak stays under the DAC ceiling.
+    fade_on = args.fade_coherence > 0.0
+    if fade_on:
+        buf_dt = nsamps / args.rate
+        fade_rho = float(np.exp(-buf_dt / args.fade_coherence))
+        fade_g = 0.0
+        peak_mult = 10.0 ** (args.fade_depth_db / 20.0 * 3.0)
+        fade_base = min(args.amplitude, 0.7 / peak_mult)
+        marker_every = max(1, int(0.1 / max(1e-6, buf_dt)))   # ~10 Hz markers
+
     t0 = time.monotonic()
     sent = 0
+    nbuf = 0
     while not stop["flag"]:
         if args.secs and (time.monotonic() - t0) >= args.secs:
             break
-        if args.mode == "cw":
-            buf = tone
+        if fade_on:
+            fade_g = fade_rho * fade_g + (1.0 - fade_rho ** 2) ** 0.5 * rng.standard_normal()
+            env = abs(fade_g)                              # correlated, mean ~0.8
+            amp = fade_base * 10.0 ** (args.fade_depth_db / 20.0 * env)
+            if nbuf % marker_every == 0:
+                sys.stderr.write(f"<interferer-fade>t={time.monotonic()-t0:.2f} "
+                                 f"env={env:.2f} amp={amp:.3f}\n")
+                sys.stderr.flush()
         else:
-            buf = (args.amplitude *
+            amp = args.amplitude
+        if args.mode == "cw":
+            buf = (tone * (amp / max(1e-9, args.amplitude))).astype(np.complex64)
+        else:
+            buf = (amp *
                    (rng.standard_normal(nsamps) + 1j * rng.standard_normal(nsamps))
                    / np.sqrt(2)).astype(np.complex64)
         tx.send(buf.reshape(1, -1), md)
         md.start_of_burst = False
         sent += nsamps
+        nbuf += 1
 
     md.end_of_burst = True
     try:

--- a/tools/precoder/adaptive_link.py
+++ b/tools/precoder/adaptive_link.py
@@ -273,7 +273,8 @@ def run_vrx(proc, link, calib, vtx_id, channel, feedback_period_ms=100):
             op = vrx.cur_op
             sys.stderr.write(
                 f"<adaptive-vrx>state={vrx.rz.state} snr={vrx.win.snr_estimate()} "
-                f"score={vrx.win.score()} -> MCS{op.mcs} ov{op.overhead} "
+                f"score={vrx.win.score()} deliv={1.0 - vrx.win.seq_gap_loss():.3f} "
+                f"-> MCS{op.mcs} ov{op.overhead} "
                 f"txagc{op.txagc} frames={vrx.win.n()}\n")
             sys.stderr.flush()
         time.sleep(0.01)


### PR DESCRIPTION
## What

On-air validation tooling to test a hypothesis surfaced by the **linklab** simulation sandbox: the adaptive controller's *fixed* margin may **under-deliver at long range under time-correlated fading**. This lands the experiment to confirm/refute it on the bench **before** any controller change — there is **no shipped-behavior change** here, only measurement.

## Why

In sim, under correlated fading the fade-blind controller's delivery fell to ~0.92 at long range (below a 0.99 SLA), because its fixed margin can't cover deep fades. That was a *nominal-calibration + synthetic-fading* result — a hypothesis, not a measured fact. This harness measures it on real hardware so we don't change the controller blind.

## Changes (all test/observability)

- **`tests/sdr_interferer.py`** — new fading mode (`--fade-coherence` / `--fade-depth-db`): an AR(1) time-correlated envelope modulates interference power so the victim link sees correlated SNR fades. Auto-scales base amplitude to avoid DAC clipping; emits `<interferer-fade>` markers.
- **`tools/precoder/adaptive_link.py`** — surfaces the VRX post-seq delivery (`deliv=`) in the `<adaptive-vrx>` trajectory line (observability only).
- **`tests/fade_sla_onair.sh`** — A/B harness: runs the closed loop (8812 VTX ↔ 8821 VRX) under **STATIC** then **FADING** interference at the *same* gain and compares VRX delivery (mean / p10 / min) against the SLA target.

## How to run (hardware)

```sh
sudo bash tests/fade_sla_onair.sh
IGAIN=80 FADE_DEPTH=14 SECS=45 sudo bash tests/fade_sla_onair.sh
```

**Decision rule:** if the FADING run's worst-window (p10/min) delivery drops below the SLA while the STATIC run holds it at the same interferer gain, the fixed-margin gap is confirmed — and *then* a variance-aware fade margin in the controller is worth adding (and would be its own, validated PR).

## Verification

Precoder suite green (215 passed); `sdr_interferer --help` shows the new args; `fade_sla_onair.sh` passes `bash -n` and the delivery-parse logic is unit-checked. The harness itself runs on hardware (8812 + 8821 + B210).

🤖 Generated with [Claude Code](https://claude.com/claude-code)