### PR TITLE
tests: mean-power-matched fading interferer + fade-SLA gain sweep

### DIFF
--- a/tests/fade_sla_onair.sh
+++ b/tests/fade_sla_onair.sh
@@ -21,8 +21,8 @@ PREC="$ROOT/tools/precoder"
 
 VTX_PID=${VTX_PID:-0x8812}; VTX_VID=${VTX_VID:-0x0bda}; VTX=${VTX_SYSFS:-9-2}
 VRX_PID=${VRX_PID:-0x0120}; VRX_VID=${VRX_VID:-0x2357}; VRX=${VRX_SYSFS:-9-1.4}
-CH=${CH:-6}; SECS=${SECS:-30}; VTX_ID=${VTX_ID:-0xABCD}
-IGAIN=${IGAIN:-78}; FADE_COH=${FADE_COH:-0.3}; FADE_DEPTH=${FADE_DEPTH:-12}
+CH=${CH:-6}; SECS=${SECS:-25}; VTX_ID=${VTX_ID:-0xABCD}
+FADE_COH=${FADE_COH:-0.3}; FADE_DEPTH=${FADE_DEPTH:-8}   # depth = power std (dB)
 SLA=${SLA:-0.99}
 
 VIDEO=/tmp/fade_sla_video.bin
@@ -35,35 +35,41 @@ KILL(){ sudo pkill -9 -f adaptive_link 2>/dev/null
         sudo pkill -9 -f sdr_interferer 2>/dev/null; }
 trap KILL EXIT
 
-# free both Wi-Fi adapters (B210 is UHD-accessed)
-for D in "$VTX" "$VRX"; do
-  for i in /sys/bus/usb/devices/$D/$D:*; do
-    ifc=$(basename "$i"); drv=$(readlink -f "$i/driver" 2>/dev/null)
-    [ -n "$drv" ] && echo "$ifc" | sudo tee "$drv/unbind" >/dev/null 2>&1
-  done
-done; sleep 1
+free_adapters(){           # detach kernel drivers so devourer can claim them
+  for D in "$VTX" "$VRX"; do
+    for i in /sys/bus/usb/devices/$D/$D:*; do
+      ifc=$(basename "$i"); drv=$(readlink -f "$i/driver" 2>/dev/null)
+      [ -n "$drv" ] && echo "$ifc" | sudo tee "$drv/unbind" >/dev/null 2>&1
+    done
+  done; sleep 2
+}
 
-head -c 4000000 /dev/urandom > "$VIDEO"   # synthetic video bytes
+head -c 4000000 /dev/urandom > "$VIDEO"   # synthetic video bytes (VTX loops it)
 
 run_phase(){               # $1=label  $2..=extra sdr_interferer args
   local label="$1"; shift
   echo "=== PHASE $label: interferer ch$CH gain=$IGAIN $* ==="
+  KILL; free_adapters                       # clean slate per phase (fix cold-start)
   sudo python3 "$ROOT/tests/sdr_interferer.py" --channel "$CH" --tx-gain "$IGAIN" \
-       --rate 20e6 --mode noise --secs $((SECS + 12)) "$@" >"$INTF_LOG" 2>&1 &
+       --rate 20e6 --mode noise --secs $((SECS + 30)) "$@" >"$INTF_LOG" 2>&1 &
   sleep 8
   sudo env DEVOURER_VID=$VRX_VID DEVOURER_PID=$VRX_PID PYTHONPATH="$PREC" \
        python3 "$PREC/adaptive_link.py" --role vrx --pid $VRX_PID --channel $CH \
        --vtx-id $VTX_ID --duplex "$ROOT/build/StreamDuplexDemo" >"${VRX_LOG[$label]}" 2>&1 &
-  sleep 5
+  sleep 4
   sudo env DEVOURER_VID=$VTX_VID DEVOURER_PID=$VTX_PID PYTHONPATH="$PREC" \
        python3 "$PREC/adaptive_link.py" --role vtx --pid $VTX_PID --channel $CH \
        --vtx-id $VTX_ID --video "$VIDEO" --duplex "$ROOT/build/StreamDuplexDemo" \
        >"${VTX_LOG[$label]}" 2>&1 &
+  # wait for the session to establish (rendezvous) before the measurement window
+  for _ in $(seq 1 20); do
+    grep -q 'state=SESSION' "${VRX_LOG[$label]}" && break; sleep 1
+  done
   sleep "$SECS"; KILL; sleep 2
 }
 
-# delivery stats from a VRX log's <adaptive-vrx> deliv= field
-stats(){ grep -oP '<adaptive-vrx>.*?deliv=\K[0-9.]+' "$1" | python3 -c '
+# delivery stats over SESSION samples only (ignore the BEACONING placeholder)
+stats(){ grep -E '<adaptive-vrx>state=SESSION' "$1" | grep -oP 'deliv=\K[0-9.]+' | python3 -c '
 import sys
 v=[float(x) for x in sys.stdin if x.strip()]
 if not v: print("n=0 (no samples)"); sys.exit()
@@ -71,17 +77,26 @@ v.sort(); n=len(v)
 mean=sum(v)/n; mn=v[0]; p10=v[max(0,int(0.10*n))]
 print(f"n={n} mean={mean:.3f} p10={p10:.3f} min={mn:.3f}")'; }
 
-run_phase static
-run_phase fading --fade-coherence "$FADE_COH" --fade-depth-db "$FADE_DEPTH"
+# Sweep interferer gain to find the regime where the STATIC baseline still holds
+# the SLA (so fading can be seen to break it). static vs fading are MEAN-POWER
+# MATCHED at each gain (the interferer's fade envelope has unit mean power).
+IGAINS=${IGAINS:-"46 52 58 64"}
 
 echo
-echo "=== RESULT (SLA target deliv >= $SLA) ==="
-echo "[static] $(stats "${VRX_LOG[static]}")"
-echo "[fading] $(stats "${VRX_LOG[fading]}")"
-echo "interferer fade envelope samples: $(grep -c '<interferer-fade>' "$INTF_LOG")"
-echo "trajectories:"
-echo "  static: $(grep -c '<adaptive-vrx>' "${VRX_LOG[static]}") samples -> ${VRX_LOG[static]}"
-echo "  fading: $(grep -c '<adaptive-vrx>' "${VRX_LOG[fading]}") samples -> ${VRX_LOG[fading]}"
+echo "=== fade-SLA gain sweep (SLA target deliv >= $SLA; static/fading mean-matched) ==="
+printf "%-5s | %-34s | %-34s\n" "gain" "STATIC" "FADING"
+for g in $IGAINS; do
+  IGAIN=$g
+  run_phase static >/dev/null 2>&1
+  s=$(stats "${VRX_LOG[static]}")
+  run_phase fading --fade-coherence "$FADE_COH" --fade-depth-db "$FADE_DEPTH" >/dev/null 2>&1
+  f=$(stats "${VRX_LOG[fading]}")
+  printf "%-5s | %-34s | %-34s\n" "$g" "$s" "$f"
+done
+echo
+echo "Read the row where STATIC mean is ~>= $SLA (baseline holds): if FADING there"
+echo "drops below it, the fixed-margin controller under-delivers under fading —"
+echo "confirming the gap and justifying the opt-in fade margin (#118)."
 echo
 echo "Interpretation: if [fading] min/p10 deliv drops below $SLA while [static]"
 echo "holds it (at the same interferer gain), the fixed-margin controller is"

--- a/tests/sdr_interferer.py
+++ b/tests/sdr_interferer.py
@@ -60,9 +60,9 @@ def main(argv=None) -> int:
                     help="if >0, modulate interference power with a time-correlated "
                          "(AR1) envelope of this coherence time (s) -> the victim "
                          "link sees correlated SNR fades (for fade-SLA validation)")
-    ap.add_argument("--fade-depth-db", type=float, default=12.0,
-                    help="peak-to-floor interference power swing (dB) of the fade "
-                         "envelope; deeper = harder fades")
+    ap.add_argument("--fade-depth-db", type=float, default=8.0,
+                    help="std of the interference power (dB) in the fade envelope; "
+                         "deeper = harder fades. Mean power is unchanged (matched A/B)")
     args = ap.parse_args(argv)
 
     if args.freq is None:
@@ -120,8 +120,10 @@ def main(argv=None) -> int:
         buf_dt = nsamps / args.rate
         fade_rho = float(np.exp(-buf_dt / args.fade_coherence))
         fade_g = 0.0
-        peak_mult = 10.0 ** (args.fade_depth_db / 20.0 * 3.0)
-        fade_base = min(args.amplitude, 0.7 / peak_mult)
+        # log-normal interference-power envelope with UNIT MEAN, so a fading run's
+        # mean power equals a static run's at the same --tx-gain (a matched A/B).
+        # fade_depth_db is the std of the interference power in dB.
+        fade_sigma = args.fade_depth_db * (np.log(10.0) / 10.0)
         marker_every = max(1, int(0.1 / max(1e-6, buf_dt)))   # ~10 Hz markers
 
     t0 = time.monotonic()
@@ -132,11 +134,12 @@ def main(argv=None) -> int:
             break
         if fade_on:
             fade_g = fade_rho * fade_g + (1.0 - fade_rho ** 2) ** 0.5 * rng.standard_normal()
-            env = abs(fade_g)                              # correlated, mean ~0.8
-            amp = fade_base * 10.0 ** (args.fade_depth_db / 20.0 * env)
+            # unit-mean log-normal power -> correlated deep fades, mean matched to static
+            power = float(np.exp(fade_sigma * fade_g - 0.5 * fade_sigma ** 2))
+            amp = min(0.95, args.amplitude * power ** 0.5)
             if nbuf % marker_every == 0:
                 sys.stderr.write(f"<interferer-fade>t={time.monotonic()-t0:.2f} "
-                                 f"env={env:.2f} amp={amp:.3f}\n")
+                                 f"powr={power:.2f} amp={amp:.3f}\n")
                 sys.stderr.flush()
         else:
             amp = args.amplitude


### PR DESCRIPTION
## What

Hardens the fade-SLA validation tooling (#117) after the first on-air run exposed two confounds, and reports the (now valid) on-air result. **No controller changes.**

## Fixes

- **`sdr_interferer.py` — mean-power-matched fading.** The fade mode scaled the base amplitude *down* for peak headroom, so at equal `--tx-gain` a fading run was weaker on average than static (fading scored spuriously *better*). Replaced with a **unit-mean log-normal power envelope** (`--fade-depth-db` = power std), so a fading run's mean power equals a static run's at the same gain — a fair A/B.
- **`fade_sla_onair.sh` — reliability + regime sweep.** Free/reset adapters per phase (first-phase cold-start was failing to rendezvous), wait for `state=SESSION` before measuring, count delivery over SESSION samples only (drop the BEACONING placeholder), and **sweep `IGAINS`** to find the regime.

## On-air result (8812 ↔ 8821 + B210, mean-matched)

| interferer gain | STATIC mean (p10) | FADING mean (p10) |
|---|---|---|
| 46 | 0.71 (0.04) | 0.70 (0.19) |
| 52 | 0.82 (0.67) | 0.81 (0.70) |
| 58 | 0.84 (0.75) | 0.83 (0.62) |
| **64** | **0.79 (0.23)** | **0.41 (0.02)** |

- **Fading degrades the controller far more than equivalent static interference** — at gain 64, matched mean power, delivery 0.79→0.41 (p10 0.23→0.02). This **directionally confirms** the sim hypothesis and the rationale for the opt-in fade margin (#118).

## Honest caveat

The static baseline never reaches the 0.99 SLA on this bench (~0.7–0.84, non-monotonic) — there's a **baseline frame loss independent of the interferer**, likely half-duplex RCF feedback contending on the same channel plus the seq-gap delivery metric. So this shows the **relative** fade penalty, **not** an absolute "baseline holds 0.99 → fading breaks it." Closing that needs a separate look at the half-duplex/measurement path (or an attenuator rig to open link margin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)