### PR TITLE
adaptive_link: app-level sequence for exact end-to-end delivery measurement

### DIFF
--- a/tools/precoder/adaptive_link.py
+++ b/tools/precoder/adaptive_link.py
@@ -256,8 +256,12 @@ def run_vrx(proc, link, calib, vtx_id, channel, feedback_period_ms=100):
                 continue
             snr = max(int(m.group("snr")), int(m.group("snr2")))
             rssi = max(int(m.group("rssi")), int(m.group("rssi2")))
-            vrx.on_video(rssi, snr, int(m.group("crc")) != 0, int(m.group("seq")),
-                         _now_ms())
+            # App-level sequence: the VTX prefixes a 12-bit per-video-frame counter,
+            # so gap-based loss is EXACT. (The 802.11 seq=... advances per transmitted
+            # frame incl. retries, so it over-counts loss — see score.seq_gap_loss.)
+            seq = (int.from_bytes(body[:2], "little") & 0xFFF
+                   if len(body) >= 2 else int(m.group("seq")))
+            vrx.on_video(rssi, snr, int(m.group("crc")) != 0, seq, _now_ms())
     threading.Thread(target=reader, daemon=True).start()
     import sys
     import time
@@ -307,6 +311,7 @@ def run_vtx(proc, vtx_id, video_path, channel):
     import sys
     import time
     vid = open(video_path, "rb") if video_path else None
+    app_seq = 0                                  # 12-bit per-video-frame counter
     last_log = 0.0
     cur_chan = channel
     prev_state = vtx.rz.state
@@ -327,10 +332,12 @@ def run_vtx(proc, vtx_id, video_path, channel):
             proc.stdin.write(ctl_frame(SET_PWR, bytes([vtx.state.txagc])))
             proc.stdin.flush()
         if vid is not None and act in (rz.A_TX_VIDEO, rz.A_FAILSAFE):
-            chunk = vid.read(1024)
+            chunk = vid.read(1022)               # room for the 2-byte app-seq header
             if not chunk:
-                vid.seek(0); chunk = vid.read(1024)
-            proc.stdin.write(psdu_frame(chunk)); proc.stdin.flush()
+                vid.seek(0); chunk = vid.read(1022)
+            proc.stdin.write(psdu_frame(app_seq.to_bytes(2, "little") + chunk))
+            proc.stdin.flush()
+            app_seq = (app_seq + 1) & 0xFFF
         if now - last_log > 1000:
             last_log = now
             sys.stderr.write(f"<adaptive-vtx>state={vtx.rz.state} txagc={vtx.state.txagc} "


### PR DESCRIPTION
## What

Follow-up to the seq-wrap fix (#120). Makes the adaptive link's delivery metric **exact and end-to-end**, and re-validates the fade-SLA result with it.

## Why

802.11 `seq=` advances per *transmitted* frame (retries, other traffic), so even wrap-corrected it's only an **upper bound** on video-frame loss. The VTX now prefixes each video frame with a **12-bit per-frame counter**; the VRX reads it from the body instead of the 802.11 seq. Gap-based loss is then **per-video-frame exact** and captures **true end-to-end delivery** — it counts every frame the VTX intended to send (including any lost in the Python/duplex pipe), not just on-air losses. DISC_ACK rendezvous frames are routed by frame type before the video path, so they don't perturb the counter.

## Corrected fade-SLA sweep (the payoff)

8812 ↔ 8821 + B210, static vs fading **mean-power-matched**, exact metric:

| interferer gain | STATIC mean (p10) | FADING mean (p10) |
|---|---|---|
| 46 | 0.864 (0.67) | 0.856 (0.80) |
| 52 | 0.890 (0.82) | **0.748 (0.09)** |
| 58 | 0.836 (0.59) | 0.771 (0.19) |
| **64** | **0.737 (0.31)** | **0.165 (0.00)** |

At matched mean interference, **time-correlated fading degrades delivery far more than equivalent static noise** (gain 64: 0.74→0.17; gain 52 worst-window p10: 0.82→0.09). This solidly confirms the sim and the rationale for the opt-in fade margin (#118).

## Honest caveat

Static tops out at ~0.89, not 0.99 — that residual is **real end-to-end loss** the exact metric now counts honestly (on-air + pipe). So this is a clean **relative** confirmation of the fade penalty, not an absolute SLA-hold.

Full precoder suite green (219).

🤖 Generated with [Claude Code](https://claude.com/claude-code)