### PR TITLE
RX-chain masking + CCK TX rates (spatial-diversity #130)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,16 @@ Both `WiFiDriverDemo` and `WiFiDriverTxDemo` honour:
   Opt-in and on a distinct tag so the two-path format its regex consumers key on
   is untouched. Consumed by `tests/antenna_decorrelation.py` to measure
   inter-chain envelope correlation and realised diversity gain.
+- `DEVOURER_RX_PATHS=0xNN` — (Jaguar1 RX) restrict which RX chains the chip
+  enables/combines by masking the RX-path-enable register (`0x808` byte 0: bits
+  0/4 = path A CCK/OFDM, 1/5 = B, 2/6 = C, 3/7 = D). Default all paths (`0xFF`).
+  `0x11` = A only, `0x33` = A+B, `0x77` = A+B+C. Validated on the 8814: a masked
+  path's per-chain RSSI collapses to the noise floor while the enabled ones stay
+  up. Applied after the channel set (so it survives IQK); a later channel switch
+  reverts it, so it targets a single-channel RX capture. The knob for measuring
+  the chip's hardware maximal-ratio-combining gain — compare frame delivery at
+  `0x11`/`0x33`/`0x77`/`0xFF` over a *marginal* link (see
+  `docs/effective-branches-rotation.md`).
 - `DEVOURER_USB_DEBUG=1` — raise libusb log level from the default WARNING to
   DEBUG (produces ~7 MB per 15 s — has filled `/tmp` mid-capture and adds
   0.5-0.8 s to init even with stderr discarded). `DEVOURER_USB_QUIET` is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,8 +203,10 @@ gate any more (an HT-MCS radiotap is honoured unconditionally):
 
 - `DEVOURER_TX_RATE=<rate>[/<bw>][/SGI][/LDPC][/STBC]` (case-insensitive). Unset
   = `6M` legacy. Examples: `MCS7`, `MCS7/40/SGI`, `VHT2SS_MCS3/80/LDPC`, `54M`.
-  - `<rate>`: `6M`/`9M`/`12M`/`18M`/`24M`/`36M`/`48M`/`54M` (legacy OFDM),
-    `MCS0`..`MCS31` (HT), or `VHT1SS_MCS0`..`VHT4SS_MCS9` (VHT).
+  - `<rate>`: `1M`/`2M`/`5.5M`/`11M` (CCK, 2.4 GHz only — the chip drops CCK at
+    5 GHz; `1M` is the most robust rate, ~9 dB more link budget than `6M` for a
+    long-range beacon), `6M`/`9M`/`12M`/`18M`/`24M`/`36M`/`48M`/`54M` (legacy
+    OFDM), `MCS0`..`MCS31` (HT), or `VHT1SS_MCS0`..`VHT4SS_MCS9` (VHT).
   - `<bw>`: `20`|`40`|`80`|`160` (default 20; legacy is always 20).
   - `SGI` / `LDPC` / `STBC`: optional modifiers.
 

--- a/docs/effective-branches-rotation.md
+++ b/docs/effective-branches-rotation.md
@@ -176,6 +176,35 @@ combining gain at the low-outage tail, which is where a long-range link lives.
 Same silicon, different truth. That difference is invisible on the spec sheet and
 obvious in five minutes of rotation.
 
+## From branch count to combining gain
+
+Effective branches tell you how many chains *could* help; the payoff is the
+**combining gain** the receiver actually extracts from them. A multi-antenna
+802.11 chip combines its RX chains in hardware and hands up one decoded frame —
+there is no per-chain baseband to combine in software — so the gain is measured
+by *starving* the chip of chains and watching what it loses:
+
+- Restrict the chip to a subset of its RX chains (one, then two, then all) and
+  compare frame delivery and post-combine link quality at each step. On this
+  driver the active-chain set is a mask on the RX-path-enable register; masking a
+  path drops its per-chain level to the noise floor, confirming the chip is
+  genuinely down a chain (not just hiding a readout).
+- The catch: at a **strong** signal a single chain already decodes everything, so
+  every subset looks identical and you learn nothing. The gain only appears at a
+  **marginal** link — deep enough that a single chain drops frames the full set
+  still recovers. So this measurement, like the correlation one, requires a weak
+  or fading channel (attenuation, distance, or the relocation below), not a
+  bench with the transmitter inches away.
+- Read the result as a curve: frames delivered (or effective SNR) versus number
+  of active chains. Its slope is the realised diversity/array gain, and it should
+  flatten once the added chains are too correlated to help — tying directly back
+  to the effective-branch count. An adapter with N_eff ≈ 2 will stop improving
+  past two chains even if it has four.
+
+Combining gain and effective branches are two views of the same property:
+N_eff says how many independent chains exist; the path-masking curve says how
+much link margin they actually buy.
+
 ## Toward the gold standard
 
 Rotation answers "are these chains independent enough to matter" cheaply and

--- a/src/RadiotapBuilder.cpp
+++ b/src/RadiotapBuilder.cpp
@@ -145,6 +145,15 @@ bool parse_uint(const std::string& s, size_t pos, unsigned* out) {
 /* Parse the rate mnemonic (first '/'-token) into cfg. Returns false if the
  * token is not a recognised rate. */
 bool parse_rate_token(const std::string& s, TxMode* cfg) {
+  /* CCK (2.4GHz only — the chip drops CCK at 5GHz, see RtlJaguarDevice). The
+   * 500kbps count doubles as the MGN_* byte here too: 1M=2=MGN_1M, 2M=4=MGN_2M,
+   * 5.5M=11=MGN_5_5M, 11M=22=MGN_11M. 1M CCK is the most robust rate (~9dB more
+   * link budget than 6M OFDM) for a long-range beacon. */
+  if (s == "1M")   { cfg->legacy_rate_500kbps = 2;  return true; }
+  if (s == "2M")   { cfg->legacy_rate_500kbps = 4;  return true; }
+  if (s == "5.5M" || s == "5_5M") { cfg->legacy_rate_500kbps = 11; return true; }
+  if (s == "11M")  { cfg->legacy_rate_500kbps = 22; return true; }
+
   if (s == "6M")  { cfg->legacy_rate_500kbps = 12;  return true; }
   if (s == "9M")  { cfg->legacy_rate_500kbps = 18;  return true; }
   if (s == "12M") { cfg->legacy_rate_500kbps = 24;  return true; }

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -403,6 +403,22 @@ void RtlJaguarDevice::Init(Action_ParsedRadioPacket packetProcessor,
   StartWithMonitorMode(channel);
   SetMonitorChannel(channel);
 
+  /* DEVOURER_RX_PATHS=0xNN restricts which RX chains the chip enables/combines,
+   * by masking the RX-path-enable register (0x808 byte 0: bits 0/4 = path A
+   * CCK/OFDM, 1/5 = B, 2/6 = C, 3/7 = D). Default is all paths (0xFF, from the
+   * BB table). This is the knob for measuring the chip's hardware maximal-ratio
+   * combining gain: capture per-chain metrics (DEVOURER_RX_ALLPATHS) at 0x11
+   * (A only), 0x33 (A+B), 0x77 (A+B+C), 0xFF (all) and compare frame delivery
+   * at a marginal link. Written after SetMonitorChannel so it is the final word
+   * (IQK saves/restores 0x808); a later channel switch reverts it to the table
+   * default, so it targets a single-channel RX capture. The 8814 has 4 paths;
+   * on 8812/8821 the high bits are no-ops. */
+  if (const char *e = std::getenv("DEVOURER_RX_PATHS")) {
+    auto mask = static_cast<uint8_t>(std::strtoul(e, nullptr, 0));
+    _device.rtw_write8(0x808, mask);
+    _logger->info("DEVOURER_RX_PATHS: RX-path mask 0x808[7:0]=0x{:02x}", mask);
+  }
+
   _logger->info("Listening air...");
   /* Keep several bulk-IN transfers in flight at once (mirrors the kernel's ~4
    * always-posted RX URBs — confirmed via usbmon: rtw88 re-submits each URB

--- a/tests/compare_8814_decorrelation.sh
+++ b/tests/compare_8814_decorrelation.sh
@@ -27,7 +27,7 @@ METRIC="${METRIC:-rssi}"
 OUTDIR="$(mktemp -d -t devourer-8814cmp.XXXXXX)"
 
 cleanup() {
-    for comm in WiFiDriverDemo WiFiDriverTxDemo; do
+    for comm in WiFiDriverDemo WiFiDriverTxDem; do
         pkill -x "$comm" 2>/dev/null || true
     done
     rm -f "${TXLOG:-}" 2>/dev/null || true

--- a/tests/run_antenna_decorrelation.sh
+++ b/tests/run_antenna_decorrelation.sh
@@ -37,7 +37,7 @@ CAP="$(mktemp -t devourer-decorr.XXXXXX.log)"
 
 cleanup() {
     # Exact-comm kills only — never a broad pkill pattern.
-    for comm in WiFiDriverDemo WiFiDriverTxDemo; do
+    for comm in WiFiDriverDemo WiFiDriverTxDem; do
         pkill -x "$comm" 2>/dev/null || true
     done
     rm -f "$CAP" "${TXLOG:-}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Two standalone-useful features that came out of the spatial-diversity RX-MRC
work (#130 / epic #127), plus a real bug fix. Both features are validated on
hardware and useful independent of the experiment's outcome.

### 1. `DEVOURER_RX_PATHS=0xNN` — RX-chain masking
The RTL8814AU combines its RX chains in hardware (one decoded frame out, no
per-chain IQ), so the only way to measure the chip's diversity/MRC gain is to
restrict the active chain set. This masks the RX-path-enable register (`0x808`
byte 0: bits 0/4 = path A CCK/OFDM, 1/5 = B, 2/6 = C, 3/7 = D) after the channel
set, so it survives IQK save/restore. `0x11` = A only, `0x33` = A+B, `0x77` =
A+B+C, `0xFF` = all. Validated on the 8814: a masked path's per-chain RSSI
collapses to the noise floor while the enabled ones stay up. Targets a
single-channel RX capture (a later channel switch reverts it).

### 2. CCK TX rates (`1M`/`2M`/`5.5M`/`11M`)
`DEVOURER_TX_RATE` could only express OFDM 6M+. The descriptor path already
handles CCK at 2.4 GHz (the CCK→OFDM clamp only fires at 5 GHz), so the gap was
purely the rate parser; the 500 kbps count equals the `MGN_*` byte for CCK too,
so it's a mechanical addition. **1M CCK is the most robust rate (~9 dB more link
budget than 6M OFDM)** — the right choice for a long-range / marginal-link
beacon. Validated on-air: `DEVOURER_TX_RATE=1M` transmits at 1.0 Mb/s
(co-located monitor confirmed); 5 GHz still clamps CCK to 6M as before.

### 3. Fix: beacon-cleanup `pkill` never matched
`WiFiDriverTxDemo` is 16 chars but the kernel `comm` truncates to 15, so
`pkill -x WiFiDriverTxDemo` silently matched nothing and left orphaned beacon
processes holding the TX adapter (the "flaky 8812 TX" seen in the decorrelation
runs). Match the 15-char comm `WiFiDriverTxDem`.

### Docs
- `docs/effective-branches-rotation.md`: a "From branch count to combining gain"
  section — the path-masking method and why it needs a marginal link.
- `CLAUDE.md`: document `DEVOURER_RX_PATHS` and the CCK rates.

## Measurement outcome (context, see #130)
On-hardware sweeps (both 8814 SKUs, 1M + 6M, several positions) found the MRC
gain over the *best* single chain is small at a static link (2–10%): the
antennas' rotation-decorrelation doesn't translate to a static-link benefit
(instantaneous channels are correlated), and part of the frame loss is
USB/pipeline rather than link-SNR. 4T4R's value is insurance against picking the
wrong antenna (~60× vs the worst chain) and fade-tracking in a *mobile* link —
not static delivery gain. The tooling here is what enabled that measurement and
is reusable for the mobile/fading follow-up.

## Testing
- `DEVOURER_RX_PATHS` mask validated on 8814 (masked paths → noise floor).
- `DEVOURER_TX_RATE=1M` validated on-air at 1.0 Mb/s via a co-located monitor.
- Full build (all chips) + the existing `tests/antenna_decorrelation.py`
  self-test remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
