### PR TITLE
Mobile combining measurement: RX-path toggle + mobility analyzer (spatial-diversity #130)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,13 @@ Both `WiFiDriverDemo` and `WiFiDriverTxDemo` honour:
   reverts it, so it targets a single-channel RX capture. The knob for measuring
   the chip's hardware maximal-ratio-combining gain — compare frame delivery at
   `0x11`/`0x33`/`0x77`/`0xFF` over a *marginal* link (see
-  `docs/effective-branches-rotation.md`).
+  `docs/effective-branches-rotation.md`). A **toggle spec**
+  `0xAA:0xBB[:0xCC]@<ms>` (e.g. `0x22:0xFF@300`) cycles the mask on a timer
+  thread instead of setting it once, printing a `<devourer-rxpath-mask>0xNN`
+  marker inline with the frame stream on each switch — the stimulus for the
+  mobile/fading combining measurement (alternate a fixed chain vs all-4 fast
+  relative to RX motion so both sample the same fading). Analyse with
+  `tests/mrc_mobility.py`.
 - `DEVOURER_USB_DEBUG=1` — raise libusb log level from the default WARNING to
   DEBUG (produces ~7 MB per 15 s — has filled `/tmp` mid-capture and adds
   0.5-0.8 s to init even with stderr discarded). `DEVOURER_USB_QUIET` is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ Both `WiFiDriverDemo` and `WiFiDriverTxDemo` honour:
   reverts it, so it targets a single-channel RX capture. The knob for measuring
   the chip's hardware maximal-ratio-combining gain — compare frame delivery at
   `0x11`/`0x33`/`0x77`/`0xFF` over a *marginal* link (see
-  `docs/effective-branches-rotation.md`). A **toggle spec**
+  `docs/measuring-spatial-diversity.md`). A **toggle spec**
   `0xAA:0xBB[:0xCC]@<ms>` (e.g. `0x22:0xFF@300`) cycles the mask on a timer
   thread instead of setting it once, printing a `<devourer-rxpath-mask>0xNN`
   marker inline with the frame stream on each switch — the stimulus for the

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ varies run-to-run (bracketed = best clean reading).
 | ----------------------------- | ----------------- | ------------- | ------------- | ---------------- | ------------------------------------------- |
 | **RTL8812AU**                 | 2T2R              | 56            | 52            | 52               | `0bda:8812`; reference part |
 | **RTL8811AU**                 | 1T1R              | mirrors 8812  | mirrors 8812  | mirrors 8812     | 1T1R cut of 8812 silicon; rides the 8812 code path (`RFType=RF_TYPE_1T1R` from `REG_SYS_CFG` bit 27). Not benchmarked |
-| **RTL8814AU**                 | 4T4R, 3-SS max    | 65            | †(32)         | †(32)            | `0bda:8813`; tested on COMFAST CF-938AC (2 ext antennas) and CF-960AC (4 internal) — effective RX-diversity branches differ (N_eff ≈ 3.8 vs 2.6) despite identical silicon, see [`docs/effective-branches-rotation.md`](docs/effective-branches-rotation.md) |
+| **RTL8814AU**                 | 4T4R, 3-SS max    | 65            | †(32)         | †(32)            | `0bda:8813`; tested on COMFAST CF-938AC (2 ext antennas) and CF-960AC (4 internal) — effective RX-diversity branches differ (N_eff ≈ 3.8 vs 2.6) despite identical silicon, see [`docs/measuring-spatial-diversity.md`](docs/measuring-spatial-diversity.md) |
 | **RTL8821AU**                 | 1T1R AC + BT      | 54            | 32            | 28               | TP-Link Archer T2U Plus (`2357:0120`) |
 | **RTL8812CU**                 | 2T2R              | 65            | 60            | 60               | LB-LINK WDN1300H (`0bda:c812`) |
 | **RTL8822CU**                 | 2T2R + BT         | —             | —             | —                | not benchmarked (`0bda:c82c`) |

--- a/docs/measuring-spatial-diversity.md
+++ b/docs/measuring-spatial-diversity.md
@@ -1,13 +1,16 @@
-# Measuring effective diversity branches by rotation
+# Measuring spatial diversity on a multi-chain adapter
 
 A multi-chain adapter's spec sheet counts **RF chains** (2T2R, 4T4R). What a
 diversity receiver actually gets is **effective branches** — the number of chains
-whose fading is independent enough to add diversity. Those are not the same
-number. Two adapters built on identical 4T4R silicon can deliver very different
-effective diversity if one wires four decorrelated antennas and the other feeds
-four chains from two antennas. This document is a lab procedure for finding the
-truth experimentally, using nothing but a second adapter and your hands to rotate
-the device under test.
+whose fading is independent enough to add diversity — and, ultimately, the
+**combining gain** those branches deliver. Those are not the same as the chain
+count. Two adapters built on identical 4T4R silicon can behave very differently if
+one wires four decorrelated antennas and the other feeds four chains from two.
+This document is a lab procedure for finding the truth experimentally, using
+nothing but a second adapter and your hands — with three escalating stimuli
+(**rotate** the device in place, **relocate** the transmitter into multipath, and
+**move** the receiver), because how much diversity you can measure depends
+entirely on how much you make the channel vary.
 
 It is written as an instruction: the concept first, then the method, then how to
 run it, read it, and not fool yourself.
@@ -62,11 +65,18 @@ Rotation measures **pattern/orientation decorrelation** under strong line of
 sight. That is a *proxy* for the multipath envelope correlation a deployed link
 sees — not identical to it, but it captures the property that dominates whether an
 adapter's chains are redundant: do the antennas respond differently to the same
-incoming wave. The *relative* comparison between two adapters on the same bench is
-robust; the absolute ρ shifts in a real multipath field. Treat rotation as the
-quick screen and relocation/mobility as the confirmation.
+incoming wave. Treat rotation as the quick screen for *potential*; relocation and
+motion are where you learn what a deployment actually gets — and, as the closing
+sections show, that can shift or even invert the rotation ranking.
 
-## The method
+## The method — correlation screen (rotation)
+
+This section covers the quick screen: measure the antennas' *correlation* and
+effective-branch count by rotating the receiver. It answers "could these chains
+help?" The two sections after it turn that potential into a realised
+combining-gain number ("do they help?") — first with path-masking, then under
+motion. All three share the same beacon and per-chain readout; only the stimulus
+and what you compute change.
 
 The receiver only needs a controlled, steady signal to measure against, and a way
 to report each chain's level per frame:
@@ -109,7 +119,8 @@ to report each chain's level per frame:
 The receiver's per-chain emission is opt-in (it does not disturb the normal
 output): the RX demo publishes an all-chains line per beacon frame when asked,
 and the analyser turns a capture into the report above. A capture is only valid
-if the operator rotates the adapter for its full duration.
+if the operator keeps the adapter moving for its full duration — rotating for the
+correlation screen, translating for the motion measurement.
 
 - **One adapter, one shot.** `tests/run_antenna_decorrelation.sh` builds
   everything, brings up the beacon transmitter (and waits for it to actually
@@ -125,6 +136,11 @@ if the operator rotates the adapter for its full duration.
   capture, and has a hardware-independent self-test that validates the correlation
   estimator, the effective-branch metric, and the combining math against
   synthesised correlated fading — run that first if you change the tool.
+- **Combining gain and motion.** The path-masking sweep restricts the active
+  chains via `DEVOURER_RX_PATHS=0xNN` (see the next section); the motion
+  measurement toggles that mask (`DEVOURER_RX_PATHS=0x22:0xFF@300`) while you move
+  the receiver, and `tests/mrc_mobility.py` reports the per-mask delivery and the
+  shifting-best-chain trace.
 
 The metric to capture is the received level; SNR and EVM are also emitted if you
 prefer to correlate on those.
@@ -163,18 +179,25 @@ Two USB adapters built on the same 4T4R chip, differing only in antenna
 front-end, measured on one bench against one beacon on the 2.4 GHz test channel,
 each rotated vigorously through a capture:
 
-| Adapter | Antennas | Worst \|ρ\| | Effective branches N_eff | MRC gain at 1 % outage | Verdict |
-|---|---|---|---|---|---|
-| 4-internal-antenna puck | 4 on-PCB internal | 0.19 | **3.8** of 4 | ~14 dB | well decorrelated |
-| 2-external-dipole stick | 2 external dipoles | 0.64 | **2.6** of 4 | ~11 dB | partially correlated |
+| Adapter | Antennas | Worst \|ρ\| | Effective branches N_eff | Verdict |
+|---|---|---|---|---|
+| 4-internal-antenna puck | 4 on-PCB internal | 0.19 | **3.8** of 4 | well decorrelated |
+| 2-external-dipole stick | 2 external dipoles | 0.64 | **2.6** of 4 | partially correlated |
 
 The stick drives four RF chains from only two physical antennas, so two of its
 chains are strongly coupled and its effective branch count sits near its antenna
 count, not its chain count. The puck's four genuine antennas decorrelate on every
-pair and it delivers close to its full four-branch diversity — and materially more
-combining gain at the low-outage tail, which is where a long-range link lives.
-Same silicon, different truth. That difference is invisible on the spec sheet and
-obvious in five minutes of rotation.
+pair, so on this rotation screen it shows the higher *potential* — N_eff 3.8 vs
+2.6.
+
+But note the word *potential*: N_eff from rotation says how decorrelated the
+antennas **could** be if you exercise every orientation. Whether that potential
+turns into realised **combining gain** is a separate question — the one the next
+two sections answer — and the answer can **invert this ranking.** The puck's four
+antennas are packed close together and see nearly the same channel at rest, so
+their potential only pays off under motion; the stick's two widely-spaced dipoles
+decorrelate even stationary. Same silicon, different truth — and "more antennas"
+is not the same as "more diversity."
 
 ## From branch count to combining gain
 
@@ -205,13 +228,59 @@ Combining gain and effective branches are two views of the same property:
 N_eff says how many independent chains exist; the path-masking curve says how
 much link margin they actually buy.
 
-## Toward the gold standard
+## Diversity under motion — where it actually pays
 
-Rotation answers "are these chains independent enough to matter" cheaply and
-comparatively. To turn a relative screen into a deployment number, repeat the
-capture with the transmitter relocated into genuine non-line-of-sight multipath
-(another room, a balcony, across a floor) and, ultimately, with one end in
-motion. The tooling is identical — only the stimulus changes; the beacon can run
-on a second host anywhere the receiver can still hear it. Expect the *ordering*
-between adapters to hold and the absolute correlation to rise toward the values a
-flying link actually experiences.
+Everything above measures *potential* — how decorrelated the antennas could be.
+The decisive question for a real link is whether combining delivers a gain **while
+the receiver moves**, because a deployed link (a flying drone, a walking operator)
+is never static. This is a different and more revealing measurement than the
+static combining sweep, and it needs the comparison to be motion-fair.
+
+**The trap.** Comparing a single-chain capture against an all-chains capture
+*sequentially* is invalid under motion: the receiver is at a different point in
+its fade during each, so any difference is motion, not combining. The comparison
+must sample the *same* fading process. The fix is to **alternate the active-chain
+set fast relative to the motion** — toggle a fixed single chain against all chains
+every few hundred milliseconds while the operator moves the receiver continuously,
+and tag every frame with the set that was active when it arrived. Because the
+toggle is fast and the motion slow, both configurations see the same fades.
+
+**The stimulus.** Translate the receiver through space — slide it back and forth
+through several wavelengths — rather than rotating it in place. Translation sweeps
+the antennas through the multipath standing-wave field, which is what makes each
+chain's fading rise and fall and the best chain change; rotation only re-points a
+fixed pattern.
+
+**What to read.** Per toggle window (equal duration, so directly comparable):
+frames delivered, and especially the *worst* windows. The signatures of real
+diversity under motion are (1) the **best chain keeps changing** — no single
+antenna wins most windows, where a static position had one clear winner; (2) a
+*fixed* single antenna hits **deep-fade windows** (dropouts), which combining
+**fills**; and (3) combining **halves the delivery variance**. The headline is not
+the modest mean gain — it is the **elimination of the dropouts** that a
+single-antenna video link would show as frozen frames.
+
+**Always run a static control** at the same spot with motion off. The result that
+matters is the *difference* between moving and static: a combining gain (and a
+shifting best chain) that appear only when moving are the confirmation that the
+value is diversity, not link margin.
+
+### What this reveals about antenna design
+
+Run across adapters, the moving-vs-static contrast exposes a design truth the
+static numbers hide: **physical antenna spacing decides whether diversity helps at
+rest.** Widely-separated antennas sit at different points of the standing-wave
+field and so decorrelate *even stationary* — they show a real combining gain
+static and only a little more moving. Antennas packed close together (a compact
+internal array) see nearly the same channel at rest — one dominates, combining is
+worthless — and only decorrelate once the array moves. Both converge to a similar
+gain under motion, and both eliminate the fixed-antenna dropouts. So a *stationary*
+ground station wants widely-spaced external antennas; a compact internal array
+earns its extra chains only on a *moving* platform. Note this can invert the
+static rotation ranking — rotation measures orientation potential, but real fading
+decorrelation rewards spacing, so fewer well-separated antennas can beat more
+closely-packed ones.
+
+The tooling is the same throughout — only the stimulus (rotate, relocate, move)
+and the mask schedule (fixed vs toggled) change; the beacon can run on a second
+host anywhere the receiver still hears it.

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -4,8 +4,10 @@
 #include "SignalStop.h"
 
 #include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -413,10 +415,33 @@ void RtlJaguarDevice::Init(Action_ParsedRadioPacket packetProcessor,
    * (IQK saves/restores 0x808); a later channel switch reverts it to the table
    * default, so it targets a single-channel RX capture. The 8814 has 4 paths;
    * on 8812/8821 the high bits are no-ops. */
+  /* A toggle spec `0xAA:0xBB[:0xCC]@<ms>` cycles the mask on a timer thread
+   * instead of setting it once — the stimulus for the mobile/fading combining
+   * measurement: alternate a fixed single chain vs all-4 fast relative to the
+   * operator's motion, so both configs sample the same fading process. Each
+   * switch prints a `<devourer-rxpath-mask>0xNN` marker inline with the frame
+   * stream so the analyser can tag each frame with the active mask. A plain
+   * `0xNN` applies once, as before. */
   if (const char *e = std::getenv("DEVOURER_RX_PATHS")) {
-    auto mask = static_cast<uint8_t>(std::strtoul(e, nullptr, 0));
-    _device.rtw_write8(0x808, mask);
-    _logger->info("DEVOURER_RX_PATHS: RX-path mask 0x808[7:0]=0x{:02x}", mask);
+    std::string spec(e);
+    auto at = spec.find('@');
+    if (at != std::string::npos && spec.find(':') != std::string::npos) {
+      uint32_t interval_ms =
+          static_cast<uint32_t>(std::strtoul(spec.c_str() + at + 1, nullptr, 0));
+      std::vector<uint8_t> masks;
+      for (size_t pos = 0; pos < at;) {
+        size_t colon = spec.find(':', pos);
+        size_t end = (colon == std::string::npos || colon > at) ? at : colon;
+        masks.push_back(static_cast<uint8_t>(
+            std::strtoul(spec.substr(pos, end - pos).c_str(), nullptr, 0)));
+        pos = end + 1;
+      }
+      start_rx_path_toggle(masks, interval_ms);
+    } else {
+      auto mask = static_cast<uint8_t>(std::strtoul(spec.c_str(), nullptr, 0));
+      _device.rtw_write8(0x808, mask);
+      _logger->info("DEVOURER_RX_PATHS: RX-path mask 0x808[7:0]=0x{:02x}", mask);
+    }
   }
 
   _logger->info("Listening air...");
@@ -455,6 +480,10 @@ void RtlJaguarDevice::Init(Action_ParsedRadioPacket packetProcessor,
   }
   for (auto &t : workers)
     t.join();
+
+  _rxmask_stop.store(true);
+  if (_rxmask_thread.joinable())
+    _rxmask_thread.join();
 
 #if 0
   _device.UsbDevice.SetBulkDataHandler(BulkDataHandler);
@@ -530,6 +559,35 @@ RtlJaguarDevice::~RtlJaguarDevice() {
   if (_therm_thread.joinable()) {
     _therm_thread.join();
   }
+  _rxmask_stop.store(true);
+  if (_rxmask_thread.joinable()) {
+    _rxmask_thread.join();
+  }
+}
+
+/* Cycle the RX-path mask (0x808 byte 0) through `masks` every `interval_ms` on a
+ * background thread, printing a `<devourer-rxpath>mask` marker on each switch.
+ * The control-transfer write runs concurrently with the RX bulk-IN workers on a
+ * different endpoint, which libusb permits (see the queue-depth poller). Used by
+ * the mobile/fading combining measurement. */
+void RtlJaguarDevice::start_rx_path_toggle(const std::vector<uint8_t> &masks,
+                                           uint32_t interval_ms) {
+  if (masks.empty() || interval_ms == 0)
+    return;
+  _logger->info("DEVOURER_RX_PATHS toggle: {} masks @ {} ms", masks.size(),
+                interval_ms);
+  _rxmask_thread = std::thread([this, masks, interval_ms]() {
+    size_t i = 0;
+    while (!_rxmask_stop.load()) {
+      uint8_t m = masks[i++ % masks.size()];
+      _device.rtw_write8(0x808, m);
+      std::printf("<devourer-rxpath-mask>0x%02x\n", m);
+      std::fflush(stdout);
+      for (uint32_t slept = 0; slept < interval_ms && !_rxmask_stop.load();
+           slept += 25)
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+  });
 }
 
 void RtlJaguarDevice::start_queue_depth_poller(uint32_t interval_ms) {

--- a/src/jaguar1/RtlJaguarDevice.h
+++ b/src/jaguar1/RtlJaguarDevice.h
@@ -146,6 +146,13 @@ private:
   std::thread _qd_thread;
   std::atomic<bool> _qd_stop{false};
 
+  /* DEVOURER_RX_PATHS toggle thread — cycles the RX-path mask (0x808) for the
+   * mobile/fading combining measurement. */
+  void start_rx_path_toggle(const std::vector<uint8_t> &masks,
+                            uint32_t interval_ms);
+  std::thread _rxmask_thread;
+  std::atomic<bool> _rxmask_stop{false};
+
   std::thread _therm_thread;
   std::atomic<bool> _therm_stop{false};
   /* Packed last thermal snapshot: bit0 = valid, [8:15] = raw,

--- a/tests/mrc_mobility.py
+++ b/tests/mrc_mobility.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""mrc_mobility.py — measure RX combining gain under motion (spatial-diversity).
+
+#130 found that at a *static* position spatial combining (4-chain MRC) barely
+beats the best single chain — one antenna dominates a fixed spot. The mobility
+hypothesis is that under motion each chain's fading is time-varying and the best
+chain keeps changing, so a *fixed* single antenna repeatedly falls into nulls it
+can't escape while MRC fills them. This tool measures that.
+
+It consumes a capture from `WiFiDriverDemo` run with the RX-path *toggle*:
+
+    DEVOURER_RX_PATHS=0x22:0xFF@300   # alternate chain-B-only and all-4 every 300ms
+    DEVOURER_RX_ALLPATHS=1            # emit per-chain <devourer-rxpath> lines
+
+The library prints a `<devourer-rxpath>mask` marker on every switch, inline with
+the frame stream, so each frame is attributed to the mask active when it arrived:
+
+    <devourer-rxpath-mask>0x22
+    <devourer-rxpath>seq=.. rssi=a,b,c,d snr=.. evm=..
+    ...
+    <devourer-rxpath-mask>0xff
+    ...
+
+Because the toggle is fast relative to hand-motion, the two configs sample the
+same fading process — an unconfounded comparison the sequential #130 sweep could
+not make. Every marker window is the same nominal duration, so **frames per
+window is directly comparable across masks** (no need to know the beacon fps).
+
+Run it twice — once MOVING the RX (translate it through several wavelengths), once
+STATIC at matched mean level — and compare: a combining gain that appears only
+when moving is the confirmation that spatial diversity's value is mobility, not
+static delivery.
+
+What it reports, per mask:
+  * windows, total frames, mean/min/std frames-per-window;
+  * zero-frame (deep-fade) window count — the fixed chain's nulls;
+  * delivery ratio of all-4 (0xff) vs each single-chain mask (the MRC gain);
+and, from the all-4 windows, how often each chain is the strongest (the best
+chain changing under motion — the mechanism).
+
+Usage:
+  uv run python mrc_mobility.py capture.log
+  uv run python mrc_mobility.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+import numpy as np
+
+_MARK = re.compile(r"<devourer-rxpath-mask>(0x[0-9a-fA-F]+)")
+_FRAME = re.compile(r"<devourer-rxpath>seq=\d+\s+rssi=([\-\d,]+)")
+# How many frames to drop right after each switch. Toggling 0x808 causes a brief
+# RX/AGC transient that drops a few frames on the leading edge of a window;
+# dropping them de-biases the per-mask delivery. Tune with --settle if the
+# ALL-mask windows show anomalous low-min/high-std (under-settled) — or slow the
+# toggle so the transient is a smaller fraction of each window.
+SETTLE_FRAMES = 5
+
+
+def parse_windows(lines):
+    """Return a list of (mask:int, rssi_rows:list[list[int]]) — one per marker
+    window. Frames before the first marker are ignored (unknown mask)."""
+    windows = []
+    cur_mask = None
+    cur_rows = []
+    for ln in lines:
+        m = _MARK.search(ln)
+        if m:
+            if cur_mask is not None:
+                windows.append((cur_mask, cur_rows))
+            cur_mask = int(m.group(1), 16)
+            cur_rows = []
+            continue
+        f = _FRAME.search(ln)
+        if f and cur_mask is not None:
+            cur_rows.append([int(x) for x in f.group(1).split(",")])
+    if cur_mask is not None:
+        windows.append((cur_mask, cur_rows))
+    return windows
+
+
+def per_mask_stats(windows, settle=SETTLE_FRAMES):
+    """Aggregate frames-per-window by mask (dropping the first `settle` frames of
+    each window as switch-transient settling)."""
+    from collections import defaultdict
+    counts = defaultdict(list)   # mask -> [frames_per_window]
+    for mask, rows in windows:
+        counts[mask].append(max(0, len(rows) - settle))
+    out = {}
+    for mask, cs in counts.items():
+        a = np.array(cs, dtype=float)
+        out[mask] = {
+            "windows": len(cs),
+            "total": int(a.sum()),
+            "mean": float(a.mean()) if len(a) else 0.0,
+            "min": float(a.min()) if len(a) else 0.0,
+            "std": float(a.std()) if len(a) else 0.0,
+            "zero_windows": int((a == 0).sum()),
+        }
+    return out
+
+
+def best_chain_trace(windows):
+    """From the all-paths (0xff) windows, how often is each chain strongest?
+    Uses per-window mean RSSI; a shifting winner under motion is the mechanism."""
+    wins = np.zeros(4, dtype=int)
+    n = 0
+    for mask, rows in windows:
+        if mask != 0xFF or not rows:
+            continue
+        a = np.array(rows, dtype=float)
+        if a.shape[1] < 4:
+            continue
+        wins[int(np.argmax(a.mean(axis=0)))] += 1
+        n += 1
+    return wins, n
+
+
+def _popcount_low(mask):
+    return bin(mask & 0x0F).count("1") or bin(mask & 0xF0).count("1")
+
+
+def report(windows, settle=SETTLE_FRAMES):
+    L = []
+    stats = per_mask_stats(windows, settle)
+    if not stats:
+        return "no mask windows found — was the capture run with a " \
+               "DEVOURER_RX_PATHS toggle spec (e.g. 0x22:0xFF@300)?"
+    labels = {0x11: "A", 0x22: "B", 0x44: "C", 0x88: "D", 0xFF: "ALL"}
+    L.append(f"{'mask':>6} {'chains':>6} {'windows':>8} {'mean/win':>9} "
+             f"{'min':>5} {'std':>6} {'0-frame win':>12}")
+    for mask in sorted(stats):
+        s = stats[mask]
+        lbl = labels.get(mask, "?")
+        L.append(f"  0x{mask:02x} {lbl:>4} {s['windows']:>8} {s['mean']:>9.1f} "
+                 f"{s['min']:>5.0f} {s['std']:>6.1f} {s['zero_windows']:>12}")
+
+    # combining gain: all-4 vs each single-chain mask present
+    if 0xFF in stats:
+        allmean = stats[0xFF]["mean"]
+        L.append("")
+        L.append(f"combining gain (all-4 mean/win = {allmean:.1f}):")
+        singles = [m for m in stats if m in (0x11, 0x22, 0x44, 0x88)]
+        for m in sorted(singles):
+            sm = stats[m]["mean"]
+            gain = (allmean / sm - 1.0) * 100 if sm > 0 else float("inf")
+            L.append(f"   vs chain {labels[m]} (mean {sm:.1f}): "
+                     f"{gain:+.0f}%  |  chain {labels[m]} deep-fade windows: "
+                     f"{stats[m]['zero_windows']}/{stats[m]['windows']}")
+
+    wins, n = best_chain_trace(windows)
+    if n:
+        L.append("")
+        L.append(f"best chain over {n} all-4 windows (mechanism — shifts under "
+                 f"motion): " + "  ".join(
+                     f"{c}={w}" for c, w in zip("ABCD", wins)))
+        dominant = wins.max() / n
+        L.append(f"  most-frequent-best chain holds {dominant*100:.0f}% of "
+                 f"windows ({'one chain dominates → static-like' if dominant > 0.8 else 'best chain shifts → mobile diversity'})")
+    return "\n".join(L)
+
+
+def self_test() -> int:
+    print("=== mrc_mobility self-test ===")
+    ok = True
+    # Synthesise a toggle capture: ALL windows deliver ~40 frames; the fixed
+    # single chain B fades (some windows near-zero), so ALL should beat B and B
+    # should show deep-fade windows.
+    rng = np.random.default_rng(0)
+    lines = []
+    for w in range(40):
+        # ALL window: steady ~40 frames, all chains ~70
+        lines.append("<devourer-rxpath-mask>0xff")
+        for _ in range(40):
+            lines.append("<devourer-rxpath>seq=1 rssi=70,71,69,72 snr=1,1,1,1 evm=0,0,0,0")
+        # B-only window: fades — half the windows deliver few frames
+        lines.append("<devourer-rxpath-mask>0x22")
+        nb = 40 if rng.random() > 0.5 else int(rng.integers(0, 5))
+        for _ in range(nb):
+            lines.append("<devourer-rxpath>seq=1 rssi=0,70,0,0 snr=1,1,1,1 evm=0,0,0,0")
+
+    windows = parse_windows(lines)
+    stats = per_mask_stats(windows)
+    cond1 = 0xFF in stats and 0x22 in stats
+    cond2 = stats[0xFF]["mean"] > stats[0x22]["mean"]        # ALL beats fixed B
+    cond3 = stats[0x22]["zero_windows"] > 0                   # B has deep fades
+    cond4 = stats[0xFF]["zero_windows"] == 0                  # ALL never fully fades
+    for name, c in [("parse both masks", cond1), ("ALL>B", cond2),
+                    ("B has fade windows", cond3), ("ALL no fade", cond4)]:
+        print(f"[{'ok' if c else 'FAIL'}] {name}")
+        ok &= c
+    print(report(windows))
+    print("=== PASS ===" if ok else "=== FAIL ===")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("input", nargs="?", default="-")
+    ap.add_argument("--settle", type=int, default=SETTLE_FRAMES,
+                    help=f"frames to drop after each mask switch (default {SETTLE_FRAMES})")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+    lines = (sys.stdin.readlines() if args.input == "-"
+             else open(args.input, errors="replace").readlines())
+    print(report(parse_windows(lines), args.settle))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The mobile/fading combining measurement (the linchpin from the #130
re-prioritisation) plus its finding — which turns the spatial-diversity story
around. Also renames the now-broader measurement doc.

### 1. RX-path toggle + mobility analyzer
`DEVOURER_RX_PATHS` gains a **toggle spec** `0xAA:0xBB[:0xCC]@<ms>` (e.g.
`0x22:0xFF@300`): a background thread cycles the RX-path mask (`0x808`) every
`<ms>`, printing a `<devourer-rxpath-mask>0xNN` marker inline with the frame
stream on each switch. Toggling fast relative to receiver motion makes a
fixed-chain-vs-all-4 comparison sample the **same** fading process — the
unconfounded comparison the sequential #130 sweep could not do. `tests/mrc_mobility.py`
attributes each frame to the active mask, reports per-mask frames-per-window,
deep-fade windows, the combining gain, and the shifting-best-chain trace;
`--self-test` covers parsing/windowing/verdict.

### 2. The measured finding (see #130)
Moving vs static, both 8814 SKUs:

| | 960AC (4 internal) | 938AC (2 external) |
|---|---|---|
| Static MRC gain | +2 % | +17 % |
| **Moving MRC gain** | **+17 %** | **+22 %** |

Under motion the best chain constantly shifts, so a *fixed* antenna hits
deep-fade **dropouts** that MRC eliminates (half the delivery variance, no
zero-frame windows). The headline is fade elimination, not the mean gain — which
is exactly the moving-drone FPV case. And **antenna spacing decides static
benefit**: wide external dipoles decorrelate even at rest; a packed internal
4-array only under motion.

### 3. Doc rename
`docs/effective-branches-rotation.md` → `docs/measuring-spatial-diversity.md`
(it now covers rotation, path-masking, and motion), with a "Diversity under
motion" section, a "What this reveals about antenna design" section, and a
reconciled worked example (the rotation N_eff is *potential* — realised combining
gain can invert the ranking).

## Testing
- Toggle validated end-to-end on the 8814 (markers alternate; static control
  reproduces #130; moving vs static confirms the effect).
- `tests/mrc_mobility.py --self-test` green; full build (all chips) green.
- Caveat documented: mask-switch transients add per-window noise — tune with
  `--settle` or a slower toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
