### PR TITLE
Concurrent TX+RX on one adapter: StartRxLoop splits bring-up from the RX loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,25 @@ Both `WiFiDriverDemo` and `WiFiDriverTxDemo` honour:
   mobile/fading combining measurement (alternate a fixed chain vs all-4 fast
   relative to RX motion so both sample the same fading). Analyse with
   `tests/mrc_mobility.py`.
+- `DEVOURER_TX_WITH_RX=thread` — (`WiFiDriverTxDemo`) run the RX worker loop on
+  a `std::thread` alongside the TX loop, on the **same claimed adapter**: one
+  bring-up (`InitWrite`), then `StartRxLoop(packetProcessor)` — the programmatic
+  API for concurrent TX+RX on one handle (all three generations). On Jaguar3 the
+  env must be set **before** `InitWrite` (it keeps the RX filters open and
+  enables the RX path during bring-up — retrofitting RX onto a TX-only bring-up
+  is unreliable), and the coex thread's C2H drain yields bulk-IN to the RX loop.
+  On the 8822E, TX+RX mode trades the per-rate TXAGC + DPK-bypass away for a
+  working RX (either one desenses the EU's RX to near-deaf; flat table TX power
+  instead). This is the single-radio beamforming self-sounding ground station —
+  pair with `DEVOURER_BF_ARM_SOUNDER`/`DEVOURER_TX_NDPA` and
+  `DEVOURER_BF_DETECT_REPORT` to sound and capture your own reports in one
+  process (`docs/beamforming-self-sounding.md`; hardware-validated on Jaguar1 —
+  the 8814AU captures its own report stream; on Jaguar3 the sounder emits
+  NDPA+NDP and the beamformee replies, but the sounder's own RX does not
+  surface the report frames — capture them on a second radio there). Any other
+  non-empty value selects the legacy `fork()` RX child — Termux-only
+  (`libusb_wrap_sys_device` keeps the fd shared across fork); on regular Linux
+  the forked bring-ups race and die with `rtw_read: iostream error`.
 - `DEVOURER_USB_DEBUG=1` — raise libusb log level from the default WARNING to
   DEBUG (produces ~7 MB per 15 s — has filled `/tmp` mid-capture and adds
   0.5-0.8 s to init even with stderr discarded). `DEVOURER_USB_QUIET` is
@@ -301,7 +320,10 @@ thin — `libusb_init`, device open, kernel driver detach, and
 to the factory. `demo/main.cpp` is the canonical boilerplate.
 
 **Chip identity is resolved at construction** from SYS_CFG bits + USB PID.
-`CreateRtlDevice` returns an `IRtlDevice` (`Init` / `InitWrite` / `send_packet`)
+`CreateRtlDevice` returns an `IRtlDevice` (`Init` / `InitWrite` / `send_packet` /
+`StartRxLoop` — the last is the blocking RX worker loop on an already-brought-up
+chip, so one process can `InitWrite` once and run TX + RX concurrently on the
+same claimed handle; `Init` = bring-up + `StartRxLoop` for RX-only callers)
 and dispatches on chip generation: Jaguar-1 PIDs construct `RtlJaguarDevice`;
 the Jaguar2 8822BU PID constructs `RtlJaguar2Device` (`SYS_CFG2` chip-id `0x0a`);
 Jaguar3 PIDs construct `RtlJaguar3Device`, with the generation (`rtl8822c` vs
@@ -325,7 +347,8 @@ generation's HAL):
 
 The Jaguar1 HAL lives under `src/jaguar1/`:
 
-- `RtlJaguarDevice` — top-level orchestrator (Init / InitWrite / send_packet).
+- `RtlJaguarDevice` — top-level orchestrator (Init / InitWrite / send_packet /
+  StartRxLoop).
 - `HalModule` — chip bring-up, power sequencing, BB/AGC/RF table application,
   USB EP priority, FIFO/page-boundary init. Most of the chip-family-specific
   divergence lives here (`_8812A`, `_8814A`, `_8821A` suffixed methods).
@@ -353,7 +376,8 @@ The Jaguar3 HAL is a parallel, self-contained set under `src/jaguar3/`. The core
 uses generation-neutral names; per-generation behaviour is behind two strategy
 interfaces selected by `ChipVariant`:
 
-- `RtlJaguar3Device` — orchestrator (Init / InitWrite / send_packet / Stop).
+- `RtlJaguar3Device` — orchestrator (Init / InitWrite / send_packet /
+  StartRxLoop / Stop).
 - `HalJaguar3` — bring-up: power-on/off PWR_SEQ, MAC/USB config, BB/AGC/RF table
   apply, `config_phydm_parameter_init` (3-wire RF), `bf_init`, `enable_tx_path`,
   efuse access (incl. the 8822e OTP burst-mode / 2-byte-header decode), RFE pins.

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -10,6 +10,7 @@
 
 #include <libusb.h>
 
+#include "BfReportDetect.h"
 #include "RxPacket.h"
 #if defined(DEVOURER_HAVE_JAGUAR1)
 #include "jaguar1/RtlJaguarDevice.h"
@@ -196,62 +197,9 @@ static void packetProcessor(const Packet &packet) {
            packet.RxAtrib.snr[0], packet.RxAtrib.snr[1]);
     fflush(stdout);
   }
-  /* BF self-sounding report detector. A VHT/HT Compressed Beamforming report
-   * is a management Action frame — subtype 0xD0 (Action) or 0xE0 (Action
-   * No-Ack; CSI reports are sent No-Ack) — whose body begins with a category
-   * + action of VHT cat 0x15 act 0x00, or HT cat 0x07 act 0x00. When an armed
-   * beamformee replies to our NDPA+NDP the report's SA is the beamformee MAC,
-   * the decode-level confirmation the unassociated responder produced CSI.
-   *
-   * DEVOURER_BF_DETECT_REPORT modes:
-   *   1  <devourer-bf-report> summary (Nc/Nr/BW/Ng, SA) per report
-   *   2  <devourer-bf-any> FC/category of EVERY frame (subtype survey)
-   *   3  mode 1 + capped CSI-payload hexdump (first frames)
-   *   4  mode 1 + <devourer-bf-report-raw> full frame hex (for the decoder,
-   *      tools/bf_report_decode.py) */
-  if (const char *mode_s = std::getenv("DEVOURER_BF_DETECT_REPORT")) {
-    if (packet.Data.size() >= 27) {
-      const char mode = mode_s[0];
-      const uint8_t *d = packet.Data.data();
-      const uint8_t cat = d[24], act = d[25];
-      const bool vht = (cat == 0x15 && act == 0x00);
-      const bool ht = (cat == 0x07 && act == 0x00);
-      if (mode == '2') {
-        static int any = 0;
-        if (++any <= 4000)
-          printf("<devourer-bf-any>fc=%02x%02x cat=%02x act=%02x crc=%u "
-                 "len=%zu\n", d[0], d[1], cat, act,
-                 packet.RxAtrib.crc_err ? 1u : 0u, packet.Data.size());
-      }
-      const uint8_t sub = d[0] & 0xF0;
-      if ((sub == 0xD0 || sub == 0xE0) && (vht || ht)) {
-        static int rpt = 0;
-        ++rpt;
-        const uint8_t *mc = d + 26;  /* VHT MIMO control field */
-        unsigned nc = (mc[0] & 0x07) + 1, nr = ((mc[0] >> 3) & 0x07) + 1;
-        unsigned chw = (mc[0] >> 6) & 0x03, ng = mc[1] & 0x03;
-        printf("<devourer-bf-report>%s n=%d sa=%02x:%02x:%02x:%02x:%02x:%02x "
-               "Nc=%u Nr=%u BW=%u Ng=%u len=%zu\n",
-               vht ? "VHT" : "HT", rpt, d[10], d[11], d[12], d[13], d[14],
-               d[15], nc, nr, chw, ng, packet.Data.size());
-        if (mode == '3' && rpt <= 6) {
-          size_t off = 26 + 3;  /* hdr(24)+cat+act+mimoctrl(3) */
-          size_t end = packet.Data.size() >= 4 ? packet.Data.size() - 4 : off;
-          printf("  csi[%zu]:", end - off);
-          for (size_t i = off; i < end && i < off + 40; ++i)
-            printf(" %02x", d[i]);
-          printf("\n");
-        }
-        if (mode == '4' && rpt <= 200) {
-          printf("<devourer-bf-report-raw>");
-          for (size_t i = 0; i < packet.Data.size(); ++i)
-            printf("%02x", d[i]);
-          printf("\n");
-        }
-        fflush(stdout);
-      }
-    }
-  }
+  /* BF self-sounding report detector (DEVOURER_BF_DETECT_REPORT modes 1-4) —
+   * shared with WiFiDriverTxDemo's single-radio capture, see BfReportDetect.h. */
+  devourer::bf::detect_report(packet);
 
   /* TX-validation hook: detect frames whose SA matches the txdemo's hardcoded
    * injected beacon (57:42:75:05:d6:00). When running this RX demo against

--- a/docs/beamforming-self-sounding.md
+++ b/docs/beamforming-self-sounding.md
@@ -68,6 +68,24 @@ DEVOURER_PID=0x8812 DEVOURER_CHANNEL=100 DEVOURER_TX_RATE=VHT2SS_MCS0 \
 # monitor mode is promiscuous). Mode 4 dumps full frames for the decoder.
 DEVOURER_PID=0x8813 DEVOURER_CHANNEL=100 DEVOURER_BF_DETECT_REPORT=4 \
   WiFiDriverDemo | tools/bf_report_decode.py
+
+# single-radio beamformer (Jaguar-1): the report is addressed TO the sounder,
+# so one adapter can sound and capture its own reports —
+# DEVOURER_TX_WITH_RX=thread runs the RX worker loop on a thread next to the
+# TX loop (one bring-up, one claimed handle; see StartRxLoop in IRtlDevice).
+# Hardware-validated on the 8814AU (thousands of self-captured reports); on a
+# Jaguar-3 sounder the NDPA+NDP+report exchange works but the sounder's own RX
+# does not surface the reports — use a second capture radio there.
+DEVOURER_PID=0x8812 DEVOURER_CHANNEL=100 DEVOURER_TX_RATE=VHT2SS_MCS0 \
+  DEVOURER_TX_NDPA_RA=<beamformee-mac> DEVOURER_TX_NDPA=1 \
+  DEVOURER_BF_ARM_SOUNDER=1 DEVOURER_TX_WITH_RX=thread \
+  DEVOURER_BF_DETECT_REPORT=4 WiFiDriverTxDemo | tools/bf_report_decode.py
+
+# Jaguar-3 sounder (NDPA descriptor mark + MAC sounding-engine arm;
+# DEVOURER_BF_ARM_SOUNDER also takes the sounder MAC to program 0x610):
+DEVOURER_PID=0xc812 DEVOURER_CHANNEL=100 DEVOURER_TX_RATE=VHT2SS_MCS0 \
+  DEVOURER_TX_NDPA_RA=<beamformee-mac> DEVOURER_TX_NDPA=1 \
+  DEVOURER_BF_ARM_SOUNDER=57:42:75:05:d6:00 WiFiDriverTxDemo
 ```
 
 Gotchas that cost time during bring-up:

--- a/src/BeamformingSounder.h
+++ b/src/BeamformingSounder.h
@@ -88,11 +88,13 @@ constexpr BfeeConfig kBfeeJaguar23{
     /*csi_content_reg*/ 0, /*csi_content_val*/ 0,
     /*set_our_aid*/ true, /*set_rxflt*/ true};
 
-/* Beamformer side (fully shared): arm the MAC sounding engine so a
+/* Beamformer side (shared): arm the MAC sounding engine so a
  * TX-descriptor-marked NDPA is followed by a hardware-generated NDP.
- * Beamformee entry 0, P_AID = 0 (unassociated). */
-inline void arm_sounder(RtlUsbAdapter& dev) {
-  dev.rtw_write8(kSndPtclCtrl, 0xCB);
+ * Beamformee entry 0, P_AID = 0 (unassociated). The one per-generation byte is
+ * the sounding-protocol control (0x718): 0xCB on Jaguar-1
+ * (hal_txbf_jaguar_enter), 0xDB on Jaguar-2/3 (hal_txbf_8822b_enter). */
+inline void arm_sounder(RtlUsbAdapter& dev, uint8_t snd_ptcl_ctrl = 0xCB) {
+  dev.rtw_write8(kSndPtclCtrl, snd_ptcl_ctrl);
   dev.rtw_write8(kSndNdpStandby, 0x50);
   dev.rtw_write16(kTxbfCtrl, 0x0000);                 /* P_AID = 0 */
   uint8_t v = dev.rtw_read8(kTxbfCtrl + 3);

--- a/src/BfReportDetect.h
+++ b/src/BfReportDetect.h
@@ -1,0 +1,76 @@
+/* BfReportDetect — console detector for beamforming self-sounding reports,
+ * shared by WiFiDriverDemo (2-adapter rig: separate capture radio) and
+ * WiFiDriverTxDemo (single-radio: the sounder captures its own reports via
+ * StartRxLoop). Header-only so the demos stay identical consumers.
+ *
+ * A VHT/HT Compressed Beamforming report is a management Action frame —
+ * subtype 0xD0 (Action) or 0xE0 (Action No-Ack; CSI reports are sent No-Ack)
+ * — whose body begins with a category + action of VHT cat 0x15 act 0x00, or
+ * HT cat 0x07 act 0x00. When an armed beamformee replies to our NDPA+NDP the
+ * report's SA is the beamformee MAC, the decode-level confirmation the
+ * unassociated responder produced CSI.
+ *
+ * DEVOURER_BF_DETECT_REPORT modes:
+ *   1  <devourer-bf-report> summary (Nc/Nr/BW/Ng, SA) per report
+ *   2  <devourer-bf-any> FC/category of EVERY frame (subtype survey)
+ *   3  mode 1 + capped CSI-payload hexdump (first frames)
+ *   4  mode 1 + <devourer-bf-report-raw> full frame hex (for the decoder,
+ *      tools/bf_report_decode.py) */
+#ifndef BF_REPORT_DETECT_H
+#define BF_REPORT_DETECT_H
+
+#include <cstdio>
+#include <cstdlib>
+
+#include "RxPacket.h"
+
+namespace devourer::bf {
+
+inline void detect_report(const Packet &packet) {
+  const char *mode_s = std::getenv("DEVOURER_BF_DETECT_REPORT");
+  if (!mode_s || packet.Data.size() < 27)
+    return;
+  const char mode = mode_s[0];
+  const uint8_t *d = packet.Data.data();
+  const uint8_t cat = d[24], act = d[25];
+  const bool vht = (cat == 0x15 && act == 0x00);
+  const bool ht = (cat == 0x07 && act == 0x00);
+  if (mode == '2') {
+    static int any = 0;
+    if (++any <= 4000)
+      printf("<devourer-bf-any>fc=%02x%02x cat=%02x act=%02x crc=%u "
+             "len=%zu\n", d[0], d[1], cat, act,
+             packet.RxAtrib.crc_err ? 1u : 0u, packet.Data.size());
+  }
+  const uint8_t sub = d[0] & 0xF0;
+  if ((sub == 0xD0 || sub == 0xE0) && (vht || ht)) {
+    static int rpt = 0;
+    ++rpt;
+    const uint8_t *mc = d + 26; /* VHT MIMO control field */
+    unsigned nc = (mc[0] & 0x07) + 1, nr = ((mc[0] >> 3) & 0x07) + 1;
+    unsigned chw = (mc[0] >> 6) & 0x03, ng = mc[1] & 0x03;
+    printf("<devourer-bf-report>%s n=%d sa=%02x:%02x:%02x:%02x:%02x:%02x "
+           "Nc=%u Nr=%u BW=%u Ng=%u len=%zu\n",
+           vht ? "VHT" : "HT", rpt, d[10], d[11], d[12], d[13], d[14],
+           d[15], nc, nr, chw, ng, packet.Data.size());
+    if (mode == '3' && rpt <= 6) {
+      size_t off = 26 + 3; /* hdr(24)+cat+act+mimoctrl(3) */
+      size_t end = packet.Data.size() >= 4 ? packet.Data.size() - 4 : off;
+      printf("  csi[%zu]:", end - off);
+      for (size_t i = off; i < end && i < off + 40; ++i)
+        printf(" %02x", d[i]);
+      printf("\n");
+    }
+    if (mode == '4' && rpt <= 200) {
+      printf("<devourer-bf-report-raw>");
+      for (size_t i = 0; i < packet.Data.size(); ++i)
+        printf("%02x", d[i]);
+      printf("\n");
+    }
+    fflush(stdout);
+  }
+}
+
+} // namespace devourer::bf
+
+#endif /* BF_REPORT_DETECT_H */

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -16,8 +16,9 @@ struct Packet;
 using Action_ParsedRadioPacket = std::function<void(const Packet &)>;
 
 /* IRtlDevice is the chip-family-agnostic device contract used by the demos and
- * the WiFiDriver factory. Two implementations exist:
+ * the WiFiDriver factory. Three implementations exist:
  *   - RtlJaguarDevice   — Realtek "Jaguar" wave-1 (8812AU/8811AU/8821AU/8814AU)
+ *   - RtlJaguar2Device  — Realtek "Jaguar2" (8822BU/8812BU)
  *   - RtlJaguar3Device  — Realtek "Jaguar3" (8822CU/8812EU/8822EU)
  *
  * Chip-family-specific research helpers (BB-debug-port reads, the 8814 queue
@@ -30,6 +31,19 @@ public:
   virtual void Init(Action_ParsedRadioPacket packetProcessor,
                     SelectedChannel channel) = 0;
   virtual void InitWrite(SelectedChannel channel) = 0;
+
+  /* Blocking RX worker loop. Assumes the chip is already brought up (a prior
+   * Init or InitWrite on this device) — performs NO bring-up, channel set, or
+   * beamforming arming. Runs on the CALLER's thread and returns once
+   * StopRxLoop() is called or the global stop flag is set; it is restartable
+   * after it returns. This is the piece that lets one process bring up once
+   * (InitWrite) and then run TX and RX concurrently on the same claimed handle
+   * — Init is the RX-only convenience wrapper (bring-up + StartRxLoop). */
+  virtual void StartRxLoop(Action_ParsedRadioPacket packetProcessor) = 0;
+
+  /* Ask a running StartRxLoop to exit (sets a flag; the caller then joins
+   * whatever thread runs StartRxLoop). Default no-op. */
+  virtual void StopRxLoop() {}
   virtual void SetMonitorChannel(SelectedChannel channel) = 0;
   virtual void SetTxPower(uint8_t power) = 0;
   virtual bool send_packet(const uint8_t *packet, size_t length) = 0;

--- a/src/RtlUsbAdapter.cpp
+++ b/src/RtlUsbAdapter.cpp
@@ -19,15 +19,15 @@ namespace {
 /* Shared state for the async RX URB queue. */
 struct AsyncRxShared {
   const std::function<void(const uint8_t *, int)> *cb;
-  const volatile bool *stop;
+  const std::function<bool()> *stop;
   int active;
 };
 extern "C" void LIBUSB_CALL devourer_rx_cb(libusb_transfer *t) {
   auto *s = static_cast<AsyncRxShared *>(t->user_data);
   if (t->status == LIBUSB_TRANSFER_COMPLETED && t->actual_length > 0)
     (*s->cb)(t->buffer, t->actual_length);
-  bool resubmit = !*s->stop && (t->status == LIBUSB_TRANSFER_COMPLETED ||
-                                t->status == LIBUSB_TRANSFER_TIMED_OUT);
+  bool resubmit = !(*s->stop)() && (t->status == LIBUSB_TRANSFER_COMPLETED ||
+                                    t->status == LIBUSB_TRANSFER_TIMED_OUT);
   if (resubmit && libusb_submit_transfer(t) == 0)
     return;
   s->active--; /* not resubmitted -> this URB is done */
@@ -37,8 +37,8 @@ extern "C" void LIBUSB_CALL devourer_rx_cb(libusb_transfer *t) {
 void RtlUsbAdapter::bulk_read_async_loop(
     int buf_size, int n_urbs,
     const std::function<void(const uint8_t *, int)> &on_data,
-    const volatile bool &stop) {
-  AsyncRxShared sh{&on_data, &stop, 0};
+    const std::function<bool()> &should_stop) {
+  AsyncRxShared sh{&on_data, &should_stop, 0};
   std::vector<libusb_transfer *> xfers;
   std::vector<std::vector<uint8_t>> bufs(n_urbs,
                                          std::vector<uint8_t>(buf_size));
@@ -54,7 +54,7 @@ void RtlUsbAdapter::bulk_read_async_loop(
     }
   }
   _logger->info("Jaguar3 RX: async queue of {} URBs submitted", sh.active);
-  while (!stop && sh.active > 0) {
+  while (!should_stop() && sh.active > 0) {
     struct timeval tv {0, 100000};
     libusb_handle_events_timeout_completed(_ctx, &tv, nullptr);
   }

--- a/src/RtlUsbAdapter.h
+++ b/src/RtlUsbAdapter.h
@@ -66,7 +66,14 @@ public:
    * Requires the libusb context the handle belongs to (passed at construction). */
   void bulk_read_async_loop(int buf_size, int n_urbs,
                             const std::function<void(const uint8_t *, int)> &on_data,
-                            const volatile bool &stop);
+                            const std::function<bool()> &should_stop);
+  /* Convenience overload for callers whose stop condition is a single flag. */
+  void bulk_read_async_loop(int buf_size, int n_urbs,
+                            const std::function<void(const uint8_t *, int)> &on_data,
+                            const volatile bool &stop) {
+    bulk_read_async_loop(buf_size, n_urbs, on_data,
+                         [&stop]() -> bool { return stop; });
+  }
 
   uint16_t idVendor() const { return _idVendor; }
   uint16_t idProduct() const { return _idProduct; }

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -426,8 +426,6 @@ std::vector<Packet> RtlJaguarDevice::read_frames() {
 
 void RtlJaguarDevice::Init(Action_ParsedRadioPacket packetProcessor,
                           SelectedChannel channel) {
-  _packetProcessor = packetProcessor;
-
   StartWithMonitorMode(channel);
   SetMonitorChannel(channel);
 
@@ -448,6 +446,14 @@ void RtlJaguarDevice::Init(Action_ParsedRadioPacket packetProcessor,
       _logger->error("DEVOURER_BF_ARM_BFEE — bad MAC '{}'", bfer);
     }
   }
+
+  StartRxLoop(std::move(packetProcessor));
+}
+
+void RtlJaguarDevice::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
+  _packetProcessor = std::move(packetProcessor);
+  /* Restartable: clear any stop request left by a prior StopRxLoop(). */
+  should_stop = false;
 
   /* DEVOURER_RX_PATHS=0xNN restricts which RX chains the chip enables/combines,
    * by masking the RX-path-enable register (0x808 byte 0: bits 0/4 = path A

--- a/src/jaguar1/RtlJaguarDevice.h
+++ b/src/jaguar1/RtlJaguarDevice.h
@@ -54,6 +54,11 @@ public:
   ~RtlJaguarDevice() override;
   void Init(Action_ParsedRadioPacket packetProcessor,
             SelectedChannel channel) override;
+  /* Blocking RX worker loop on an already-brought-up chip (see IRtlDevice).
+   * Init = bring-up + BFEE arm + StartRxLoop; a TX+RX caller does InitWrite
+   * once, then runs this on its own std::thread next to the TX loop. */
+  void StartRxLoop(Action_ParsedRadioPacket packetProcessor) override;
+  void StopRxLoop() override { should_stop = true; }
   void SetMonitorChannel(SelectedChannel channel) override;
   /* Lean frequency-hop retune: switches the RF channel only, skipping the
    * per-rate TX-power loop, bandwidth post-set, and thermal pwrtrk tick that

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -109,7 +109,6 @@ void RtlJaguar2Device::bring_up(SelectedChannel channel) {
 
 void RtlJaguar2Device::Init(Action_ParsedRadioPacket packetProcessor,
                             SelectedChannel channel) {
-  _packetProcessor = std::move(packetProcessor);
   _channel = channel;
   bring_up(channel);
 
@@ -128,6 +127,14 @@ void RtlJaguar2Device::Init(Action_ParsedRadioPacket packetProcessor,
       _logger->info("RFDUMP 0x{:02x} A=0x{:05x} B=0x{:05x}", r,
                     _hal.dbg_rf_read(0, r), _hal.dbg_rf_read(1, r));
   }
+
+  StartRxLoop(std::move(packetProcessor));
+}
+
+void RtlJaguar2Device::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
+  _packetProcessor = std::move(packetProcessor);
+  /* Restartable: clear any stop request left by a prior StopRxLoop(). */
+  _rx_stop = false;
   /* Start the DIG thread: track IGI to the false-alarm rate so weak signals are
    * caught without an FA storm (a fixed IGI can't span the range). */
   _dig_stop = false;
@@ -141,7 +148,7 @@ void RtlJaguar2Device::Init(Action_ParsedRadioPacket packetProcessor,
     _logger->info("RtlJaguar2Device: DIG thread started");
   }
 
-  _logger->info("RtlJaguar2Device: entering RX loop (ch={})", channel.Channel);
+  _logger->info("RtlJaguar2Device: entering RX loop (ch={})", _channel.Channel);
 
   /* RX loop: async bulk-IN URB queue; walk the aggregated 8822B RX descriptors
    * per completion and hand each PSDU to the packet processor. */
@@ -173,7 +180,9 @@ void RtlJaguar2Device::Init(Action_ParsedRadioPacket packetProcessor,
       off += f.next_offset;
     }
   };
-  _device.bulk_read_async_loop(32 * 1024, 8, on_data, g_devourer_should_stop);
+  _device.bulk_read_async_loop(32 * 1024, 8, on_data, [this]() -> bool {
+    return _rx_stop || g_devourer_should_stop;
+  });
   stop_dig();
   _logger->info("RtlJaguar2Device: RX loop exited ({} frames, {} reads)", frames,
                 reads);

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -36,6 +36,12 @@ public:
 
   void Init(Action_ParsedRadioPacket packetProcessor,
             SelectedChannel channel) override;
+  /* Blocking RX worker loop on an already-brought-up chip (see IRtlDevice).
+   * Init = bring_up + StartRxLoop; a TX+RX caller does InitWrite once, then
+   * runs this on its own std::thread next to the TX loop. Starts (and on exit
+   * stops) the DIG thread — TX-only sessions stay DIG-free. */
+  void StartRxLoop(Action_ParsedRadioPacket packetProcessor) override;
+  void StopRxLoop() override { _rx_stop = true; }
   void SetMonitorChannel(SelectedChannel channel) override;
   void InitWrite(SelectedChannel channel) override;
   void SetTxPower(uint8_t power) override;
@@ -61,6 +67,10 @@ private:
   std::thread _dig_thread;
   std::atomic<bool> _dig_stop{false};
   void stop_dig();
+
+  /* StartRxLoop stop request (StopRxLoop). volatile (not atomic) to match the
+   * signal-flag pattern used across the library (g_devourer_should_stop). */
+  volatile bool _rx_stop = false;
 
   /* Shared cold bring-up (power-on -> DLFW -> MAC/BB/RF -> channel -> LCK ->
    * IQK -> coex -> enable RX/TX engine). Used by both Init (RX) and InitWrite

--- a/src/jaguar3/FrameParserJaguar3.h
+++ b/src/jaguar3/FrameParserJaguar3.h
@@ -39,6 +39,8 @@ constexpr size_t RXDESC_SIZE_8822C = 24; /* RX_DESC_SIZE_88XX */
 #define SET_TX_DESC_PKT_OFFSET_8822C(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x04, 24, 5, v)
 #define SET_TX_DESC_USE_RATE_8822C(d, v)   SET_BITS_TO_LE_4BYTE((d) + 0x0C, 8, 1, v)
 #define SET_TX_DESC_DISDATAFB_8822C(d, v)  SET_BITS_TO_LE_4BYTE((d) + 0x0C, 10, 1, v)
+#define SET_TX_DESC_NAVUSEHDR_8822C(d, v)  SET_BITS_TO_LE_4BYTE((d) + 0x0C, 15, 1, v)
+#define SET_TX_DESC_NDPA_8822C(d, v)       SET_BITS_TO_LE_4BYTE((d) + 0x0C, 22, 2, v)
 #define SET_TX_DESC_DATARATE_8822C(d, v)   SET_BITS_TO_LE_4BYTE((d) + 0x10, 0, 7, v)
 #define SET_TX_DESC_DATA_SHORT_8822C(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x14, 4, 1, v)
 #define SET_TX_DESC_DATA_BW_8822C(d, v)    SET_BITS_TO_LE_4BYTE((d) + 0x14, 5, 2, v)
@@ -92,7 +94,7 @@ inline void cal_txdesc_chksum_8822c(uint8_t *txdesc) {
 inline void fill_data_tx_desc_8822c(uint8_t *d, uint16_t pkt_size,
                                     uint8_t rate_hw, uint8_t rate_id, uint8_t bw,
                                     bool short_gi, bool ldpc, uint8_t stbc,
-                                    bool bmc = false) {
+                                    bool bmc = false, bool ndpa = false) {
   SET_TX_DESC_TXPKTSIZE_8822C(d, pkt_size);
   SET_TX_DESC_OFFSET_8822C(d, static_cast<uint32_t>(TXDESC_SIZE_8822C));
   SET_TX_DESC_LS_8822C(d, 1);
@@ -122,6 +124,18 @@ inline void fill_data_tx_desc_8822c(uint8_t *d, uint16_t pkt_size,
   SET_TX_DESC_DATA_LDPC_8822C(d, ldpc ? 1 : 0);
   SET_TX_DESC_DATA_STBC_8822C(d, stbc & 0x3);
   SET_TX_DESC_EN_HWSEQ_8822C(d, 1);
+  /* Beamforming self-sounding: mark the frame as an NDPA (halmac NDPA field,
+   * dword3 [23:22] = 1) so the armed MAC sounding engine follows it with a
+   * hardware-generated NDP — the Jaguar-3 mirror of the Jaguar-1
+   * SET_TX_DESC_NDPA_8812 recipe: unicast control frame, so no HW sequence
+   * stamp, not broadcast, use-header NAV, no rate fallback. */
+  if (ndpa) {
+    SET_TX_DESC_NDPA_8822C(d, 1);
+    SET_TX_DESC_EN_HWSEQ_8822C(d, 0);
+    SET_TX_DESC_BMC_8822C(d, 0);
+    SET_TX_DESC_NAVUSEHDR_8822C(d, 1);
+    SET_TX_DESC_DISDATAFB_8822C(d, 1);
+  }
   cal_txdesc_chksum_8822c(d);
 }
 

--- a/src/jaguar3/HalJaguar3.cpp
+++ b/src/jaguar3/HalJaguar3.cpp
@@ -342,6 +342,60 @@ void HalJaguar3::bf_init() {
   _logger->info("Jaguar3: bf_init (NDPA/MU TX setup) applied");
 }
 
+/* Port of phydm_txbf_rfmode (phydm_hal_txbf_api.c), su_bfee_cnt > 0 branch —
+ * the beamformer-side RF/BB sounding config. The RF mode-table entries make
+ * the RF front-end able to transmit while the mode table says "RX" (the NDP
+ * goes out SIFS after the NDPA, while the chip is turning to receive the
+ * report); the BB writes enable the TxBF antenna mapping so the 2-antenna NDP
+ * is emitted on both paths. RF registers are written through the direct
+ * per-path BB window (0x3c00/0x4c00 + (addr<<2), 20-bit), the same mechanism
+ * as the RF table load and the halrf calibration code. All masks are
+ * contiguous, so phy_set_bb_reg's field-value semantics match the vendor
+ * odm_set_rf_reg. */
+void HalJaguar3::txbf_rfmode_sounder() {
+  auto rf = [this](int path, uint16_t addr, uint32_t mask, uint32_t val) {
+    uint16_t direct = static_cast<uint16_t>((path ? 0x4c00 : 0x3c00) +
+                                            ((addr & 0xff) << 2));
+    _device.phy_set_bb_reg(direct, mask & 0xfffff, val);
+  };
+  if (_variant == jaguar3::ChipVariant::C8822C) {
+    /* Path A: RX-mode table entry with TX IQ generator on */
+    rf(0, 0xef, 1u << 19, 1);      /* mode-table write enable */
+    rf(0, 0x33, 0xF, 3);           /* select RX mode entry */
+    rf(0, 0x3e, 0x3, 0x2);
+    rf(0, 0x3f, 0xfffff, 0x65AFF);
+    rf(0, 0xef, 1u << 19, 0);
+    /* Path B: RX-mode + standby-mode entries */
+    rf(1, 0xef, 1u << 19, 1);
+    rf(1, 0x33, 0xF, 3);
+    rf(1, 0x3f, 0xfffff, 0x996BF);
+    rf(1, 0x33, 0xF, 1);           /* select standby entry */
+    rf(1, 0x3f, 0xfffff, 0x99230);
+    rf(1, 0xef, 1u << 19, 0);
+  } else { /* C8822E */
+    rf(0, 0xef, 1u << 19, 1);
+    rf(0, 0x33, 0xF, 3);
+    rf(0, 0x3e, 0xF, 0x4);
+    rf(0, 0x3f, 0xfffff, 0xc1aff);
+    rf(0, 0xef, 1u << 19, 0);
+    rf(1, 0xef, 1u << 19, 1);
+    rf(1, 0x33, 0xF, 3);
+    rf(1, 0x3e, 0xF, 0x1);
+    rf(1, 0x3f, 0xfffff, 0x306bf);
+    rf(1, 0xef, 1u << 19, 0);
+  }
+  /* BB TxBF antenna mapping (same on both variants). */
+  _device.phy_set_bb_reg(0x1e24, 1u << 11, 1); /* Nsts > Nc: no V matrix */
+  _device.phy_set_bb_reg(0x1e24, (1u << 28) | (1u << 29), 0x2);
+  _device.phy_set_bb_reg(0x1e24, 1u << 30, 1);
+  /* TX BF logic map + TX path enable for Nsts 1..2 */
+  _device.phy_set_bb_reg(0x0820, 0xff, 0x33);
+  _device.phy_set_bb_reg(0x1e2c, 0xffff, 0x404);
+  _device.phy_set_bb_reg(0x0820, 0xffff0000, 0x33);
+  _device.phy_set_bb_reg(0x1e30, 0xffff, 0x404);
+  _logger->info("Jaguar3: txbf rf-mode (beamformer sounding RF/BB) applied");
+}
+
 /* Clean de-init — the counterpart to rtw_hal_init, run on shutdown. The kernel
  * rtw88 driver does this on unbind and the adapter always re-enumerates cleanly
  * afterwards; devourer skipping it is what left the chip hung (RX DMA running,

--- a/src/jaguar3/HalJaguar3.h
+++ b/src/jaguar3/HalJaguar3.h
@@ -90,6 +90,13 @@ public:
    * set (the 3-wire RX-mode command must follow the channel config). */
   void enable_rx_path();
 
+  /* Beamformer-side sounding RF/BB config (port of phydm_txbf_rfmode, the
+   * su_bfee_cnt > 0 branch): RF mode-table entries + the BB TxBF antenna
+   * mapping (0x1e24/0x820/0x1e2c/0x1e30) the chip needs to emit the hardware
+   * NDP that follows a descriptor-marked NDPA. Per-variant RF values (8822C vs
+   * 8822E). Call when arming the self-sounding beamformer, after bring-up. */
+  void txbf_rfmode_sounder();
+
   /* Configure the 8822E RFE control pins (port of phydm_rfe_8822e). These drive
    * the external antenna-switch / PAPE (PA enable) GPIOs and are only set for
    * rfe_type 21..24; without them the TX PA is not enabled (TX dark) even when

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -37,7 +37,6 @@ RtlJaguar3Device::RtlJaguar3Device(RtlUsbAdapter device, Logger_t logger,
 
 void RtlJaguar3Device::Init(Action_ParsedRadioPacket packetProcessor,
                             SelectedChannel channel) {
-  _packetProcessor = std::move(packetProcessor);
   _channel = channel;
   _hal.rtw_hal_init(channel);  /* full vendor-source bring-up */
   /* Tune the channel/bandwidth (5/10 MHz ChannelWidth re-clocks to narrowband),
@@ -87,6 +86,50 @@ void RtlJaguar3Device::Init(Action_ParsedRadioPacket packetProcessor,
     }
   }
 
+  StartRxLoop(std::move(packetProcessor));
+}
+
+void RtlJaguar3Device::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
+  _packetProcessor = std::move(packetProcessor);
+  /* Restartable: clear any stop request left by a prior StopRxLoop(). */
+  _rx_stop = false;
+  /* Take over bulk-IN from the coex thread's C2H drain up front — also during
+   * the register restore below, so its 200 ms bulk reads don't interleave with
+   * the RX-path enable sequence. */
+  _rx_loop_active = true;
+
+  /* An InitWrite bring-up is TX-oriented: it closed the RX filters
+   * (0x6A0-0x6A4, so a TX-only session's unread frames can't fill the on-chip
+   * RX FIFO) and never ran enable_rx_path (the 3-wire IGI toggle that puts the
+   * RF into RX mode — without it the chip delivers zero frames). This caller
+   * wants RX, so restore the monitor_rx_cfg accept-all filters and enable the
+   * RX path. Serialized against the coex housekeeping tick, the only other
+   * register writer right now. */
+  if (_rx_filters_closed) {
+    /* A register read can transiently fail right after InitWrite (the FW is
+     * still settling from the coex H2C burst) — give it a beat and retry a few
+     * times instead of letting the exception tear down the caller's RX
+     * thread. */
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    for (int attempt = 0; attempt < 5; ++attempt) {
+      try {
+        std::lock_guard<std::mutex> lk(_reg_mu);
+        _device.rtw_write<uint16_t>(0x06A0, 0xFFFF);
+        _device.rtw_write<uint16_t>(0x06A2, 0xFFFF);
+        _device.rtw_write<uint16_t>(0x06A4, 0xFFFF);
+        _hal.enable_rx_path();
+        _rx_filters_closed = false;
+        _logger->info("Jaguar3: RX filters re-opened + RX path enabled for "
+                      "concurrent TX+RX");
+        break;
+      } catch (const std::exception &e) {
+        _logger->error("Jaguar3: RX-path restore failed ({}){}", e.what(),
+                       attempt < 4 ? " — retrying" : " — giving up");
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+      }
+    }
+  }
+
   _logger->info("Jaguar3: entering RX loop (kernel-style async URB queue)");
   uint64_t frames = 0, reads = 0;
   /* Process one bulk-IN completion: walk the aggregated 8822C RX descriptors. */
@@ -106,7 +149,13 @@ void RtlJaguar3Device::Init(Action_ParsedRadioPacket packetProcessor,
         p.RxAtrib.data_rate = f.rx_rate;
         p.RxAtrib.drvinfo_sz = static_cast<uint8_t>(f.drvinfo_size);
         p.RxAtrib.shift_sz = f.shift;
-        p.RxAtrib.pkt_rpt_type = RX_PACKET_TYPE::NORMAL_RX;
+        /* RX desc word2 BIT(28) = FW C2H report, not an 802.11 frame. During
+         * concurrent TX+RX the FW emits one small C2H per TX, so tag them for
+         * the packetProcessor (which skips C2H) instead of surfacing a flood
+         * of short "frames". Same check the coex drain uses. */
+        p.RxAtrib.pkt_rpt_type = (data[off + 11] & 0x10)
+                                     ? RX_PACKET_TYPE::C2H_PACKET
+                                     : RX_PACKET_TYPE::NORMAL_RX;
         p.Data = std::span<uint8_t>(const_cast<uint8_t *>(f.frame), f.frame_len);
         _packetProcessor(p);
       }
@@ -118,7 +167,13 @@ void RtlJaguar3Device::Init(Action_ParsedRadioPacket packetProcessor,
       off += f.next_offset;
     }
   };
-  _device.bulk_read_async_loop(32 * 1024, 8, on_data, g_devourer_should_stop);
+  /* _rx_loop_active was set on entry (bulk-IN handover from the coex thread's
+   * C2H drain — its one in-flight 200 ms bulk_read_raw may steal at most one
+   * completion, harmless). Give the endpoint back on exit. */
+  _device.bulk_read_async_loop(32 * 1024, 8, on_data, [this]() -> bool {
+    return _rx_stop || g_devourer_should_stop;
+  });
+  _rx_loop_active = false;
 }
 
 /* Coex runtime (port of the rtw88 watchdog's coex path): drain the firmware's
@@ -143,18 +198,26 @@ void RtlJaguar3Device::coex_runtime_loop() {
   auto next_tick = std::chrono::steady_clock::now();
   const auto period = std::chrono::seconds(2);
   while (!_coex_stop && !g_devourer_should_stop) {
-    /* Drain bulk-IN (empties the FW C2H buffer). 200 ms timeout bounds shutdown
-     * latency when the pipe is idle. */
-    int n = _device.bulk_read_raw(buf.data(), static_cast<int>(buf.size()), 200);
-    if (n >= static_cast<int>(jaguar3::RXDESC_SIZE_8822C)) {
-      ++rx;
-      if (buf[11] & 0x10) /* RX desc word2 BIT(28) = C2H report */
-        ++c2h;
+    if (!_rx_loop_active.load()) {
+      /* Drain bulk-IN (empties the FW C2H buffer). 200 ms timeout bounds
+       * shutdown latency when the pipe is idle. */
+      int n =
+          _device.bulk_read_raw(buf.data(), static_cast<int>(buf.size()), 200);
+      if (n >= static_cast<int>(jaguar3::RXDESC_SIZE_8822C)) {
+        ++rx;
+        if (buf[11] & 0x10) /* RX desc word2 BIT(28) = C2H report */
+          ++c2h;
+      }
+    } else {
+      /* StartRxLoop owns bulk-IN — its async URB queue sees the C2H reports
+       * as part of the RX stream. Keep the loop pacing without reading. */
+      std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
     if (std::chrono::steady_clock::now() < next_tick)
       continue;
     next_tick += period;
     try {
+      std::lock_guard<std::mutex> lk(_reg_mu);
       _hal.coex_run_5g();
       _hal.pwr_track(); /* thermal TX-power compensation (sustains upper 5 GHz) */
       _hal.fw_update_wl_phy_info();
@@ -182,14 +245,36 @@ void RtlJaguar3Device::Stop() {
 
 void RtlJaguar3Device::InitWrite(SelectedChannel channel) {
   _channel = channel;
+  /* Concurrent TX+RX intent (DEVOURER_TX_WITH_RX / a later StartRxLoop on this
+   * bring-up): enable the RX path at the same point in the sequence Init does
+   * and keep the RX filters open. Retrofitting RX state after the TX-oriented
+   * bring-up completes is not reliable (validated on 8822EU: enable_rx_path
+   * after the coex/FW steps leaves the RX path dead, and the register RMWs
+   * race the running TX). */
+  const bool want_rx = std::getenv("DEVOURER_TX_WITH_RX") != nullptr;
   _hal.rtw_hal_init(channel);  /* full vendor-source bring-up */
   _radioManagement.set_channel_bwmode(channel.Channel, channel.ChannelOffset,
                                       channel.ChannelWidth);
   _hal.run_iqk(channel);
-  _hal.dpk_force_bypass_8822e(); /* 8822e rfe 21/22: kernel bypasses DPK (after IQK) */
+  if (want_rx)
+    _hal.enable_rx_path(); /* RF into RX mode — same slot as the Init path */
+  /* 8822e DPK force-bypass + per-rate TXAGC (below) each DESENSE the EU's RX
+   * to near-deaf when applied on a bring-up that also runs the RX path (bisected
+   * on hardware: either alone kills RX; skipping both restores it; a later
+   * enable_rx_path does not recover). In TX+RX mode trade them away: TX runs at
+   * the flat table power (no per-rate spread, no DPK-LUT bypass state), RX
+   * works. TX-only behavior is unchanged. Root cause is an open question —
+   * suspect the RMW reads of the live 0x18e8/0x1b00 blocks folding HW-status
+   * bits back into config. */
+  if (!want_rx)
+    _hal.dpk_force_bypass_8822e(); /* 8822e rfe 21/22: kernel bypasses DPK (after IQK) */
   _hal.config_rfe(channel.Channel); /* 8822e RFE/PAPE antenna-switch pins (PA enable) */
   _hal.config_channel_8822e(channel.Channel); /* 8822e band TX scaling/backoff + shaping */
-  if (_tx_pwr_override >= 0) {
+  if (want_rx && _variant == jaguar3::ChipVariant::C8822E) {
+    /* See the DPK note above — the EU's TXAGC ref/diff writes desense RX. */
+    _logger->info("Jaguar3(8822e): TX+RX mode — flat table TX power "
+                  "(per-rate TXAGC skipped, keeps RX alive)");
+  } else if (_tx_pwr_override >= 0) {
     _radioManagement.set_tx_power_ref(static_cast<uint8_t>(_tx_pwr_override));
   } else if (_variant == jaguar3::ChipVariant::C8822E) {
     /* Default TX power (8822e). The TXAGC reference base is the per-channel 5 GHz
@@ -239,13 +324,41 @@ void RtlJaguar3Device::InitWrite(SelectedChannel channel) {
   _hal.fw_set_pwr_mode_active(); /* keep all FW power domains on (no auto-PS) */
   _hal.fw_coex_query_bt_info();  /* make the FW confirm BT is absent */
   _hal.fw_coex_tdma_off();       /* disable coex time-division (WL keeps antenna) */
-  /* TX-only: the bring-up enables accept-all RX (monitor_rx_cfg), but the TX path
-   * never reads bulk-IN — so on a trafficked channel the on-chip RX FIFO fills
-   * with unread frames and throttles TX. Close the RX filter so no over-the-air
-   * frames are buffered (the coex thread still receives FW C2H reports). */
-  _device.rtw_write<uint16_t>(0x06A0, 0x0000);
-  _device.rtw_write<uint16_t>(0x06A2, 0x0000);
-  _device.rtw_write<uint16_t>(0x06A4, 0x0000);
+  /* DEVOURER_BF_ARM_SOUNDER=1 — beamforming self-sounding probe (beamformer
+   * side): arm the MAC's hardware sounding engine so a TX-descriptor-marked
+   * NDPA (DEVOURER_TX_NDPA=1) is followed by a hardware-generated NDP. The MAC
+   * sounding registers are family-neutral (BeamformingSounder.h); the Jaguar-3
+   * sounding-protocol control byte is 0xDB (hal_txbf_8822b_enter, shared
+   * 8822B/C/E) where Jaguar-1 uses 0xCB. */
+  if (const char *snd = std::getenv("DEVOURER_BF_ARM_SOUNDER")) {
+    /* Jaguar-3 bring-up never programs the self-MAC (0x0610); the sounding
+     * engine matches the injected NDPA's TA against it before firing the NDP.
+     * DEVOURER_BF_ARM_SOUNDER=aa:bb:cc:dd:ee:ff programs that MAC (use the
+     * NDPA TA the caller injects — the txdemo's canonical SA); a bare "1"
+     * leaves it unprogrammed (Jaguar-1 semantics). */
+    unsigned m[6];
+    if (std::sscanf(snd, "%x:%x:%x:%x:%x:%x", &m[0], &m[1], &m[2], &m[3],
+                    &m[4], &m[5]) == 6) {
+      for (uint16_t i = 0; i < 6; ++i)
+        _device.rtw_write8(0x0610 + i, static_cast<uint8_t>(m[i]));
+      _logger->info("Jaguar3 BF sounder: self-MAC programmed to {}", snd);
+    }
+    _hal.txbf_rfmode_sounder(); /* RF/BB sounding config — needed for the NDP */
+    devourer::bf::arm_sounder(_device, /*snd_ptcl_ctrl=*/0xDB);
+    _logger->info("Jaguar3 BF sounder armed (beamformer side)");
+  }
+  /* TX-only: the bring-up enables accept-all RX (monitor_rx_cfg), but the TX
+   * path never reads bulk-IN — so on a trafficked channel the on-chip RX FIFO
+   * fills with unread frames and throttles TX. Close the RX filter so no
+   * over-the-air frames are buffered (the coex thread still receives FW C2H
+   * reports). Skipped when the caller wants concurrent RX — the RX loop will
+   * drain bulk-IN. */
+  if (!want_rx) {
+    _device.rtw_write<uint16_t>(0x06A0, 0x0000);
+    _device.rtw_write<uint16_t>(0x06A2, 0x0000);
+    _device.rtw_write<uint16_t>(0x06A4, 0x0000);
+    _rx_filters_closed = true; /* StartRxLoop re-opens them (best effort) */
+  }
   /* Start the coex runtime thread: it drains C2H and re-applies the 5 GHz coex
    * decision every ~2 s so sustained TX isn't silenced by the FW's PTA. */
   _coex_thread = std::thread([this] { coex_runtime_loop(); });
@@ -373,11 +486,15 @@ bool RtlJaguar3Device::send_packet(const uint8_t *packet, size_t length) {
    * the kernel's descriptor for group-addressed frames. */
   const uint8_t *dot11 = packet + radiotap_length;
   bool bmc = frame_len >= 6 && (dot11[4] & 0x01);
+  /* DEVOURER_TX_NDPA=1 — beamforming self-sounding probe: mark injected frames
+   * as NDPA so the armed sounding engine (DEVOURER_BF_ARM_SOUNDER, InitWrite)
+   * follows each with a hardware NDP. Same knob as the Jaguar-1 path. */
+  static const bool ndpa = std::getenv("DEVOURER_TX_NDPA") != nullptr;
   std::vector<uint8_t> usb_frame(jaguar3::TXDESC_SIZE_8822C + frame_len, 0);
   jaguar3::fill_data_tx_desc_8822c(
       usb_frame.data(), static_cast<uint16_t>(frame_len),
       MRateToHwRate(fixed_rate), rate_id, bw_desc, sgi != 0, ldpc != 0, stbc,
-      bmc);
+      bmc, ndpa);
   std::memcpy(usb_frame.data() + jaguar3::TXDESC_SIZE_8822C,
               packet + radiotap_length, frame_len);
 

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -1,6 +1,8 @@
 #ifndef RTL_JAGUAR3_DEVICE_H
 #define RTL_JAGUAR3_DEVICE_H
 
+#include <atomic>
+#include <mutex>
 #include <optional>
 #include <thread>
 
@@ -31,6 +33,18 @@ public:
 
   void Init(Action_ParsedRadioPacket packetProcessor,
             SelectedChannel channel) override;
+  /* Blocking RX worker loop on an already-brought-up chip (see IRtlDevice).
+   * Init = bring-up + BFEE arm + StartRxLoop; a TX+RX caller (self-sounding
+   * single-radio ground station) does InitWrite once, then runs this on its
+   * own std::thread next to the TX loop. NB: for reliable RX the TX+RX intent
+   * must be declared at InitWrite time (DEVOURER_TX_WITH_RX set) — InitWrite
+   * then keeps the RX filters open and enables the RX path during bring-up.
+   * On a plain TX-only bring-up this falls back to a best-effort retrofit
+   * (filter re-open + enable_rx_path), which has proven unreliable on 8822E.
+   * Takes over the bulk-IN endpoint from the coex thread's C2H drain for as
+   * long as it runs. */
+  void StartRxLoop(Action_ParsedRadioPacket packetProcessor) override;
+  void StopRxLoop() override { _rx_stop = true; }
   void SetMonitorChannel(SelectedChannel channel) override;
   void InitWrite(SelectedChannel channel) override;
   void SetTxPower(uint8_t power) override;
@@ -63,13 +77,27 @@ private:
    * C2H reports (BT-info etc.) and runs the periodic coex decision so the FW's
    * PTA keeps the antenna with WLAN during sustained TX.
    * THREADING CONTRACT: while a TX session is active (between InitWrite and Stop)
-   * this thread owns all chip register access. The TX hot path (send_packet) does
-   * no register I/O, so it runs lock-free alongside it; callers must NOT invoke
-   * SetMonitorChannel/SetTxPower (which do register RMW) during an active TX
-   * session, or those reads-modify-writes will race the coex thread. */
+   * this thread owns all chip register access; the ~2 s housekeeping tick and
+   * StartRxLoop's one-shot RX-filter restore serialize on _reg_mu. The TX hot
+   * path (send_packet) does no register I/O, so it runs lock-free alongside it;
+   * callers must NOT invoke SetMonitorChannel/SetTxPower (which do register RMW)
+   * during an active TX session, or those reads-modify-writes will race the coex
+   * thread. Bulk-IN has exactly one reader at a time: while StartRxLoop is
+   * active (_rx_loop_active) the coex thread skips its C2H drain — the RX async
+   * loop sees the C2H reports as part of its stream. */
   std::thread _coex_thread;
   volatile bool _coex_stop = false;
   void coex_runtime_loop();
+  /* StartRxLoop stop request (StopRxLoop). */
+  volatile bool _rx_stop = false;
+  /* True while StartRxLoop owns bulk-IN (gates the coex thread's drain). */
+  std::atomic<bool> _rx_loop_active{false};
+  /* Set when InitWrite zeroes the RX filters (0x6A0-0x6A4) for TX-only
+   * throughput; StartRxLoop restores the monitor_rx_cfg values and clears it. */
+  bool _rx_filters_closed = false;
+  /* Serializes the coex housekeeping tick against StartRxLoop's register
+   * restore (the only two register writers during an active TX session). */
+  std::mutex _reg_mu;
 };
 
 #endif /* RTL_JAGUAR3_DEVICE_H */

--- a/txdemo/main.cpp
+++ b/txdemo/main.cpp
@@ -26,6 +26,7 @@
   #include <libusb-1.0/libusb.h>
 #endif
 
+#include "BfReportDetect.h"
 #include "RxPacket.h"
 #if defined(DEVOURER_HAVE_JAGUAR1)
 #include "jaguar1/RtlJaguarDevice.h"
@@ -88,7 +89,21 @@ static std::vector<uint8_t> build_frame_with_channel(uint16_t freq,
 
 static int g_rx_count = 0;
 static void packetProcessor(const Packet &packet) {
+  /* C2H packets are chip-side status (one per TX during concurrent TX+RX on
+   * Jaguar3), not 802.11 frames — skip before counting/parsing. */
+  if (packet.RxAtrib.pkt_rpt_type == RX_PACKET_TYPE::C2H_PACKET)
+    return;
   ++g_rx_count;
+  /* RX liveness marker for the TX+RX=thread mode: first frame + every 500th.
+   * Without it a deaf RX loop is indistinguishable from a quiet channel. */
+  if (g_rx_count == 1 || g_rx_count % 500 == 0) {
+    printf("<devourer-rx>total=%d len=%zu\n", g_rx_count, packet.Data.size());
+    fflush(stdout);
+  }
+  /* BF self-sounding report detector (DEVOURER_BF_DETECT_REPORT modes 1-4,
+   * shared with WiFiDriverDemo): with DEVOURER_TX_WITH_RX=thread this is how
+   * a single-radio sounder surfaces its own captured beamforming reports. */
+  devourer::bf::detect_report(packet);
   /* Surface frames whose source MAC matches the txdemo's injected beacon
    * (57:42:75:05:d6:00). The 802.11 header starts at packet.Data[0]; SA is
    * at bytes [10..15] for a non-FromDS, non-ToDS frame. */
@@ -421,16 +436,23 @@ int main(int argc, char **argv) {
   if (const char *p = std::getenv("DEVOURER_TX_PWR"))
     rtlDevice->SetTxPower(static_cast<uint8_t>(std::strtol(p, nullptr, 0)));
 
-  /* The original txdemo forked an RX child and a TX parent on the same
-   * libusb handle. That pattern is Termux-specific (libusb_wrap_sys_device
-   * keeps the kernel fd shared across fork); on a regular Linux libusb
-   * context after fork(), both processes race on the same URB submission
-   * queue and the first vendor request after fork tends to fail with
-   * "rtw_read: iostream error". Skip the fork unless DEVOURER_TX_WITH_RX=1
-   * is explicitly set (Termux callers can opt back in). For cross-adapter
-   * TX validation a second RX process on a separate adapter is what you
-   * want anyway. */
-  if (std::getenv("DEVOURER_TX_WITH_RX")) {
+  /* DEVOURER_TX_WITH_RX — concurrent RX alongside the TX loop on the SAME
+   * claimed adapter. Two modes:
+   *
+   * =thread (recommended): one bring-up (InitWrite below), then StartRxLoop on
+   * a std::thread next to the TX loop — the single-radio self-sounding ground
+   * station (arm the sounder with DEVOURER_BF_ARM_SOUNDER and surface the
+   * captured reports with DEVOURER_BF_DETECT_REPORT). The RX thread is spawned
+   * after InitWrite, further down.
+   *
+   * Any other non-empty value: the legacy fork of an RX child on the same
+   * handle. That pattern is Termux-specific (libusb_wrap_sys_device keeps the
+   * kernel fd shared across fork); on a regular Linux libusb context after
+   * fork(), both processes race on the same URB submission queue and the first
+   * vendor request after fork tends to fail with "rtw_read: iostream error". */
+  const char *tx_with_rx = std::getenv("DEVOURER_TX_WITH_RX");
+  const bool rx_thread_mode = tx_with_rx && std::string(tx_with_rx) == "thread";
+  if (tx_with_rx && !rx_thread_mode) {
     pid_t fpid = fork();
     if (fpid == 0) {
       rtlDevice->Init(packetProcessor,
@@ -452,6 +474,25 @@ int main(int argc, char **argv) {
   logger->info("init-timing: txdemo.init_write = {} ms", ms_since_start());
 
   std::thread usb_thread(usb_event_loop, logger, context);
+
+  /* DEVOURER_TX_WITH_RX=thread: run the RX worker loop on its own thread next
+   * to the TX loop — one bring-up (the InitWrite above), one claimed handle.
+   * StartRxLoop assumes the chip is up and takes over bulk-IN; send_packet's
+   * bulk-OUT is safe alongside it. packetProcessor runs on this thread. */
+  std::thread rx_thread;
+  if (rx_thread_mode) {
+    rx_thread = std::thread([&rtlDevice, logger] {
+      /* An uncaught exception in a std::thread is std::terminate — a transient
+       * USB read failure in the RX loop must not tear down the TX process. */
+      try {
+        rtlDevice->StartRxLoop(packetProcessor);
+      } catch (const std::exception &e) {
+        logger->error("RX loop died: {} (TX continues)", e.what());
+      }
+    });
+    logger->info("DEVOURER_TX_WITH_RX=thread: RX loop started alongside TX");
+  }
+
   uint8_t beacon_frame[] = {
       0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x00, 0x00, 0x08,
       0x00, // radiotap: TX_FLAGS only (rate-less) — rate comes from SetTxMode
@@ -832,6 +873,11 @@ int main(int argc, char **argv) {
    * (core dump). Setting the flag also covers the back-off exit path, where no
    * signal was delivered. */
   g_devourer_should_stop = true;
+  /* Join the RX loop BEFORE Stop(): the chip de-init must not race in-flight
+   * RX URBs (and StartRxLoop's event pump must exit before libusb_exit). */
+  rtlDevice->StopRxLoop();
+  if (rx_thread.joinable())
+    rx_thread.join();
   if (usb_thread.joinable())
     usb_thread.join();
 


### PR DESCRIPTION
Fixes #156.

## What

`Init` (RX) and `InitWrite` (TX) each performed a full chip bring-up, so a process wanting both raced two bring-ups on one claimed handle and died with `rtw_read: iostream error`. This splits the RX worker loop out of `Init` into a new `IRtlDevice::StartRxLoop(packetProcessor)` — a blocking loop that assumes the chip is already up (caller supplies the thread) — plus `StopRxLoop()`. `Init` stays as the RX-only convenience wrapper (bring-up + arming + `StartRxLoop`), so existing callers are unchanged. The sequence from the issue works: **bring up once → arm → TX loop + RX loop concurrently on one handle.**

- **Jaguar1**: pure code motion of the 4-worker RX pool (+ `DEVOURER_RX_PATHS` toggle) into `StartRxLoop`.
- **Jaguar2**: same split via the existing `bring_up()`; the DIG thread lifecycle moves into `StartRxLoop` (TX-only stays DIG-free).
- **Jaguar3**: TX+RX intent is declared at `InitWrite` time (`DEVOURER_TX_WITH_RX` set) — the RX filters stay open and the RX path is enabled in the same bring-up slot `Init` uses; the coex runtime's C2H drain yields bulk-IN to the RX loop (single reader per endpoint), and its ~2 s housekeeping serializes with the RX-path writes. FW C2H reports (RX desc BIT28) are tagged `C2H_PACKET` so packet processors skip the one-per-TX report flood.
- **`WiFiDriverTxDemo`**: `DEVOURER_TX_WITH_RX=thread` runs `StartRxLoop` on a `std::thread` next to the TX loop; any other non-empty value keeps the legacy Termux `fork()` path verbatim. The BF-report detector is factored into shared `src/BfReportDetect.h` (used by both demos).

The acceptance flow also required the **Jaguar3 sounder side** (previously Jaguar1-only): NDPA TX-descriptor mark (`SET_TX_DESC_NDPA_8822C`), MAC sounding-engine arm (0xDB protocol byte, optional self-MAC), and the phydm txbf rf-mode RF/BB config the hardware NDP requires.

## Hardware validation (5-DUT rig: 8814AU / 8821AU / 8822BU / 8822CU / 8822EU)

- **Acceptance (issue's case), Jaguar1**: 8814AU single-radio sounder vs armed 8822EU beamformee at ch100 — **8.8k VHT BF reports captured in the sounder's own process** (armed) vs 0 (unarmed control), no `rtw_read` abort, TX flowing throughout.
- **Jaguar3 sounder**: 8822CU/8822EU sounding an armed beamformee → 26k–70k reports/20 s on air (8814AU sniffer). The Jaguar3 sounder's *own* RX does not surface the report frames — use a second capture radio there (follow-up).
- **RX-only / TX-only unchanged** per generation; Jaguar3 5 GHz TX sustained past 60 s with the gated coex drain (31k frames, coex ticks intact).
- **8822E TX+RX trade-off** (hardware-bisected): per-rate TXAGC and DPK-bypass each desense the EU's RX to near-deaf on a bring-up that also runs RX; TX+RX mode skips both (flat table TX power). TX-only behavior unchanged.
- `ctest` green; per-chip subset builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)