### PR TITLE
Pseudo preamble puncturing: keep a wide channel usable when one 20 MHz slice is dirty

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -137,14 +137,16 @@ jobs:
           -DCMAKE_C_COMPILER=gcc
           -DCMAKE_CXX_COMPILER=g++
 
-      - name: Build (library + stream demos + self-test)
+      - name: Build (library + stream demos + self-tests)
         # WiFiDriverDemo / WiFiDriverTxDemo / PrecoderDemo use POSIX-only APIs
         # (e.g. fork() in txdemo/main.cpp for the DEVOURER_TX_WITH_RX path) and
         # are not mingw targets. This job guards the stdin-driven stream demos
-        # and their headless self-test — what the binary-stdin fix touches.
+        # and the headless self-tests ctest runs — every registered test's
+        # binary must be listed here, or the Test step fails it as Not Run.
         run: >
           cmake --build build --target
           WiFiDriver StreamTxDemo StreamDuplexDemo StreamStdinSelftest
+          ToneMaskSelftest
 
       - name: Test
         working-directory: build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,20 @@ Both `WiFiDriverDemo` and `WiFiDriverTxDemo` honour:
   mobile/fading combining measurement (alternate a fixed chain vs all-4 fast
   relative to RX motion so both sample the same fading). Analyse with
   `tests/mrc_mobility.py`.
+- `DEVOURER_RX_CSI_MASK=<f_lo>[-<f_hi>][/wgt]` — (all generations, RX)
+  de-weight a frequency range (MHz) in the receive equalizer's per-tone CSI
+  mask — the RX half of pseudo preamble puncturing (`src/ToneMask.h`,
+  `docs/pseudo-preamble-puncturing.md`). Masks every 312.5 kHz subcarrier in
+  the range (e.g. `5230-5250` = the top 20 MHz slice of the ch36 80 MHz
+  block); `/wgt` (0..7, default 7) is the Jaguar3 per-tone weight. Applied
+  when the RX loop starts, after the channel set; a channel switch reverts it
+  (same contract as `DEVOURER_RX_PATHS`). Register-landing checked per chip by
+  `tests/tone_mask_regcheck.sh`. NB measured: inert against a *jammed* slice
+  (that loss is pre-FCS sync/AGC, upstream of the equalizer) — it targets
+  in-band spurs riding on decodable frames.
+- `DEVOURER_RX_NBI=<f_mhz>` — (all generations, RX) arm the narrowband-
+  interference notch filter at one in-channel frequency (vendor-parity,
+  LUT-quantized — a single narrow notch, not a slice mask).
 - `DEVOURER_TX_WITH_RX=thread` — (`WiFiDriverTxDemo`) run the RX worker loop on
   a `std::thread` alongside the TX loop, on the **same claimed adapter**: one
   bring-up (`InitWrite`), then `StartRxLoop(packetProcessor)` — the programmatic

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,3 +245,14 @@ add_test(
             -DSELFTEST_EXE=$<TARGET_FILE:StreamStdinSelftest>
             -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/stream_stdin_test.cmake
 )
+
+# Headless guard for the ToneMask tone-index math (src/ToneMask.h) — the fc
+# derivation + subcarrier enumeration behind DEVOURER_RX_CSI_MASK /
+# DEVOURER_RX_NBI. Pure math only; the register encodings are hardware-checked
+# via the apply-time readback logging.
+add_executable(ToneMaskSelftest
+    tests/tone_mask_selftest.cpp
+)
+target_link_libraries(ToneMaskSelftest PRIVATE WiFiDriver)
+
+add_test(NAME tone_mask_math COMMAND ToneMaskSelftest)

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -558,19 +558,21 @@ int main() {
     channel = std::atoi(ch_env);
     logger->info("DEVOURER_CHANNEL set — tuning to channel {}", channel);
   }
-  /* RX bandwidth: 20 MHz by default. DEVOURER_BW=40 selects a 40 MHz monitor
-   * channel (for receiving HT40 frames); DEVOURER_CHOFFSET picks the secondary
-   * half (1 = secondary above the primary, 2 = secondary below).
+  /* RX bandwidth: 20 MHz by default. DEVOURER_BW=40|80 selects a wide monitor
+   * channel (for receiving HT40 / VHT80 frames); DEVOURER_CHOFFSET picks the
+   * secondary half (1 = secondary above the primary, 2 = secondary below).
    * DEVOURER_NB_BW=5|10 re-clocks the baseband to narrowband (Jaguar3 only). */
   ChannelWidth_t width = CHANNEL_WIDTH_20;
   uint8_t ch_offset = 0;
   if (const char *bw_env = std::getenv("DEVOURER_BW")) {
-    if (std::atoi(bw_env) == 40) {
-      width = CHANNEL_WIDTH_40;
+    int bw = std::atoi(bw_env);
+    if (bw == 40 || bw == 80) {
+      width = (bw == 40) ? CHANNEL_WIDTH_40 : CHANNEL_WIDTH_80;
       ch_offset = 1; // default: secondary channel above the primary
       if (const char *off_env = std::getenv("DEVOURER_CHOFFSET"))
         ch_offset = static_cast<uint8_t>(std::atoi(off_env));
-      logger->info("DEVOURER_BW=40 — 40 MHz RX, channel-offset {}", ch_offset);
+      logger->info("DEVOURER_BW={} — {} MHz RX, channel-offset {}", bw, bw,
+                   ch_offset);
     }
   }
   if (const char *nb = std::getenv("DEVOURER_NB_BW")) {

--- a/docs/pseudo-preamble-puncturing.md
+++ b/docs/pseudo-preamble-puncturing.md
@@ -104,6 +104,22 @@ next-narrower-bandwidth quantization (80 → 40 loses the clean ch44 slice
 too) — that gap, [clean][clean][dirty][clean] → 60 MHz usable vs 40 MHz
 usable, is the real cost of not having puncturing signaling.
 
+**And it is unilateral, at zero receiver cost.** A receiver tuned at 80 MHz
+decodes narrower frames sent on its primary sub-channels *without retuning*
+(`tests/rx80_narrow_tx_probe.sh`), and pays no measurable sensitivity price
+for staying wide: the differential delivery-vs-noise sweep puts the wide-RX
+penalty at 0 dB (≤ 1 dB, bounded by the capture-cliff width —
+`tests/wide_rx_penalty_sweep.sh`). So the RX parks at 80 MHz and the TX
+shrinks or grows per-packet along the **primary-nested ladder**
+`20 ⊂ 40 ⊂ 80` with no coordination — the one geometric constraint being
+that every rung must contain the RX's primary 20 MHz (the upper-40 is
+unreachable without a coordinated primary move). The adaptive-link
+controller consumes exactly this: bandwidth as an energy-ranked op-table
+dimension (`ControllerConfig.bw_set`), a shared seq-derived probe schedule
+that senses per-rung delivery with zero extra wire fields
+(`rc_proto.probe_bw`, `score.RungWindow`), and a `primary_dirty` escalation
+for the one case no unilateral bandwidth choice can fix.
+
 ## Finding the dirty slice
 
 Two detectors measured (`tests/pseudo_puncture_detect.sh`):

--- a/docs/pseudo-preamble-puncturing.md
+++ b/docs/pseudo-preamble-puncturing.md
@@ -1,0 +1,140 @@
+# Pseudo preamble puncturing — using a wide channel with a dirty slice
+
+Wi-Fi 7 preamble puncturing lets a transmitter keep an 80/160 MHz channel
+while skipping one dirty 20 MHz slice: the EHT preamble carries a per-PPDU
+puncturing bitmap, the TX IFFT zeroes the punctured tones, and the receiver
+skips them during equalization. This document is the answer to "how close can
+the 802.11ac-era Jaguar silicon get?" — what the chips offer, what devourer
+now exposes, and what a jammed-slice experiment measured about each
+mechanism's real worth.
+
+## Why true puncturing is out of reach
+
+Puncturing is **PHY signaling, not a driver trick**. Three independent walls:
+
+- **The VHT preamble must be contiguous full-band.** L-STF/L-LTF/L-SIG/
+  VHT-SIG are wideband training sequences; there is no 802.11ac encoding for
+  "this 80 MHz PPDU skips 20 MHz in the middle", so even a hypothetically
+  tone-nulled transmission could not tell a receiver which tones to skip.
+- **No TX tone nulling exists on this silicon.** Neither the vendor drivers
+  nor the firmware expose per-subcarrier TX amplitude control on any Jaguar
+  generation. Every tone-level knob the hardware has lives in the RX path.
+- **The nearest 11ac concept, non-contiguous 80+80, is absent too** — none of
+  the supported USB parts implement it (register-level plumbing for it exists
+  only on later silicon).
+
+What the silicon *does* offer composes into a three-part approximation:
+per-tone **detection** (find the dirty slice), an RX-side **tone mask**
+(de-weight it in the equalizer), and TX-side **avoidance** (place a narrower
+transmission on the clean sub-channels). All three are now in devourer; the
+measurements below say which ones carry their weight.
+
+## The RX tone mask (`DEVOURER_RX_CSI_MASK`, `DEVOURER_RX_NBI`)
+
+All three generations carry two receive-path tone-level mechanisms, ported
+from vendor phydm into `src/ToneMask.h` and exposed on both demos:
+
+- **CSI mask** — a per-tone receive-equalizer de-weight table: the BB treats
+  masked subcarriers' channel estimates as garbage. On 11ac silicon
+  (Jaguar-1: 8812/8811/8821/8814; Jaguar-2: 8822B) it is a plain bit array —
+  enable `0x874[0]`, positive tones `0x880-0x88F`, negative `0x890-0x89F`,
+  one bit per 312.5 kHz subcarrier. On Jaguar-3 (8822C/E) it is an indexed
+  table behind `0x1D94` (bracketed by `0x1EE8[1:0]`, two 4-bit entries per
+  byte: enable bit + 3-bit weight), enable `0xC0C[3]`. The vendor wrapper
+  only ever masks a handful of tones around one interferer frequency;
+  devourer's `DEVOURER_RX_CSI_MASK=<f_lo>-<f_hi>[/wgt]` (MHz) loops the
+  low-level setter across an arbitrary range, so one env var masks a whole
+  20 MHz slice. On Jaguar-3 note the sharing trap: adjacent tones share a
+  table byte, so a range must be accumulated host-side before writing —
+  the vendor's one-tone-at-a-time sequence would clobber neighbours.
+- **NBI notch** — a single narrowband notch filter, LUT-quantized
+  (`0x87C[19:14]` + enable `0x87C[13]` on 11ac, with `0xC20[28]`/`0xE20[28]`
+  added on 8822B; `0x1944/0x4044[20:12]` per path + `0x818[3]` (inverted
+  polarity on 8822C/E), `0x818[11]`, `0x1D3C[30:27]` on Jaguar-3).
+  `DEVOURER_RX_NBI=<f_mhz>` — vendor-parity, one interferer.
+
+Both knobs are applied when the RX loop starts, after the channel set (same
+contract as `DEVOURER_RX_PATHS`: the final word for a single-channel capture;
+a channel switch reverts them). The tone math (`phydm_find_fc` port +
+subcarrier enumeration) is unit-tested headlessly (`ctest -R tone_mask_math`);
+the register encodings are asserted on hardware by
+`tests/tone_mask_regcheck.sh` — validated on 8821AU, 8814AU, 8822BU, 8812CU
+and 8822EU, including an 80 MHz cell (masking 5230-5250 of the ch36 block
+sets exactly tones +64..+128).
+
+The mask is provably *active*, not just a register that reads back:
+`tests/tone_mask_rx_sanity.sh` shows an off-frequency mask leaves a live link
+untouched (29 → 30 hits) while masking the tuned channel collapses it
+(29 → 6).
+
+## What the jammed-slice experiment measured
+
+`tests/pseudo_puncture_onair.sh`: 8822BU transmits VHT80 beacons on the ch36
+block (fc 5210) to an 8814AU receiver at 80 MHz, while a USRP B210 jams
+exactly one 20 MHz slice (5230-5250) with band-limited AWGN
+(`tests/sdr_interferer.py` — the TX gain is the reproducible damage knob).
+Hits per 15 s cell:
+
+| cell                                   | hits | vs clean |
+|----------------------------------------|------|----------|
+| A — clean VHT80                        | 61   | 100%     |
+| B — jammed VHT80                       | 31   | 50%      |
+| C — jammed VHT80 + CSI mask on slice   | 33   | 54%      |
+| D — jammed, TX drops to clean-half 40  | 48   | 78%      |
+
+**The CSI mask is inert against a jammed slice** (+2 hits ≈ run-to-run
+noise; a higher jam gain repeats the same picture), and the mechanism behind
+that is the central finding: re-running the jammed cell with
+`DEVOURER_RX_KEEP_CORRUPTED=1` delivers **zero FCS-failed frames** — the
+missing 50% never reach the FCS stage at all. The jam kills wide frames at
+the detection/AGC/sync level, *upstream* of the equalizer the CSI mask
+programs, and equally upstream of the sub-block salvage layer
+(`docs/fused-fec.md`), which needs a delivered-but-corrupt body to work on.
+The mask remains the right tool for what the vendor built it for — a narrow
+in-band interferer riding on top of decodable frames — but it cannot emulate
+punctured *reception* of a wide PPDU.
+
+**TX-side avoidance is the lever that works.** Dropping the transmission to
+the clean 40 MHz half recovers most of the delivery (78% of clean-80). It is
+also cheap and per-packet-capable: bandwidth and rate ride in the radiotap
+header, the primary-channel offset in `SelectedChannel.ChannelOffset`, and an
+intra-band retune costs ~1.5 ms (`docs/frequency-hopping.md`). Wi-Fi 7 keeps
+the punctured channel's full clean tones where this fallback pays the
+next-narrower-bandwidth quantization (80 → 40 loses the clean ch44 slice
+too) — that gap, [clean][clean][dirty][clean] → 60 MHz usable vs 40 MHz
+usable, is the real cost of not having puncturing signaling.
+
+## Finding the dirty slice
+
+Two detectors measured (`tests/pseudo_puncture_detect.sh`):
+
+- **Per-tone SNR self-sounding** (`sound` mode) — the MU-report machinery
+  from `docs/beamforming-self-sounding.md`, sounding each 20 MHz slice in
+  turn. Measured caveat: the report describes the channel **at the
+  beamformee**. On a bench where the sounding pair sits point-blank (NDP SNR
+  ~50 dB) the jam neither suppresses the report count nor moves the per-tone
+  SNR beyond its ±5 dB wobble — the detector does not discriminate the
+  jammed slice. Use it when the sounding peer *is* the far end of the link
+  whose spectrum you care about.
+- **Victim-link probe scan** (`probe` mode) — hop the actual TX/RX pair
+  across the four 20 MHz slices and compare delivery. Picks the jammed slice
+  correctly (29 hits on ch48 vs 35-37 elsewhere). Crude, but it senses the
+  only channel that matters — the victim's own — and needs no extra
+  hardware. `FastRetune` makes the scan cheap enough to repeat.
+
+## Verdict
+
+| mechanism                            | works? | notes                                    |
+|--------------------------------------|--------|------------------------------------------|
+| TX tone nulling / true puncturing    | no     | no silicon hook, no VHT signaling         |
+| RX CSI mask against a jammed slice   | no     | loss is pre-FCS (sync/AGC), mask is later |
+| RX CSI mask against in-band spurs    | yes    | the vendor's original use; knob now open  |
+| Sub-block salvage of jammed frames   | no     | nothing delivered to salvage              |
+| TX avoidance (narrower, clean half)  | yes    | 78% of clean delivery; per-packet capable |
+| Detection: self-sounding per-tone SNR| partly | senses the peer's channel, not the victim's |
+| Detection: victim-link probe scan    | yes    | picks the jammed slice                    |
+
+So the honest Jaguar rendition of "[clean][clean][skip][clean]" is:
+**probe-scan the slices, then transmit around the dirty one at the widest
+clean bandwidth, re-scanning on a cadence** — puncturing by primary-channel
+selection, at the cost of the bandwidth quantization Wi-Fi 7 avoids.

--- a/src/ToneMask.h
+++ b/src/ToneMask.h
@@ -1,0 +1,460 @@
+/* ToneMask — RX-side per-subcarrier masking, shared across chip generations.
+ *
+ * Two receive-path mechanisms ported from vendor phydm (phydm_api.c):
+ *
+ *   CSI mask — a per-tone receive-equalizer de-weight table. Tells the BB "these
+ *   subcarriers carry garbage" so a jammed slice stops dragging the whole-frame
+ *   channel estimate / equalization down. This is the closest an 11ac chip gets
+ *   to Wi-Fi 7 preamble puncturing, and only on the RX side: the vendor wrapper
+ *   (phydm_csi_mask_setting) masks a handful of tones around one interferer
+ *   frequency; here the low-level per-tone setter is looped so an entire 20 MHz
+ *   slice of an 80 MHz channel can be de-weighted (DEVOURER_RX_CSI_MASK).
+ *
+ *   NBI notch — a narrowband-interference notch filter at one tone position
+ *   (phydm_nbi_setting). Much coarser lever (one notch, LUT-quantized), kept
+ *   for vendor parity as DEVOURER_RX_NBI.
+ *
+ * Neither touches the TX path — the silicon exposes no TX tone nulling, and a
+ * VHT preamble must be contiguous full-band (true puncturing is 11be EHT-SIG
+ * signaling). See docs/pseudo-preamble-puncturing.md.
+ *
+ * Register recipes transcribed from:
+ *   11ac (Jaguar-1 8812/8811/8821/8814 + Jaguar-2 8822B):
+ *     reference/rtl8812au/hal/phydm/phydm_api.c — phydm_csi_mask_enable
+ *     (0x874[0]), phydm_set_csi_mask (bit arrays 0x880-0x88F positive /
+ *     0x890-0x89F negative, one bit per 312.5 kHz subcarrier),
+ *     phydm_set_nbi_reg (LUT -> 0x87C[19:14]), phydm_nbi_enable (0x87C[13];
+ *     8822B additionally 0xC20[28]/0xE20[28]).
+ *   Jaguar-3 (8822C/8822E):
+ *     reference/rtl88x2cu/hal/phydm/phydm_api.c — the _jgr3 variants: CSI mask
+ *     is an indexed table behind 0x1D94 (0x1EE8[1:0] write bracket, BYTE2 =
+ *     table address = tone_idx/2, [7:0] = two 4-bit tone entries: BIT3 enable |
+ *     3-bit weight), enable 0xC0C[3]; NBI tone index at 0x1944/0x4044[20:12]
+ *     per path, enable 0x818[3] (inverted on 8822C/E) + 0x818[11] +
+ *     0x1D3C[30:27] + 0x1940/0x4040[31].
+ *
+ * All tone math is in 312.5 kHz subcarrier units relative to the wide channel's
+ * center frequency fc (phydm_find_fc port). The pure helpers (find_fc_mhz,
+ * enumerate_tones, parse_*) have no device dependency so they can be unit-
+ * checked headlessly.
+ */
+#ifndef DEVOURER_TONE_MASK_H
+#define DEVOURER_TONE_MASK_H
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "RtlUsbAdapter.h"
+#include "SelectedChannel.h"
+#include "logger.h"
+
+namespace devourer {
+namespace tonemask {
+
+/* Which register recipe applies. AC1 = 8812/8811/8821 (NBI LUT always
+ * 256-FFT); AC2 = 8814A / 8822B (NBI LUT 128-FFT at 20/40, 256-FFT at 80;
+ * 8822B adds the 0xC20/0xE20 NBI enable bits). */
+enum class Family { AC1, AC2_8814, AC2_8822B, JGR3 };
+
+/* Vendor secondary-channel position (PHYDM_DONT_CARE/ABOVE/BELOW). */
+enum SecCh : int { kSecDontCare = 0, kSecAbove = 1, kSecBelow = 2 };
+
+/* HAL_PRIME_CHNL_OFFSET_* (SelectedChannel.ChannelOffset) -> vendor secondary
+ * position: primary LOWER means the secondary (and fc) sit ABOVE the primary. */
+inline int sec_from_prime_offset(uint8_t prime_offset) {
+  if (prime_offset == 1) return kSecAbove; /* HAL_PRIME_CHNL_OFFSET_LOWER */
+  if (prime_offset == 2) return kSecBelow; /* HAL_PRIME_CHNL_OFFSET_UPPER */
+  return kSecDontCare;
+}
+
+inline uint32_t bw_mhz_from(ChannelWidth_t bw) {
+  switch (bw) {
+  case CHANNEL_WIDTH_40: return 40;
+  case CHANNEL_WIDTH_80: return 80;
+  default: return 20; /* 20 + the Jaguar-3 5/10 MHz re-clocks tune as 20 */
+  }
+}
+
+/* phydm_find_fc port — wide-channel center frequency in MHz from the PRIMARY
+ * 20 MHz channel + bandwidth (+ secondary position, 2.4 GHz 40 MHz only).
+ * Returns 0 on an invalid combination. */
+inline uint32_t find_fc_mhz(uint32_t channel, uint32_t bw, int sec_ch) {
+  /* 2.4G */
+  if (channel >= 1 && channel <= 14) {
+    if (bw == 80) return 0;
+    uint32_t fc = 2412 + (channel - 1) * 5;
+    if (bw == 40 && sec_ch == kSecAbove) {
+      if (channel >= 10) return 0;
+      fc += 10;
+    } else if (bw == 40 && sec_ch == kSecBelow) {
+      if (channel <= 2) return 0;
+      fc -= 10;
+    }
+    return fc;
+  }
+  /* 5G */
+  if (channel >= 16 && channel <= 253) {
+    static constexpr uint32_t start_40m[] = {20, 28, 36, 44, 52, 60, 68, 76,
+                                             84, 92, 100, 108, 116, 124, 132,
+                                             140, 149, 157, 165, 173, 181, 189,
+                                             197, 205, 213, 221, 229, 237, 245};
+    static constexpr uint32_t start_80m[] = {20, 36, 52, 68, 84, 100, 116,
+                                             132, 149, 165, 181, 197, 213, 229};
+    if (bw == 40 || bw == 80) {
+      const uint32_t *start = (bw == 40) ? start_40m : start_80m;
+      size_t n = (bw == 40) ? sizeof(start_40m) / sizeof(start_40m[0])
+                            : sizeof(start_80m) / sizeof(start_80m[0]);
+      uint32_t off = (bw == 40) ? 2 : 6; /* CH_OFFSET_40M / CH_OFFSET_80M */
+      for (size_t i = 0; i + 1 < n; i++) {
+        if (channel < start[i + 1]) {
+          channel = start[i] + off;
+          break;
+        }
+      }
+    }
+    return 5080 + (channel - 16) * 5;
+  }
+  return 0;
+}
+
+/* Signed subcarrier indices (312.5 kHz units, relative to fc) covering
+ * [f_lo_khz, f_hi_khz], clipped to the RF bandwidth edge (bw_mhz * 1.6 =
+ * bw/2 / 0.3125 subcarriers each side). */
+inline std::vector<int> enumerate_tones(uint32_t fc_mhz, uint32_t bw_mhz,
+                                        uint32_t f_lo_khz, uint32_t f_hi_khz) {
+  std::vector<int> tones;
+  if (!fc_mhz || f_hi_khz < f_lo_khz) return tones;
+  int64_t fc_khz = int64_t(fc_mhz) * 1000;
+  int k_edge = int(bw_mhz * 8 / 5); /* bw/2 / 0.3125 */
+  /* k*312.5 kHz = k*625/2 — ceil/floor in integer math on 2*offset/625. */
+  int64_t lo2 = (int64_t(f_lo_khz) - fc_khz) * 2;
+  int64_t hi2 = (int64_t(f_hi_khz) - fc_khz) * 2;
+  auto div_ceil = [](int64_t a, int64_t b) {
+    return (a >= 0) ? (a + b - 1) / b : -((-a) / b);
+  };
+  auto div_floor = [](int64_t a, int64_t b) {
+    return (a >= 0) ? a / b : -((-a + b - 1) / b);
+  };
+  int k_lo = int(div_ceil(lo2, 625));
+  int k_hi = int(div_floor(hi2, 625));
+  if (k_lo > k_hi && f_lo_khz == f_hi_khz) {
+    /* Single-frequency spec — mask the nearest tone (vendor rounding). */
+    int64_t k10 = (int64_t(f_lo_khz) - fc_khz) * 32 / 1000; /* x10 units */
+    k_lo = k_hi = int((k10 + ((k10 >= 0) ? 5 : -5)) / 10);
+  }
+  for (int k = k_lo; k <= k_hi; k++) {
+    if (k < -k_edge || k > k_edge) continue;
+    tones.push_back(k);
+  }
+  return tones;
+}
+
+/* ---- env spec parsing ---------------------------------------------------- */
+
+struct CsiMaskSpec {
+  bool valid = false;
+  uint32_t f_lo_khz = 0, f_hi_khz = 0;
+  uint8_t wgt = 7; /* Jaguar-3 3-bit suppression weight (7 = strongest) */
+};
+
+/* "5210-5230" (MHz range) | "5220" (single frequency) with optional "/W"
+ * Jaguar-3 weight suffix, e.g. "5210-5230/7". */
+inline CsiMaskSpec parse_csi_spec(const char *s) {
+  CsiMaskSpec spec;
+  if (!s || !*s) return spec;
+  char *end = nullptr;
+  unsigned long lo = std::strtoul(s, &end, 10);
+  if (end == s) return spec;
+  unsigned long hi = lo;
+  if (*end == '-') {
+    const char *p = end + 1;
+    hi = std::strtoul(p, &end, 10);
+    if (end == p) return spec;
+  }
+  if (*end == '/') {
+    const char *p = end + 1;
+    unsigned long w = std::strtoul(p, &end, 10);
+    if (end != p && w <= 7) spec.wgt = uint8_t(w);
+  }
+  if (*end != '\0' || hi < lo) return spec;
+  spec.f_lo_khz = uint32_t(lo) * 1000;
+  spec.f_hi_khz = uint32_t(hi) * 1000;
+  spec.valid = true;
+  return spec;
+}
+
+/* ---- 11ac (Jaguar-1 + Jaguar-2) ------------------------------------------ */
+
+/* CSI-mask bit arrays: 0x880-0x88F = positive tones 0..127 (one bit per
+ * subcarrier), 0x890-0x89F = negative (bit index 128 - |k|). Builds the full
+ * 32-byte shadow host-side and writes 8 dwords, then sets the 0x874[0] enable.
+ * Returns the number of tones masked. */
+inline size_t csi_mask_apply_11ac(RtlUsbAdapter &dev, uint32_t fc_mhz,
+                                  uint32_t bw_mhz, const CsiMaskSpec &spec) {
+  auto tones = enumerate_tones(fc_mhz, bw_mhz, spec.f_lo_khz, spec.f_hi_khz);
+  uint8_t shadow[32] = {};
+  for (int k : tones) {
+    uint32_t idx;
+    if (k >= 0) { /* FREQ_POSITIVE */
+      idx = (uint32_t(k) >= 127) ? 127 : uint32_t(k);
+    } else {
+      uint32_t a = uint32_t(-k);
+      idx = 128 + (128 - ((a >= 128) ? 128 : a));
+      if (idx >= 256) idx = 255;
+    }
+    shadow[idx >> 3] |= uint8_t(1u << (idx & 7));
+  }
+  for (int i = 0; i < 8; i++) {
+    uint32_t dw = uint32_t(shadow[i * 4]) | (uint32_t(shadow[i * 4 + 1]) << 8) |
+                  (uint32_t(shadow[i * 4 + 2]) << 16) |
+                  (uint32_t(shadow[i * 4 + 3]) << 24);
+    dev.rtw_write32(uint16_t(0x880 + i * 4), dw);
+  }
+  dev.phy_set_bb_reg(0x874, 0x1, tones.empty() ? 0 : 1);
+  return tones.size();
+}
+
+inline void csi_mask_clear_11ac(RtlUsbAdapter &dev) {
+  for (int i = 0; i < 8; i++)
+    dev.rtw_write32(uint16_t(0x880 + i * 4), 0);
+  dev.phy_set_bb_reg(0x874, 0x1, 0);
+}
+
+/* NBI notch, 11ac: quantize the tone offset (x10 fixed point, vendor units)
+ * into the register LUT and write 0x87C[19:14] + the per-family enables.
+ * f_intf must fall inside the tuned bandwidth. */
+inline bool nbi_apply_11ac(RtlUsbAdapter &dev, Family fam, uint32_t fc_mhz,
+                           uint32_t bw_mhz, uint32_t f_intf_mhz,
+                           bool paths_ge_2t) {
+  /* tone_idx x10 units */
+  static constexpr uint32_t nbi_128[] = {25, 55, 85, 115, 135, 155, 185, 205,
+                                         225, 245, 265, 285, 305, 335, 355,
+                                         375, 395, 415, 435, 455, 485, 505,
+                                         525, 555, 585, 615, 635};
+  static constexpr uint32_t nbi_256[] = {
+      25,  55,  85,  115, 135, 155, 175, 195, 225,  245,  265,  285,
+      305, 325, 345, 365, 385, 405, 425, 445, 465,  485,  505,  525,
+      545, 565, 585, 605, 625, 645, 665, 695, 715,  735,  755,  775,
+      795, 815, 835, 855, 875, 895, 915, 935, 955,  975,  995,  1015,
+      1035, 1055, 1085, 1105, 1125, 1145, 1175, 1195, 1225, 1255, 1275};
+  uint32_t bw_up = fc_mhz + bw_mhz / 2, bw_low = fc_mhz - bw_mhz / 2;
+  if (f_intf_mhz < bw_low || f_intf_mhz > bw_up) return false;
+  uint32_t dist = (f_intf_mhz > fc_mhz) ? (f_intf_mhz - fc_mhz)
+                                        : (fc_mhz - f_intf_mhz);
+  uint32_t idx10 = dist << 5; /* 10 * (dist / 0.3125) */
+
+  bool use_256 = (fam == Family::AC1) || (bw_mhz == 80);
+  const uint32_t *lut = use_256 ? nbi_256 : nbi_128;
+  size_t n = use_256 ? sizeof(nbi_256) / sizeof(nbi_256[0])
+                     : sizeof(nbi_128) / sizeof(nbi_128[0]);
+  uint32_t reg_idx = 0;
+  for (size_t i = 0; i < n; i++) {
+    if (idx10 < lut[i]) {
+      reg_idx = uint32_t(i) + 1;
+      break;
+    }
+  }
+  dev.phy_set_bb_reg(0x87c, 0xfc000, reg_idx);
+  dev.phy_set_bb_reg(0x87c, 1u << 13, 1);
+  if (fam == Family::AC2_8822B) {
+    dev.phy_set_bb_reg(0xc20, 1u << 28, 1);
+    if (paths_ge_2t) dev.phy_set_bb_reg(0xe20, 1u << 28, 1);
+  }
+  return true;
+}
+
+inline void nbi_disable_11ac(RtlUsbAdapter &dev, Family fam,
+                             bool paths_ge_2t) {
+  dev.phy_set_bb_reg(0x87c, 1u << 13, 0);
+  if (fam == Family::AC2_8822B) {
+    dev.phy_set_bb_reg(0xc20, 1u << 28, 0);
+    if (paths_ge_2t) dev.phy_set_bb_reg(0xe20, 1u << 28, 0);
+  }
+}
+
+/* ---- Jaguar-3 (8822C / 8822E) -------------------------------------------- */
+
+/* The CSI-mask table lives behind an indexed window: 0x1EE8[1:0]=3 opens it,
+ * 0x1D94[31:30]=1 selects write mode, BYTE2 = table address (= tone_idx/2),
+ * [7:0] = two 4-bit entries (low nibble even tone, high nibble odd tone),
+ * each BIT3-enable | 3-bit weight. tone_num tracks the RF bandwidth via
+ * 0x9B0[3:2] (RF80 -> 128, else 64). Adjacent tones share a table byte, so the
+ * per-address byte is accumulated host-side first — the vendor's one-tone
+ * setter would clobber its neighbour's nibble when looped over a range. */
+inline size_t csi_mask_apply_jgr3(RtlUsbAdapter &dev, uint32_t fc_mhz,
+                                  uint32_t bw_mhz, const CsiMaskSpec &spec) {
+  uint8_t rf_bw = dev.rtw_read8(0x9b0);
+  uint32_t tone_num = (((rf_bw & 0xc) >> 2) == 0x2) ? 128 : 64;
+  auto tones = enumerate_tones(fc_mhz, bw_mhz, spec.f_lo_khz, spec.f_hi_khz);
+
+  uint8_t table[128] = {}; /* 256 tone entries / 2 per byte */
+  uint8_t nib = uint8_t(0x8 | (spec.wgt & 0x7));
+  for (int k : tones) {
+    uint32_t idx;
+    if (k >= 0) {
+      idx = (uint32_t(k) >= tone_num - 1) ? (tone_num - 1) : uint32_t(k);
+    } else {
+      uint32_t a = uint32_t(-k);
+      if (a >= tone_num) a = tone_num;
+      idx = (tone_num << 1) - a;
+    }
+    if (idx >= 256) continue;
+    table[idx >> 1] |= (idx & 1) ? uint8_t(nib << 4) : nib;
+  }
+
+  uint32_t idx_lmt = tone_num; /* full table for the current FFT size */
+  dev.phy_set_bb_reg(0x1ee8, 0x3, 0x3);
+  dev.phy_set_bb_reg(0x1d94, 0xc0000000, 0x1);
+  for (uint32_t a = 0; a < idx_lmt; a++) {
+    dev.phy_set_bb_reg(0x1d94, 0x00ff0000, a);
+    dev.phy_set_bb_reg(0x1d94, 0x000000ff, table[a]);
+  }
+  dev.phy_set_bb_reg(0x1ee8, 0x3, 0x0);
+  dev.phy_set_bb_reg(0xc0c, 1u << 3, tones.empty() ? 0 : 1);
+  return tones.size();
+}
+
+inline void csi_mask_clear_jgr3(RtlUsbAdapter &dev) {
+  dev.phy_set_bb_reg(0x1ee8, 0x3, 0x3);
+  dev.phy_set_bb_reg(0x1d94, 0xc0000000, 0x1);
+  for (uint32_t a = 0; a < 128; a++) {
+    dev.phy_set_bb_reg(0x1d94, 0x00ff0000, a);
+    dev.phy_set_bb_reg(0x1d94, 0x000000ff, 0);
+  }
+  dev.phy_set_bb_reg(0x1ee8, 0x3, 0x0);
+  dev.phy_set_bb_reg(0xc0c, 1u << 3, 0);
+}
+
+/* NBI notch, Jaguar-3: tone index (312.5 kHz units, kHz-exact per the x2cu
+ * tree) into 0x1944/0x4044[20:12] per path; enable 0x818[3]=0 (inverted on
+ * 8822C/E) + 0x818[11]=1 + 0x1D3C[30:27]=0xF + 0x1940/0x4040[31]. */
+inline bool nbi_apply_jgr3(RtlUsbAdapter &dev, uint32_t fc_mhz,
+                           uint32_t bw_mhz, uint32_t f_intf_khz, int n_paths) {
+  uint32_t fc_khz = fc_mhz * 1000;
+  uint32_t bw_up = fc_khz + bw_mhz * 500, bw_low = fc_khz - bw_mhz * 500;
+  if (f_intf_khz < bw_low || f_intf_khz > bw_up) return false;
+  uint32_t dist = (f_intf_khz > fc_khz) ? (f_intf_khz - fc_khz)
+                                        : (fc_khz - f_intf_khz);
+  uint32_t idx = dist / 312;
+
+  uint8_t rf_bw = dev.rtw_read8(0x9b0);
+  uint32_t tone_num = (((rf_bw & 0xc) >> 2) == 0x2) ? 128 : 64;
+  if (f_intf_khz >= fc_khz) { /* FREQ_POSITIVE */
+    if (idx >= tone_num - 1) idx = tone_num - 1;
+  } else {
+    if (idx >= tone_num) idx = tone_num;
+    idx = (tone_num << 1) - idx;
+  }
+
+  static constexpr uint16_t tone_reg[] = {0x1944, 0x4044};
+  static constexpr uint16_t en_reg[] = {0x1940, 0x4040};
+  if (n_paths > 2) n_paths = 2; /* 8822C/E are 2T2R */
+  for (int p = 0; p < n_paths; p++)
+    dev.phy_set_bb_reg(tone_reg[p], 0x001FF000, idx);
+
+  dev.phy_set_bb_reg(0x818, 1u << 3, 0); /* !enable on 8822C/8822E */
+  dev.phy_set_bb_reg(0x818, 1u << 11, 1);
+  dev.phy_set_bb_reg(0x1d3c, 0x78000000, 0xf);
+  for (int p = 0; p < n_paths; p++)
+    dev.phy_set_bb_reg(en_reg[p], 1u << 31, 1);
+  return true;
+}
+
+/* phydm_nbi_reset_jgr3 (8822C/E subset). */
+inline void nbi_disable_jgr3(RtlUsbAdapter &dev) {
+  dev.phy_set_bb_reg(0x818, 1u << 3, 1);
+  dev.phy_set_bb_reg(0x1d3c, 0x78000000, 0);
+  dev.phy_set_bb_reg(0x818, 1u << 3, 0);
+  dev.phy_set_bb_reg(0x818, 1u << 11, 0);
+  dev.phy_set_bb_reg(0x1940, 1u << 31, 0);
+  dev.phy_set_bb_reg(0x4040, 1u << 31, 0);
+}
+
+/* ---- env-driven entry point ----------------------------------------------
+ *
+ * Reads DEVOURER_RX_CSI_MASK / DEVOURER_RX_NBI and applies whichever is set,
+ * for the current channel state. Call after the channel set (like
+ * DEVOURER_RX_PATHS, the mask is the final word for a single-channel capture;
+ * a later channel switch does not re-derive it). n_paths: RX chains to arm for
+ * the Jaguar-3 NBI / the 8822B second-path enable. */
+inline void apply_from_env(RtlUsbAdapter &dev, Logger_t logger, Family fam,
+                           const SelectedChannel &ch, int n_paths) {
+  const char *csi_env = std::getenv("DEVOURER_RX_CSI_MASK");
+  const char *nbi_env = std::getenv("DEVOURER_RX_NBI");
+  if (!csi_env && !nbi_env) return;
+
+  uint32_t bw_mhz = bw_mhz_from(ch.ChannelWidth);
+  int sec = sec_from_prime_offset(ch.ChannelOffset);
+  uint32_t fc = find_fc_mhz(ch.Channel, bw_mhz, sec);
+  if (!fc) {
+    logger->error("ToneMask: no fc for ch={} bw={} sec={} — knobs ignored",
+                  unsigned(ch.Channel), bw_mhz, sec);
+    return;
+  }
+
+  if (csi_env) {
+    CsiMaskSpec spec = parse_csi_spec(csi_env);
+    if (!spec.valid) {
+      logger->error("DEVOURER_RX_CSI_MASK — bad spec '{}' "
+                    "(want <fstart>[-<fend>][/wgt], MHz)", csi_env);
+    } else {
+      size_t masked = (fam == Family::JGR3)
+                          ? csi_mask_apply_jgr3(dev, fc, bw_mhz, spec)
+                          : csi_mask_apply_11ac(dev, fc, bw_mhz, spec);
+      if (fam == Family::JGR3) {
+        logger->info("DEVOURER_RX_CSI_MASK: {} tones masked (fc={} MHz, "
+                     "wgt={}), 0xc0c=0x{:08x}",
+                     masked, fc, spec.wgt, dev.rtw_read32(0xc0c));
+      } else {
+        logger->info("DEVOURER_RX_CSI_MASK: {} tones masked (fc={} MHz), "
+                     "0x874=0x{:08x} mask[0x880..0x89c]={:08x} {:08x} {:08x} "
+                     "{:08x} {:08x} {:08x} {:08x} {:08x}",
+                     masked, fc, dev.rtw_read32(0x874), dev.rtw_read32(0x880),
+                     dev.rtw_read32(0x884), dev.rtw_read32(0x888),
+                     dev.rtw_read32(0x88c), dev.rtw_read32(0x890),
+                     dev.rtw_read32(0x894), dev.rtw_read32(0x898),
+                     dev.rtw_read32(0x89c));
+      }
+      if (!masked)
+        logger->warn("DEVOURER_RX_CSI_MASK: spec '{}' covers no tone inside "
+                     "the tuned {} MHz channel — mask disabled", csi_env,
+                     bw_mhz);
+    }
+  }
+
+  if (nbi_env) {
+    char *end = nullptr;
+    unsigned long f_mhz = std::strtoul(nbi_env, &end, 10);
+    if (end == nbi_env || *end != '\0') {
+      logger->error("DEVOURER_RX_NBI — bad frequency '{}' (want MHz)", nbi_env);
+    } else {
+      bool ok = (fam == Family::JGR3)
+                    ? nbi_apply_jgr3(dev, fc, bw_mhz, uint32_t(f_mhz) * 1000,
+                                     n_paths)
+                    : nbi_apply_11ac(dev, fam, fc, bw_mhz, uint32_t(f_mhz),
+                                     n_paths >= 2);
+      if (ok) {
+        if (fam == Family::JGR3)
+          logger->info("DEVOURER_RX_NBI: notch at {} MHz (fc={}), "
+                       "0x818=0x{:08x} 0x1944=0x{:08x}",
+                       f_mhz, fc, dev.rtw_read32(0x818),
+                       dev.rtw_read32(0x1944));
+        else
+          logger->info("DEVOURER_RX_NBI: notch at {} MHz (fc={}), "
+                       "0x87c=0x{:08x}",
+                       f_mhz, fc, dev.rtw_read32(0x87c));
+      } else {
+        logger->warn("DEVOURER_RX_NBI: {} MHz outside the tuned {} MHz "
+                     "channel (fc={}) — notch not armed", f_mhz, bw_mhz, fc);
+      }
+    }
+  }
+}
+
+} /* namespace tonemask */
+} /* namespace devourer */
+
+#endif /* DEVOURER_TONE_MASK_H */

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -3,6 +3,7 @@
 #include "EepromManager.h"
 #include "RadioManagementModule.h"
 #include "SignalStop.h"
+#include "ToneMask.h"
 
 #include <chrono>
 #include <cstdio>
@@ -492,6 +493,20 @@ void RtlJaguarDevice::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
       _device.rtw_write8(0x808, mask);
       _logger->info("DEVOURER_RX_PATHS: RX-path mask 0x808[7:0]=0x{:02x}", mask);
     }
+  }
+
+  /* DEVOURER_RX_CSI_MASK / DEVOURER_RX_NBI — RX-side per-subcarrier masking
+   * (receive-equalizer CSI mask / narrowband notch), the poor-man's preamble
+   * puncturing. Applied here for the same reason as DEVOURER_RX_PATHS: after
+   * the channel set it is the final word; a later channel switch reverts it,
+   * so it targets a single-channel RX capture. See ToneMask.h. */
+  {
+    auto fam = (_eepromManager->version_id.ICType == CHIP_8814A)
+                   ? devourer::tonemask::Family::AC2_8814
+                   : devourer::tonemask::Family::AC1;
+    devourer::tonemask::apply_from_env(
+        _device, _logger, fam, _channel,
+        (_eepromManager->version_id.ICType == CHIP_8814A) ? 4 : 2);
   }
 
   _logger->info("Listening air...");

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -13,6 +13,7 @@
 
 #include "FrameParserJaguar2.h"
 #include "Halrf8822b.h"
+#include "ToneMask.h"
 #include "RateDefinitions.h"
 #include "RxPacket.h"
 #include "SignalStop.h" /* g_devourer_should_stop */
@@ -147,6 +148,13 @@ void RtlJaguar2Device::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
     });
     _logger->info("RtlJaguar2Device: DIG thread started");
   }
+
+  /* DEVOURER_RX_CSI_MASK / DEVOURER_RX_NBI — RX-side per-subcarrier masking
+   * (receive-equalizer CSI mask / narrowband notch). Applied after the channel
+   * set so it is the final word for a single-channel capture. See ToneMask.h. */
+  devourer::tonemask::apply_from_env(_device, _logger,
+                                     devourer::tonemask::Family::AC2_8822B,
+                                     _channel, 2);
 
   _logger->info("RtlJaguar2Device: entering RX loop (ch={})", _channel.Channel);
 

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -11,6 +11,7 @@
 #include "FrameParserJaguar3.h"
 #include "RateDefinitions.h" /* MGN_* rate enum (shared across the family) */
 #include "SignalStop.h" /* g_devourer_should_stop — set by demo signal handlers */
+#include "ToneMask.h"   /* DEVOURER_RX_CSI_MASK / DEVOURER_RX_NBI knobs */
 
 extern "C" {
 #include "ieee80211_radiotap.h" /* MRateToHwRate + radiotap iterator */
@@ -128,6 +129,17 @@ void RtlJaguar3Device::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
         std::this_thread::sleep_for(std::chrono::milliseconds(250));
       }
     }
+  }
+
+  /* DEVOURER_RX_CSI_MASK / DEVOURER_RX_NBI — RX-side per-subcarrier masking
+   * (receive-equalizer CSI mask / narrowband notch). Applied after the channel
+   * set so it is the final word for a single-channel capture; serialized
+   * against the coex housekeeping tick like every other register writer here.
+   * See ToneMask.h. */
+  if (std::getenv("DEVOURER_RX_CSI_MASK") || std::getenv("DEVOURER_RX_NBI")) {
+    std::lock_guard<std::mutex> lk(_reg_mu);
+    devourer::tonemask::apply_from_env(
+        _device, _logger, devourer::tonemask::Family::JGR3, _channel, 2);
   }
 
   _logger->info("Jaguar3: entering RX loop (kernel-style async URB queue)");

--- a/tests/pseudo_puncture_detect.sh
+++ b/tests/pseudo_puncture_detect.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# pseudo_puncture_detect.sh — the DETECTION half of the pseudo-puncturing
+# study (docs/pseudo-preamble-puncturing.md): locate the jammed 20 MHz slice
+# of the ch36 80 MHz block. B210 AWGN jams the ch48 slice (5230-5250).
+#
+# Two detector modes (MODE arg):
+#
+#   sound — per-tone SNR via MU self-sounding (docs/beamforming-self-sounding
+#           .md): sound each 20 MHz slice in turn, decode the beamformee's MU
+#           report. Roles: 8822EU sounder (0bda:a81a), 8812CU MU beamformee
+#           (0bda:c812), 8814AU sniffer (0bda:8813 — RX-only role, works even
+#           when its TX FW-boot fails). MEASURED CAVEAT: this senses the
+#           channel AT THE BEAMFORMEE; on a bench where the sounding pair sits
+#           point-blank (NDP SNR ~50 dB) the jam barely dents the report and
+#           the detector does NOT discriminate the slice.
+#
+#   probe — per-slice link probing with the victim pair itself: TX (8822BU
+#           T3U) + RX (8814AU) hop 20 MHz across ch36/40/44/48 and compare
+#           canonical-SA hit rates. The jammed slice is the delivery minimum.
+#           This senses the victim's own channel — the quantity that matters.
+#
+# Usage: sudo tests/pseudo_puncture_detect.sh [sound|probe|both] [JAM_GAIN] [DUR]
+
+set -u
+cd "$(dirname "$0")/.."
+
+MODE=${1:-probe}
+JAM_GAIN=${2:-70}
+DUR=${3:-12}
+
+SND_PID=0xa81a   # 8822EU sounder
+BFEE_PID=0xc812  # 8812CU MU beamformee
+SNF_PID=0x8813   # 8814AU sniffer
+PROBE_TX_VID=2357; PROBE_TX_PID=0x012d  # 8822BU T3U
+PROBE_RX_VID=0bda; PROBE_RX_PID=0x8813  # 8814AU
+
+BFER_MAC="57:42:75:05:d6:00"   # canonical SA = NDPA TA
+BFEE_MAC="00:e0:4c:88:22:ce"   # 8812CU EFUSE MAC (see tests/bf_waterfall.sh)
+
+JAM_FREQ=5240e6  # center of the ch48 slice (5230-5250)
+JAM_RATE=20e6
+
+LOGDIR=/tmp/devourer-pseudo-puncture-detect
+mkdir -p "$LOGDIR"
+
+JAM_PID=""
+cleanup() {
+  [ -n "$JAM_PID" ] && kill -INT "$JAM_PID" 2>/dev/null
+  pkill -INT -x WiFiDriverTxDemo 2>/dev/null
+  pkill -INT -x WiFiDriverDemo 2>/dev/null
+  pkill -INT -f sdr_interferer 2>/dev/null
+  sleep 1
+  pkill -KILL -x WiFiDriverTxDemo 2>/dev/null
+  pkill -KILL -x WiFiDriverDemo 2>/dev/null
+  pkill -KILL -f sdr_interferer 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+jam_start() {
+  python3 tests/sdr_interferer.py --freq "$JAM_FREQ" --rate "$JAM_RATE" \
+    --tx-gain "$JAM_GAIN" >"$LOGDIR/jammer.log" 2>&1 &
+  JAM_PID=$!
+  sleep 3
+  kill -0 "$JAM_PID" 2>/dev/null || {
+    echo "FATAL: jammer died — $LOGDIR/jammer.log"; exit 2; }
+}
+
+jam_stop() {
+  [ -n "$JAM_PID" ] && { kill -INT "$JAM_PID" 2>/dev/null; wait "$JAM_PID" 2>/dev/null; }
+  JAM_PID=""
+  sleep 1
+}
+
+# ---- sound mode -----------------------------------------------------------
+
+sound_slice() { # <label> <channel>
+  local label=$1 ch=$2
+  local bfee_log="$LOGDIR/$label.bfee.log" snf_log="$LOGDIR/$label.snf.log"
+  local tx_log="$LOGDIR/$label.tx.log"
+
+  env DEVOURER_PID=$BFEE_PID DEVOURER_CHANNEL="$ch" \
+      DEVOURER_BF_ARM_BFEE="$BFER_MAC" DEVOURER_BF_ARM_BFEE_MU=1 \
+      timeout -s INT -k 5 $((DUR + 55)) ./build/WiFiDriverDemo >"$bfee_log" 2>&1 &
+  local bfee_pid=$!
+  for _ in $(seq 80); do grep -q "entering RX loop\|Listening air" "$bfee_log" && break; sleep 0.5; done
+
+  env DEVOURER_PID=$SNF_PID DEVOURER_CHANNEL="$ch" DEVOURER_BF_DETECT_REPORT=4 \
+      timeout -s INT -k 5 $((DUR + 35)) ./build/WiFiDriverDemo >"$snf_log" 2>&1 &
+  local snf_pid=$!
+  for _ in $(seq 60); do grep -q "Listening air\|entering RX loop" "$snf_log" && break; sleep 0.5; done
+
+  env DEVOURER_PID=$SND_PID DEVOURER_CHANNEL="$ch" DEVOURER_TX_RATE=VHT2SS_MCS0 \
+      DEVOURER_TX_NDPA_RA="$BFEE_MAC" DEVOURER_TX_NDPA=1 DEVOURER_TX_NDPA_MU=1 \
+      DEVOURER_BF_ARM_SOUNDER=1 \
+      timeout -s INT -k 5 "$DUR" ./build/WiFiDriverTxDemo >"$tx_log" 2>&1
+
+  kill -INT "$bfee_pid" "$snf_pid" 2>/dev/null
+  wait "$bfee_pid" "$snf_pid" 2>/dev/null
+  sleep 5  # warm-FW settle before re-opening the same dongles
+
+  local n
+  n=$(grep -c "devourer-bf-report-raw" "$snf_log")
+  echo "$n" >"$LOGDIR/$label.count"
+  if [ "$n" -gt 0 ]; then
+    grep "devourer-bf-report-raw" "$snf_log" \
+      | python3 tools/bf_report_decode.py --max-frames 50 \
+      >"$LOGDIR/$label.decode" 2>&1 || true
+  fi
+  echo "  slice ch$ch [$label]: $n reports"
+}
+
+run_sound() {
+  echo "== sound detector: jam OFF (reference) =="
+  for ch in 36 40 44 48; do sound_slice "off-ch$ch" "$ch"; done
+  echo "== sound detector: jam ON =="
+  jam_start
+  for ch in 36 40 44 48; do sound_slice "on-ch$ch" "$ch"; done
+  jam_stop
+  echo
+  echo "== report counts (off -> on); per-tone SNR in $LOGDIR/*.decode =="
+  for ch in 36 40 44 48; do
+    printf "  ch%-3s %5s -> %s\n" "$ch" \
+      "$(cat "$LOGDIR/off-ch$ch.count")" "$(cat "$LOGDIR/on-ch$ch.count")"
+  done
+}
+
+# ---- probe mode -----------------------------------------------------------
+
+probe_slice() { # <label> <channel>
+  local label=$1 ch=$2
+  local rxlog="$LOGDIR/$label.rx.log" txlog="$LOGDIR/$label.tx.log"
+
+  env DEVOURER_VID="0x$PROBE_TX_VID" DEVOURER_PID="$PROBE_TX_PID" \
+      DEVOURER_CHANNEL="$ch" \
+      timeout -s INT -k 5 $((DUR + 10)) ./build/WiFiDriverTxDemo >"$txlog" 2>&1 &
+  local txpid=$!
+  sleep 5
+
+  env DEVOURER_VID="0x$PROBE_RX_VID" DEVOURER_PID="$PROBE_RX_PID" \
+      DEVOURER_CHANNEL="$ch" \
+      timeout -s INT -k 5 "$DUR" ./build/WiFiDriverDemo >"$rxlog" 2>&1
+  wait "$txpid" 2>/dev/null
+  sleep 5
+
+  local hits
+  hits=$(grep -c "devourer-tx-hit" "$rxlog")
+  echo "$hits" >"$LOGDIR/$label.count"
+  echo "  slice ch$ch [$label]: $hits hits"
+}
+
+run_probe() {
+  echo "== probe detector: jam ON, scanning slices =="
+  jam_start
+  for ch in 36 40 44 48; do probe_slice "probe-ch$ch" "$ch"; done
+  jam_stop
+  echo
+  local min_ch="" min_n=999999 n
+  echo "== per-slice delivery =="
+  for ch in 36 40 44 48; do
+    n=$(cat "$LOGDIR/probe-ch$ch.count")
+    printf "  ch%-3s %s hits\n" "$ch" "$n"
+    if [ "$n" -lt "$min_n" ]; then min_n=$n; min_ch=$ch; fi
+  done
+  echo
+  if [ "$min_ch" = 48 ]; then
+    echo "VERDICT: probe detector PICKS the jammed slice (ch48 minimum, $min_n hits)"
+  else
+    echo "VERDICT: probe detector MISSED — minimum is ch$min_ch, expected ch48"
+    return 1
+  fi
+}
+
+echo "pseudo-puncture detect: mode=$MODE, jam ch48-slice @ ${JAM_GAIN} dB, ${DUR}s cells"
+echo
+rc=0
+case "$MODE" in
+  sound) run_sound ;;
+  probe) run_probe || rc=1 ;;
+  both)  run_sound; run_probe || rc=1 ;;
+  *) echo "usage: $0 [sound|probe|both] [JAM_GAIN] [DUR]"; exit 2 ;;
+esac
+exit $rc

--- a/tests/pseudo_puncture_onair.sh
+++ b/tests/pseudo_puncture_onair.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# pseudo_puncture_onair.sh — the jammed-slice experiment behind
+# docs/pseudo-preamble-puncturing.md.
+#
+# Question: with one 20 MHz slice of an 80 MHz channel jammed, how much of the
+# Wi-Fi 7 "transmit around the dirty slice" win can 802.11ac silicon recover?
+#
+# Rig: two devourer DUTs on the ch36 80 MHz block (5170-5250, fc 5210) + a
+# USRP B210 jamming the TOP 20 MHz slice (5230-5250, center 5240) with
+# band-limited AWGN (tests/sdr_interferer.py — reproducible via --tx-gain).
+#
+# Cells (RX counts canonical-SA hits over a fixed window):
+#   A clean-80   VHT80 TX, 80 MHz RX, no jam            — bench baseline
+#   B jam-80     same + jammer                          — the damage
+#   C jam-80-csi same + DEVOURER_RX_CSI_MASK=5230-5250  — RX-side "puncturing"
+#   D jam-40     TX+RX drop to ch36 BW40 (clean half)   — TX-side avoidance
+#
+# Verdict logic: C > B means the receive-equalizer mask recovers real goodput
+# under a jammed slice; D ≈ A (at half the PHY rate) is the avoidance bound.
+#
+# Usage:
+#   sudo tests/pseudo_puncture_onair.sh [TX_VID:PID] [RX_VID:PID] [JAM_GAIN] [DUR]
+# Defaults: TX 2357:012d (8822BU T3U — BW80 TX validated), RX 0bda:8813
+# (8814AU), gain 60 dB, 15 s per cell. Sweep JAM_GAIN until cell B drops
+# hard but not to zero (a fully-saturated front-end can't be masked back).
+
+set -u
+cd "$(dirname "$0")/.."
+
+TX_SPEC=${1:-2357:012d}
+RX_SPEC=${2:-0bda:8813}
+JAM_GAIN=${3:-60}
+DUR=${4:-15}
+
+TX_VID=${TX_SPEC%:*}; TX_PID=${TX_SPEC#*:}
+RX_VID=${RX_SPEC%:*}; RX_PID=${RX_SPEC#*:}
+
+JAM_FREQ=5240e6   # center of the 5230-5250 slice (ch48 quarter of the block)
+JAM_RATE=20e6
+MASK_SPEC=5230-5250
+
+LOGDIR=/tmp/devourer-pseudo-puncture
+rm -rf "$LOGDIR"; mkdir -p "$LOGDIR"
+
+JAM_PID=""
+cleanup() {
+  [ -n "$JAM_PID" ] && kill -INT "$JAM_PID" 2>/dev/null
+  pkill -INT -x WiFiDriverTxDemo 2>/dev/null
+  pkill -INT -x WiFiDriverDemo 2>/dev/null
+  pkill -INT -f sdr_interferer 2>/dev/null
+  sleep 1
+  pkill -KILL -x WiFiDriverTxDemo 2>/dev/null
+  pkill -KILL -x WiFiDriverDemo 2>/dev/null
+  pkill -KILL -f sdr_interferer 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+jam_start() {
+  python3 tests/sdr_interferer.py --freq "$JAM_FREQ" --rate "$JAM_RATE" \
+    --tx-gain "$JAM_GAIN" >"$LOGDIR/jammer.log" 2>&1 &
+  JAM_PID=$!
+  sleep 3
+  kill -0 "$JAM_PID" 2>/dev/null || {
+    echo "FATAL: jammer died — $LOGDIR/jammer.log"; exit 2; }
+}
+
+jam_stop() {
+  [ -n "$JAM_PID" ] && { kill -INT "$JAM_PID" 2>/dev/null; wait "$JAM_PID" 2>/dev/null; }
+  JAM_PID=""
+  sleep 1
+}
+
+# run_cell <name> <bw> <tx_rate> <rx_mask ('' = none)>
+run_cell() {
+  local name=$1 bw=$2 rate=$3 mask=$4
+  local rxlog="$LOGDIR/rx-$name.log" txlog="$LOGDIR/tx-$name.log"
+  local mask_env=()
+  [ -n "$mask" ] && mask_env=(DEVOURER_RX_CSI_MASK="$mask")
+
+  env DEVOURER_VID="0x$TX_VID" DEVOURER_PID="0x$TX_PID" DEVOURER_CHANNEL=36 \
+      DEVOURER_HOP_BW="$bw" DEVOURER_TX_RATE="$rate" \
+      timeout -s INT -k 5 $((DUR + 10)) ./build/WiFiDriverTxDemo >"$txlog" 2>&1 &
+  local txpid=$!
+  sleep 5  # TX bring-up (DLFW + cal)
+
+  env DEVOURER_VID="0x$RX_VID" DEVOURER_PID="0x$RX_PID" DEVOURER_CHANNEL=36 \
+      DEVOURER_BW="$bw" "${mask_env[@]}" \
+      timeout -s INT -k 5 "$DUR" ./build/WiFiDriverDemo >"$rxlog" 2>&1
+
+  wait "$txpid" 2>/dev/null
+  sleep 5  # warm-FW settle before the same dongles re-open
+
+  local hits
+  hits=$(grep -c "devourer-tx-hit" "$rxlog")
+  echo "$hits" >"$LOGDIR/$name.count"
+  echo "cell $name: $hits hits  (bw=$bw rate=$rate mask='${mask:-none}')"
+}
+
+echo "pseudo-puncture on-air: TX $TX_SPEC -> RX $RX_SPEC, jam ${JAM_FREQ} @ ${JAM_GAIN} dB, ${DUR}s cells"
+echo
+
+run_cell clean-80 80 VHT1SS_MCS0/80 ""
+
+jam_start
+run_cell jam-80     80 VHT1SS_MCS0/80 ""
+run_cell jam-80-csi 80 VHT1SS_MCS0/80 "$MASK_SPEC"
+run_cell jam-40     40 VHT1SS_MCS0/40 ""
+jam_stop
+
+A=$(cat "$LOGDIR/clean-80.count")
+B=$(cat "$LOGDIR/jam-80.count")
+C=$(cat "$LOGDIR/jam-80-csi.count")
+D=$(cat "$LOGDIR/jam-40.count")
+
+echo
+echo "== results (canonical-SA hits / ${DUR}s) =="
+printf "  %-28s %s\n" "A clean VHT80:" "$A"
+printf "  %-28s %s\n" "B jammed VHT80:" "$B"
+printf "  %-28s %s\n" "C jammed VHT80 + CSI mask:" "$C"
+printf "  %-28s %s\n" "D jammed, 40 MHz avoidance:" "$D"
+echo
+if [ "$A" -lt 20 ]; then
+  echo "VERDICT: bench broken (clean baseline $A hits) — fix the rig first"
+  exit 1
+fi
+if [ "$B" -ge $((A * 7 / 10)) ]; then
+  echo "VERDICT: jammer too weak (B=$B vs A=$A) — raise JAM_GAIN and re-run"
+  exit 1
+fi
+echo "damage:            B/A = $((B * 100 / A))%"
+echo "CSI-mask recovery: C/A = $((C * 100 / A))%  (uplift vs B: $((C - B)) hits)"
+echo "40MHz avoidance:   D/A = $((D * 100 / A))%"

--- a/tests/rx80_narrow_tx_probe.sh
+++ b/tests/rx80_narrow_tx_probe.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# rx80_narrow_tx_probe.sh — can a receiver tuned at 80 MHz decode narrower
+# frames sent on its primary sub-channels, WITHOUT retuning?
+#
+# Decides whether TX-side bandwidth adaptation (the "puncture by primary
+# selection" lever from docs/pseudo-preamble-puncturing.md) is UNILATERAL —
+# a VTX shrinking 80->40->20 frame-by-frame with no RX coordination — or
+# needs a lockstep bandwidth change over the feedback channel first.
+#
+# Cells (TX bw varies, RX fixed at ch36 BW80; controls bracket the question):
+#   80->80   control: known-good wide link
+#   40->80   THE QUESTION (primary 40 of the block)
+#   20->80   bonus: legacy-20 on the primary
+#   40->40   control: proves the 40 MHz TX itself is healthy
+#
+# Usage: sudo tests/rx80_narrow_tx_probe.sh [TX_VID:PID] [RX_VID:PID] [DUR]
+# Defaults: TX 2357:012d (8822BU T3U), RX 0bda:8813 (8814AU), 15 s cells.
+
+set -u
+cd "$(dirname "$0")/.."
+
+TX_SPEC=${1:-2357:012d}
+RX_SPEC=${2:-0bda:8813}
+DUR=${3:-15}
+
+TX_VID=${TX_SPEC%:*}; TX_PID=${TX_SPEC#*:}
+RX_VID=${RX_SPEC%:*}; RX_PID=${RX_SPEC#*:}
+
+LOGDIR=/tmp/devourer-rx80-narrow-tx
+rm -rf "$LOGDIR"; mkdir -p "$LOGDIR"
+
+cleanup() {
+  pkill -INT -x WiFiDriverTxDemo 2>/dev/null
+  pkill -INT -x WiFiDriverDemo 2>/dev/null
+  sleep 1
+  pkill -KILL -x WiFiDriverTxDemo 2>/dev/null
+  pkill -KILL -x WiFiDriverDemo 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+# run_cell <name> <tx_bw 20|40|80> <tx_rate> <rx_bw 20|40|80>
+run_cell() {
+  local name=$1 tx_bw=$2 rate=$3 rx_bw=$4
+  local rxlog="$LOGDIR/rx-$name.log" txlog="$LOGDIR/tx-$name.log"
+  local tx_env=() rx_env=()
+  [ "$tx_bw" != 20 ] && tx_env=(DEVOURER_HOP_BW="$tx_bw")
+  [ "$rx_bw" != 20 ] && rx_env=(DEVOURER_BW="$rx_bw")
+
+  env DEVOURER_VID="0x$TX_VID" DEVOURER_PID="0x$TX_PID" DEVOURER_CHANNEL=36 \
+      "${tx_env[@]}" DEVOURER_TX_RATE="$rate" \
+      timeout -s INT -k 5 $((DUR + 10)) ./build/WiFiDriverTxDemo >"$txlog" 2>&1 &
+  local txpid=$!
+  sleep 5
+
+  env DEVOURER_VID="0x$RX_VID" DEVOURER_PID="0x$RX_PID" DEVOURER_CHANNEL=36 \
+      "${rx_env[@]}" \
+      timeout -s INT -k 5 "$DUR" ./build/WiFiDriverDemo >"$rxlog" 2>&1
+  wait "$txpid" 2>/dev/null
+  sleep 5
+
+  local hits
+  hits=$(grep -c "devourer-tx-hit" "$rxlog")
+  echo "$hits" >"$LOGDIR/$name.count"
+  printf "  %-9s TX@%-2s -> RX@%-2s : %s hits\n" "$name" "$tx_bw" "$rx_bw" "$hits"
+}
+
+echo "rx80-narrow-tx probe: TX $TX_SPEC -> RX $RX_SPEC, ch36 block, ${DUR}s cells"
+run_cell 80to80 80 VHT1SS_MCS0/80 80
+run_cell 40to80 40 VHT1SS_MCS0/40 80
+run_cell 20to80 20 6M             80
+run_cell 40to40 40 VHT1SS_MCS0/40 40
+
+A=$(cat "$LOGDIR/80to80.count"); B=$(cat "$LOGDIR/40to80.count")
+C=$(cat "$LOGDIR/20to80.count"); D=$(cat "$LOGDIR/40to40.count")
+echo
+if [ "$A" -lt 20 ]; then
+  echo "VERDICT: bench broken (80->80 control $A hits)"; exit 1
+fi
+if [ "$D" -lt 20 ]; then
+  echo "VERDICT: 40 MHz TX itself broken (40->40 control $D hits)"; exit 1
+fi
+if [ "$B" -ge $((D / 2)) ]; then
+  echo "VERDICT: UNILATERAL — RX@80 decodes primary-40 frames ($B vs $D retuned)."
+  echo "         TX can shrink/grow bandwidth per-packet with no RX coordination."
+else
+  echo "VERDICT: LOCKSTEP — RX@80 misses primary-40 frames ($B vs $D retuned)."
+  echo "         Bandwidth changes must ride the feedback channel."
+fi
+[ "$C" -ge $((D / 2)) ] \
+  && echo "         (legacy-20 on the primary also decodes at RX@80: $C hits)" \
+  || echo "         (legacy-20 at RX@80: only $C hits)"

--- a/tests/sdr_interferer.py
+++ b/tests/sdr_interferer.py
@@ -101,6 +101,16 @@ def main(argv=None) -> int:
         # +2.5 MHz tone within the band — a deterministic, strong interferer.
         t = np.arange(nsamps) / args.rate
         tone = (args.amplitude * np.exp(2j * np.pi * 2.5e6 * t)).astype(np.complex64)
+    else:
+        # Pre-generated noise ring: drawing fresh Gaussians per 8192-sample
+        # buffer in Python cannot keep 20 MS/s fed — the TX stream starves
+        # (solid 'U' underflow spam) and the jam radiates only in bursts.
+        # 64 fixed-seed buffers cycle with a ~26 ms period at 20 MS/s: still
+        # band-filling AWGN to the victim PHY, still reproducible per seed.
+        NRING = 64
+        ring = [((rng.standard_normal(nsamps) + 1j * rng.standard_normal(nsamps))
+                 / np.sqrt(2)).astype(np.complex64) for _ in range(NRING)]
+        ring_scaled = [(args.amplitude * b).astype(np.complex64) for b in ring]
 
     sys.stderr.write(
         f"[interferer] freq={args.freq/1e9:.4f} GHz rate={args.rate/1e6:g} MS/s "
@@ -145,10 +155,10 @@ def main(argv=None) -> int:
             amp = args.amplitude
         if args.mode == "cw":
             buf = (tone * (amp / max(1e-9, args.amplitude))).astype(np.complex64)
+        elif fade_on:
+            buf = (amp * ring[nbuf % NRING]).astype(np.complex64)
         else:
-            buf = (amp *
-                   (rng.standard_normal(nsamps) + 1j * rng.standard_normal(nsamps))
-                   / np.sqrt(2)).astype(np.complex64)
+            buf = ring_scaled[nbuf % NRING]
         tx.send(buf.reshape(1, -1), md)
         md.start_of_burst = False
         sent += nsamps

--- a/tests/tone_mask_regcheck.sh
+++ b/tests/tone_mask_regcheck.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# tone_mask_regcheck.sh — register-landing check for the DEVOURER_RX_CSI_MASK /
+# DEVOURER_RX_NBI knobs (src/ToneMask.h) on every plugged Jaguar generation.
+#
+# Per DUT: run WiFiDriverDemo briefly with a CSI-mask slice + an NBI notch
+# inside the tuned channel, then assert from the demo log that
+#   - the CSI mask enumerated >0 tones and the enable bit reads back set
+#     (0x874[0] on 11ac, 0xC0C[3] on Jaguar-3), and
+#   - the NBI notch armed (0x87C[13] on 11ac, 0x818[11] on Jaguar-3).
+#
+# This validates that the ported phydm register recipes land on real silicon;
+# whether the mask *helps* under a jammed slice is the separate on-air
+# experiment (tests/pseudo_puncture_onair.sh).
+#
+# Usage: sudo tests/tone_mask_regcheck.sh   (after cmake --build build)
+
+set -u
+cd "$(dirname "$0")/.."
+
+DEMO=./build/WiFiDriverDemo
+[ -x "$DEMO" ] || { echo "FATAL: $DEMO not built"; exit 2; }
+
+LOGDIR=/tmp/devourer-tonemask-regcheck
+rm -rf "$LOGDIR"; mkdir -p "$LOGDIR"
+
+cleanup() {
+  # Exact-comm kill: only our demo binary, nothing else.
+  pkill -INT -x WiFiDriverDemo 2>/dev/null
+  sleep 1
+  pkill -KILL -x WiFiDriverDemo 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+PASS=0; FAIL=0; SKIP=0
+
+# run_cell <name> <vid> <pid> <family> <channel> <bw> <csi_spec> <nbi_mhz>
+#   family: 11ac | jgr3  (selects which readback registers to assert)
+run_cell() {
+  local name=$1 vid=$2 pid=$3 fam=$4 ch=$5 bw=$6 csi=$7 nbi=$8
+  local log="$LOGDIR/${name}.log"
+
+  if ! lsusb -d "${vid}:${pid#0x}" >/dev/null 2>&1; then
+    echo "SKIP  $name (${vid}:${pid#0x} not plugged)"
+    SKIP=$((SKIP+1)); return
+  fi
+
+  local bw_env=()
+  [ "$bw" != 20 ] && bw_env=(DEVOURER_BW="$bw")
+
+  env DEVOURER_VID="0x$vid" DEVOURER_PID="$pid" \
+      DEVOURER_CHANNEL="$ch" "${bw_env[@]}" \
+      DEVOURER_RX_CSI_MASK="$csi" DEVOURER_RX_NBI="$nbi" \
+      timeout -s INT -k 5 15 "$DEMO" >"$log" 2>&1
+  sleep 5  # settle before the next cell — a back-to-back re-open of the same
+           # dongle can fail DLFW when the firmware is still winding down
+
+  local ok=1
+  local csi_line nbi_line
+  csi_line=$(grep -o "DEVOURER_RX_CSI_MASK: [0-9]* tones masked.*" "$log" | head -1)
+  nbi_line=$(grep -o "DEVOURER_RX_NBI: notch at .*" "$log" | head -1)
+
+  if [ -z "$csi_line" ]; then
+    echo "FAIL  $name: no CSI-mask apply line"; ok=0
+  else
+    local ntones; ntones=$(echo "$csi_line" | grep -o "[0-9]* tones" | cut -d' ' -f1)
+    [ "${ntones:-0}" -gt 0 ] || { echo "FAIL  $name: 0 tones masked"; ok=0; }
+    if [ "$fam" = 11ac ]; then
+      # 0x874 readback: bit0 must be set
+      local r874; r874=$(echo "$csi_line" | grep -o "0x874=0x[0-9a-f]*" | cut -d= -f2)
+      [ $(( ${r874:-0} & 1 )) -eq 1 ] || { echo "FAIL  $name: 0x874[0] not set ($r874)"; ok=0; }
+      # at least one mask array dword nonzero
+      echo "$csi_line" | sed 's/.*mask\[0x880\.\.0x89c\]=//' \
+        | grep -qE "[1-9a-f]" \
+        || { echo "FAIL  $name: mask arrays read back all-zero"; ok=0; }
+    else
+      local rc0c; rc0c=$(echo "$csi_line" | grep -o "0xc0c=0x[0-9a-f]*" | cut -d= -f2)
+      [ $(( ${rc0c:-0} & 8 )) -eq 8 ] || { echo "FAIL  $name: 0xc0c[3] not set ($rc0c)"; ok=0; }
+    fi
+  fi
+
+  if [ -z "$nbi_line" ]; then
+    echo "FAIL  $name: no NBI apply line"; ok=0
+  else
+    if [ "$fam" = 11ac ]; then
+      local r87c; r87c=$(echo "$nbi_line" | grep -o "0x87c=0x[0-9a-f]*" | cut -d= -f2)
+      [ $(( ${r87c:-0} & 0x2000 )) -ne 0 ] || { echo "FAIL  $name: 0x87c[13] not set ($r87c)"; ok=0; }
+    else
+      local r818; r818=$(echo "$nbi_line" | grep -o "0x818=0x[0-9a-f]*" | cut -d= -f2)
+      [ $(( ${r818:-0} & 0x800 )) -ne 0 ] || { echo "FAIL  $name: 0x818[11] not set ($r818)"; ok=0; }
+    fi
+  fi
+
+  if [ "$ok" = 1 ]; then
+    echo "PASS  $name: $csi_line"
+    PASS=$((PASS+1))
+  else
+    echo "      log: $log"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# 2.4 GHz ch6 BW20 (fc 2437): mask 2440-2445 MHz, notch 2442 MHz.
+run_cell 8821au-ac1     2357 0x0120 11ac 6 20 2440-2445 2442
+run_cell 8814au-ac2     0bda 0x8813 11ac 6 20 2440-2445 2442
+run_cell 8822bu-jaguar2 2357 0x012d 11ac 6 20 2440-2445 2442
+run_cell 8812cu-jaguar3 0bda 0xc812 jgr3 6 20 2440-2445 2442
+run_cell 8822eu-jaguar3 0bda 0xa81a jgr3 6 20 2440-2445 2442
+# BW80 cell on the Jaguar2 (validated 20/40/80): ch36-48 block (fc 5210),
+# mask the top 20 MHz slice, notch mid-slice.
+run_cell 8822bu-bw80    2357 0x012d 11ac 36 80 5230-5250 5240
+
+echo
+echo "tone_mask_regcheck: $PASS pass, $FAIL fail, $SKIP skip (logs: $LOGDIR)"
+[ "$FAIL" -eq 0 ]

--- a/tests/tone_mask_rx_sanity.sh
+++ b/tests/tone_mask_rx_sanity.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# tone_mask_rx_sanity.sh — paired TX/RX sanity for the tone-mask knobs.
+#
+# Cell A (baseline): devourer TX beacons on one adapter, devourer RX on another,
+#   no tone-mask knobs -> expect canonical-SA hits (proves the bench itself).
+# Cell B (mask off-frequency): same, RX with DEVOURER_RX_CSI_MASK on a slice
+#   AWAY from the TX frequency -> hits must survive (mask doesn't break RX).
+# Cell C (mask on-frequency): RX masks the slice CONTAINING the 20 MHz TX
+#   channel -> expect hits to drop (the mask provably affects demodulation).
+#
+# Usage: sudo tests/tone_mask_rx_sanity.sh [TX_VID:TX_PID RX_VID:RX_PID [ch]]
+# Defaults: TX = 2357:0120 (8821AU), RX = 2357:012d (8822BU T3U), ch 6.
+
+set -u
+cd "$(dirname "$0")/.."
+
+TX_SPEC=${1:-2357:0120}
+RX_SPEC=${2:-2357:012d}
+CH=${3:-6}
+DUR=12
+
+TX_VID=${TX_SPEC%:*}; TX_PID=${TX_SPEC#*:}
+RX_VID=${RX_SPEC%:*}; RX_PID=${RX_SPEC#*:}
+
+LOGDIR=/tmp/devourer-tonemask-sanity
+rm -rf "$LOGDIR"; mkdir -p "$LOGDIR"
+
+cleanup() {
+  pkill -INT -x WiFiDriverTxDemo 2>/dev/null
+  pkill -INT -x WiFiDriverDemo 2>/dev/null
+  sleep 1
+  pkill -KILL -x WiFiDriverTxDemo 2>/dev/null
+  pkill -KILL -x WiFiDriverDemo 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+# ch -> 2.4G frequency (MHz)
+FREQ=$((2412 + (CH - 1) * 5))
+
+run_cell() {
+  local name=$1 csi=$2
+  local rxlog="$LOGDIR/rx-$name.log" txlog="$LOGDIR/tx-$name.log"
+  local csi_env=()
+  [ -n "$csi" ] && csi_env=(DEVOURER_RX_CSI_MASK="$csi")
+
+  env DEVOURER_VID="0x$TX_VID" DEVOURER_PID="0x$TX_PID" DEVOURER_CHANNEL="$CH" \
+      timeout -s INT -k 5 $((DUR + 8)) ./build/WiFiDriverTxDemo >"$txlog" 2>&1 &
+  local txpid=$!
+  sleep 4  # TX bring-up
+
+  env DEVOURER_VID="0x$RX_VID" DEVOURER_PID="0x$RX_PID" DEVOURER_CHANNEL="$CH" \
+      "${csi_env[@]}" \
+      timeout -s INT -k 5 "$DUR" ./build/WiFiDriverDemo >"$rxlog" 2>&1
+
+  wait "$txpid" 2>/dev/null
+  sleep 4  # settle before the next cell re-opens both dongles
+
+  local hits
+  hits=$(grep -c "devourer-tx-hit" "$rxlog")
+  echo "$name: $hits canonical-SA hits  (rx log: $rxlog)"
+  echo "$hits" > "$LOGDIR/$name.count"
+}
+
+# 20 MHz channel: fc = FREQ, band edges +-10 MHz.
+ON_LO=$((FREQ - 8)); ON_HI=$((FREQ + 8))       # mask covering the TX channel
+OFF_LO=$((FREQ + 30)); OFF_HI=$((FREQ + 40))   # outside the tuned 20 MHz -> no-op
+
+run_cell baseline ""
+run_cell mask-off "${OFF_LO}-${OFF_HI}"
+run_cell mask-on  "${ON_LO}-${ON_HI}"
+
+BASE=$(cat "$LOGDIR/baseline.count")
+OFF=$(cat "$LOGDIR/mask-off.count")
+ON=$(cat "$LOGDIR/mask-on.count")
+
+echo
+RC=0
+if [ "$BASE" -lt 10 ]; then
+  echo "FAIL: baseline delivered $BASE hits — bench itself is not working"
+  RC=1
+else
+  # off-frequency mask must not tank RX (allow 50% variance)
+  if [ "$OFF" -lt $((BASE / 2)) ]; then
+    echo "FAIL: off-frequency mask dropped hits $BASE -> $OFF"
+    RC=1
+  else
+    echo "PASS: off-frequency mask preserves RX ($BASE -> $OFF)"
+  fi
+  # on-frequency mask should measurably hurt (expect < 50% of baseline)
+  if [ "$ON" -lt $((BASE / 2)) ]; then
+    echo "PASS: on-frequency mask suppresses RX ($BASE -> $ON) — mask provably active"
+  else
+    echo "WARN: on-frequency mask did not suppress RX ($BASE -> $ON) — mask may be demod-inert at 20 MHz"
+  fi
+fi
+exit $RC

--- a/tests/tone_mask_selftest.cpp
+++ b/tests/tone_mask_selftest.cpp
@@ -1,0 +1,108 @@
+/* Headless regression guard for the ToneMask tone-index math (src/ToneMask.h):
+ * fc derivation (phydm_find_fc port), subcarrier enumeration for a frequency
+ * range, and the env-spec parser. No libusb device is opened — only the pure
+ * helpers are exercised — but the header pulls in RtlUsbAdapter.h, so the
+ * target links like the demos. Register encodings are validated on hardware
+ * (readback logging in apply_from_env), not here. */
+#include <cstdio>
+#include <cstdlib>
+
+#include "ToneMask.h"
+
+using namespace devourer::tonemask;
+
+static int failures = 0;
+
+#define CHECK_EQ(expr, want)                                                   \
+  do {                                                                         \
+    auto got_ = (expr);                                                        \
+    if (got_ != (want)) {                                                      \
+      std::fprintf(stderr, "FAIL %s:%d: %s = %ld, want %ld\n", __FILE__,       \
+                   __LINE__, #expr, long(got_), long(want));                   \
+      failures++;                                                              \
+    }                                                                          \
+  } while (0)
+
+int main() {
+  /* fc derivation — 5 GHz wide blocks center on the block, not the primary. */
+  CHECK_EQ(find_fc_mhz(36, 80, kSecDontCare), 5210);  /* ch36-48 block  */
+  CHECK_EQ(find_fc_mhz(48, 80, kSecDontCare), 5210);  /* any primary    */
+  CHECK_EQ(find_fc_mhz(36, 40, kSecDontCare), 5190);  /* ch36+40        */
+  CHECK_EQ(find_fc_mhz(100, 80, kSecDontCare), 5530); /* ch100-112      */
+  CHECK_EQ(find_fc_mhz(149, 80, kSecDontCare), 5775); /* ch149-161      */
+  CHECK_EQ(find_fc_mhz(36, 20, kSecDontCare), 5180);
+  /* 2.4 GHz: 40 MHz fc via the secondary position; 80 MHz is invalid. */
+  CHECK_EQ(find_fc_mhz(6, 20, kSecDontCare), 2437);
+  CHECK_EQ(find_fc_mhz(6, 40, kSecAbove), 2447);
+  CHECK_EQ(find_fc_mhz(6, 40, kSecBelow), 2427);
+  CHECK_EQ(find_fc_mhz(11, 40, kSecAbove), 0); /* no room above ch>=10 */
+  CHECK_EQ(find_fc_mhz(1, 40, kSecBelow), 0);  /* no room below ch<=2  */
+  CHECK_EQ(find_fc_mhz(6, 80, kSecDontCare), 0);
+  CHECK_EQ(find_fc_mhz(15, 20, kSecDontCare), 0); /* dead channel */
+
+  /* Subcarrier enumeration — mask the top 20 MHz slice (5230-5250) of the
+   * ch36-48 80 MHz block (fc 5210): tones +64..+128 inclusive = 65. */
+  auto top = enumerate_tones(5210, 80, 5230000, 5250000);
+  CHECK_EQ(top.size(), 65);
+  CHECK_EQ(top.front(), 64);
+  CHECK_EQ(top.back(), 128);
+  /* Bottom slice (5170-5190): -128..-64. */
+  auto bot = enumerate_tones(5210, 80, 5170000, 5190000);
+  CHECK_EQ(bot.size(), 65);
+  CHECK_EQ(bot.front(), -128);
+  CHECK_EQ(bot.back(), -64);
+  /* A DC-spanning middle range. */
+  auto mid = enumerate_tones(5210, 80, 5209000, 5211000);
+  CHECK_EQ(mid.size(), 7); /* -3.2..+3.2 -> -3..+3 */
+  CHECK_EQ(mid.front(), -3);
+  CHECK_EQ(mid.back(), 3);
+  /* Clipping at the RF edge: a spec wider than the channel. */
+  auto wide = enumerate_tones(5210, 80, 5100000, 5300000);
+  CHECK_EQ(wide.size(), 257); /* -128..+128 */
+  /* Single-frequency spec on an exact tone / between tones. */
+  auto exact = enumerate_tones(5210, 80, 5220000, 5220000);
+  CHECK_EQ(exact.size(), 1);
+  CHECK_EQ(exact.front(), 32);
+  auto between = enumerate_tones(5210, 80, 5211000, 5211000);
+  CHECK_EQ(between.size(), 1);
+  CHECK_EQ(between.front(), 3); /* 3.2 rounds to 3 */
+  /* Out-of-band single frequency -> nothing. */
+  auto oob = enumerate_tones(5210, 80, 5300000, 5300000);
+  CHECK_EQ(oob.size(), 0);
+
+  /* 20 MHz channel budget: +-32 tones. */
+  auto ch20 = enumerate_tones(5180, 20, 5170000, 5190000);
+  CHECK_EQ(ch20.size(), 65);
+  CHECK_EQ(ch20.front(), -32);
+  CHECK_EQ(ch20.back(), 32);
+
+  /* Spec parsing. */
+  auto s1 = parse_csi_spec("5230-5250");
+  CHECK_EQ(s1.valid, true);
+  CHECK_EQ(s1.f_lo_khz, 5230000);
+  CHECK_EQ(s1.f_hi_khz, 5250000);
+  CHECK_EQ(s1.wgt, 7);
+  auto s2 = parse_csi_spec("5230-5250/5");
+  CHECK_EQ(s2.valid, true);
+  CHECK_EQ(s2.wgt, 5);
+  auto s3 = parse_csi_spec("2447");
+  CHECK_EQ(s3.valid, true);
+  CHECK_EQ(s3.f_lo_khz, 2447000);
+  CHECK_EQ(s3.f_hi_khz, 2447000);
+  CHECK_EQ(parse_csi_spec("junk").valid, false);
+  CHECK_EQ(parse_csi_spec("5250-5230").valid, false);
+  CHECK_EQ(parse_csi_spec("").valid, false);
+  CHECK_EQ(parse_csi_spec("5230-").valid, false);
+
+  /* Prime-offset -> vendor secondary mapping. */
+  CHECK_EQ(sec_from_prime_offset(0), kSecDontCare);
+  CHECK_EQ(sec_from_prime_offset(1), kSecAbove); /* primary LOWER */
+  CHECK_EQ(sec_from_prime_offset(2), kSecBelow); /* primary UPPER */
+
+  if (failures) {
+    std::fprintf(stderr, "tone_mask_selftest: %d failure(s)\n", failures);
+    return 1;
+  }
+  std::printf("tone_mask_selftest: all checks passed\n");
+  return 0;
+}

--- a/tests/wide_rx_penalty_sweep.sh
+++ b/tests/wide_rx_penalty_sweep.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# wide_rx_penalty_sweep.sh — calibrate the WIDE-RX PENALTY: the extra SNR a
+# receiver tuned at 80 MHz needs to decode a 40 MHz frame on its primary half,
+# vs the same receiver retuned to 40 MHz (tests/rx80_narrow_tx_probe.sh proved
+# the frames decode at all; this measures the dB cost, the constant the
+# adaptive op-table needs for rows narrower than the RX tune).
+#
+# Method: differential delivery-vs-NOISE curves. The TX waveform is identical
+# in both cells (T3U, VHT 40 MHz, fixed flat TXAGC); only the RX tune differs
+# (80 vs 40). A B210 AWGN source over the signal band is stepped up in gain
+# (dB-linear, ~1 dB granularity — far more usable range than the 24 dB TXAGC
+# ladder, which point-blank bench margin swallows whole); the penalty is the
+# horizontal shift between the two delivery curves at the 50% crossing,
+# directly in dB. Everything else (TX nonlinearity, absolute path loss, B210
+# calibration) is common to both curves and cancels.
+#
+# The RX is started FIRST and the TX window opens only after the RX logs its
+# listening marker — per-bandwidth init time varies by seconds and otherwise
+# aliases into the hit counts.
+#
+# Usage: sudo tests/wide_rx_penalty_sweep.sh [GAINS] [TXAGC] [DUR] [TX_VID:PID] [RX_VID:PID]
+#   GAINS: quoted noise-gain ladder, default "66 70 74 78 82 86"
+
+set -u
+cd "$(dirname "$0")/.."
+
+GAINS=${1:-"66 70 74 78 82 86"}
+TXAGC=${2:-32}
+DUR=${3:-12}
+TX_SPEC=${4:-2357:012d}
+RX_SPEC=${5:-0bda:8813}
+
+TX_VID=${TX_SPEC%:*}; TX_PID=${TX_SPEC#*:}
+RX_VID=${RX_SPEC%:*}; RX_PID=${RX_SPEC#*:}
+
+RATE=VHT1SS_MCS7/40
+NOISE_FREQ=5190e6           # center of the primary 40 (5170-5210)
+NOISE_RATE=20e6
+
+LOGDIR=/tmp/devourer-wide-rx-penalty
+rm -rf "$LOGDIR"; mkdir -p "$LOGDIR"
+
+JAM_PID=""
+cleanup() {
+  [ -n "$JAM_PID" ] && kill -INT "$JAM_PID" 2>/dev/null
+  pkill -INT -x WiFiDriverTxDemo 2>/dev/null
+  pkill -INT -x WiFiDriverDemo 2>/dev/null
+  pkill -INT -f sdr_interferer 2>/dev/null
+  sleep 1
+  pkill -KILL -x WiFiDriverTxDemo 2>/dev/null
+  pkill -KILL -x WiFiDriverDemo 2>/dev/null
+  pkill -KILL -f sdr_interferer 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+noise_start() { # <gain>
+  python3 tests/sdr_interferer.py --freq "$NOISE_FREQ" --rate "$NOISE_RATE" \
+    --tx-gain "$1" >"$LOGDIR/noise-$1.log" 2>&1 &
+  JAM_PID=$!
+  sleep 3
+  kill -0 "$JAM_PID" 2>/dev/null || {
+    echo "FATAL: noise source died — $LOGDIR/noise-$1.log"; exit 2; }
+}
+
+noise_stop() {
+  [ -n "$JAM_PID" ] && { kill -INT "$JAM_PID" 2>/dev/null; wait "$JAM_PID" 2>/dev/null; }
+  JAM_PID=""
+}
+
+# run_cell <gain> <rx_bw>: RX up first, TX window of exactly DUR, then stop.
+run_cell() {
+  local gain=$1 rx_bw=$2
+  local tag="g$gain-rx$rx_bw"
+  local rxlog="$LOGDIR/rx-$tag.log" txlog="$LOGDIR/tx-$tag.log"
+
+  env DEVOURER_VID="0x$RX_VID" DEVOURER_PID="0x$RX_PID" DEVOURER_CHANNEL=36 \
+      DEVOURER_BW="$rx_bw" \
+      timeout -s INT -k 5 $((DUR + 60)) ./build/WiFiDriverDemo >"$rxlog" 2>&1 &
+  local rxpid=$!
+  for _ in $(seq 60); do
+    grep -q "Listening air" "$rxlog" && break
+    sleep 0.5
+  done
+  grep -q "Listening air" "$rxlog" || {
+    echo "  gain=$gain rx@$rx_bw : RX never came up — see $rxlog"
+    kill -INT "$rxpid" 2>/dev/null; wait "$rxpid" 2>/dev/null
+    echo 0 >"$LOGDIR/$tag.count"; sleep 5; return
+  }
+
+  # A back-to-back re-open of the T3U can fail DLFW while its firmware is
+  # still winding down (std::runtime_error -> abort); retry the TX once.
+  local attempt
+  for attempt in 1 2; do
+    env DEVOURER_VID="0x$TX_VID" DEVOURER_PID="0x$TX_PID" DEVOURER_CHANNEL=36 \
+        DEVOURER_HOP_BW=40 DEVOURER_TX_RATE="$RATE" DEVOURER_TX_PWR="$TXAGC" \
+        timeout -s INT -k 5 $((DUR + 12)) ./build/WiFiDriverTxDemo >"$txlog" 2>&1 \
+      && break
+    grep -q "DLFW failed" "$txlog" || break
+    echo "    (TX DLFW warm-failure — retrying cell TX)"
+    sleep 8
+  done
+  kill -INT "$rxpid" 2>/dev/null
+  wait "$rxpid" 2>/dev/null
+  sleep 5  # warm-FW settle before the same dongles re-open
+
+  local hits
+  hits=$(grep -c "devourer-tx-hit" "$rxlog")
+  echo "$hits" >"$LOGDIR/$tag.count"
+  printf "  noise=%-3s rx@%-2s : %s hits\n" "$gain" "$rx_bw" "$hits"
+}
+
+echo "wide-RX penalty sweep: TX $TX_SPEC ($RATE, txagc=$TXAGC) -> RX $RX_SPEC, ch36"
+echo "noise ladder (dB): $GAINS at ${NOISE_FREQ}/${NOISE_RATE}"
+echo
+
+for g in $GAINS; do
+  noise_start "$g"
+  run_cell "$g" 40
+  run_cell "$g" 80
+  noise_stop
+done
+
+echo
+echo "== delivery vs noise gain =="
+printf "%8s %10s %10s\n" "noise" "rx@40" "rx@80"
+for g in $GAINS; do
+  printf "%8s %10s %10s\n" "$g" \
+    "$(cat "$LOGDIR/g$g-rx40.count")" "$(cat "$LOGDIR/g$g-rx80.count")"
+done
+
+# 50%-crossing per curve (linear interpolation in noise-dB), penalty =
+# crossing(rx@40) - crossing(rx@80): the narrower-tuned RX should survive MORE
+# noise, so a positive value is the wide-RX cost, already in dB.
+python3 - "$LOGDIR" $GAINS <<'EOF'
+import sys
+logdir, ladder = sys.argv[1], [int(x) for x in sys.argv[2:]]
+def curve(bw):
+    return [(g, int(open(f"{logdir}/g{g}-rx{bw}.count").read())) for g in ladder]
+c40, c80 = curve(40), curve(80)
+ref = max(h for _, h in c40 + c80)
+if ref < 20:
+    print(f"\nVERDICT: bench broken (max {ref} hits)"); sys.exit(1)
+half = ref / 2.0
+def crossing(c):
+    # walk low->high noise; find the first segment straddling half delivery
+    for (g1, h1), (g2, h2) in zip(c, c[1:]):
+        if h1 >= half > h2:
+            return g1 + (h1 - half) * (g2 - g1) / (h1 - h2)
+    return None
+x40, x80 = crossing(c40), crossing(c80)
+print()
+if x40 is None or x80 is None:
+    print("VERDICT: cliff not bracketed "
+          f"(50% crossing rx@40={x40}, rx@80={x80}) — adjust the GAINS ladder")
+    sys.exit(1)
+print(f"50% crossing: rx@40 at noise {x40:.1f} dB, rx@80 at noise {x80:.1f} dB")
+print(f"WIDE-RX PENALTY = {x40 - x80:.1f} dB")
+EOF

--- a/tools/precoder/adaptive_link.py
+++ b/tools/precoder/adaptive_link.py
@@ -25,24 +25,28 @@ from dataclasses import dataclass
 import rc_proto as rp
 import rendezvous as rz
 from controller import Controller, ControllerConfig
-from score import ScoreWindow, ScoreConfig
+from score import ScoreWindow, ScoreConfig, RungWindow
 import op_table
 
 
-def op_to_ladder(op) -> str:
-    """Map a controller OpPoint to a DEVOURER_SVC_LADDER spec (per-layer MCS).
+def ladder_spec(mode: str, mcs: int, bw: int) -> str:
+    """DEVOURER_SVC_LADDER spec for a (mode, base-MCS, bw) operating point.
     Base/critical fly the chosen (robust) MCS; enhancement steps up from there.
     VHT rows (the bandwidth-dimension rungs, incl. 80 MHz) map to VHT1SS_MCSn
     rate strings; the bandwidth rides every layer's /bw suffix — per-packet
     and unilateral while it stays on the RX's primary
-    (tests/rx80_narrow_tx_probe.sh)."""
-    m = op.mcs
-    bw = op.bw
-    top, name = (8, "VHT1SS_MCS") if getattr(op, "mode", "ht") == "vht" \
-        else (7, "MCS")
+    (tests/rx80_narrow_tx_probe.sh). Shared by the VRX-side op mapping and the
+    VTX-side RCF profile decode so both ends build the identical ladder."""
+    top, name = (8, "VHT1SS_MCS") if mode == "vht" else (7, "MCS")
+    m = max(0, min(top, mcs))
     e = min(top, m + 2)
     return (f"CRIT={name}{m}/{bw};T0={name}{m}/{bw};"
             f"T1={name}{min(top, m + 1)}/{bw};T2={name}{e}/{bw}")
+
+
+def op_to_ladder(op) -> str:
+    """Map a controller OpPoint to a DEVOURER_SVC_LADDER spec."""
+    return ladder_spec(getattr(op, "mode", "ht"), op.mcs, op.bw)
 
 
 def overhead_to_16ths(ov: float) -> int:
@@ -60,6 +64,14 @@ class AdaptiveVrx:
         self.vtx_id = vtx_id
         self.ctrl = Controller(link, calib, ctrl_cfg or ControllerConfig())
         self.win = ScoreWindow(score_cfg)
+        # Per-rung delivery sensing (with the bandwidth dimension open): every
+        # video seq — received or gap-inferred-lost — is attributed to its
+        # probe rung by the shared schedule, and the stats feed the
+        # controller's rung blocker / primary-dirty detector each feedback
+        # tick. `primary_dirty` (property below) is the escalation signal the
+        # embedding app turns into a coordinated channel move.
+        bw_set = self.ctrl.cfg.bw_set
+        self.rungs = RungWindow(bw_set) if bw_set else None
         self.rz = rz.VrxRendezvous(rz.VrxConfig(vtx_id=vtx_id, op_channel=op_channel))
         self.feedback_period_ms = feedback_period_ms
         self._last_fb_ms = -1 << 60
@@ -67,9 +79,15 @@ class AdaptiveVrx:
         self.cur_op = op_table.MAX_RANGE
         self._cur_txagc = 32
 
+    @property
+    def primary_dirty(self) -> bool:
+        return self.ctrl.primary_dirty
+
     def on_video(self, rssi: float, snr: float, crc_err: bool, seq: int,
                  now_ms: float, residual_loss: float | None = None) -> None:
         self.win.add_frame(rssi, snr, crc_err, seq, now_ms / 1000.0)
+        if self.rungs is not None:
+            self.rungs.add_seq(seq)
         self.rz.feed_video(now_ms)
         self._residual = residual_loss
 
@@ -88,6 +106,8 @@ class AdaptiveVrx:
         if now_ms - self._last_fb_ms < self.feedback_period_ms:
             return None
         self._last_fb_ms = now_ms
+        if self.rungs is not None:
+            self.ctrl.report_rung_delivery(self.rungs.stats(), now_ms)
         snr = self.win.snr_estimate()
         if snr is not None:
             op = self.ctrl.update(snr, self._cur_txagc, now_ms)
@@ -95,10 +115,12 @@ class AdaptiveVrx:
                 self.cur_op = op
                 self._cur_txagc = op.txagc
         self._seq = (self._seq + 1) & 0xFFFF
-        # profile carries the GS-chosen base MCS (0..7); the VTX builds its SVC
-        # ladder from it (base/critical at this MCS, enhancement steps up).
+        # profile carries the GS-chosen operating point — mode/MCS/bw packed by
+        # the shared v2 encoding; the VTX builds its SVC ladder from it
+        # (base/critical at this MCS, enhancement steps up).
         rcf = rp.Rcf(vtx_id=self.vtx_id, seq=self._seq, ack_seq=self.win.ack_seq(),
-                     profile=self.cur_op.mcs,
+                     profile=rp.encode_profile(getattr(self.cur_op, "mode", "ht"),
+                                               self.cur_op.mcs, self.cur_op.bw),
                      score=self.win.score(getattr(self, "_residual", None)),
                      pwr_idx=self.cur_op.txagc,
                      fec_overhead_16ths=overhead_to_16ths(self.cur_op.overhead),
@@ -120,7 +142,8 @@ class TxState:
 class AdaptiveVtx:
     def __init__(self, vtx_id: int, vtx_cfg: rz.VtxConfig | None = None,
                  failsafe_txagc: int = 63, failsafe_overhead: float = 1.0,
-                 failsafe_ladder: str | None = None):
+                 failsafe_ladder: str | None = None,
+                 bw_set: tuple | None = None):
         self.vtx_id = vtx_id
         self.rz = rz.VtxRendezvous(vtx_cfg or rz.VtxConfig(vtx_id=vtx_id))
         self.state = TxState()
@@ -128,6 +151,18 @@ class AdaptiveVtx:
         self.failsafe_overhead = failsafe_overhead
         self.failsafe_ladder = failsafe_ladder or \
             "CRIT=MCS0/20/LDPC;T0=MCS0/20/LDPC;T1=MCS0/20;T2=MCS0/20"
+        # Bandwidth-probe rungs — must match the VRX controller's bw_set (a
+        # config invariant, like the profile-table version). None = no probing.
+        self.bw_set = tuple(sorted(bw_set)) if bw_set else None
+
+    def probe_bw_for_seq(self, seq: int) -> int | None:
+        """Rung this video seq must fly at as a bandwidth probe (the shared
+        schedule the VRX attributes against), else None -> the commanded op
+        bandwidth. Injectors apply it as the frame's radiotap bandwidth —
+        per-packet and unilateral (tests/rx80_narrow_tx_probe.sh)."""
+        if self.bw_set is None or self.state.failsafe:
+            return None
+        return rp.probe_bw(seq, self.bw_set)
 
     def on_rc_frame(self, buf: bytes, now_ms: float) -> bytes | None:
         """Process an inbound control frame. Applies an RCF (updates TxState) or
@@ -142,11 +177,10 @@ class AdaptiveVtx:
                 self.state.txagc = r.pwr_idx
             self.state.overhead = r.fec_overhead
             self.state.failsafe = False
-            # MCS ladder follows the GS-chosen base MCS in `profile`.
-            m = max(0, min(7, r.profile))
-            bw = 20
-            self.state.ladder = (f"CRIT=MCS{m}/{bw};T0=MCS{m}/{bw};"
-                                 f"T1=MCS{min(7, m + 1)}/{bw};T2=MCS{min(7, m + 2)}/{bw}")
+            # Ladder follows the GS-chosen operating point in `profile`
+            # (mode/MCS/bw, shared v2 encoding + shared ladder builder).
+            mode, m, bw = rp.decode_profile(r.profile)
+            self.state.ladder = ladder_spec(mode, m, bw)
             return None
         if t == rp.T_DISC:
             d = rp.parse_disc(buf)

--- a/tools/precoder/adaptive_link.py
+++ b/tools/precoder/adaptive_link.py
@@ -31,12 +31,18 @@ import op_table
 
 def op_to_ladder(op) -> str:
     """Map a controller OpPoint to a DEVOURER_SVC_LADDER spec (per-layer MCS).
-    Base/critical fly the chosen (robust) MCS; enhancement steps up from there."""
+    Base/critical fly the chosen (robust) MCS; enhancement steps up from there.
+    VHT rows (the bandwidth-dimension rungs, incl. 80 MHz) map to VHT1SS_MCSn
+    rate strings; the bandwidth rides every layer's /bw suffix — per-packet
+    and unilateral while it stays on the RX's primary
+    (tests/rx80_narrow_tx_probe.sh)."""
     m = op.mcs
-    e = min(7, m + 2)
     bw = op.bw
-    return (f"CRIT=MCS{m}/{bw};T0=MCS{m}/{bw};"
-            f"T1=MCS{min(7, m + 1)}/{bw};T2=MCS{e}/{bw}")
+    top, name = (8, "VHT1SS_MCS") if getattr(op, "mode", "ht") == "vht" \
+        else (7, "MCS")
+    e = min(top, m + 2)
+    return (f"CRIT={name}{m}/{bw};T0={name}{m}/{bw};"
+            f"T1={name}{min(top, m + 1)}/{bw};T2={name}{e}/{bw}")
 
 
 def overhead_to_16ths(ov: float) -> int:

--- a/tools/precoder/controller.py
+++ b/tools/precoder/controller.py
@@ -35,6 +35,13 @@ class ControllerConfig:
     mcs_set: tuple = tuple(range(8))
     overhead_set: tuple = (0.10, 0.25, 0.50, 0.75, 1.00)
     bw: int = 20
+    # Bandwidth dimension (opt-in, default None -> single-bw rows as before):
+    # the primary-nested rungs the TX may pick per-packet while the RX parks at
+    # the widest (e.g. bw_set=(20, 40, 80), mode='vht'). Rows pay their
+    # +3 dB/doubling noise-bandwidth cost in snr_req; the e_bit ranking then
+    # answers "drop bandwidth or drop MCS?" per tick.
+    bw_set: tuple | None = None
+    mode: str = "ht"
     sbi: bool = True
     ema_alpha: float = 0.3            # SNR EWMA weight when SNR is RISING (cautious)
     ema_alpha_down: float = 0.8       # ...when FALLING (react fast -> raise power in time)
@@ -63,7 +70,9 @@ class Controller:
         self.calib = calib
         self.cfg = cfg or ControllerConfig()
         self.rows = build_link_rows(link, self.cfg.target, self.cfg.mcs_set,
-                                    self.cfg.overhead_set, self.cfg.bw, sbi=self.cfg.sbi)
+                                    self.cfg.overhead_set, self.cfg.bw,
+                                    sbi=self.cfg.sbi, bw_set=self.cfg.bw_set,
+                                    mode=self.cfg.mode)
         self.snr_ema: float | None = None
         self.pl_var_ema: float = 0.0        # EWMA of path-loss variance (fade depth)
         self.cur: OpPoint | None = None

--- a/tools/precoder/controller.py
+++ b/tools/precoder/controller.py
@@ -62,6 +62,18 @@ class ControllerConfig:
     fade_margin_k: float = 0.0        # 0 = disabled
     fade_margin_max_db: float = 12.0  # clamp on the extra TXAGC headroom (dB)
     fade_var_alpha: float = 0.2       # EWMA weight for the path-loss variance
+    # Per-rung interference sensing (with bw_set): report_rung_delivery()
+    # BLOCKS a rung whose probed delivery falls this far below the best
+    # rung's — detection by CONTRAST across rungs, not by model prediction, so
+    # it fires on the interference signature (one rung's extra spectrum is
+    # dirty) and not on plain path loss (all rungs sag together). The
+    # narrowest rung is never blocked: it is the fallback; when IT also
+    # underperforms alongside every other rung the primary itself is dirty
+    # (`primary_dirty`), which no unilateral bandwidth choice can fix — the
+    # escalation to a coordinated channel move belongs to the embedding app.
+    rung_block_delta: float = 0.15
+    rung_block_hold_ms: int = 5000
+    rung_min_samples: int = 8
 
 
 class Controller:
@@ -80,15 +92,45 @@ class Controller:
         self._last_change_ms = -1 << 60
         self._last_downgrade_ms = -1 << 60
         self._last_feedback_ms = -1 << 60
+        self._rung_block: dict[int, float] = {}   # bw -> blocked-until (ms)
+        self._now_ms: float = -1 << 60            # last update() time, for _best
+        self.primary_dirty = False                # all rungs bad incl. narrowest
 
     # --- estimation -------------------------------------------------------- #
     def _path_loss(self, reported_snr: float, reported_txagc: int) -> float:
         """Channel SNR with TX power removed: snr = path_loss + gain(txagc)."""
         return reported_snr - self.calib.gain_db(reported_txagc)
 
+    def _rung_blocked(self, bw: int) -> bool:
+        until = self._rung_block.get(bw)
+        return until is not None and self._now_ms < until
+
+    def report_rung_delivery(self, stats: dict[int, tuple[float, int]],
+                             now_ms: float) -> None:
+        """Feed per-rung probe delivery (bw -> (delivery, n), score.RungWindow
+        .stats()). Blocks rungs whose delivery contrasts badly with the best
+        rung's (interference on that rung's extra spectrum); sets
+        `primary_dirty` when every sampled rung — the narrowest included —
+        misses the target (nothing a bandwidth choice can fix)."""
+        usable = {bw: d for bw, (d, n) in stats.items()
+                  if n >= self.cfg.rung_min_samples}
+        if not usable:
+            return
+        best = max(usable.values())
+        narrowest = min(usable)
+        for bw, d in usable.items():
+            if bw != narrowest and d < best - self.cfg.rung_block_delta:
+                self._rung_block[bw] = now_ms + self.cfg.rung_block_hold_ms
+        self.primary_dirty = (len(usable) >= 2 and
+                              all(d < self.cfg.target -
+                                  self.cfg.rung_block_delta
+                                  for d in usable.values()))
+
     def _best(self, path_loss: float, margin: float) -> OpPoint | None:
         best = None
         for r in self.rows:
+            if self._rung_blocked(r.bw):
+                continue
             op = resolve(r, path_loss, self.calib, self.link,
                          self.cfg.payload_bytes, self.cfg.src_bitrate_bps, margin)
             # skip rows that can't clear the SLA OR can't carry the bitrate (e_bit=inf)
@@ -104,6 +146,7 @@ class Controller:
         """Apply one VRX feedback sample; return the chosen op point (or None if
         this layer is shed)."""
         self._last_feedback_ms = now_ms
+        self._now_ms = now_ms
         # EWMA the PATH LOSS (channel SNR with TX power removed), not the SNR —
         # SNR moves with our own TXAGC, path loss doesn't. Asymmetric: track a
         # worsening channel fast (raise power in time), an improving one slow. Also
@@ -132,7 +175,8 @@ class Controller:
                               self.cur.bw, self.cur.sgi, self.cur.overhead,
                               self.cur.snr_req), path_loss, self.calib, self.link,
                               self.cfg.payload_bytes, self.cfg.src_bitrate_bps, 0.0)
-            cur_ok = cur_now is not None and cur_now.p_deliver >= self.cfg.target
+            cur_ok = (cur_now is not None and cur_now.p_deliver >= self.cfg.target
+                      and not self._rung_blocked(self.cur.bw))
             if cur_ok:
                 self.cur = cur_now            # refresh txagc/e_bit at new path loss
 

--- a/tools/precoder/energy_model.py
+++ b/tools/precoder/energy_model.py
@@ -30,24 +30,42 @@ numpy-free (imports into the GNU Radio / orchestrator env like fec_subblock).
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass, field
 
 # --------------------------------------------------------------------------- #
-# 802.11 PHY data rates (Mbps). HT = 1 spatial stream, MCS 0..7.
+# 802.11 PHY data rates (Mbps). HT/VHT = 1 spatial stream. HT MCS 0..7;
+# VHT MCS 0..8 (MCS9 is invalid for 1SS/20 and 1SS with BCC constraints vary,
+# and the link model has no SNR centre for it — 0..8 is the modelled set).
+# VHT 80 MHz is the bandwidth rung HT lacks — the ladder the adaptive
+# controller's bandwidth dimension rides (20 c 40 c 80, primary-nested).
 # --------------------------------------------------------------------------- #
 HT20_LGI_MBPS = [6.5, 13.0, 19.5, 26.0, 39.0, 52.0, 58.5, 65.0]
 HT40_LGI_MBPS = [13.5, 27.0, 40.5, 54.0, 81.0, 108.0, 121.5, 135.0]
+VHT_LGI_MBPS = {
+    20: [6.5, 13.0, 19.5, 26.0, 39.0, 52.0, 58.5, 65.0, 78.0],
+    40: [13.5, 27.0, 40.5, 54.0, 81.0, 108.0, 121.5, 135.0, 162.0],
+    80: [29.3, 58.5, 87.8, 117.0, 175.5, 234.0, 263.3, 292.5, 351.0],
+}
 LEGACY_MBPS = {6: 6.0, 9: 9.0, 12: 12.0, 18: 18.0, 24: 24.0, 36: 36.0, 48: 48.0,
                54: 54.0}
 SGI_FACTOR = 10.0 / 9.0  # short guard interval: 400 vs 800 ns -> x1.111
 
 
 def phy_rate_mbps(mode: str, mcs: int, bw: int = 20, sgi: bool = False) -> float:
-    """On-air PHY data rate. mode='ht' (mcs 0..7) or 'legacy' (mcs = Mbps)."""
+    """On-air PHY data rate. mode='ht' (mcs 0..7), 'vht' (1SS mcs 0..8,
+    bw 20/40/80) or 'legacy' (mcs = Mbps)."""
     if mode == "ht":
         base = HT40_LGI_MBPS if bw == 40 else HT20_LGI_MBPS
         if not (0 <= mcs < len(base)):
             raise ValueError(f"HT mcs {mcs} out of range 0..7")
+        r = base[mcs]
+    elif mode == "vht":
+        if bw not in VHT_LGI_MBPS:
+            raise ValueError(f"VHT bw {bw} not one of 20/40/80")
+        base = VHT_LGI_MBPS[bw]
+        if not (0 <= mcs < len(base)):
+            raise ValueError(f"VHT 1SS mcs {mcs} out of range 0..8")
         r = base[mcs]
     elif mode == "legacy":
         if mcs not in LEGACY_MBPS:
@@ -56,6 +74,19 @@ def phy_rate_mbps(mode: str, mcs: int, bw: int = 20, sgi: bool = False) -> float
     else:
         raise ValueError(f"unknown mode {mode!r}")
     return r * (SGI_FACTOR if sgi else 1.0)
+
+
+def bw_noise_db(bw: int) -> float:
+    """Extra noise power a receiver integrates at `bw` vs the 20 MHz reference:
+    10*log10(bw/20) — +3 dB per bandwidth doubling. The op-table adds this to a
+    row's required SNR so wider rows honestly pay their noise-bandwidth cost.
+    The measured WIDE-RX penalty (an 80 MHz-tuned RX decoding a narrower frame
+    on its primary, vs retuning) is 0 dB / <=1 dB on real silicon
+    (tests/wide_rx_penalty_sweep.sh), so no extra term is added for rows
+    narrower than the RX tune."""
+    if bw <= 20:
+        return 0.0
+    return 10.0 * math.log10(bw / 20.0)
 
 
 # --------------------------------------------------------------------------- #

--- a/tools/precoder/op_table.py
+++ b/tools/precoder/op_table.py
@@ -43,13 +43,24 @@ class OpPoint:
 
 def build_link_rows(link, target: float, mcs_set=range(8),
                     overhead_set=(0.10, 0.25, 0.50, 0.75, 1.00),
-                    bw: int = 20, sgi: bool = False, sbi: bool = True) -> list[LinkRow]:
-    """(MCS, overhead) -> snr_req for the given delivery target. Computed once."""
+                    bw: int = 20, sgi: bool = False, sbi: bool = True,
+                    bw_set=None, mode: str = "ht") -> list[LinkRow]:
+    """(bw, MCS, overhead) -> snr_req for the given delivery target. Computed once.
+
+    `bw_set` opens the BANDWIDTH dimension (e.g. (20, 40, 80) with mode='vht'):
+    one row per rung of the primary-nested ladder the TX can pick per-packet
+    with no RX coordination (the RX parks at the widest rung —
+    tests/rx80_narrow_tx_probe.sh). A wider row's snr_req carries its
+    +3 dB/doubling noise-bandwidth cost (em.bw_noise_db), so the e_bit ranking
+    trades airtime against noise bandwidth honestly; the measured wide-RX
+    penalty for narrower-than-tune frames is 0 dB and adds nothing. Default
+    (bw_set=None) keeps the single-bw behaviour."""
     rows = []
-    for mcs in mcs_set:
-        for ov in overhead_set:
-            req = link.snr_required(mcs, ov, target, sbi=sbi)
-            rows.append(LinkRow("ht", mcs, bw, sgi, ov, req))
+    for w in (bw_set if bw_set is not None else (bw,)):
+        for mcs in mcs_set:
+            for ov in overhead_set:
+                req = link.snr_required(mcs, ov, target, sbi=sbi)
+                rows.append(LinkRow(mode, mcs, w, sgi, ov, req + em.bw_noise_db(w)))
     return rows
 
 
@@ -64,7 +75,10 @@ def resolve(row: LinkRow, path_loss_db: float, calib, link,
     if txagc is None:
         return None
     recv = path_loss_db + calib.gain_db(txagc)
-    pdel = link.p_deliver(recv, row.mcs, row.overhead)
+    # recv is in the 20 MHz-noise reference frame (path loss + gain); the
+    # demodulator at this row's bandwidth sees bw_noise_db less SNR — the same
+    # term build_link_rows folded into snr_req, kept consistent here.
+    pdel = link.p_deliver(recv - em.bw_noise_db(row.bw), row.mcs, row.overhead)
     eb = em.energy_per_delivered_bit(
         em.TxPoint(row.mode, row.mcs, row.bw, row.sgi, txagc),
         src_bitrate_bps, row.overhead, payload_bytes, pdel, calib)

--- a/tools/precoder/rc_proto.py
+++ b/tools/precoder/rc_proto.py
@@ -39,6 +39,55 @@ F_DISCOVERY = 0x04          # discovery context
 PWR_NO_CHANGE = 0xFF        # PWR_IDX sentinel: leave TX power as-is
 
 
+# --------------------------------------------------------------------------- #
+# PROFILE byte encoding v2 — bandwidth-dimension aware.
+# bits[3:0] = MCS (0..8), bits[5:4] = bw code (0=20, 1=40, 2=80), bit6 = VHT.
+# Legacy v1 values 0..7 decode as HT/20, so a v1 receiver (which clamps the
+# byte to 0..7) still gets a sane MCS from a v2 sender.
+# --------------------------------------------------------------------------- #
+_BW_CODE = {20: 0, 40: 1, 80: 2}
+_BW_FROM_CODE = {v: k for k, v in _BW_CODE.items()}
+
+
+def encode_profile(mode: str, mcs: int, bw: int = 20) -> int:
+    """(mode, mcs, bw) -> wire PROFILE byte."""
+    p = (mcs & 0x0F) | (_BW_CODE.get(bw, 0) << 4)
+    if mode == "vht":
+        p |= 0x40
+    return p
+
+
+def decode_profile(p: int) -> tuple[str, int, int]:
+    """Wire PROFILE byte -> (mode, mcs, bw)."""
+    mode = "vht" if p & 0x40 else "ht"
+    bw = _BW_FROM_CODE.get((p >> 4) & 0x3, 20)
+    mcs = p & 0x0F
+    return mode, min(mcs, 8 if mode == "vht" else 7), bw
+
+
+# --------------------------------------------------------------------------- #
+# Bandwidth probe schedule — a PROTOCOL INVARIANT both ends derive from the
+# video seq alone, so per-rung delivery sensing needs no extra wire fields:
+# the VTX flies the scheduled seqs on the scheduled rung, the VRX attributes
+# every (received or gap-inferred-lost) seq to its rung by the same rule.
+# Slots 0/8/16 of each 32-seq cycle probe the sorted rungs of the (config-
+# agreed) bw_set; every other seq rides the commanded operating bandwidth.
+# ~3% duty per rung — cheap enough to leave always on.
+# --------------------------------------------------------------------------- #
+PROBE_PERIOD = 32
+_PROBE_SLOTS = (0, 8, 16)
+
+
+def probe_bw(seq: int, bw_set) -> int | None:
+    """Bandwidth this video seq must fly at as a rung probe, else None."""
+    rungs = sorted(bw_set)
+    slot = seq % PROBE_PERIOD
+    for i, s in enumerate(_PROBE_SLOTS):
+        if slot == s and i < len(rungs):
+            return rungs[i]
+    return None
+
+
 def _crc(buf: bytes) -> int:
     return fec_subblock.crc16_ccitt(buf)
 

--- a/tools/precoder/score.py
+++ b/tools/precoder/score.py
@@ -102,3 +102,48 @@ class ScoreWindow:
         loss = self.seq_gap_loss() if residual_loss is None else residual_loss
         s -= self.cfg.loss_penalty * loss
         return int(max(1000, min(2000, s)))
+
+
+class RungWindow:
+    """Per-rung (bandwidth) delivery from the video seq stream.
+
+    Both ends derive each seq's rung from the shared probe schedule
+    (rc_proto.probe_bw), so no wire fields are needed: received seqs are
+    attributed on arrival, missed seqs are inferred from the wrap-safe gaps
+    between arrivals and attributed the same way. Only scheduled probe seqs
+    are tracked — the commanded-op frames tell us nothing about the OTHER
+    rungs, which is the whole point of probing.
+    """
+
+    def __init__(self, bw_set, samples_per_rung: int = 24):
+        import rc_proto as _rp
+        self._probe_bw = _rp.probe_bw
+        self.bw_set = tuple(sorted(bw_set))
+        self._hist: dict[int, deque] = {bw: deque(maxlen=samples_per_rung)
+                                        for bw in self.bw_set}
+        self._last_seq: int | None = None
+
+    def _attribute(self, seq: int, ok: bool) -> None:
+        bw = self._probe_bw(seq, self.bw_set)
+        if bw is not None:
+            self._hist[bw].append(ok)
+
+    def add_seq(self, seq: int) -> None:
+        """One RECEIVED video seq; the (wrap-safe) gap since the previous
+        arrival is attributed as losses."""
+        if self._last_seq is not None:
+            gap = (seq - self._last_seq) % 4096
+            # walk the missing seqs (bounded: a monster gap is a link outage,
+            # not per-rung information — cap the walk at one probe period x4)
+            for d in range(1, min(gap, 128)):
+                self._attribute((self._last_seq + d) % 4096, ok=False)
+        self._attribute(seq, ok=True)
+        self._last_seq = seq
+
+    def stats(self) -> dict[int, tuple[float, int]]:
+        """bw -> (delivery fraction, n samples) for rungs with any samples."""
+        out = {}
+        for bw, h in self._hist.items():
+            if h:
+                out[bw] = (sum(h) / len(h), len(h))
+        return out

--- a/tools/precoder/test_adaptive_link.py
+++ b/tools/precoder/test_adaptive_link.py
@@ -25,6 +25,11 @@ def test_op_to_ladder_and_overhead_mapping():
         mcs, bw, overhead = 3, 20, 0.5
     spec = al.op_to_ladder(Op())
     assert "CRIT=MCS3/20" in spec and "T2=MCS5/20" in spec   # base robust, enh steps up
+
+    class VhtOp:                       # bandwidth-dimension rung (VHT row)
+        mcs, bw, overhead, mode = 3, 80, 0.5, "vht"
+    vspec = al.op_to_ladder(VhtOp())
+    assert "CRIT=VHT1SS_MCS3/80" in vspec and "T2=VHT1SS_MCS5/80" in vspec
     assert al.overhead_to_16ths(0.25) == 4
     assert al.overhead_to_16ths(1.0) == 16
     assert al.overhead_to_16ths(0.0) == 1                    # clamped to >=1

--- a/tools/precoder/test_adaptive_link.py
+++ b/tools/precoder/test_adaptive_link.py
@@ -72,3 +72,55 @@ def test_vrx_answers_disc_handshake():
     ack = vtx.on_rc_frame(disc, t)
     assert ack is not None and rp.frame_type(ack) == rp.T_DISC_ACK
     assert vtx.rz.state == rz.RC_OK and vtx.rz.op_channel == 36
+
+
+def test_vtx_decodes_v2_profile_to_vht_ladder_and_probes():
+    vtx = al.AdaptiveVtx(0xABCD, bw_set=(20, 40, 80))
+    rcf = rp.pack_rcf(rp.Rcf(vtx_id=0xABCD,
+                             profile=rp.encode_profile("vht", 2, 80),
+                             pwr_idx=40, fec_overhead_16ths=8))
+    vtx.on_rc_frame(rcf, now_ms=0)
+    assert "CRIT=VHT1SS_MCS2/80" in vtx.state.ladder
+    # shared probe schedule: slots 0/8/16 fly the rungs, others ride the op bw
+    assert vtx.probe_bw_for_seq(0) == 20
+    assert vtx.probe_bw_for_seq(8) == 40
+    assert vtx.probe_bw_for_seq(16) == 80
+    assert vtx.probe_bw_for_seq(1) is None
+    # legacy v1 profile byte (raw MCS) still yields the old HT/20 ladder
+    rcf1 = rp.pack_rcf(rp.Rcf(vtx_id=0xABCD, profile=3, pwr_idx=40,
+                              fec_overhead_16ths=8))
+    vtx.on_rc_frame(rcf1, now_ms=100)
+    assert "CRIT=MCS3/20" in vtx.state.ladder
+
+
+def test_vrx_senses_rungs_and_flags_primary_dirty():
+    """Closed VRX-side loop: video seqs arrive with the 80-rung probes missing
+    -> the controller vacates 80; then ALL probe rungs go missing while video
+    still flows -> primary_dirty escalation fires."""
+    import energy_model as em
+    import link_model as lm
+    from controller import ControllerConfig
+    link, calib = lm.LinkModel(trials=300), em.load_calibration()
+    vrx = al.AdaptiveVrx(link, calib, 0xABCD,
+                         ControllerConfig(target=0.99, allow_shed=False,
+                                          bw_set=(20, 40, 80), mode="vht",
+                                          src_bitrate_bps=8e6))
+
+    def run(secs_of_frames, lost_rungs, t0):
+        t = t0
+        for s in range(secs_of_frames):
+            seq = s % 4096
+            if rp.probe_bw(seq, (20, 40, 80)) in lost_rungs:
+                continue
+            t = t0 + s * 2.0
+            vrx.on_video(rssi=-52.0, snr=38.0, crc_err=False, seq=seq, now_ms=t)
+            fb = vrx.step(t)
+        return t
+
+    t = run(1024, lost_rungs=(), t0=0)
+    assert vrx.cur_op.bw == 80                       # clean: rides the top rung
+    t = run(1024, lost_rungs=(80,), t0=t + 10)
+    assert vrx.cur_op.bw <= 40                       # dirty 80 rung vacated
+    assert not vrx.primary_dirty
+    run(1024, lost_rungs=(20, 40, 80), t0=t + 10)
+    assert vrx.primary_dirty                         # nothing bandwidth can fix

--- a/tools/precoder/test_controller.py
+++ b/tools/precoder/test_controller.py
@@ -182,3 +182,38 @@ def test_bandwidth_dimension_wide_when_strong_narrow_when_weak():
     assert strong.bw > weak.bw
     assert strong.bw == 80                       # airtime-min rides the top rung
     assert strong.e_bit < weak.e_bit
+
+
+def test_rung_blocking_vacates_dirty_wide_rung_and_recovers():
+    """Probe sensing says the 80 rung's extra spectrum is dirty (delivery
+    contrast vs the best rung): the controller must vacate 80 even though the
+    SNR estimate alone says it is the cheapest, then return after the hold."""
+    # improve_frac=0 disables the anti-churn hysteresis: this test pins the
+    # rung block/unblock semantics, and the 80-vs-40 e_bit gap at low airtime
+    # duty is smaller than the default 3% churn threshold.
+    c = _ctrl(target=0.99, allow_shed=False, bw_set=(20, 40, 80), mode="vht",
+              src_bitrate_bps=8e6, rung_block_hold_ms=5000, improve_frac=0.0)
+    assert c.update(45.0, 32, now_ms=0).bw == 80          # strong link rides 80
+    c.report_rung_delivery({20: (1.0, 12), 40: (1.0, 12), 80: (0.4, 12)},
+                           now_ms=100)
+    op = c.update(45.0, 32, now_ms=200)
+    assert op.bw <= 40                                     # vacated the dirty rung
+    assert not c.primary_dirty                             # narrow rungs are fine
+    # after the hold expires (and probes look clean) 80 is rankable again
+    c.report_rung_delivery({20: (1.0, 12), 40: (1.0, 12), 80: (1.0, 12)},
+                           now_ms=6000)
+    late = c.update(45.0, 32, now_ms=20000)                # past hysteresis holds
+    assert late.bw == 80
+
+
+def test_primary_dirty_fires_only_when_narrowest_rung_bad_too():
+    c = _ctrl(target=0.99, allow_shed=False, bw_set=(20, 40, 80), mode="vht")
+    c.report_rung_delivery({20: (0.5, 12), 40: (0.5, 12), 80: (0.4, 12)},
+                           now_ms=0)
+    assert c.primary_dirty                                 # nothing bw can fix
+    c.report_rung_delivery({20: (1.0, 12), 40: (0.5, 12), 80: (0.4, 12)},
+                           now_ms=100)
+    assert not c.primary_dirty                             # 20 is clean: avoidable
+    # too few samples -> no verdict change
+    c.report_rung_delivery({20: (0.0, 2)}, now_ms=200)
+    assert not c.primary_dirty

--- a/tools/precoder/test_controller.py
+++ b/tools/precoder/test_controller.py
@@ -155,3 +155,30 @@ def test_svc_shared_power_is_max_over_active():
     ops, shared, active = svc.update(10.0, 32, now_ms=0)
     present = [ops[s].txagc for s in active]
     assert shared == max(present)                         # one PA: max over active layers
+
+
+def test_bandwidth_rows_pay_noise_bandwidth():
+    """A wider row's snr_req carries +3 dB per bandwidth doubling — the honest
+    cost that lets the e_bit ranking trade airtime against noise bandwidth."""
+    link = lm.LinkModel(trials=300)
+    rows = op_table.build_link_rows(link, 0.99, mcs_set=(3,),
+                                    overhead_set=(0.25,), bw_set=(20, 40, 80),
+                                    mode="vht")
+    req = {r.bw: r.snr_req for r in rows}
+    assert abs((req[40] - req[20]) - 3.0103) < 1e-3
+    assert abs((req[80] - req[20]) - 6.0206) < 1e-3
+
+
+def test_bandwidth_dimension_wide_when_strong_narrow_when_weak():
+    """With the bandwidth dimension open (20 c 40 c 80, the primary-nested
+    unilateral ladder), a strong link rides a wide rung (less airtime = less
+    energy), a weak one falls back to a narrow rung (its +3 dB/doubling noise
+    cost is the first thing to go)."""
+    kw = dict(target=0.99, allow_shed=False, bw_set=(20, 40, 80), mode="vht",
+              src_bitrate_bps=8e6)
+    strong = _ctrl(**kw).update(45.0, 32, now_ms=0)
+    weak = _ctrl(**kw).update(9.0, 32, now_ms=0)
+    assert strong is not None and weak is not None
+    assert strong.bw > weak.bw
+    assert strong.bw == 80                       # airtime-min rides the top rung
+    assert strong.e_bit < weak.e_bit

--- a/tools/precoder/test_energy_model.py
+++ b/tools/precoder/test_energy_model.py
@@ -27,6 +27,29 @@ def test_phy_rates():
     assert em.phy_rate_mbps("legacy", 54) == 54.0
 
 
+def test_vht_rates_and_bandwidth_ladder():
+    """VHT 1SS rates for the bandwidth dimension (20 c 40 c 80)."""
+    assert em.phy_rate_mbps("vht", 0, bw=20) == 6.5     # matches HT MCS0
+    assert em.phy_rate_mbps("vht", 7, bw=40) == 135.0   # matches HT40 MCS7
+    assert em.phy_rate_mbps("vht", 0, bw=80) == 29.3
+    assert em.phy_rate_mbps("vht", 8, bw=80) == 351.0
+    for bw in (40, 80):                                  # wider is always faster
+        assert em.phy_rate_mbps("vht", 3, bw=bw) > \
+               em.phy_rate_mbps("vht", 3, bw=bw // 2)
+    try:
+        em.phy_rate_mbps("vht", 0, bw=160)
+        assert False, "bw=160 must raise"
+    except ValueError:
+        pass
+
+
+def test_bw_noise_db():
+    """+3 dB of noise bandwidth per doubling; 20 MHz is the reference."""
+    assert em.bw_noise_db(20) == 0.0
+    assert abs(em.bw_noise_db(40) - 3.0103) < 1e-3
+    assert abs(em.bw_noise_db(80) - 6.0206) < 1e-3
+
+
 def test_higher_mcs_lowers_energy_per_bit_clean():
     """Core thesis: carrying a fixed bitrate, higher MCS = less airtime = less
     energy/bit (monotone)."""

--- a/tools/precoder/test_rc_proto.py
+++ b/tools/precoder/test_rc_proto.py
@@ -74,3 +74,32 @@ def test_profile_table():
     # index 0 = most robust (max power, heaviest FEC)
     assert rp.DEFAULT_PROFILE_TABLE[0].pwr_idx >= rp.DEFAULT_PROFILE_TABLE[-1].pwr_idx
     assert rp.DEFAULT_PROFILE_TABLE[0].fec_overhead >= rp.DEFAULT_PROFILE_TABLE[-1].fec_overhead
+
+
+def test_profile_v2_encoding_roundtrip_and_legacy_compat():
+    # v2 roundtrip across the bandwidth ladder
+    for mode in ("ht", "vht"):
+        for bw in (20, 40, 80):
+            for mcs in (0, 3, 7):
+                p = rp.encode_profile(mode, mcs, bw)
+                assert rp.decode_profile(p) == (mode, mcs, bw)
+    # legacy v1 bytes (raw MCS 0..7) decode as HT/20 — wire compatible
+    for m in range(8):
+        assert rp.decode_profile(m) == ("ht", m, 20)
+    # and an HT/20 v2 encoding IS the legacy byte
+    assert rp.encode_profile("ht", 5, 20) == 5
+
+
+def test_probe_schedule_is_shared_and_low_duty():
+    bw_set = (20, 40, 80)
+    # slots 0/8/16 probe the sorted rungs; everything else rides the op bw
+    assert rp.probe_bw(0, bw_set) == 20
+    assert rp.probe_bw(8, bw_set) == 40
+    assert rp.probe_bw(16, bw_set) == 80
+    assert rp.probe_bw(1, bw_set) is None
+    assert rp.probe_bw(32, bw_set) == 20          # periodic
+    # duty: 3 probes per 32 seqs
+    probes = sum(1 for s in range(320) if rp.probe_bw(s, bw_set) is not None)
+    assert probes == 30
+    # two-rung set only uses two slots
+    assert rp.probe_bw(16, (20, 40)) is None

--- a/tools/precoder/test_score.py
+++ b/tools/precoder/test_score.py
@@ -63,3 +63,19 @@ def test_ack_seq_tracks_max():
     w = ScoreWindow()
     _fill(w, 5, -60, 20, start_seq=100)
     assert w.ack_seq() == 104
+
+
+def test_rung_window_attributes_losses_by_probe_schedule():
+    """Kill exactly the seqs whose probe rung is 80 MHz: the 80 rung's delivery
+    collapses while 20/40 stay perfect — per-rung sensing from seq gaps alone."""
+    import rc_proto as rp
+    from score import RungWindow
+    bw_set = (20, 40, 80)
+    rw = RungWindow(bw_set)
+    for s in range(0, 32 * 12):
+        if rp.probe_bw(s, bw_set) == 80:
+            continue                       # lost on air -> a gap at the VRX
+        rw.add_seq(s)
+    st = rw.stats()
+    assert st[20][0] == 1.0 and st[40][0] == 1.0
+    assert st[80][0] == 0.0 and st[80][1] >= 8


### PR DESCRIPTION
## Problem

A long-range link wants the widest channel it can get, but one dirty 20 MHz slice (an interferer, a neighbouring network) conventionally forces the whole 80 MHz block to be abandoned. Wi-Fi 7 solves this with preamble puncturing — transmit around the dirty slice — but that is 802.11be PHY signaling (EHT-SIG puncturing bitmap + TX IFFT tone nulls). **The question this PR answers: how much of that capability can 802.11ac-era Jaguar silicon recover, and which mechanism actually carries the weight?** Answered with ported vendor knobs + on-air measurements; the study lives in `docs/pseudo-preamble-puncturing.md`.

## What lands

**1. The RX tone-mask knobs — the only tone-level hardware the silicon has** (`src/ToneMask.h`, all three generations):
- `DEVOURER_RX_CSI_MASK=<f_lo>[-<f_hi>][/wgt]` — per-tone receive-equalizer de-weight over an arbitrary frequency range (the vendor phydm wrapper only notches one interferer; masking a 20 MHz slice needs the range form). 11ac: `0x874[0]` + bit arrays `0x880-0x89C`; Jaguar3: indexed table behind `0x1D94`, per-tone 3-bit weight, enable `0xC0C[3]`.
- `DEVOURER_RX_NBI=<f_mhz>` — the vendor-parity narrowband notch.
- Validated on **8821AU, 8814AU, 8822BU, 8812CU, 8822EU** (`tests/tone_mask_regcheck.sh`), demod-active not just readback (`tests/tone_mask_rx_sanity.sh`: masking the tuned channel collapses a live link 29→6 hits, off-frequency mask 29→30), tone math ctest-guarded (`tone_mask_math`).

**2. The jammed-slice measurements — which lever works** (`tests/pseudo_puncture_onair.sh`, B210 jamming one slice of a VHT80 link):

| cell | hits/15s |
|---|---|
| clean VHT80 | 61 |
| jammed VHT80 | 31 |
| jammed + CSI mask on the slice | 33 |
| jammed, TX on the clean 40 MHz half | 48 |

The CSI mask is **inert against a jammed slice** — and the PR shows why: with `DEVOURER_RX_KEEP_CORRUPTED=1` the jammed cell delivers *zero* FCS-failed frames, i.e. the loss is pre-FCS (sync/AGC), upstream of the equalizer and of sub-block salvage. The mask stays valuable for its designed purpose (in-band spurs on decodable frames), now exposed. **TX-side avoidance is the working lever** (78% of clean delivery), and a victim-link probe scan locates the dirty slice where per-tone SNR self-sounding cannot (it senses the peer's channel, not the victim's — `tests/pseudo_puncture_detect.sh`).

**3. The avoidance lever measured precisely** (`tests/rx80_narrow_tx_probe.sh`, `tests/wide_rx_penalty_sweep.sh`): an 80 MHz-tuned RX decodes narrower frames on its primary sub-channels **without retuning** and at **0 dB (≤1 dB) sensitivity cost** — so TX bandwidth adaptation along the primary-nested ladder `20 ⊂ 40 ⊂ 80` is unilateral and per-packet, no coordination protocol needed.

**4. The adaptive-link integration** (`tools/precoder/`, 230 tests): bandwidth as an energy-ranked op-table dimension (`ControllerConfig.bw_set`, VHT 1SS rates incl. the 80 MHz rung, +3 dB/doubling noise cost per row); per-rung delivery sensing with **zero new wire fields** (a shared seq-derived probe schedule, ~3% duty per rung); rung blocking by delivery *contrast* (fires on interference, not on path loss); and a `primary_dirty` escalation flag for the one case no unilateral bandwidth choice can fix. Wire-compatible: legacy PROFILE bytes decode unchanged.

Also fixed en route: `tests/sdr_interferer.py` could not feed 20 MS/s from per-buffer numpy draws — the jam radiated only in underflow bursts and its gain knob silently did nothing (pre-generated fixed-seed noise ring now); `WiFiDriverDemo` accepts `DEVOURER_BW=80`.

## Verdict

The honest Jaguar rendition of `[clean][clean][skip][clean]` is **puncturing by primary-channel selection**: probe-scan the slices with the victim link, transmit around the dirty one at the widest clean primary-nested bandwidth, escalate to a coordinated channel move only when the primary itself is dirty. The cost vs Wi-Fi 7 is the bandwidth quantization (60 MHz usable → 40).

## Validation

- CI green across the matrix (incl. the mingw selective-target fix for the new ctest binary); `ctest` 2/2; precoder `pytest` 230/230.
- Hardware: 5-chip register-landing matrix, 3-cell mask sanity, 4-cell jammed-slice experiment (+ gain-85 repeat), probe-scan detection run, wide-RX penalty sweep — all scripts in `tests/` are re-runnable on the 2-DUT + B210 bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)