### PR TITLE
Jaguar3: RCR AAP bit + 8822E path-B TXAGC ref fix — single-radio self-capture works

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,15 +216,15 @@ Both `WiFiDriverDemo` and `WiFiDriverTxDemo` honour:
   env must be set **before** `InitWrite` (it keeps the RX filters open and
   enables the RX path during bring-up — retrofitting RX onto a TX-only bring-up
   is unreliable), and the coex thread's C2H drain yields bulk-IN to the RX loop.
-  On the 8822E, TX+RX mode trades the per-rate TXAGC + DPK-bypass away for a
-  working RX (either one desenses the EU's RX to near-deaf; flat table TX power
-  instead). This is the single-radio beamforming self-sounding ground station —
-  pair with `DEVOURER_BF_ARM_SOUNDER`/`DEVOURER_TX_NDPA` and
+  On the 8822E, TX+RX mode leaves the path-B OFDM TXAGC reference (0x41e8) at
+  its table default — any nonzero value in that one field desenses the EU's RX
+  to near-deaf (hardware-bisected, value-independent; the rest of the per-rate
+  power applies normally). This is the single-radio beamforming self-sounding
+  ground station — pair with `DEVOURER_BF_ARM_SOUNDER`/`DEVOURER_TX_NDPA` and
   `DEVOURER_BF_DETECT_REPORT` to sound and capture your own reports in one
-  process (`docs/beamforming-self-sounding.md`; hardware-validated on Jaguar1 —
-  the 8814AU captures its own report stream; on Jaguar3 the sounder emits
-  NDPA+NDP and the beamformee replies, but the sounder's own RX does not
-  surface the report frames — capture them on a second radio there). Any other
+  process (`docs/beamforming-self-sounding.md`; hardware-validated on Jaguar1
+  (8814AU) and on both Jaguar3 variants — 50k+ self-captured reports per 20 s
+  at full sounding rate). Any other
   non-empty value selects the legacy `fork()` RX child — Termux-only
   (`libusb_wrap_sys_device` keeps the fd shared across fork); on regular Linux
   the forked bring-ups race and die with `rtw_read: iostream error`.

--- a/docs/beamforming-self-sounding.md
+++ b/docs/beamforming-self-sounding.md
@@ -69,23 +69,17 @@ DEVOURER_PID=0x8812 DEVOURER_CHANNEL=100 DEVOURER_TX_RATE=VHT2SS_MCS0 \
 DEVOURER_PID=0x8813 DEVOURER_CHANNEL=100 DEVOURER_BF_DETECT_REPORT=4 \
   WiFiDriverDemo | tools/bf_report_decode.py
 
-# single-radio beamformer (Jaguar-1): the report is addressed TO the sounder,
-# so one adapter can sound and capture its own reports —
-# DEVOURER_TX_WITH_RX=thread runs the RX worker loop on a thread next to the
-# TX loop (one bring-up, one claimed handle; see StartRxLoop in IRtlDevice).
-# Hardware-validated on the 8814AU (thousands of self-captured reports); on a
-# Jaguar-3 sounder the NDPA+NDP+report exchange works but the sounder's own RX
-# does not surface the reports — use a second capture radio there.
+# single-radio beamformer: the report is addressed TO the sounder, so one
+# adapter can sound and capture its own reports — DEVOURER_TX_WITH_RX=thread
+# runs the RX worker loop on a thread next to the TX loop (one bring-up, one
+# claimed handle; see StartRxLoop in IRtlDevice). Hardware-validated on the
+# 8814AU (Jaguar-1) and on both Jaguar-3 variants (8822CU / 8822EU, 50k+
+# self-captured reports per 20 s at full sounding rate). On Jaguar-3,
+# DEVOURER_BF_ARM_SOUNDER takes the sounder MAC (programs the self-MAC 0x610).
 DEVOURER_PID=0x8812 DEVOURER_CHANNEL=100 DEVOURER_TX_RATE=VHT2SS_MCS0 \
   DEVOURER_TX_NDPA_RA=<beamformee-mac> DEVOURER_TX_NDPA=1 \
   DEVOURER_BF_ARM_SOUNDER=1 DEVOURER_TX_WITH_RX=thread \
   DEVOURER_BF_DETECT_REPORT=4 WiFiDriverTxDemo | tools/bf_report_decode.py
-
-# Jaguar-3 sounder (NDPA descriptor mark + MAC sounding-engine arm;
-# DEVOURER_BF_ARM_SOUNDER also takes the sounder MAC to program 0x610):
-DEVOURER_PID=0xc812 DEVOURER_CHANNEL=100 DEVOURER_TX_RATE=VHT2SS_MCS0 \
-  DEVOURER_TX_NDPA_RA=<beamformee-mac> DEVOURER_TX_NDPA=1 \
-  DEVOURER_BF_ARM_SOUNDER=57:42:75:05:d6:00 WiFiDriverTxDemo
 ```
 
 Gotchas that cost time during bring-up:

--- a/src/jaguar3/HalJaguar3.cpp
+++ b/src/jaguar3/HalJaguar3.cpp
@@ -358,6 +358,10 @@ void HalJaguar3::txbf_rfmode_sounder() {
                                             ((addr & 0xff) << 2));
     _device.phy_set_bb_reg(direct, mask & 0xfffff, val);
   };
+  /* Bracket the RF mode-table writes with rstb_3wire like the RF table load
+   * (RadioManagementJaguar3 / apply_bb_rf_agc_tables do the same) — without
+   * it the mode-table entry writes can be dropped by the live 3-wire engine. */
+  _device.phy_set_bb_reg(0x1c90, 1u << 8, 0);
   if (_variant == jaguar3::ChipVariant::C8822C) {
     /* Path A: RX-mode table entry with TX IQ generator on */
     rf(0, 0xef, 1u << 19, 1);      /* mode-table write enable */
@@ -384,6 +388,10 @@ void HalJaguar3::txbf_rfmode_sounder() {
     rf(1, 0x3f, 0xfffff, 0x306bf);
     rf(1, 0xef, 1u << 19, 0);
   }
+  /* rstb_3wire back on + force anapar update (same tail as the table load). */
+  _device.phy_set_bb_reg(0x1c90, 1u << 8, 1);
+  _device.phy_set_bb_reg(0x1830, 1u << 29, 1);
+  _device.phy_set_bb_reg(0x4130, 1u << 29, 1);
   /* BB TxBF antenna mapping (same on both variants). */
   _device.phy_set_bb_reg(0x1e24, 1u << 11, 1); /* Nsts > Nc: no V matrix */
   _device.phy_set_bb_reg(0x1e24, (1u << 28) | (1u << 29), 0x2);
@@ -423,8 +431,14 @@ void HalJaguar3::monitor_rx_cfg() {
    * MACRXEN(+ENSWBCN). init_mac_cfg only set CR=0x0F (DMA enable); without
    * MACRXEN (BIT7) the MAC RX engine never runs — the structured-path RX gap. */
   _device.rtw_write16(0x0100, 0x06FF);
-  /* accept-all + keep FCS/ICV-error frames + append phy-status (BIT28) */
-  _device.rtw_write32(REG_RCR_8822C, 0xF410400E | (1u << 28));
+  /* accept-all + keep FCS/ICV-error frames + append phy-status (BIT28).
+   * BIT0 (AAP) is what makes monitor mode promiscuous for unicast: without it
+   * the WMAC passes only broadcast/multicast/physical-match (APM|AM|AB) up,
+   * silently dropping unicast frames addressed to third parties — e.g. NDPA
+   * control frames and VHT beamforming reports, which is why the beamformee
+   * (whose arm programs the self-MAC to the NDPA RA) saw sounding frames while
+   * a plain monitor did not. */
+  _device.rtw_write32(REG_RCR_8822C, 0xF410400F | (1u << 28));
   _device.rtw_write8(REG_RX_DRVINFO_SZ_8822C, 0x04);
   _device.rtw_write16(REG_RXFLTMAP0_8822C, 0xFFFF);
   _device.rtw_write16(REG_RXFLTMAP1_8822C, 0xFFFF);

--- a/src/jaguar3/RadioManagementJaguar3.cpp
+++ b/src/jaguar3/RadioManagementJaguar3.cpp
@@ -263,9 +263,8 @@ static bool pg_addr_to_rates(uint32_t addr, std::array<uint8_t, 4> &rates) {
 }
 #endif /* DEVOURER_HAVE_JAGUAR3_8822E */
 
-void RadioManagementJaguar3::apply_power_by_rate_8822e(uint8_t channel,
-                                                       uint8_t ref_a,
-                                                       uint8_t ref_b) {
+void RadioManagementJaguar3::apply_power_by_rate_8822e(
+    uint8_t channel, uint8_t ref_a, uint8_t ref_b, bool skip_path_b_ofdm_ref) {
 #if defined(DEVOURER_HAVE_JAGUAR3_8822E)
   /* Port of the phy_reg_pg (power-by-rate) apply that devourer's table walk
    * skips. The 8822e TXAGC is ref + per-rate diff: the OFDM/HT/VHT reference
@@ -306,7 +305,8 @@ void RadioManagementJaguar3::apply_power_by_rate_8822e(uint8_t channel,
     _device.phy_set_bb_reg(off, mask, v);
   };
   wr(0x18e8, 0x1fc00, ref_a);     /* path A OFDM/HT/VHT ref */
-  wr(0x41e8, 0x1fc00, ref_b);     /* path B (efuse gives a distinct per-path base) */
+  if (!skip_path_b_ofdm_ref)
+    wr(0x41e8, 0x1fc00, ref_b);   /* path B — RX-desense hazard, see header */
   wr(0x18a0, 0x7f0000, ref_a);    /* CCK ref (2.4G) */
   wr(0x41a0, 0x7f0000, ref_b);
 

--- a/src/jaguar3/RadioManagementJaguar3.h
+++ b/src/jaguar3/RadioManagementJaguar3.h
@@ -45,8 +45,17 @@ public:
    * 0x41a0) and writes the per-rate diff table (0x3a00) so robust low rates get
    * the kernel's by-rate boost instead of a flat reference. The per-path refs
    * come from the efuse per-channel base (the kernel programs a distinct path-A/
-   * path-B base, e.g. 0x4b/0x54 at ch36). */
-  void apply_power_by_rate_8822e(uint8_t channel, uint8_t ref_a, uint8_t ref_b);
+   * path-B base, e.g. 0x4b/0x54 at ch36).
+   *
+   * skip_path_b_ofdm_ref: leave 0x41e8 (path-B OFDM ref) at its table default.
+   * Hardware-bisected: ANY nonzero value in that one field desenses the EU's RX
+   * to near-deaf (value-independent; path-A ref, CCK refs, the diff table and
+   * the DPK bypass are all RX-safe) — root cause open, suspected path-B
+   * TSSI/gain-stage asymmetry in devourer's bring-up vs the kernel's. TX+RX
+   * callers set this so RX works at the cost of path-B OFDM TX running at the
+   * table-default reference. */
+  void apply_power_by_rate_8822e(uint8_t channel, uint8_t ref_a, uint8_t ref_b,
+                                 bool skip_path_b_ofdm_ref = false);
 
 private:
   /* Jaguar3 baseband bandwidth/clock registers (from

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -270,23 +270,10 @@ void RtlJaguar3Device::InitWrite(SelectedChannel channel) {
   _hal.run_iqk(channel);
   if (want_rx)
     _hal.enable_rx_path(); /* RF into RX mode — same slot as the Init path */
-  /* 8822e DPK force-bypass + per-rate TXAGC (below) each DESENSE the EU's RX
-   * to near-deaf when applied on a bring-up that also runs the RX path (bisected
-   * on hardware: either alone kills RX; skipping both restores it; a later
-   * enable_rx_path does not recover). In TX+RX mode trade them away: TX runs at
-   * the flat table power (no per-rate spread, no DPK-LUT bypass state), RX
-   * works. TX-only behavior is unchanged. Root cause is an open question —
-   * suspect the RMW reads of the live 0x18e8/0x1b00 blocks folding HW-status
-   * bits back into config. */
-  if (!want_rx)
-    _hal.dpk_force_bypass_8822e(); /* 8822e rfe 21/22: kernel bypasses DPK (after IQK) */
+  _hal.dpk_force_bypass_8822e(); /* 8822e rfe 21/22: kernel bypasses DPK (after IQK) */
   _hal.config_rfe(channel.Channel); /* 8822e RFE/PAPE antenna-switch pins (PA enable) */
   _hal.config_channel_8822e(channel.Channel); /* 8822e band TX scaling/backoff + shaping */
-  if (want_rx && _variant == jaguar3::ChipVariant::C8822E) {
-    /* See the DPK note above — the EU's TXAGC ref/diff writes desense RX. */
-    _logger->info("Jaguar3(8822e): TX+RX mode — flat table TX power "
-                  "(per-rate TXAGC skipped, keeps RX alive)");
-  } else if (_tx_pwr_override >= 0) {
+  if (_tx_pwr_override >= 0) {
     _radioManagement.set_tx_power_ref(static_cast<uint8_t>(_tx_pwr_override));
   } else if (_variant == jaguar3::ChipVariant::C8822E) {
     /* Default TX power (8822e). The TXAGC reference base is the per-channel 5 GHz
@@ -303,7 +290,14 @@ void RtlJaguar3Device::InitWrite(SelectedChannel channel) {
     _hal.read_efuse_txpwr_base_8822e(channel.Channel, efuse_a, efuse_b);
     uint8_t ref_a = (efuse_a <= 127) ? efuse_a : JAGUAR3_TXPWR_REF_BASE;
     uint8_t ref_b = (efuse_b <= 127) ? efuse_b : JAGUAR3_TXPWR_REF_BASE;
-    _radioManagement.apply_power_by_rate_8822e(channel.Channel, ref_a, ref_b);
+    /* TX+RX mode: the path-B OFDM reference (0x41e8) desenses the EU's RX
+     * (hardware-bisected, value-independent) — skip that one write and keep
+     * the rest of the per-rate power intact. See apply_power_by_rate_8822e. */
+    _radioManagement.apply_power_by_rate_8822e(channel.Channel, ref_a, ref_b,
+                                               /*skip_path_b_ofdm_ref=*/want_rx);
+    if (want_rx)
+      _logger->info("Jaguar3(8822e): TX+RX mode — path-B OFDM TXAGC ref left "
+                    "at table default (keeps RX alive)");
   } else {
     /* 8822c (CU): preserve the flat reference the demo used to impose (40) so
      * the SDR-validated CU TX power is unchanged now that the demo no longer


### PR DESCRIPTION
Closes the two hardware follow-ups from #158, both root-caused by cold-chip bisection (VBUS power-cycling the DUT per experiment — chip state provably leaks across soft re-inits and had produced several false leads).

## 1. Jaguar3 monitor mode was never promiscuous (RCR AAP)

`monitor_rx_cfg`'s RCR (`0xF410400E`, commented "accept-all") was missing **`BIT_AAP` (bit 0, accept-all unicast)** — decoded against `halmac_bit_8822c.h`, only APM|AM|AB were set. The host therefore received broadcast/multicast/self-addressed frames only, silently dropping every third-party unicast: NDPA control frames, VHT beamforming reports, unicast data. The beamformee only ever surfaced NDPAs because its arm programs the self-MAC to the NDPA RA (physical match).

With AAP set, the **single-radio beamforming self-sounding ground station works on both Jaguar3 variants**: 53,132 (8822CU) / 53,409 (8822EU) self-captured reports per 20 s at full sounding rate (2,215 at the 10 Hz design rate), zero errors — and a bare Jaguar3 monitor finally sees all traffic. Jaguar1/Jaguar2 RCRs already accept all unicast.

## 2. 8822E RX-desense: one register field

The EU's TX+RX desense bisected down to **0x41e8[16:10] — the path-B OFDM TXAGC reference: any nonzero value desenses the EU's RX to near-deaf** (value-independent; double-reads stable and the written value lands exactly, so RMW pollution is ruled out). Everything else is RX-safe: path-A ref, CCK refs, the per-rate diff table, DPK force-bypass, the 0x1c90 gate, the coex/pwr_track runtime — earlier observations blaming DPK/TXAGC broadly were chip-state pollution.

`apply_power_by_rate_8822e` gains `skip_path_b_ofdm_ref`: TX+RX mode on the EU now applies the **full per-rate power-by-rate table + DPK bypass** and leaves only that one field at its table default (previously the entire per-rate path was traded for flat power). TX-only behavior unchanged. Why the kernel tolerates a nonzero 0x41e8 where devourer's bring-up does not remains open; the practical impact is one skipped write in one mode.

Also: `txbf_rfmode_sounder` now brackets its RF mode-table writes with `rstb_3wire` + the anapar-update tail (same mechanism as the RF table load; readback-verified).

## Hardware validation (cold chips)

- EU TX+RX: ambient RX alive with the near-full power path
- EU + CU single-radio self-capture acceptance: 53k reports each / 20 s
- EU TX-only ch100 sustain: unchanged (29k frames / 70 s, coex housekeeping intact)
- build + ctest green

🤖 Generated with [Claude Code](https://claude.com/claude-code)