### PR TITLE
Beamforming self-sounding: Jaguar2 (8822BU) — three-generation matrix complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,8 @@ Both `WiFiDriverDemo` and `WiFiDriverTxDemo` honour:
   API for concurrent TX+RX on one handle (all three generations). On Jaguar3 the
   env must be set **before** `InitWrite` (it keeps the RX filters open and
   enables the RX path during bring-up — retrofitting RX onto a TX-only bring-up
-  is unreliable), and the coex thread's C2H drain yields bulk-IN to the RX loop.
+  is unreliable), and the coex thread's C2H drain yields bulk-IN to the RX loop;
+  Jaguar2's shared bring-up always enables RX, so it has no such constraint.
   On the 8822E, TX+RX mode leaves the path-B OFDM TXAGC reference (0x41e8) at
   its table default — any nonzero value in that one field desenses the EU's RX
   to near-deaf (hardware-bisected, value-independent; the rest of the per-rate
@@ -223,8 +224,8 @@ Both `WiFiDriverDemo` and `WiFiDriverTxDemo` honour:
   ground station — pair with `DEVOURER_BF_ARM_SOUNDER`/`DEVOURER_TX_NDPA` and
   `DEVOURER_BF_DETECT_REPORT` to sound and capture your own reports in one
   process (`docs/beamforming-self-sounding.md`; hardware-validated on Jaguar1
-  (8814AU) and on both Jaguar3 variants — 50k+ self-captured reports per 20 s
-  at full sounding rate). Any other
+  (8814AU), Jaguar2 (8822BU) and both Jaguar3 variants — 50k+ self-captured
+  reports per 20 s at full sounding rate). Any other
   non-empty value selects the legacy `fork()` RX child — Termux-only
   (`libusb_wrap_sys_device` keeps the fd shared across fork); on regular Linux
   the forked bring-ups race and die with `rtw_read: iostream error`.

--- a/docs/beamforming-self-sounding.md
+++ b/docs/beamforming-self-sounding.md
@@ -40,9 +40,11 @@ Two hardware facts made this work, both validated on real silicon:
 
 ## Register recipe
 
-All register values are in `src/jaguar1/BeamformingSounder.h`, transcribed from
-the vendor `hal_txbf_jaguar_enter()`
-(`reference/rtl8812au/hal/phydm/txbf/haltxbfjaguar.c`). Entry 0, P_AID 0.
+All register values are in the generation-shared `src/BeamformingSounder.h`,
+transcribed from the vendor beamformee-entry functions — Jaguar-1
+`hal_txbf_jaguar_enter()` (`reference/rtl8812au/hal/phydm/txbf/haltxbfjaguar.c`),
+Jaguar-2/3 `hal_txbf_8822b_enter()` (`haltxbf8822b.c`, byte-identical between
+the rtl88x2bu and rtl88x2cu trees). Entry 0, P_AID 0.
 
 - **Beamformer (`arm_sounder`)**: `REG_SND_PTCL_CTRL` enable, NDP standby
   timeout, `REG_TXBF_CTRL` NDPA-transmit enables, `REG_BFMEE_SEL` entry select.
@@ -73,9 +75,10 @@ DEVOURER_PID=0x8813 DEVOURER_CHANNEL=100 DEVOURER_BF_DETECT_REPORT=4 \
 # adapter can sound and capture its own reports — DEVOURER_TX_WITH_RX=thread
 # runs the RX worker loop on a thread next to the TX loop (one bring-up, one
 # claimed handle; see StartRxLoop in IRtlDevice). Hardware-validated on the
-# 8814AU (Jaguar-1) and on both Jaguar-3 variants (8822CU / 8822EU, 50k+
-# self-captured reports per 20 s at full sounding rate). On Jaguar-3,
-# DEVOURER_BF_ARM_SOUNDER takes the sounder MAC (programs the self-MAC 0x610).
+# 8814AU (Jaguar-1), the 8822BU (Jaguar-2) and both Jaguar-3 variants
+# (8822CU / 8822EU) — 50k+ self-captured reports per 20 s at full sounding
+# rate. On Jaguar-2/3, DEVOURER_BF_ARM_SOUNDER takes the sounder MAC
+# (programs the self-MAC 0x610).
 DEVOURER_PID=0x8812 DEVOURER_CHANNEL=100 DEVOURER_TX_RATE=VHT2SS_MCS0 \
   DEVOURER_TX_NDPA_RA=<beamformee-mac> DEVOURER_TX_NDPA=1 \
   DEVOURER_BF_ARM_SOUNDER=1 DEVOURER_TX_WITH_RX=thread \

--- a/src/jaguar2/FrameParserJaguar2.h
+++ b/src/jaguar2/FrameParserJaguar2.h
@@ -42,6 +42,8 @@ constexpr size_t RXDESC_SIZE_8822B = 24; /* RX_DESC_SIZE_88XX */
 #define SET_TX_DESC_DATA_BW_8822B(d, v)    SET_BITS_TO_LE_4BYTE((d) + 0x14, 5, 2, v)
 #define SET_TX_DESC_DATA_LDPC_8822B(d, v)  SET_BITS_TO_LE_4BYTE((d) + 0x14, 7, 1, v)
 #define SET_TX_DESC_DATA_STBC_8822B(d, v)  SET_BITS_TO_LE_4BYTE((d) + 0x14, 8, 2, v)
+#define SET_TX_DESC_NAVUSEHDR_8822B(d, v)  SET_BITS_TO_LE_4BYTE((d) + 0x0C, 15, 1, v)
+#define SET_TX_DESC_NDPA_8822B(d, v)       SET_BITS_TO_LE_4BYTE((d) + 0x0C, 22, 2, v)
 #define SET_TX_DESC_DISQSELSEQ_8822B(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x00, 31, 1, v)
 #define SET_TX_DESC_G_ID_8822B(d, v)       SET_BITS_TO_LE_4BYTE((d) + 0x08, 24, 6, v)
 #define SET_TX_DESC_RTY_LMT_EN_8822B(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x10, 17, 1, v)
@@ -87,7 +89,8 @@ inline void cal_txdesc_chksum_8822b(uint8_t *txdesc) {
 inline void fill_data_tx_desc_8822b(uint8_t *d, uint16_t pkt_size,
                                     uint8_t rate_hw, uint8_t rate_id, uint8_t bw,
                                     bool short_gi, bool ldpc, uint8_t stbc,
-                                    bool bmc = false, uint8_t wheader_len = 12) {
+                                    bool bmc = false, uint8_t wheader_len = 12,
+                                    bool ndpa = false) {
   SET_TX_DESC_TXPKTSIZE_8822B(d, pkt_size);
   SET_TX_DESC_OFFSET_8822B(d, static_cast<uint32_t>(TXDESC_SIZE_8822B));
   SET_TX_DESC_LS_8822B(d, 1);
@@ -116,6 +119,19 @@ inline void fill_data_tx_desc_8822b(uint8_t *d, uint16_t pkt_size,
    * checksum at 0x1C is still computed (the kernel fills it even with CHK_EN=0).
    * `wheader_len` is retained in the signature for callers but not written. */
   (void)wheader_len;
+  /* Beamforming self-sounding: mark the frame as an NDPA (halmac NDPA field,
+   * dword3 [23:22] = 1) so the armed MAC sounding engine follows it with a
+   * hardware-generated NDP — same recipe as the Jaguar-1/-3 paths: unicast
+   * control frame, so no HW sequence stamp, not broadcast, use-header NAV, no
+   * rate fallback. Must stay ABOVE the checksum: dword3 is inside the 32 bytes
+   * the 8822B HW checksums, and a mismatch silently drops the frame at TXDMA. */
+  if (ndpa) {
+    SET_TX_DESC_NDPA_8822B(d, 1);
+    SET_TX_DESC_EN_HWSEQ_8822B(d, 0);
+    SET_TX_DESC_BMC_8822B(d, 0);
+    SET_TX_DESC_NAVUSEHDR_8822B(d, 1);
+    SET_TX_DESC_DISDATAFB_8822B(d, 1);
+  }
   cal_txdesc_chksum_8822b(d);
 }
 

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "BeamformingSounder.h"
 #include "FrameParserJaguar2.h"
 #include "Halrf8822b.h"
 #include "ToneMask.h"
@@ -113,6 +114,44 @@ void RtlJaguar2Device::Init(Action_ParsedRadioPacket packetProcessor,
   _channel = channel;
   bring_up(channel);
 
+  /* DEVOURER_BF_ARM_BFEE=aa:bb:cc:dd:ee:ff — beamforming self-sounding
+   * (beamformee side), Jaguar-2 variant. Arms the hardware CSI responder to
+   * reply to NDPA+NDP from the given beamformer MAC with a VHT Compressed
+   * Beamforming report, no association. Uses the shared MAC recipe with the
+   * Jaguar-2/3 config (0xDB, 16-bit CSI param, RX-filter + own-AID gates) —
+   * kBfeeJaguar23 is transcribed from the vendor hal_txbf_8822b_enter(), i.e.
+   * it IS the 8822B recipe. Must come after bring_up: the recipe RMWs the
+   * RXFLTMAP registers init_wmac_cfg writes. See BeamformingSounder.h. */
+  if (const char *bfer = std::getenv("DEVOURER_BF_ARM_BFEE")) {
+    unsigned m[6];
+    if (std::sscanf(bfer, "%x:%x:%x:%x:%x:%x", &m[0], &m[1], &m[2], &m[3],
+                    &m[4], &m[5]) == 6) {
+      uint8_t mac[6];
+      for (int i = 0; i < 6; ++i) mac[i] = static_cast<uint8_t>(m[i]);
+      /* Jaguar-2 bring-up never programs the self-MAC (0x0610), so the NDPA
+       * RA has nothing to match. Give the beamformee a known identity here so
+       * the sounder can address it; log it for the test harness. */
+      static const uint8_t kBfeeMac[6] = {0x00, 0xe0, 0x4c, 0x88, 0x22, 0xbb};
+      for (uint16_t i = 0; i < 6; ++i)
+        _device.rtw_write8(0x0610 + i, kBfeeMac[i]);
+      /* DEVOURER_BF_ARM_BFEE_MU=1 upgrades the responder to an MU beamformee,
+       * whose report appends the per-subcarrier delta-SNR (MU Exclusive
+       * Beamforming Report) the SU report omits. Pair with the sounder's
+       * DEVOURER_TX_NDPA_MU=1 (MU feedback bit in the NDPA STA-info). */
+      if (std::getenv("DEVOURER_BF_ARM_BFEE_MU")) {
+        devourer::bf::arm_beamformee_mu(_device, mac, devourer::bf::kBfeeJaguar23);
+        _logger->info("Jaguar2 BF MU-beamformee armed for beamformer {} — "
+                      "beamformee MAC 00:e0:4c:88:22:bb", bfer);
+      } else {
+        devourer::bf::arm_beamformee(_device, mac, devourer::bf::kBfeeJaguar23);
+        _logger->info("Jaguar2 BF beamformee armed for beamformer {} — "
+                      "beamformee MAC 00:e0:4c:88:22:bb", bfer);
+      }
+    } else {
+      _logger->error("DEVOURER_BF_ARM_BFEE — bad MAC '{}'", bfer);
+    }
+  }
+
   if (getenv("DEVOURER_BB_DUMP")) {
     /* Full BB/RF register dump in the vendor rtw_proc format for canary diff
      * against the kernel driver (tests/jaguar2_rx_canary.sh). */
@@ -214,6 +253,29 @@ void RtlJaguar2Device::InitWrite(SelectedChannel channel) {
   if (const char *e = getenv("DEVOURER_TX_PWR")) {
     uint8_t idx = static_cast<uint8_t>(strtol(e, nullptr, 0) & 0x3f);
     _hal.set_tx_power_flat(idx);
+  }
+  /* DEVOURER_BF_ARM_SOUNDER — beamforming self-sounding (beamformer side):
+   * arm the MAC's hardware sounding engine so a TX-descriptor-marked NDPA
+   * (DEVOURER_TX_NDPA=1) is followed by a hardware-generated NDP. The MAC
+   * sounding registers are family-neutral (BeamformingSounder.h); the
+   * sounding-protocol control byte is 0xDB (hal_txbf_8822b_enter — Jaguar-1
+   * uses 0xCB). No RF mode-table poke here, unlike Jaguar-3: the vendor's
+   * hal_txbf_8822b_rf_mode() body is entirely #if 0'd out. */
+  if (const char *snd = std::getenv("DEVOURER_BF_ARM_SOUNDER")) {
+    /* Jaguar-2 bring-up never programs the self-MAC (0x0610); the sounding
+     * engine matches the injected NDPA's TA against it before firing the NDP.
+     * DEVOURER_BF_ARM_SOUNDER=aa:bb:cc:dd:ee:ff programs that MAC (use the
+     * NDPA TA the caller injects — the txdemo's canonical SA); a bare "1"
+     * leaves it unprogrammed (Jaguar-1 semantics). */
+    unsigned m[6];
+    if (std::sscanf(snd, "%x:%x:%x:%x:%x:%x", &m[0], &m[1], &m[2], &m[3],
+                    &m[4], &m[5]) == 6) {
+      for (uint16_t i = 0; i < 6; ++i)
+        _device.rtw_write8(0x0610 + i, static_cast<uint8_t>(m[i]));
+      _logger->info("Jaguar2 BF sounder: self-MAC programmed to {}", snd);
+    }
+    devourer::bf::arm_sounder(_device, /*snd_ptcl_ctrl=*/0xDB);
+    _logger->info("Jaguar2 BF sounder armed (beamformer side)");
   }
   _logger->info("Jaguar2: ready for TX (monitor inject, ch={})",
                 channel.Channel);
@@ -332,11 +394,15 @@ bool RtlJaguar2Device::send_packet(const uint8_t *packet, size_t length) {
       hdrlen += 6; /* 4-address */
   }
 
+  /* DEVOURER_TX_NDPA=1 — beamforming self-sounding: mark injected frames as
+   * NDPA so the armed sounding engine (DEVOURER_BF_ARM_SOUNDER, InitWrite)
+   * follows each with a hardware-generated NDP. Same knob as Jaguar-1/-3. */
+  static const bool ndpa = std::getenv("DEVOURER_TX_NDPA") != nullptr;
   std::vector<uint8_t> usb_frame(jaguar2::TXDESC_SIZE_8822B + frame_len, 0);
   jaguar2::fill_data_tx_desc_8822b(
       usb_frame.data(), static_cast<uint16_t>(frame_len),
       MRateToHwRate(fixed_rate), rate_id, bw_desc, sgi != 0, ldpc != 0, stbc,
-      bmc, static_cast<uint8_t>(hdrlen >> 1));
+      bmc, static_cast<uint8_t>(hdrlen >> 1), ndpa);
   std::memcpy(usb_frame.data() + jaguar2::TXDESC_SIZE_8822B, dot11, frame_len);
 
   int rc = _device.bulk_send_sync_ep(_device.first_bulk_out_ep(),

--- a/tests/bf_selfsound_jaguar2.sh
+++ b/tests/bf_selfsound_jaguar2.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# BF self-sounding cross-generation test, Jaguar-2 (8822BU) edition — both
+# directions plus the single-radio ground station:
+#
+#   cells A/B (beamformee direction, unarmed/armed):
+#     Jaguar-1 sounder (default 8814AU — proven single-radio GS path)
+#     8822BU  : beamformee   (shared recipe, kBfeeJaguar23) — chip under test
+#     Jaguar-1 sniffer (default 8821AU), DEVOURER_BF_DETECT_REPORT=4
+#     PASS = <devourer-bf-report> with SA = the Jaguar-2 beamformee MAC
+#     (00:e0:4c:88:22:bb, programmed at arm time) only when armed.
+#
+#   cell C (sounder direction + single-radio ground station):
+#     Jaguar-1 beamformee (default 8821AU — the original gate-2 chip; EFUSE
+#     MAC learned from its init log)
+#     8822BU  : sounder + self-capture (DEVOURER_TX_WITH_RX=thread) — under test
+#     Jaguar-1 sniffer (default 8814AU) cross-check
+#     PASS = <devourer-bf-report> lines in the 8822BU's OWN log (self-capture).
+#     Sniffer>0 with self-capture==0 isolates an RX-side issue; both 0 = the
+#     NDPA descriptor / HW NDP never fired.
+#
+# Usage: sudo tests/bf_selfsound_jaguar2.sh [bfee_pid] [bfee_vid]
+#        defaults: 0x012d 0x2357 (TP-Link Archer T3U); pass "0xb82c 0x0bda"
+#        for a plain Realtek-VID 8822BU. RUN_MU=1 adds an MU-report cell.
+#        J1 helpers override via J1SND_VID/PID (sounder), J1AUX_VID/PID
+#        (sniffer in A/B, beamformee in C).
+
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(dirname "$HERE")"
+TXDEMO="$ROOT/build/WiFiDriverTxDemo"
+RXDEMO="$ROOT/build/WiFiDriverDemo"
+OUT="/tmp/bf-jaguar2"
+CHANNEL=100
+DUR=8
+BFER_MAC="57:42:75:05:d6:00"          # canonical SA = NDPA TA
+BFEE_MAC="00:e0:4c:88:22:bb"          # programmed onto the Jaguar-2 beamformee
+J2_PID="${1:-0x012d}"                 # Archer T3U default
+J2_VID="${2:-0x2357}"
+J1SND_VID="${J1SND_VID:-0x0bda}"      # cells A/B sounder + cell C sniffer
+J1SND_PID="${J1SND_PID:-0x8813}"      #   (8814AU)
+J1AUX_VID="${J1AUX_VID:-0x2357}"      # cells A/B sniffer + cell C beamformee
+J1AUX_PID="${J1AUX_PID:-0x0120}"      #   (8821AU, Archer T2U Plus)
+
+[ -x "$TXDEMO" ] && [ -x "$RXDEMO" ] || { echo "build demos first"; exit 1; }
+mkdir -p "$OUT"
+
+cleanup() {
+    pkill -x WiFiDriverTxDemo 2>/dev/null
+    pkill -x WiFiDriverDemo 2>/dev/null
+    wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+start_sniffer() { # $1=name $2=vid $3=pid  -> sets sniff_pid
+    env DEVOURER_VID=$2 DEVOURER_PID=$3 DEVOURER_CHANNEL=$CHANNEL \
+        DEVOURER_BF_DETECT_REPORT=4 \
+        timeout $((DUR + 90)) "$RXDEMO" > "$OUT/$1.sniff.log" 2>&1 &
+    sniff_pid=$!
+    # RX demo signals monitor-ready with "Listening air..." (the Init path).
+    for _ in $(seq 40); do
+        grep -q "Listening air" "$OUT/$1.sniff.log" && break; sleep 0.5; done
+}
+
+run_bfee_cell() { # $1=name $2=arm(0|1) $3=mu(0|1)
+    local name="$1" arm="$2" mu="${3:-0}"
+    echo "== cell $name (Jaguar-2 bfee armed=$arm mu=$mu, $J2_VID:$J2_PID) =="
+    start_sniffer "$name" "$J1AUX_VID" "$J1AUX_PID"
+
+    # Jaguar-2 beamformee (arming happens in Init, after bring_up).
+    local be=(DEVOURER_VID=$J2_VID DEVOURER_PID=$J2_PID DEVOURER_CHANNEL=$CHANNEL)
+    [ "$arm" = 1 ] && be+=(DEVOURER_BF_ARM_BFEE="$BFER_MAC")
+    [ "$mu" = 1 ] && be+=(DEVOURER_BF_ARM_BFEE_MU=1)
+    env "${be[@]}" timeout $((DUR + 30)) "$RXDEMO" > "$OUT/$name.bfee.log" 2>&1 &
+    local bfee_pid=$!
+    # Jaguar-2 init includes DLFW + IQK; wait for the RX loop banner.
+    for _ in $(seq 80); do
+        grep -q "entering RX loop" "$OUT/$name.bfee.log" && break; sleep 0.5; done
+    grep -q "armed" "$OUT/$name.bfee.log" && echo "  (bfee arm logged)"
+    sleep 1
+
+    # Jaguar-1 sounder.
+    local tx=(DEVOURER_VID=$J1SND_VID DEVOURER_PID=$J1SND_PID
+              DEVOURER_CHANNEL=$CHANNEL DEVOURER_TX_RATE=VHT2SS_MCS0
+              DEVOURER_TX_NDPA_RA="$BFEE_MAC" DEVOURER_TX_NDPA=1
+              DEVOURER_BF_ARM_SOUNDER=1)
+    [ "$mu" = 1 ] && tx+=(DEVOURER_TX_NDPA_MU=1)
+    env "${tx[@]}" timeout "$DUR" "$TXDEMO" > "$OUT/$name.tx.log" 2>&1
+
+    kill "$bfee_pid" "$sniff_pid" 2>/dev/null
+    wait "$bfee_pid" "$sniff_pid" 2>/dev/null
+    local n
+    n=$(grep -c "<devourer-bf-report>" "$OUT/$name.sniff.log")
+    echo "  sniffer bf-report lines: $n"
+    grep "<devourer-bf-report>" "$OUT/$name.sniff.log" | grep "$BFEE_MAC" | head -2
+}
+
+run_sounder_cell() { # cell C: Jaguar-2 as beamformer + single-radio self-capture
+    local name="sounder_gs"
+    echo "== cell $name (Jaguar-2 sounder + TX_WITH_RX self-capture) =="
+
+    # Learn the Jaguar-1 beamformee's EFUSE MAC — the NDPA RA in this direction.
+    env DEVOURER_VID=$J1AUX_VID DEVOURER_PID=$J1AUX_PID DEVOURER_CHANNEL=$CHANNEL \
+        timeout 25 "$RXDEMO" > "$OUT/mac_scan.log" 2>&1
+    local j1_mac
+    j1_mac=$(grep -o "REG_MACID programmed from EFUSE: [0-9a-f:]*" "$OUT/mac_scan.log" \
+             | awk '{print $NF}')
+    [ -n "$j1_mac" ] || { echo "  could not read J1 bfee MAC — see $OUT/mac_scan.log"; return 1; }
+    echo "  Jaguar-1 bfee MAC = $j1_mac"
+    sleep 2
+
+    start_sniffer "$name" "$J1SND_VID" "$J1SND_PID"
+
+    # Jaguar-1 armed beamformee.
+    env DEVOURER_VID=$J1AUX_VID DEVOURER_PID=$J1AUX_PID DEVOURER_CHANNEL=$CHANNEL \
+        DEVOURER_BF_ARM_BFEE="$BFER_MAC" \
+        timeout $((DUR + 30)) "$RXDEMO" > "$OUT/$name.bfee.log" 2>&1 &
+    local bfee_pid=$!
+    for _ in $(seq 40); do
+        grep -q "Listening air" "$OUT/$name.bfee.log" && break; sleep 0.5; done
+    sleep 1
+
+    # Jaguar-2 ground station: one adapter sounds AND captures its own reports.
+    env DEVOURER_VID=$J2_VID DEVOURER_PID=$J2_PID DEVOURER_CHANNEL=$CHANNEL \
+        DEVOURER_TX_RATE=VHT2SS_MCS0 DEVOURER_TX_WITH_RX=thread \
+        DEVOURER_BF_ARM_SOUNDER="$BFER_MAC" DEVOURER_TX_NDPA=1 \
+        DEVOURER_TX_NDPA_RA="$j1_mac" DEVOURER_BF_DETECT_REPORT=4 \
+        timeout $((DUR + 25)) "$TXDEMO" > "$OUT/$name.gs.log" 2>&1
+
+    kill "$bfee_pid" "$sniff_pid" 2>/dev/null
+    wait "$bfee_pid" "$sniff_pid" 2>/dev/null
+    local self air
+    self=$(grep -c "<devourer-bf-report>" "$OUT/$name.gs.log")
+    air=$(grep -c "<devourer-bf-report>" "$OUT/$name.sniff.log")
+    echo "  self-captured reports: $self   sniffer cross-check: $air"
+    grep "<devourer-bf-report>" "$OUT/$name.gs.log" | head -2
+}
+
+run_bfee_cell "unarmed" 0
+sleep 2
+run_bfee_cell "armed" 1
+sleep 2
+[ "${RUN_MU:-0}" = 1 ] && { run_bfee_cell "armed_mu" 1 1; sleep 2; }
+run_sounder_cell
+
+echo
+echo "== verdict ($J2_VID:$J2_PID) =="
+echo "bfee direction — unarmed reports: $(grep '<devourer-bf-report>' "$OUT/unarmed.sniff.log" | grep -c "$BFEE_MAC")"
+echo "bfee direction — armed   reports: $(grep '<devourer-bf-report>' "$OUT/armed.sniff.log" | grep -c "$BFEE_MAC")"
+[ "${RUN_MU:-0}" = 1 ] && \
+echo "bfee direction — armed MU reports: $(grep '<devourer-bf-report>' "$OUT/armed_mu.sniff.log" | grep -c "$BFEE_MAC")"
+echo "sounder direction — self-captured: $(grep -c '<devourer-bf-report>' "$OUT/sounder_gs.gs.log" 2>/dev/null)"
+echo "(logs in $OUT)"


### PR DESCRIPTION
Executes the Jaguar-2 plan recorded in #151 (deferred there until the Jaguar-2 port landed, which #157 did): mirror the Jaguar-3 arming/NDPA blocks into `src/jaguar2/` and validate on hardware. Self-sounding now covers all three devourer generations, in both directions, including the single-radio ground station. Closes #151.

## What

- **`FrameParserJaguar2.h`**: `SET_TX_DESC_NDPA_8822B` / `SET_TX_DESC_NAVUSEHDR_8822B` (dword3 `+0x0C` bits [23:22] / bit 15 — verified against the vendor `halmac_tx_desc_nic.h`, same positions as Jaguar-3) and a `ndpa` param on `fill_data_tx_desc_8822b`. The NDPA block sits **above the descriptor checksum**: dword3 is inside the 32 bytes the 8822B HW checksums, and a mismatch silently drops the frame at TXDMA.
- **`RtlJaguar2Device`**: beamformee arm in `Init` (`DEVOURER_BF_ARM_BFEE` / `_MU`) using the shared `kBfeeJaguar23` — which was transcribed from `hal_txbf_8822b_enter()`, i.e. it *is* the 8822B recipe — with self-MAC `00:e0:4c:88:22:bb` programmed to 0x0610 (Jaguar-2 bring-up, like Jaguar-3's, never writes it) and placed after `bring_up` so the recipe's RXFLTMAP RMW follows `init_wmac_cfg`; sounder arm in `InitWrite` (`DEVOURER_BF_ARM_SOUNDER`, protocol byte 0xDB); `DEVOURER_TX_NDPA` gate in `send_packet`.
- **`tests/bf_selfsound_jaguar2.sh`**: 3-cell matrix — unarmed/armed beamformee direction (+ optional `RUN_MU=1` cell), and a sounder-direction cell that doubles as the single-radio ground-station check (`DEVOURER_TX_WITH_RX=thread`, self-capture vs. independent sniffer separates RX-side from NDP-side failures).

## Vendor-parity notes

- **No RF mode-table poke on the sounder side**: the vendor's `hal_txbf_8822b_rf_mode()` body is entirely `#if 0`'d in rtl88x2bu — unlike the 8822C, whose active equivalent became Jaguar-3's `txbf_rfmode_sounder`. Confirmed unnecessary on-air.
- **No pre-`InitWrite` env constraint for TX+RX** (unlike Jaguar-3): Jaguar-2's shared bring-up always enables RX, never closes the RX filters, and has no coex thread on bulk-IN.
- Jaguar-2's RCR already carries AAP (per #160), so report capture needed no RX work.

## Hardware validation (Archer T3U 2357:012d, ch100, reproduced twice)

| cell | result |
|---|---|
| beamformee, unarmed | **0** reports (negative control) |
| beamformee, armed | **855 / 888** reports, `sa=00:e0:4c:88:22:bb Nc=2 Nr=2` — unassociated HW responder |
| beamformee, MU | **920** reports, len=153 — MU Exclusive per-tone SNR decodes clean (20 groups, 20.7–21.7 dB) |
| sounder + single-radio GS | **85k self-captured** reports / 33 s (sniffer cross-check 78k) |

`tools/bf_report_decode.py` on the captures confirms the same Realtek compact 10-bit codebook seen on Jaguar-1/-3: stable cross-frame Givens angles (var 0.008), per-stream SNR 33.75/21.75 dB, smooth per-tone |h_B/h_A| structure. Build + ctest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)