### PR TITLE
Jaguar3 8822e: 5 MHz narrowband — MAC clock reconfig + vendor NB extras

### DIFF
--- a/src/jaguar3/RadioManagementJaguar3.cpp
+++ b/src/jaguar3/RadioManagementJaguar3.cpp
@@ -1,6 +1,7 @@
 #include "RadioManagementJaguar3.h"
 
 #include <array>
+#include <cstdlib>
 #include <utility>
 
 #include "RateDefinitions.h" /* MGN_* rate enum */
@@ -37,6 +38,8 @@ void RadioManagementJaguar3::set_channel_bwmode(uint8_t channel,
     _device.phy_set_bb_reg(static_cast<uint16_t>(base + (rfaddr << 2)),
                            0x000fffff, v);
   };
+
+  _last_channel = channel;
 
   /* --- bandwidth 20 MHz (config_phydm_switch_bandwidth_8822c) --- */
   _device.phy_set_bb_reg(0x810, 0x3ff0, 0x19b);        /* RX DFIR 20M */
@@ -343,15 +346,20 @@ void RadioManagementJaguar3::apply_power_by_rate_8822e(
 void RadioManagementJaguar3::set_bandwidth_dividers(ChannelWidth_t bwmode) {
   /* Narrowband baseband underclock — the Jaguar3-only payoff. Applies ONLY the
    * clock-divider / small-BW / RX-DFIR delta from config_phydm_switch_bandwidth
-   * _8822c, on top of an already-tuned channel (this re-clocks the baseband
-   * without re-running the RF channel tune). 10 MHz halves the DAC/ADC clock,
-   * 5 MHz quarters it; radiotap stays
-   * 20 MHz so only an SDR sees the change.
-   *
-   *   small-BW 0x9b0[7:6] : 20M=0x0  10M=0x2  5M=0x1
-   *   DAC clk  0x9b4[10:8] : 20M=0x7  10M=0x6  5M=0x4
-   *   ADC clk  0x9b4[22:20]: 20M=0x6  10M=0x5  5M=0x4
-   *   RX DFIR  0x810[13:4] : 20M=0x19b  5/10M=0x2ab */
+   * _8822c / _8822e, on top of an already-tuned channel (this re-clocks the
+   * baseband without re-running the RF channel tune). 10 MHz halves the DAC/ADC
+   * clock, 5 MHz quarters it; radiotap stays 20 MHz so only an SDR sees the
+   * change. The DAC-divider codes differ per variant for the SAME clock — see
+   * the encoding table in the header. */
+  const bool is_e = (_variant == ChipVariant::C8822E);
+  /* One DAC-code table for BOTH variants — the 8822c values. The 8822e
+   * vendor phydm ships different codes (5M=0x2/10M=0x4/20M=0x6, commented as
+   * the same clocks) but 0x2 is DEAD on real 8812EU silicon (TX keys up,
+   * frames drain, nothing airs — SDR-bisected via DEVOURER_NB_DAC sweep:
+   * only 0x4 and 0x6 emit the 5 MHz lobe). libc0607 hit the same wall and
+   * patched the vendor table to these values ("Fix DAC clock setting for
+   * 5MHz BW, from 8812cu driver"), which the OpenHD ecosystem has been
+   * running at 10 MHz on 8812EU since. */
   uint8_t small_bw, dac, adc;
   uint16_t dfir;
   switch (bwmode) {
@@ -360,25 +368,135 @@ void RadioManagementJaguar3::set_bandwidth_dividers(ChannelWidth_t bwmode) {
   case CHANNEL_WIDTH_5:
     small_bw = NB_SMALLBW_5M;  dac = 0x4; adc = 0x4; dfir = 0x2ab; break;
   default: /* CHANNEL_WIDTH_20 — restore full-rate clocks */
-    small_bw = 0x0; dac = 0x7; adc = 0x6; dfir = 0x19b; break;
+    small_bw = 0x0;            dac = 0x7; adc = 0x6; dfir = 0x19b; break;
+  }
+  /* DEVOURER_NB_DAC=0xN — debug knob: force the DAC-divider code. For mirror
+   * A/B experiments and for empirically mapping the (undocumented) divider
+   * field encoding; not for normal use. */
+  const char *dac_env = std::getenv("DEVOURER_NB_DAC");
+  if (dac_env != nullptr && *dac_env != '\0') {
+    dac = static_cast<uint8_t>(std::strtol(dac_env, nullptr, 0) & 0x7);
+    _logger->info("Jaguar3: DEVOURER_NB_DAC override — DAC code {:#x}", dac);
   }
   _device.phy_set_bb_reg(R_RX_DFIR_8822C, 0x3ff0, dfir);
-  _device.phy_set_bb_reg(R_SMALL_BW_8822C, 0xc0, small_bw);   /* 0x9b0[7:6] */
+  /* 8822e vendor parity: the small-BW write also zeroes the TX/RX pri-ch
+   * fields [15:8] (mask 0xffc0); the SDR-validated 8822c path keeps its
+   * original [7:6]-only write. */
+  _device.phy_set_bb_reg(R_SMALL_BW_8822C, is_e ? 0xffc0 : 0xc0, small_bw);
   _device.phy_set_bb_reg(R_CLK_DIV_8822C, 0x00000700, dac);   /* 0x9b4[10:8] */
   _device.phy_set_bb_reg(R_CLK_DIV_8822C, 0x00700000, adc);   /* 0x9b4[22:20] */
 
-  /* phydm_bb_reset_8822c: toggle MAC 0x0 BIT16 (1->0->1) so the receiver/DFE
+  if (is_e) {
+    /* halmac cfg_mac_clk_88xx — the MAC-side half of the narrowband re-clock:
+     * MAC clock select at REG_AFE_CTRL1 0x24[21:20] (0=80M, 2=20M, 3=the
+     * dedicated 20M_BW_5 mode) + the TSF/EDCA microsecond-tick clocks
+     * (0x55c/0x638, in MHz). The vendor applies this for BW5/BW10 on every
+     * Jaguar3; the SDR-validated 8822c NB path works without it, so it is
+     * applied on the 8822e only, where 5 MHz TX never reaches the air without
+     * the 20M_BW_5 MAC mode. */
+    uint8_t clk_sel, ustime;
+    if (bwmode == CHANNEL_WIDTH_5)       { clk_sel = 3; ustime = 20; }
+    else if (bwmode == CHANNEL_WIDTH_10) { clk_sel = 2; ustime = 20; }
+    else                                 { clk_sel = 0; ustime = 80; }
+    uint32_t afe = _device.rtw_read32(0x24);
+    afe = (afe & ~((1u << 20) | (1u << 21))) |
+          (static_cast<uint32_t>(clk_sel) << 20);
+    _device.rtw_write32(0x24, afe);
+    _device.rtw_write8(0x55c, ustime);
+    _device.rtw_write8(0x638, ustime);
+
+    /* config_phydm_switch_bandwidth_8822e narrowband extras the 8822c recipe
+     * doesn't have: CFR (crest-factor reduction) params + TX triangular-shape
+     * spectrum shaping OFF for 5/10 MHz; the 20 MHz restore re-applies the
+     * band-dependent shaping (phydm_tx_triangular_shap_cfg_8822e). */
+    if (bwmode == CHANNEL_WIDTH_5 || bwmode == CHANNEL_WIDTH_10) {
+      _device.phy_set_bb_reg(0xa74, 1u << 31, 0x0);
+      _device.phy_set_bb_reg(0xa74, 0x3ff, 0x15);
+      _device.phy_set_bb_reg(0xa74, 0xffc00, 0x13);
+      _device.phy_set_bb_reg(0x808, 0x70, 0x1);
+      _device.phy_set_bb_reg(0x80c, 0xf, 0x5);
+      _device.phy_set_bb_reg(0x81c, 0xff, 0x0);
+      _device.phy_set_bb_reg(0x81c, 0xf000000, 0x0);
+      _device.phy_set_bb_reg(0x8a0, 0xf0000000, 0x0);
+    } else {
+      const bool is_2g = (_last_channel != 0 && _last_channel <= 14);
+      _device.phy_set_bb_reg(0xa74, 1u << 31, 0x1);
+      _device.phy_set_bb_reg(0x808, 0x70, 0x3);
+      if (is_2g) {
+        _device.phy_set_bb_reg(0xa74, 0x3ff, 0x15);
+        _device.phy_set_bb_reg(0xa74, 0xffc00, 0x13);
+        _device.phy_set_bb_reg(0x80c, 0xf, 0x5);
+        _device.phy_set_bb_reg(0x81c, 0xff, 0xff);
+        _device.phy_set_bb_reg(0x81c, 0xf000000, 0x0);
+        _device.phy_set_bb_reg(0x8a0, 0xf0000000, 0xb);
+      } else {
+        _device.phy_set_bb_reg(0xa74, 0x3ff, 0x3f);
+        _device.phy_set_bb_reg(0xa74, 0xffc00, 0x3f);
+        _device.phy_set_bb_reg(0x80c, 0xf, 0x8);
+        _device.phy_set_bb_reg(0x81c, 0xff, 0x55);
+        _device.phy_set_bb_reg(0x81c, 0xf000000, 0x7);
+        _device.phy_set_bb_reg(0x8a0, 0xf0000000, 0x0);
+      }
+    }
+  }
+
+  /* phydm_bb_reset: toggle MAC 0x0 BIT16 (1->0->1) so the receiver/DFE
    * relatches at the new sample rate — without it the re-clock doesn't take. */
   uint32_t r0 = _device.rtw_read32(0x0);
   _device.rtw_write32(0x0, r0 | (1u << 16));
   _device.rtw_write32(0x0, r0 & ~(1u << 16));
   _device.rtw_write32(0x0, r0 | (1u << 16));
 
+  if (is_e) {
+    /* phydm_igi_toggle_8822e: bump IGI down/up so the BB HW issues 3-wire and
+     * the RF re-enters RX — the BB does not send 3-wire automatically on a
+     * path/channel/BW config change. */
+    uint32_t igi = _device.rtw_read32(0x1d70);
+    _device.rtw_write32(0x1d70, igi - 0x202);
+    _device.rtw_write32(0x1d70, igi);
+
+    /* halrf_ex_dac_fifo_rst — "fix dac fifo error after TXCK setting": the
+     * DAC FIFO can come out of a TX-clock change misaligned and emit spectral
+     * images (the OpenHD 5 MHz "mirror"); soft-reset the AFE DACK banks. */
+    dack_soft_rst_8822e();
+  }
+
   const char *name = bwmode == CHANNEL_WIDTH_10  ? "10 MHz"
                      : bwmode == CHANNEL_WIDTH_5 ? "5 MHz"
                                                  : "20 MHz";
   _logger->info("Jaguar3: baseband re-clocked to {} (small_bw={} DAC={} ADC={} "
                 "DFIR=0x{:03x})", name, small_bw, dac, adc, dfir);
+}
+
+/* halrf_write_check_afe_8822e: an AFE write must be confirmed (the bank reads
+ * back non-zero); retry up to 100x past an IO race. Faithful duplicate of
+ * Halrf8822e::write_check_afe (see the header note on the shared-base
+ * follow-up). */
+void RadioManagementJaguar3::write_check_afe_8822e(uint16_t add, uint32_t data) {
+  const uint32_t wd = (add == 0x3800 || add == 0x3900) ? data : 0xee32001fu;
+  const uint16_t wa = ((add >> 8) == 0x38) ? 0x3800 : 0x3900;
+  for (uint32_t count = 0; count < 100; ++count) {
+    _device.rtw_write32(0x2dd4, 0x0);
+    _device.rtw_write32(add, data);
+    _device.rtw_write32(add, data);
+    _device.rtw_write32(0x2dd4, 0x0);
+    if (_device.rtw_read32(wa) != 0x0)
+      return;
+    _device.rtw_write32(wa, wd);
+    _device.rtw_write32(wa, wd);
+  }
+}
+
+/* halrf_dack_soft_rst_8822e — soft-reset all four AFE DACK banks (S0/S1 x I/Q). */
+void RadioManagementJaguar3::dack_soft_rst_8822e() {
+  write_check_afe_8822e(0x3800, 0xee30001fu);
+  write_check_afe_8822e(0x3800, 0xee32001fu);
+  write_check_afe_8822e(0x382c, 0xee30001fu);
+  write_check_afe_8822e(0x382c, 0xee32001fu);
+  write_check_afe_8822e(0x3900, 0xee30001fu);
+  write_check_afe_8822e(0x3900, 0xee32001fu);
+  write_check_afe_8822e(0x392c, 0xee30001fu);
+  write_check_afe_8822e(0x392c, 0xee32001fu);
 }
 
 } /* namespace jaguar3 */

--- a/src/jaguar3/RadioManagementJaguar3.h
+++ b/src/jaguar3/RadioManagementJaguar3.h
@@ -64,18 +64,33 @@ private:
   static constexpr uint16_t R_SMALL_BW_8822C  = 0x9b0; /* [7:6] small-BW field */
   static constexpr uint16_t R_CLK_DIV_8822C   = 0x9b4; /* [10:8] DAC, [22:20] ADC clk */
 
-  /* Narrowband recipe (small-BW field at 0x9b0[7:6]):
-   *   5 MHz  -> 0x1 ;  10 MHz -> 0x2 ;  20 MHz -> 0x0
-   * DAC clock 0x9b4[10:8]:  5M->0x4(120M)  10M->0x6(240M)  20M->0x7(480M)
-   * ADC clock 0x9b4[22:20]: 5M->0x4(40M)   10M->0x5(80M)   20M->0x6(160M)
-   * RX DFIR  0x810[13:4]:   5/10M->0x2ab   20M->0x19b
-   * 5 MHz has known DAC mirror/leakage; 10 MHz is the reliable target. */
+  /* Narrowband recipe (both variants — the 8822c codes):
+   *   small-BW 0x9b0[7:6]:    5M->0x1  10M->0x2  20M->0x0
+   *   DAC clk  0x9b4[10:8]:   5M->0x4  10M->0x6  20M->0x7 (120/240/480M)
+   *   ADC clk  0x9b4[22:20]:  5M->0x4  10M->0x5  20M->0x6 (40/80/160M)
+   *   RX DFIR  0x810[13:4]:   5/10M->0x2ab  20M->0x19b
+   * The 8822e vendor phydm ships lower DAC codes (5M=0x2/10M=0x4/20M=0x6,
+   * same clock comments) but on real 8812EU silicon 0x2 does not transmit —
+   * SDR-bisected in set_bandwidth_dividers; the 8822c codes air on both
+   * chips. On the 8822e, narrowband ALSO needs the MAC-clock reconfig
+   * (REG_AFE_CTRL1 0x24[21:20] + the 0x55c/0x638 us-tick clocks) applied in
+   * set_bandwidth_dividers — without it 5 MHz never reaches the air at any
+   * DAC code. */
   static constexpr uint8_t NB_SMALLBW_5M  = 0x1;
   static constexpr uint8_t NB_SMALLBW_10M = 0x2;
+
+  /* 8822e AFE write-with-readback-check + DACK soft reset (the vendor's
+   * halrf_ex_dac_fifo_rst: "fix dac fifo error after TXCK setting" — required
+   * after a DAC-clock change or the FIFO can misalign and emit images).
+   * Duplicates Halrf8822e's private helpers; folding both into a shared
+   * Jaguar3RfAccess base is the already-noted follow-up. */
+  void write_check_afe_8822e(uint16_t add, uint32_t data);
+  void dack_soft_rst_8822e();
 
   RtlUsbAdapter _device;
   Logger_t _logger;
   ChipVariant _variant;
+  uint8_t _last_channel = 0; /* set by set_channel_bwmode; 0 = not yet tuned */
 };
 
 } /* namespace jaguar3 */

--- a/tests/jaguar3_devourer_run.sh
+++ b/tests/jaguar3_devourer_run.sh
@@ -12,8 +12,14 @@ set -u
 PID=${PID:-c812}
 SYS=${SYS:-}
 if [ -z "$SYS" ]; then
-  for d in /sys/bus/usb/devices/*/idProduct; do
-    [ "$(cat "$d" 2>/dev/null)" = "$PID" ] && { SYS=$(basename "$(dirname "$d")"); break; }
+  # Retry the search: a prior run's recovery power-cycle can leave the DUT
+  # still re-enumerating for several seconds.
+  for _try in $(seq 15); do
+    for d in /sys/bus/usb/devices/*/idProduct; do
+      [ "$(cat "$d" 2>/dev/null)" = "$PID" ] && { SYS=$(basename "$(dirname "$d")"); break; }
+    done
+    [ -n "$SYS" ] && break
+    sleep 1
   done
 fi
 if [ -z "$SYS" ] || [ ! -e "/sys/bus/usb/devices/$SYS" ]; then
@@ -56,10 +62,12 @@ if [ -n "$MONOUT" ]; then
 fi
 
 echo "=== running $BIN for ${SECS}s against $SYS (devnum $DEVNUM) ==="
-sudo env DEVOURER_VID=0x0bda DEVOURER_PID=0xc812 \
+sudo env DEVOURER_VID=0x0bda DEVOURER_PID="0x$PID" \
      DEVOURER_CHANNEL="${DEVOURER_CHANNEL:-36}" \
      DEVOURER_NB_BW="${DEVOURER_NB_BW:-}" \
+     DEVOURER_NB_DAC="${DEVOURER_NB_DAC:-}" \
      DEVOURER_TX_PWR="${DEVOURER_TX_PWR:-}" \
+     DEVOURER_TX_GAP_US="${DEVOURER_TX_GAP_US:-}" \
      DEVOURER_SKIP_RESET="${DEVOURER_SKIP_RESET:-}" \
      stdbuf -oL -eL timeout -k 5 "$SECS" "$BIN" 2>&1 | sed -E 's/^/[dev] /'
 # timeout sends SIGTERM at $SECS; the binary now catches it, runs a clean chip

--- a/tests/jaguar3_eu_5mhz_mirror_ab.sh
+++ b/tests/jaguar3_eu_5mhz_mirror_ab.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# 5 MHz spectral A/B on the RTL8812EU (0bda:a81a, chip 8822e).
+#
+# Compares the SHIPPED 5 MHz DAC-divider code (0x9b4[10:8]=0x4, the 8822c
+# value libc0607's rtl88x2eu 5mhz_bw branch adopted) against the 8822e vendor
+# phydm's own table value (0x2), which is dead on real silicon (TX keys up
+# and frames drain but nothing airs). Quantifies the worst out-of-lobe spur
+# relative to the main lobe in a differential PSD (TX minus silent baseline):
+#   shipped : DEVOURER_NB_BW=5                      (dac=0x4, this driver)
+#   vendtbl : DEVOURER_NB_BW=5 DEVOURER_NB_DAC=0x2  (8822e vendor table)
+# plus a 20 MHz reference run to confirm the wide channel is unaffected.
+#
+#   sudo tests/jaguar3_eu_5mhz_mirror_ab.sh
+set -u
+cd "$(dirname "$0")/.."
+
+# CHANNEL/FREQ must agree (ch44=5220e6, ch140=5700e6). Default ch140 — a
+# DFS channel that is quiet indoors; ch36-48 carry ambient APs whose bursts
+# poison the differential PSD.
+CHANNEL=${CHANNEL:-140}
+FREQ=${FREQ:-5700e6}
+RATE=46.08e6   # ±23 MHz of visibility around the 5 MHz lobe
+OUT=/tmp/j3_eu_mirror
+rm -rf "$OUT"; mkdir -p "$OUT"
+
+probe() { # label  psd_out
+  # Mean PSD on a quiet DFS channel (median suppresses the DUT's own bursty
+  # frames; back-to-back TX overruns the 4x-slower 5 MHz PHY drain and the
+  # demo aborts on NAKs — so paced TX + mean it is).
+  python3 tests/sdr_tx_probe.py --freq "$FREQ" --rate "$RATE" --gain 50 \
+      --nsamps 12e6 --label "$1" --psd-out "$2" 2>&1 \
+      | grep '\[sdr' || true
+}
+
+run_case() { # name  nb_bw  nb_dac('' = default)
+  local name=$1 bw=$2 dacovr=$3
+  echo "=== case $name: NB_BW=$bw NB_DAC=${dacovr:-<native>} ==="
+  # TX_PWR: flat TXAGC boost for SDR visibility (same for every case, so the
+  # A/B stays fair). The EU's efuse-level TX is too weak for the differential
+  # PSD at bench distance.
+  sudo PID=a81a DEVOURER_CHANNEL="$CHANNEL" DEVOURER_NB_BW="$bw" \
+      DEVOURER_NB_DAC="$dacovr" DEVOURER_TX_PWR="${TX_PWR:-0x3f}" SECS=24 \
+      tests/jaguar3_devourer_run.sh build/WiFiDriverTxDemo 24 \
+      > "$OUT/dev_${name}.log" 2>&1 &
+  local H=$!
+  sleep 11   # power-on -> DLFW -> init -> narrowband re-clock -> TX
+  probe "$name" "$OUT/${name}.npy"
+  sleep 5
+  probe "${name}_b" "$OUT/${name}_b.npy"   # second look: catches mid-run death
+  grep -m1 -E "re-clock|NB_DAC" "$OUT/dev_${name}.log" | sed 's/^/    /' || \
+    echo "    (no re-clock log — check $OUT/dev_${name}.log)"
+  wait "$H" 2>/dev/null
+  grep -m1 "TX aborting" "$OUT/dev_${name}.log" | sed 's/^/    !! /' || true
+  echo "    bulks: $(grep -c 'bulk_send EP 5 OK' "$OUT/dev_${name}.log")"
+  sleep 2
+}
+
+echo "=== baseline: a81a silent (ambient PSD) ==="
+probe baseline "$OUT/baseline.npy"
+
+run_case shipped 5  ""
+run_case vendtbl 5  "0x2"
+run_case ref20   20 ""
+
+echo "=== differential-PSD mirror analysis ==="
+python3 - "$OUT" <<'PY'
+import sys, numpy as np
+out = sys.argv[1]
+base = np.load(f"{out}/baseline.npy"); bf, bp = base[0], base[1]
+
+def analyse(label, half_lobe_hz):
+    a = np.load(f"{out}/{label}.npy"); f, p = a[0], a[1]
+    diff = np.clip(p - bp, 0, None)
+    k = 33
+    sm = np.convolve(diff, np.ones(k)/k, mode='same')
+    if sm.max() <= 0:
+        return None
+    ipk = int(np.argmax(sm)); fpk = f[ipk]; pk = sm[ipk]
+    # -10 dB width about the peak (the M6 discriminator)
+    above = np.where(sm >= pk/10.0)[0]
+    bw10 = (f[above[-1]] - f[above[0]]) if len(above) else 0.0
+    # worst spur OUTSIDE the main lobe (exclude ±half_lobe around the peak,
+    # and the outer 10% of the span where the B210's own filter skirts live)
+    span = f[-1] - f[0]
+    guard = (np.abs(f - fpk) > half_lobe_hz) & \
+            (f > f[0] + 0.05*span) & (f < f[-1] - 0.05*span)
+    spur_db = None; fspur = None
+    if guard.any() and sm[guard].max() > 0:
+        j = np.flatnonzero(guard)[int(np.argmax(sm[guard]))]
+        spur_db = 10*np.log10(sm[j]/pk); fspur = f[j]
+    return dict(fpk=fpk, bw10=bw10, spur_db=spur_db, fspur=fspur)
+
+print(f"{'case':>8} {'-10dB BW(MHz)':>14} {'worst spur(dB rel lobe)':>24} {'@offset(MHz)':>13}")
+res = {}
+for label, half in (("shipped", 4e6), ("vendtbl", 4e6), ("ref20", 12e6)):
+    r = analyse(label, half)
+    res[label] = r
+    if r is None:
+        print(f"{label:>8} {'n/a':>14}")
+        continue
+    sp = f"{r['spur_db']:.1f}" if r['spur_db'] is not None else "none"
+    off = f"{(r['fspur']-r['fpk'])/1e6:+.2f}" if r['fspur'] is not None else "-"
+    print(f"{label:>8} {r['bw10']/1e6:>14.2f} {sp:>24} {off:>13}")
+
+n, o = res.get("shipped"), res.get("vendtbl")
+if n and o and n["spur_db"] is not None and o["spur_db"] is not None:
+    print(f"\nspur delta (vendtbl - shipped): {o['spur_db']-n['spur_db']:+.1f} dB")
+PY
+echo "PSDs kept in $OUT for offline inspection"

--- a/tests/jaguar3_eu_nb_dac_sweep.sh
+++ b/tests/jaguar3_eu_nb_dac_sweep.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Empirically map the 8822e DAC-divider field (0x9b4[10:8]) in narrowband mode
+# on the RTL8812EU: sweep DEVOURER_NB_DAC codes at a fixed NB_BW and measure
+# what actually reaches the air (differential PSD vs silent baseline).
+#
+# Motivation: the field is undocumented ("no even definitions in .h files" —
+# OpenHD), the 8822c and 8822e vendor drivers use different codes for the same
+# nominal clock, and the vendor-native 5 MHz code must be verified on real
+# silicon before trusting it.
+#
+#   sudo tests/jaguar3_eu_nb_dac_sweep.sh            # 5 MHz, codes 1-6
+#   sudo NB_BW=10 CODES="3 4 5" tests/jaguar3_eu_nb_dac_sweep.sh
+set -u
+cd "$(dirname "$0")/.."
+
+CHANNEL=${CHANNEL:-44}
+FREQ=${FREQ:-5220e6}
+RATE=46.08e6
+NB_BW=${NB_BW:-5}
+CODES=${CODES:-"1 2 3 4 5 6"}
+OUT=/tmp/j3_eu_dac_sweep
+rm -rf "$OUT"; mkdir -p "$OUT"
+
+probe() { # label  psd_out
+  python3 tests/sdr_tx_probe.py --freq "$FREQ" --rate "$RATE" --gain 50 \
+      --nsamps 6e6 --label "$1" --psd-out "$2" 2>&1 | grep '\[sdr' || true
+}
+
+echo "=== baseline: a81a silent (ambient PSD) ==="
+probe baseline "$OUT/baseline.npy"
+
+for CODE in $CODES; do
+  echo "=== NB_BW=${NB_BW} DAC code ${CODE} ==="
+  sudo PID=a81a DEVOURER_CHANNEL="$CHANNEL" DEVOURER_NB_BW="$NB_BW" \
+      DEVOURER_NB_DAC="$CODE" DEVOURER_TX_PWR="${TX_PWR:-0x3f}" SECS=24 \
+      tests/jaguar3_devourer_run.sh build/WiFiDriverTxDemo 24 \
+      > "$OUT/dev_${CODE}.log" 2>&1 &
+  H=$!
+  sleep 11
+  probe "dac${CODE}" "$OUT/dac_${CODE}.npy"
+  grep -m1 -E "NB_DAC override" "$OUT/dev_${CODE}.log" | sed 's/^/    /' || \
+    echo "    (override log missing — check $OUT/dev_${CODE}.log)"
+  wait "$H" 2>/dev/null
+  grep -m1 "TX aborting" "$OUT/dev_${CODE}.log" | sed 's/^/    !! /' || true
+  echo "    bulks: $(grep -c 'bulk_send EP 5 OK' "$OUT/dev_${CODE}.log")"
+  sleep 2
+done
+
+echo "=== differential-PSD per DAC code ==="
+python3 - "$OUT" "$CODES" <<'PY'
+import sys, numpy as np
+out, codes = sys.argv[1], sys.argv[2].split()
+base = np.load(f"{out}/baseline.npy"); bf, bp = base[0], base[1]
+
+print(f"{'code':>5} {'lobe?':>6} {'-10dB BW(MHz)':>14} {'peak vs noise(dB)':>18} {'peak@(MHz off ctr)':>19}")
+for c in codes:
+    a = np.load(f"{out}/dac_{c}.npy"); f, p = a[0], a[1]
+    diff = np.clip(p - bp, 0, None)
+    k = 33
+    sm = np.convolve(diff, np.ones(k)/k, mode='same')
+    if sm.max() <= 0:
+        print(f"{c:>5} {'no':>6}")
+        continue
+    ipk = int(np.argmax(sm)); pk = sm[ipk]
+    med = np.median(sm[sm > 0]) if (sm > 0).any() else 1e-30
+    snr_db = 10*np.log10(pk/med) if med > 0 else 0.0
+    above = np.where(sm >= pk/10.0)[0]
+    bw10 = (f[above[-1]] - f[above[0]]) if len(above) else 0.0
+    span = f[-1] - f[0]
+    # a real lobe: narrow (not the whole span) and well above the diff floor
+    lobe = "YES" if (bw10 < 0.6*span and snr_db > 8.0) else "no"
+    fctr = (f[0] + f[-1]) / 2
+    print(f"{c:>5} {lobe:>6} {bw10/1e6:>14.2f} {snr_db:>18.1f} {(f[ipk]-fctr)/1e6:>+19.2f}")
+PY
+echo "PSDs kept in $OUT"

--- a/tests/jaguar3_narrowband_sdr.sh
+++ b/tests/jaguar3_narrowband_sdr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# M6 narrowband validation for the Jaguar-3 port (RTL8812CU, 0bda:c812).
+# M6 narrowband validation for the Jaguar-3 port (RTL8812CU, 0bda:c812, the
+# default; PID=a81a selects the RTL8812EU).
 #
 # The original goal of the whole Jaguar-3 port: 5/10 MHz channels via the
 # baseband clock divider (0x9b0/0x9b4), which Jaguar-1 cannot do. Radiotap stays
@@ -15,7 +16,10 @@
 set -u
 cd "$(dirname "$0")/.."
 
-FREQ=5180e6
+# CHANNEL/FREQ must agree (ch36=5180e6, ch44=5220e6). Default ch44 — ch36
+# frequently has a strong ambient AP that swamps the differential PSD.
+CHANNEL=${CHANNEL:-44}
+FREQ=${FREQ:-5220e6}
 RATE=46.08e6   # wide enough to see the full 20 MHz channel + skirts
 OUT=/tmp/j3_nb
 rm -rf "$OUT"; mkdir -p "$OUT"
@@ -30,7 +34,11 @@ probe baseline "$OUT/baseline.npy"
 
 for BW in 20 10 5; do
   echo "=== TX at ${BW} MHz: devourer continuous, capture PSD ==="
-  sudo DEVOURER_NB_BW="$BW" SECS=24 tests/jaguar3_devourer_run.sh \
+  # TX_PWR: optional flat-TXAGC boost (e.g. TX_PWR=0x3f) — needed on the EU,
+  # whose efuse-level TX can sit below the ambient floor at bench distance.
+  sudo PID="${PID:-c812}" DEVOURER_CHANNEL="$CHANNEL" DEVOURER_NB_BW="$BW" \
+      DEVOURER_TX_PWR="${TX_PWR:-}" \
+      SECS=24 tests/jaguar3_devourer_run.sh \
       build/WiFiDriverTxDemo 24 > "$OUT/dev_${BW}.log" 2>&1 &
   H=$!
   sleep 11   # power-on -> DLFW -> replay -> narrowband re-clock -> TX
@@ -61,10 +69,18 @@ def occ_bw(label):
     lo = np.searchsorted(csum, 0.005*tot)
     hi = np.searchsorted(csum, 0.995*tot)
     bw = f[min(hi, len(f)-1)] - f[max(lo,0)]
-    # also -10 dB width about the peak for a second estimate
+    # also -10 dB width about the peak for a second estimate. CONTIGUOUS run
+    # containing the peak — first/last-above-threshold bridges the DUT lobe
+    # with any ambient burst elsewhere in the span and inflates the width.
     pk = sm.max(); thr = pk/10.0
-    above = np.where(sm >= thr)[0]
-    bw10 = (f[above[-1]] - f[above[0]]) if len(above) else 0.0
+    ipk = int(np.argmax(sm))
+    lo_i = ipk
+    while lo_i > 0 and sm[lo_i-1] >= thr:
+        lo_i -= 1
+    hi_i = ipk
+    while hi_i < len(sm)-1 and sm[hi_i+1] >= thr:
+        hi_i += 1
+    bw10 = f[hi_i] - f[lo_i]
     return bw, bw10
 
 # The -10 dB-about-peak width is the clean discriminator for an OFDM signal with

--- a/tests/sdr_tx_probe.py
+++ b/tests/sdr_tx_probe.py
@@ -26,7 +26,7 @@ import numpy as np
 import uhd
 
 
-def measure(freq, rate, gain, nsamps):
+def measure(freq, rate, gain, nsamps, median=False):
     usrp = uhd.usrp.MultiUSRP("")
     # recv_num_samps tunes, sets rate+gain, streams, and returns a complex64
     # array shaped (channels, nsamps). One channel (RX A).
@@ -42,11 +42,22 @@ def measure(freq, rate, gain, nsamps):
     nfft = 4096
     win = np.hanning(nfft)
     nseg = len(x) // nfft
-    acc = np.zeros(nfft)
-    for i in range(nseg):
-        seg = x[i * nfft:(i + 1) * nfft] * win
-        acc += np.abs(np.fft.fftshift(np.fft.fft(seg))) ** 2
-    psd = acc / max(nseg, 1)
+    if median:
+        # Median across segments instead of mean: suppresses bursty, low-duty
+        # ambient (an AP beaconing through the capture) so a high-duty DUT
+        # (DEVOURER_TX_GAP_US=0) dominates the estimate. Use for differential
+        # A/Bs on a band with neighbours.
+        segs = np.empty((nseg, nfft), dtype=np.float32)
+        for i in range(nseg):
+            seg = x[i * nfft:(i + 1) * nfft] * win
+            segs[i] = np.abs(np.fft.fftshift(np.fft.fft(seg))) ** 2
+        psd = np.median(segs, axis=0).astype(np.float64)
+    else:
+        acc = np.zeros(nfft)
+        for i in range(nseg):
+            seg = x[i * nfft:(i + 1) * nfft] * win
+            acc += np.abs(np.fft.fftshift(np.fft.fft(seg))) ** 2
+        psd = acc / max(nseg, 1)
     freqs = np.fft.fftshift(np.fft.fftfreq(nfft, d=1.0 / rate))
 
     total = psd.sum()
@@ -79,10 +90,12 @@ def main():
     ap.add_argument("--label", default="probe")
     ap.add_argument("--json", default="", help="append result as JSON to this file")
     ap.add_argument("--psd-out", default="", help="save [freqs;psd] to this .npy")
+    ap.add_argument("--psd-median", action="store_true",
+                    help="median PSD across segments (suppresses bursty ambient)")
     a = ap.parse_args()
 
     r, freqs, psd = measure(float(a.freq), float(a.rate), float(a.gain),
-                            float(a.nsamps))
+                            float(a.nsamps), median=a.psd_median)
     r["label"] = a.label
     if a.psd_out:
         np.save(a.psd_out, np.vstack([freqs, psd]))


### PR DESCRIPTION
## Problem

5 MHz narrowband TX on the RTL8812EU (8822e) never reached the air — frames drained, zero RF. This is the same wall OpenHD's rtl88x2eu hit ([Notes About 5MHz](https://github.com/OpenHD/rtl88x2eu#notes-about-5mhz)): *"Some leakage (mirror?) can be observed in the 5MHz mode, and I have no idea how to configure the DAC clock properly."*

## Root cause (two independent pieces)

1. **The MAC-side half of the re-clock was missing.** The vendor's `halmac cfg_mac_clk_88xx` reconfigures the MAC clock for narrowband: `REG_AFE_CTRL1 0x24[21:20]` select (**3 = dedicated `20M_BW_5` mode**, 2 = 20M for BW10, 0 = 80M restore) plus the TSF/EDCA µs-tick clocks `0x55c`/`0x638`. Without it the 8822e emits nothing at 5 MHz **at any DAC divider code**; 10 MHz is more tolerant and aired anyway.
2. **The 8822e vendor phydm's own 5 MHz DAC table value is dead on real silicon.** A `DEVOURER_NB_DAC` sweep (codes 1–6 at 5 MHz, differential PSD on a B210) shows only `0x4`/`0x6` emit the lobe; the vendor table's `0x2` keys the TX chain (LO carrier) but never modulates. This is exactly why libc0607's `5mhz_bw` branch [adopted the 8812CU value](https://github.com/libc0607/rtl88x2eu-20230815/commit/67dbbff1f01b8edd5b532c2a2c6e719452740ff5) — so the DAC codes stay the 8822c values on both variants (one shared table; the SDR-validated 8822c path is untouched).

## The mirror

With the full recipe — MAC clock + the vendor NB extras the 2023 OpenHD tree pre-dated (CFR params, TX triangular-shape off with band-dependent 20 MHz restore, IGI toggle, `halrf_ex_dac_fifo_rst` — *"fix dac fifo error after TXCK setting"*) — **the mirror leakage does not reproduce**: clean 4.23 MHz lobe, reproducible out-of-lobe spurs ≤ −20 dB.

## Validation (BL-M8812EU2 + USRP B210, differential PSD)

| BW | lobe width | note |
|---|---|---|
| 20 MHz | 17.5 MHz | unaffected by the NB changes |
| 10 MHz | 9.5 MHz | ratio ~1.9 |
| 5 MHz | 4.2 MHz | ratio ~4.1, spurs ≤ −20 dB |

Harness gained the instruments used to get here: `tests/jaguar3_eu_nb_dac_sweep.sh` (empirical DAC-field mapping), `tests/jaguar3_eu_5mhz_mirror_ab.sh` (spectral A/B vs the vendor-table code), PID/CHANNEL/TX_PWR parameterization + device-wait retry in the run scripts, `--psd-median` in `sdr_tx_probe.py`, and a contiguous `-10 dB`-width metric that ambient AP bursts can't bridge.

Bench gotcha documented in-code: `DEVOURER_TX_PWR=0x3f` flat-max at 5.7 GHz stalls 5 MHz TX mid-run (NAK); efuse-level power runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)