### PR TITLE
Jaguar1 RX: unify onto the async URB queue — fixes the radxa sounding TX wedge

### DIFF
--- a/src/RtlUsbAdapter.cpp
+++ b/src/RtlUsbAdapter.cpp
@@ -1,5 +1,6 @@
 #include "RtlUsbAdapter.h"
 
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #if defined(__ANDROID__) || defined(_MSC_VER) || defined(__APPLE__)
@@ -20,7 +21,10 @@ namespace {
 struct AsyncRxShared {
   const std::function<void(const uint8_t *, int)> *cb;
   const std::function<bool()> *stop;
-  int active;
+  /* Atomic: in co-running (TX + self-capture RX) mode both the RX loop's own
+   * event pump and the TX event loop may run this callback, so `active` is
+   * written from the pump thread while the loop below reads it. */
+  std::atomic<int> active{0};
 };
 extern "C" void LIBUSB_CALL devourer_rx_cb(libusb_transfer *t) {
   auto *s = static_cast<AsyncRxShared *>(t->user_data);
@@ -38,7 +42,7 @@ void RtlUsbAdapter::bulk_read_async_loop(
     int buf_size, int n_urbs,
     const std::function<void(const uint8_t *, int)> &on_data,
     const std::function<bool()> &should_stop) {
-  AsyncRxShared sh{&on_data, &should_stop, 0};
+  AsyncRxShared sh{&on_data, &should_stop};
   std::vector<libusb_transfer *> xfers;
   std::vector<std::vector<uint8_t>> bufs(n_urbs,
                                          std::vector<uint8_t>(buf_size));
@@ -53,7 +57,7 @@ void RtlUsbAdapter::bulk_read_async_loop(
       libusb_free_transfer(t);
     }
   }
-  _logger->info("Jaguar3 RX: async queue of {} URBs submitted", sh.active);
+  _logger->info("RX: async queue of {} URBs submitted", sh.active.load());
   while (!should_stop() && sh.active > 0) {
     struct timeval tv {0, 100000};
     libusb_handle_events_timeout_completed(_ctx, &tv, nullptr);
@@ -410,15 +414,18 @@ void RtlUsbAdapter::GetChipOutEP8812() {
                 (int)OutEpNumber);
 }
 
-void transfer_callback(struct libusb_transfer *transfer) {
-  Logger *_logger = (Logger *)(transfer->user_data);
+void RtlUsbAdapter::transfer_callback(struct libusb_transfer *transfer) {
+  auto *self = static_cast<RtlUsbAdapter *>(transfer->user_data);
   if (transfer->status == LIBUSB_TRANSFER_COMPLETED &&
       transfer->actual_length == transfer->length) {
-    _logger->debug("Packet {} sent successfully, length: {}", _logger,
-                  transfer->length);
+    self->_logger->debug("Packet sent successfully, length: {}",
+                         transfer->length);
   } else {
-    _logger->error("Failed to send packet {}, status: {}, actual length: {}",
-                   _logger, transfer->status, transfer->actual_length);
+    /* Flag the bulk-OUT as possibly halted so the next send_packet (on the TX
+     * thread) re-clear_halts it before the following frame. */
+    self->_tx_wedged->store(true, std::memory_order_relaxed);
+    self->_logger->error("Failed to send packet, status: {}, actual length: {}",
+                         transfer->status, transfer->actual_length);
   }
   libusb_free_transfer(transfer);
 }
@@ -443,6 +450,24 @@ bool RtlUsbAdapter::send_packet(uint8_t *packet, size_t length) {
       return _bulk_out_eps[0];
     }
     return 0x02;
+  }();
+
+  /* Recover a bulk-OUT that a prior async TX wedged (TIMED_OUT / stall). Only
+   * the first send used to clear_halt; a mid-stream stall (e.g. hardware NDP
+   * generation on some xhci hosts) then stayed wedged forever. */
+  if (_tx_wedged->exchange(false)) {
+    int hr = libusb_clear_halt(_dev_handle, tx_ep);
+    _logger->info("TX EP 0x{:02X} re-clear_halt after wedge rc={}", (int)tx_ep,
+                  hr);
+  }
+
+  /* TX bulk-OUT timeout (ms). DEVOURER_TX_TIMEOUT_MS override, default
+   * USB_TIMEOUT. Scoped to TX only — control transfers keep USB_TIMEOUT.
+   * Computed once. */
+  static const unsigned tx_timeout_ms = []() -> unsigned {
+    if (const char *e = std::getenv("DEVOURER_TX_TIMEOUT_MS"))
+      return static_cast<unsigned>(std::strtoul(e, nullptr, 0));
+    return USB_TIMEOUT;
   }();
 
   /* On the FIRST send only, dump the bulk-OUT bytes to compare against
@@ -484,8 +509,8 @@ bool RtlUsbAdapter::send_packet(uint8_t *packet, size_t length) {
   }
 
   libusb_fill_bulk_transfer(transfer, _dev_handle, tx_ep, packet, length,
-                            transfer_callback, (void *)(_logger.get()),
-                            USB_TIMEOUT);
+                            &RtlUsbAdapter::transfer_callback, (void *)this,
+                            tx_timeout_ms);
   /* Upstream OOT (rtl8814a/usb/rtl8814au_xmit.c) sets URB_ZERO_PACKET on
    * every TX URB. libusb equivalent: LIBUSB_TRANSFER_ADD_ZERO_PACKET.
    * Without it the chip's SuperSpeed bulk OUT controller can wait

--- a/src/RtlUsbAdapter.h
+++ b/src/RtlUsbAdapter.h
@@ -3,10 +3,12 @@
 
 #include <iostream>
 
+#include <atomic>
 #include <cstdio>
 #include <cstdlib>
 #include <functional>
 #include <libusb.h>
+#include <memory>
 #include <thread>
 #include <vector>
 
@@ -54,6 +56,17 @@ class RtlUsbAdapter {
 
   uint16_t _idVendor = 0;
   uint16_t _idProduct = 0;
+
+  /* Set by transfer_callback when an async TX bulk-OUT completes non-OK
+   * (TIMED_OUT / stall). Consumed at the top of the next send_packet on the TX
+   * thread to re-clear_halt the endpoint — a mid-stream stall (e.g. hardware
+   * NDP generation on some xhci hosts) would otherwise stay wedged, since the
+   * first-send clear_halt only runs once. Heap-owned via shared_ptr because
+   * RtlUsbAdapter is a copyable value type (passed by value throughout); an
+   * atomic member would delete the copy ctor. All copies of an adapter share
+   * the one flag (only the TX-driving copy touches it). */
+  std::shared_ptr<std::atomic<bool>> _tx_wedged =
+      std::make_shared<std::atomic<bool>>(false);
 
 public:
   RtlUsbAdapter(libusb_device_handle *dev_handle, Logger_t logger,
@@ -146,6 +159,10 @@ public:
   void ReadEFuseByte(uint16_t _offset, uint8_t *pbuf);
 
 private:
+  /* Async TX bulk-OUT completion callback. user_data is the RtlUsbAdapter* so
+   * it can flag _tx_wedged on a non-OK completion; a static member (not a free
+   * function) to reach that private state. */
+  static void transfer_callback(struct libusb_transfer *transfer);
   void InitDvObj();
   const char *strUsbSpeed();
   void GetChipOutEP8812();

--- a/src/WiFiDriver.cpp
+++ b/src/WiFiDriver.cpp
@@ -113,8 +113,11 @@ WiFiDriver::CreateRtlDevice(libusb_device_handle *dev_handle,
 #if defined(DEVOURER_HAVE_JAGUAR1)
   _logger->info("Creating RtlJaguarDevice (PID 0x{:04x}, chip-id 0x{:02x})", pid,
                 chip_id);
-  return std::make_unique<RtlJaguarDevice>(RtlUsbAdapter(dev_handle, _logger),
-                                           _logger);
+  /* Pass ctx so RtlUsbAdapter::_ctx is set: the Jaguar1 RX loop now drives an
+   * async URB queue (bulk_read_async_loop) whose event pump needs the same
+   * libusb context the handle was opened on (as Jaguar2/3 already do above). */
+  return std::make_unique<RtlJaguarDevice>(
+      RtlUsbAdapter(dev_handle, _logger, ctx), _logger);
 #else
   _logger->error("Jaguar1 chip (PID 0x{:04x}, chip-id 0x{:02x}) detected but "
                  "Jaguar1 support not compiled in",

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -404,27 +404,6 @@ bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
   return resp;
 }
 
-std::vector<Packet> RtlJaguarDevice::read_frames() {
-  /* Cover one full chip-side RX aggregate (the 8814 pairs a 20K DMA-agg
-   * threshold with a 32K host read). 32K buffer, an exact multiple of
-   * wMaxPacketSize so no short packet truncates the transfer. */
-  static constexpr int BUF_SIZE = 32 * 1024;
-  uint8_t buffer[BUF_SIZE] = {};
-  int n = _device.bulk_read_raw(buffer, sizeof(buffer), USB_TIMEOUT * 10);
-  if (n < 0) {
-    /* Rate-limit the error log + sleep so a fast-failing rc (e.g. NO_DEVICE
-     * after the chip drops off USB) can't spin the RX loop at full CPU. */
-    static uint64_t err_count = 0;
-    if ((err_count++ % 100) == 0)
-      _logger->error("bulk_read_raw failed with error: {} (count={})", n,
-                     err_count);
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    n = 0;
-  }
-  FrameParser fp{_logger};
-  return fp.recvbuf2recvframe(std::span<uint8_t>{buffer, (size_t)n});
-}
-
 void RtlJaguarDevice::Init(Action_ParsedRadioPacket packetProcessor,
                           SelectedChannel channel) {
   StartWithMonitorMode(channel);
@@ -510,41 +489,33 @@ void RtlJaguarDevice::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
   }
 
   _logger->info("Listening air...");
-  /* Keep several bulk-IN transfers in flight at once (mirrors the kernel's ~4
-   * always-posted RX URBs — confirmed via usbmon: rtw88 re-submits each URB
-   * ~20us after completion and cycles 4 of them). With a single synchronous
-   * transfer there is a window between transfers where NO URB is posted; the
-   * 8814's RX-DMA ring pauses in that gap and, under sparse traffic,
-   * intermittently wedges after a short burst — the "RX stalls at ~10 frames"
-   * bug (8812/8821 tolerate it, the 8814 does not). read_frames() is
-   * reentrant (local buffer + local FrameParser; libusb is thread-safe), so a
-   * small worker pool restores the always-posted behaviour. Frame order across
-   * workers is not preserved, which is fine for monitor-mode RX. Set
-   * DEVOURER_RX_URBS=1 to restore the old single-transfer behaviour. */
-  int rx_workers = 4;
+  /* Unified RX transport (shared with Jaguar2/3): a single-threaded async
+   * bulk-IN URB queue keeps N URBs always-posted on the bulk-IN endpoint and
+   * parses each completion inline (while its buffer is alive), instead of a
+   * pool of blocking bulk_read_raw worker threads. The always-posted URBs give
+   * the 8814's RX-DMA ring the continuity the old worker pool existed to
+   * provide (no gap between transfers), and removing the blocking worker
+   * threads removes the multi-thread USB contention that starved concurrent
+   * NDP-generation TX on some xhci hosts — the beamforming-sounding wedge on
+   * the radxa-x4. Consumes on the event pump, so no proc_mu is needed.
+   * DEVOURER_RX_URBS sets the queue depth (default 8). */
+  int rx_urbs = 8;
   if (const char *e = std::getenv("DEVOURER_RX_URBS")) {
-    rx_workers = std::atoi(e);
-    if (rx_workers < 1) rx_workers = 1;
+    rx_urbs = std::atoi(e);
+    if (rx_urbs < 1) rx_urbs = 1;
   }
-  std::mutex proc_mu;
-  std::vector<std::thread> workers;
-  for (int i = 0; i < rx_workers; ++i) {
-    workers.emplace_back([this, &proc_mu]() {
-      while (!should_stop && !g_devourer_should_stop) {
-        auto packets = read_frames();
-        if (packets.empty())
-          continue;
-        std::lock_guard<std::mutex> lk(proc_mu);
-        for (auto &p : packets) {
-          if (should_stop || g_devourer_should_stop)
-            break;
-          _packetProcessor(p);
-        }
-      }
-    });
-  }
-  for (auto &t : workers)
-    t.join();
+  auto on_data = [this](const uint8_t *data, int n) {
+    FrameParser fp{_logger};
+    for (auto &p : fp.recvbuf2recvframe(
+             std::span<uint8_t>{const_cast<uint8_t *>(data), (size_t)n})) {
+      if (should_stop || g_devourer_should_stop)
+        break;
+      _packetProcessor(p);
+    }
+  };
+  _device.bulk_read_async_loop(32 * 1024, rx_urbs, on_data, [this]() -> bool {
+    return should_stop || g_devourer_should_stop;
+  });
 
   _rxmask_stop.store(true);
   if (_rxmask_thread.joinable())

--- a/src/jaguar1/RtlJaguarDevice.h
+++ b/src/jaguar1/RtlJaguarDevice.h
@@ -141,12 +141,6 @@ private:
   void StartWithMonitorMode(SelectedChannel selectedChannel);
   bool NetDevOpen(SelectedChannel selectedChannel);
 
-  /* One bulk-IN read + Jaguar1 RX-descriptor parse. Reentrant (local buffer +
-   * local FrameParser), so the RX worker pool can call it concurrently. The
-   * generation-agnostic USB read lives in RtlUsbAdapter::bulk_read_raw; the
-   * Jaguar1-specific parse stays here (Jaguar3 parses via FrameParserJaguar3). */
-  std::vector<Packet> read_frames();
-
   std::array<std::atomic<uint32_t>, 5> _qd_snap{};
   std::thread _qd_thread;
   std::atomic<bool> _qd_stop{false};


### PR DESCRIPTION
## Problem

On the radxa-x4 (Intel N100, Debian kernel 6.12, xhci), beamforming sounding could not run: when the MAC hardware-generates an NDP after an injected NDPA (sounder-arm + `DEVOURER_TX_NDPA`), the TX bulk-OUT wedged (`LIBUSB_TRANSFER_TIMED_OUT`, `actual_length 0`). ~19% of NDP-generating sends failed TX-only; **~90%** with the single-radio self-capture RX thread (`DEVOURER_TX_WITH_RX=thread`). Plain beacon TX never failed, and the identical code sounds fine on other hosts — so this is a host/xhci robustness issue, not a correctness bug.

Root cause: Jaguar1's RX loop ran **4 blocking `bulk_read_raw` worker threads** on the same libusb context as the async TX + event pump, unserialized. That thundering herd starved the long NDP-generation bulk-OUT on the radxa's xhci.

## Fix

- **Unify Jaguar1 RX onto the single-threaded async URB queue** Jaguar2/3 already use (`RtlUsbAdapter::bulk_read_async_loop`): parse/consume inside the completion callback while the buffer is alive, 8 always-posted URBs (the 8814 RX-DMA-ring continuity the pool existed for), no blocking threads, no `proc_mu`. Removes the contention and the `read_frames`/worker pool. Also fixes a latent **dangling-span** bug (`read_frames` returned `Packet` spans into a stack buffer).
- `WiFiDriver` passes `ctx` to the Jaguar1 adapter so the async event pump uses the right context (Jaguar2/3 already did).
- **TX endpoint-stall recovery**: on a wedged async bulk-OUT the callback flags the endpoint and the next `send_packet` re-`clear_halt`s it (the first-send `clear_halt` only ran once). New `DEVOURER_TX_TIMEOUT_MS` tunes the TX bulk timeout (default 500, scoped to TX).

## Results (radxa 8812AU, ch36)

| | before | after |
|---|---|---|
| self-sounding self-capture | 0 reports | **28k+ reports / 14 s** (real VHT MU per-tone CSI) |
| NDP-gen send-fail, self-capture on | ~90% | ~25% (default) → **0%** at a 4 ms inter-frame gap |

- Reports carry the correct beamformee SA and decode to genuine per-tone V-angles + per-stream SNR.
- **Regression**: 8812AU RX-only 1100 frames/10 s, no crash; the shared async path is unchanged for Jaguar2/3 (exercised as the beamformee throughout). Mac + Linux builds clean.
- Untested on hardware: 8814/8821 RX-only (not plugged during this pass) — same async path, low risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)