### PR TITLE
RX URBs: infinite timeout — stop the darwin idle-RX timeout flood

### DIFF
--- a/src/RtlUsbAdapter.cpp
+++ b/src/RtlUsbAdapter.cpp
@@ -48,8 +48,17 @@ void RtlUsbAdapter::bulk_read_async_loop(
                                          std::vector<uint8_t>(buf_size));
   for (int i = 0; i < n_urbs; i++) {
     libusb_transfer *t = libusb_alloc_transfer(0);
+    /* timeout=0 (infinite): a persistent RX ring — each URB stays posted until
+     * a frame arrives (COMPLETED), the queue is torn down (CANCELLED, below),
+     * or the device errors. This is the kernel rtw88 RX-URB idiom. A finite
+     * timeout here would fire once per idle interval on a quiet channel, and
+     * libusb's darwin backend logs every LIBUSB_TRANSFER_TIMED_OUT at WARNING
+     * level — a continuous "transfer error: timed out" flood that carries no
+     * information (RX is healthy; bulk-IN is simply idle) and can bloat a long
+     * capture's stderr. The devourer_rx_cb resubmit-on-TIMED_OUT branch is kept
+     * as a defensive no-op should a backend still surface a timeout. */
     libusb_fill_bulk_transfer(t, _dev_handle, _bulk_in_ep, bufs[i].data(),
-                              buf_size, devourer_rx_cb, &sh, 1000);
+                              buf_size, devourer_rx_cb, &sh, 0);
     if (libusb_submit_transfer(t) == 0) {
       xfers.push_back(t);
       sh.active++;


### PR DESCRIPTION
## Problem

On macOS the RX demos emit a continuous stderr flood on a quiet channel:

```
libusb: warning [darwin_transfer_status] transfer error: timed out
```

`RtlUsbAdapter::bulk_read_async_loop` posts its RX bulk-IN URBs with a finite **1000 ms** timeout. On an idle channel each of the 8 URBs expires with `LIBUSB_TRANSFER_TIMED_OUT` roughly once per second; libusb's darwin backend logs every one at WARNING level and the callback resubmits — an information-free drip (~1/sec) that can bloat a long idle capture's stderr. RX itself is healthy the whole time: when bulk-IN carries traffic the URBs complete on data and there are zero timeouts, so the flood is purely cosmetic.

## Fix

Post the RX URBs with **`timeout = 0` (infinite)** — the standard persistent-RX-ring idiom (the kernel rtw88 RX URBs live until data or unlink). The `resubmit-on-TIMED_OUT` branch stays as a defensive no-op; shutdown is unaffected (the ring is torn down with `libusb_cancel_transfer`, not the timeout). This is the shared async RX path, so it applies identically to all three chip generations.

## Validation

Same-channel A/B on a genuinely dead channel (RX idle, every URB timing out):

| RX URB timeout | libusb timeout warnings / 20 s |
| --- | --- |
| 1000 ms (before) | ~19 |
| 0 / infinite (after) | 0 |

RX keeps delivering frames in both cases. Smoke-checked on Jaguar1 (RTL8821AU) and Jaguar3 (RTL8822CU) RX; the change lives in the shared `bulk_read_async_loop`, so Jaguar2 uses the same path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)