### PR TITLE
README: name RTL8812AU reference part, drop untested RTL8811AU figures

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ varies run-to-run (bracketed = best clean reading).
 
 | Part                          | RF / streams      | 2.4 GHz (ch6) | UNII-1 (ch36) | UNII-2/3 (ch149) | Notes                                       |
 | ----------------------------- | ----------------- | ------------- | ------------- | ---------------- | ------------------------------------------- |
-| **RTL8812AU**                 | 2T2R              | 56            | 52            | 52               | `0bda:8812`; reference part |
-| **RTL8811AU**                 | 1T1R              | mirrors 8812  | mirrors 8812  | mirrors 8812     | 1T1R cut of 8812 silicon; rides the 8812 code path (`RFType=RF_TYPE_1T1R` from `REG_SYS_CFG` bit 27). Not benchmarked |
+| **RTL8812AU**                 | 2T2R              | 56            | 52            | 52               | [CHANEVE CHW50L](https://www.aliexpress.com/item/4000762461362.html) (`0bda:8812`) |
+| **RTL8811AU**                 | 1T1R              | —             | —             | —                | 1T1R cut of 8812 silicon; rides the 8812 code path (`RFType=RF_TYPE_1T1R` from `REG_SYS_CFG` bit 27). Not benchmarked |
 | **RTL8814AU**                 | 4T4R, 3-SS max    | 65            | †(32)         | †(32)            | `0bda:8813`; tested on COMFAST CF-938AC (2 ext antennas) and CF-960AC (4 internal) — effective RX-diversity branches differ (N_eff ≈ 3.8 vs 2.6) despite identical silicon, see [`docs/measuring-spatial-diversity.md`](docs/measuring-spatial-diversity.md) |
 | **RTL8821AU**                 | 1T1R AC + BT      | 54            | 32            | 28               | TP-Link Archer T2U Plus (`2357:0120`) |
 | **RTL8822BU**                 | 2T2R + BT         | 52            | 50            | 49               | TP-Link Archer T3U (`2357:012d`) |


### PR DESCRIPTION
## Hardware landscape table cleanup

Docs-only touch to the **Hardware landscape** table; no code changes.

- **RTL8812AU** — the reference `0bda:8812` device is a [CHANEVE CHW50L](https://www.aliexpress.com/item/4000762461362.html). The Notes column now names and links the product instead of the vague "reference part" label, matching the `Product (`pid`)` format every other row uses.
- **RTL8811AU** — there is no lab unit and it was never benchmarked, so the `mirrors 8812` throughput cells overstated what was actually measured. Replaced them with em-dashes and kept the "Not benchmarked" note, mirroring the RTL8812BU row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)