### PR TITLE
Docs refactor — CLAUDE.md signal-to-noise, README as a product pitch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,111 +4,38 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-Userspace re-implementation of Realtek's RTL88xxAU Wi-Fi driver — speaks to the chip
-directly via libusb instead of a kernel module. Static library `devourer` (CMake
-target) + example executables under `examples/` — the two canonical demos are
-`rxdemo` (RX) and `txdemo` (TX). Used by the OpenIPC project for long-range
+Userspace re-implementation of Realtek's RTL88xxAU Wi-Fi driver — speaks to the
+chip directly via libusb instead of a kernel module. Static library `devourer`
+(CMake target) + example executables under `examples/` (`rxdemo` and `txdemo`
+are the canonical RX/TX demos). Used by the OpenIPC project for long-range
 video links.
 
-Three chip generations are supported, dispatched at construction (see
-**Architecture**):
+Three chip generations, each behind its own self-contained HAL, dispatched at
+construction from the `SYS_CFG2` chip-id (see **Architecture**):
 
-**Jaguar (1st-gen 802.11ac).** The original family: **RTL8812AU** (2T2R,
-reference), **RTL8811AU** (1T1R cut of 8812 silicon — rides the 8812 code
-path with `RFType=RF_TYPE_1T1R` selected via `REG_SYS_CFG` bit 27),
-**RTL8814AU** (4T4R RF / 3-SS baseband; host-pushed TX requires the
-on-chip 3081 MCU, which devourer boots during firmware download —
-a failed FW-boot poll means dead TX while RX still works), and
-**RTL8821AU** (1T1R AC + BT combo). These share one HAL (`src/jaguar1/`,
-e.g. `HalModule`, `RtlJaguarDevice`) with chip-family branches.
+- **Jaguar1** (`src/jaguar1/`): RTL8812AU (2T2R reference), RTL8811AU (1T1R cut,
+  rides the 8812 path), RTL8814AU (4T4R RF / 3-SS baseband — host-pushed TX
+  requires the on-chip 3081 MCU booted during FW download; a failed FW-boot
+  poll means dead TX while RX still works), RTL8821AU (1T1R + BT).
+- **Jaguar2** (`src/jaguar2/`): RTL8822BU / RTL8812BU (chip-id `0x0a`) and
+  RTL8811CU / RTL8821CU (chip 8821C, chip-id `0x09`). A hybrid: HalMAC FW
+  download / MAC init / power sequencing like Jaguar3, phydm `check_positive`
+  register tables like Jaguar1 (shared `PhyTableLoader`). RX + TX on 2.4/5 GHz
+  at 20/40/80 MHz, per-rate bandwidth-aware efuse TX power clamped to generated
+  `txpwr_lmt` tables.
+- **Jaguar3** (`src/jaguar3/`): rtl8822c (RTL8812CU/8822CU, chip-id `0x13`) and
+  rtl8822e (RTL8812EU/8822EU, chip-id `0x17`). Adds **5/10 MHz narrowband**
+  the Jaguar1 silicon lacks, 80 MHz (incl. a 40-in-80 frame via TX-descriptor
+  DATA_SC), and halrf calibration (DACK/IQK/TXGAPK/thermal tracking).
+  Sustained 5 GHz TX needs the **coex runtime thread**
+  (`RtlJaguar3Device::coex_runtime_loop`, started in `InitWrite`) — without its
+  ~2 s WiFi-only coex re-apply + FW heartbeats, the combo chip's coex firmware
+  silences the antenna.
 
-**Jaguar2.** A second, self-contained HAL under `src/jaguar2/` covering two chips
-that share one core: **RTL8822BU** (chip 8822B, 2T2R USB, `2357:012d` Archer T3U /
-`0bda:b82c` — the T3U reports 2T2R via `REG_SYS_CFG` bit 27, its 1T1R cut
-**RTL8812BU** rides the same path) and the 1T1R AC600 + BT **RTL8821C**
-(RTL8811CU / RTL8821CU, `0bda:c811`, `SYS_CFG2` chip-id `0x09`). It is a hybrid of
-the other two: HalMAC firmware download, MAC init and power sequencing follow the
-Jaguar3 path, while the BB/AGC/RF register tables use the older phydm
-`check_positive` format (like Jaguar1, via the shared `PhyTableLoader`). Bring-up
-is ported from the vendor rtl88x2bu / rtl8821cu trees — power-on, DLFW, MAC/BB/RF
-init, LC calibration + IQK, RX, and on-air TX across **2.4 and 5 GHz at 20/40/80
-MHz** with per-rate, bandwidth-aware efuse TX power. Per-generation PHY/RF tables
-and calibration sit behind strategy interfaces (`Jaguar2PhyTables`,
-`Jaguar2Calibration`) selected by `ChipVariant`, mirroring the Jaguar3 split; the
-flow and table-walker are shared. Each variant's `txpwr_lmt` regulatory-limit
-table is generated (`tools/extract_8822b_txpwr_lmt.py` worldwide-min rfe_type-3
-for the T3U; `tools/extract_8821c_txpwr_lmt.py` for the 8821C); the RF/AGC tune to
-the wide channel's **central** channel, and the RF18/LCK `CHNLBW` value keeps the
-5 GHz band bits (8/16) the vendor preserves.
-
-**Jaguar3.** A third, self-contained HAL under `src/jaguar3/` covering two PHY
-generations that share one core: **rtl8822c** (RTL8812CU / RTL8822CU, `0bda:c812`)
-and **rtl8822e** (RTL8812EU / RTL8822EU, `0bda:a81a`). Bring-up is ported from
-Realtek's vendor source — power-on, HalMAC firmware download, MAC/BB/RF init,
-halrf calibration (DACK, IQK, TXGAPK, thermal tracking), RX, and on-air TX at
-20/40 MHz, the **5/10 MHz narrowband** re-clock the Jaguar-1 silicon lacks, and
-an **80 MHz** channel that also carries a **40-in-80** frame (a 40 MHz frame on
-an 80 MHz-tuned channel, landing on the lower 40 via the TX-descriptor DATA_SC —
-the userspace equivalent of `iw 80MHz` + a 40 MHz radiotap; the 40 MHz frame
-decodes on a standard HT40 receiver on the lower-40 channel). HT40 tunes the
-central channel (primary ± 2, `DEVOURER_HOP_BW=40` / `DEVOURER_HOP_OFFSET`);
-80 MHz takes the block's lowest 20 MHz as primary (`DEVOURER_HOP_BW=80`).
-Per-generation PHY/RF tables and calibration sit behind strategy interfaces
-(`Jaguar3PhyTables`, `Jaguar3Calibration`); the flow and table-walker are shared.
-
-Sustained 5 GHz TX needs the **coex runtime thread**
-(`RtlJaguar3Device::coex_runtime_loop`, started in `InitWrite`): it drains the
-firmware C2H reports off bulk-IN and every ~2 s re-applies the WiFi-only coex
-decision (GNT_WL, antenna owner = WL), the FW heartbeats, and thermal TX-power
-tracking. Without it the combo chip's coex firmware silences the antenna.
-
-TX power: by default the chip transmits at its efuse-calibrated per-path,
-per-channel level (the rtl8822e TXAGC references match the kernel driver's).
-`DEVOURER_TX_PWR=0xNN` forces a flat TXAGC reference — a debug/SDR-visibility
-knob, not for sustained use.
-
-Runtime TX-power control (all three generations, the adaptive-link power
-lever — see `src/TxPower.h`): `SetTxPowerOffsetQdb(qdb)` adjusts power in
-quarter-dB relative to the efuse per-rate table (per-rate shape preserved
-until rates saturate at the rails; saturation flags in `GetTxPowerState`),
-`SetTxPowerIndexOverride(idx)` forces/clears the flat index (`SetTxPower`
-forwards here), both live mid-stream and sticky across `SetMonitorChannel`
-(re-folded against the new channel's table) and `FastRetune` (hop path never
-rewrites TXAGC). `GetTxPowerCaps` reports the family step (0.5 dB Jaguar1/2,
-0.25 dB Jaguar3 — on-air-measured via `tests/txpwr_offset_onair.sh`, which
-uses a second chip's per-frame RSSI as the sensor: at bench range the B210
-front-end limits on the frames at any gain and cannot see TXAGC slopes).
-`GetThermalStatus` reads the RF 0x42 meter with the family baseline on every
-generation. `txpower` (examples/txpower/, CLI-only) is the reference
-consumer; register-level validation lives in `tests/txpwr_offset_regcheck.sh`
-(canary parity vs master, exact-step moves, rails, stickiness, the 8822E
-TX+RX 0x41e8 quirk cell). The 8822B's VHT TXAGC sections are programmed from
-the same stream-count bases as HT (vendor parity) so the offset covers VHT
-there; the Jaguar2 TXAGC block and the 8814A's packed port are write-only, so
-their `GetTxPowerState` reports the software shadow (`hw_readback=false`).
-
-**Per-packet TX power (Jaguar2 only).** Distinct from the per-rate TXAGC that
-`SetTxPowerOffsetQdb` shifts, the 8822B/8821C TX descriptor has a `TXPWR_OFSET`
-field (`+0x14[30:28]`) — a hardware LUT applied per-frame *on top of* the
-rate's power at **zero USB cost** (a bitfield in the descriptor `send_packet`
-already builds): `0`=none, `1`=-3, `2`=-7, `3`=-11, `4`=+3, `5`=+6 dB
-(vendor `PHYDM_OFFSET_*`). `send_packet` honours a per-frame radiotap
-`DBM_TX_POWER` field as a dB delta quantized to that LUT
-(`jaguar2::txpkt_pwr_step_for_db`, selftest `tests/txpkt_pwr_selftest.cpp`) —
-the adaptive-link per-packet power knob (wfb-style injection sets it per
-frame); `RtlJaguar2Device::SetTxPacketPowerStep` sets a session default for
-rate-less frames. On-air-confirmed both paths (`tests/txpkt_pwr_ofset_onair.sh`:
-the LUT tracks on-air power ±dB). The classic 8812AU has no such descriptor
-field — its per-packet power *is* per-rate selection (radiotap rate → the
-TXAGC table), which the library already does; Jaguar3's `TXPWR_OFSET_TYPE` is
-a 2-bit variant left unwired.
-
-**RTL8821AU is Jaguar wave 1** (CHIP_8821 = 7, shares the enum with CHIP_8812),
-not Jaguar2 — distinct from the Jaguar2 **RTL8821C** (8811CU/8821CU) despite the
-similar name. The Jaguar2 **8822BU/8812BU** and **8811CU/8821CU** USB parts are
-supported (see the Jaguar2 HAL above); the **8822BE** (PCIe variant) and the
-**Kestrel (11ax)** families remain out of scope — same "AU"/"BU"/"CU" branding,
-different bus/baseband.
+Naming traps: **RTL8821AU is Jaguar1** (not Jaguar2, despite the Jaguar2
+RTL8821C's similar name); RTL8822**B**U (Jaguar2) ≠ RTL8822**C**U (Jaguar3).
+The 8822BE (PCIe) and the Kestrel 11ax families are out of scope. Full chip /
+bench-throughput table: README **Supported hardware**.
 
 ## Build
 
@@ -117,444 +44,243 @@ cmake -S . -B build
 cmake --build build -j
 ```
 
-Per-chip build options select which drivers are compiled in — all default ON,
-so the command above builds every chip. Turn off the ones you don't need to
-drop their firmware blobs + PHY tables (an 8812AU-only `rxdemo` is
-~1.0 MB vs ~2.6 MB): `DEVOURER_JAGUAR1` (8812/8811/8821), `DEVOURER_8814`
-(requires JAGUAR1), `DEVOURER_JAGUAR2_8822B` (8822BU/8812BU),
-`DEVOURER_JAGUAR2_8821C` (8811CU/8821CU), `DEVOURER_JAGUAR3_8822C`,
-`DEVOURER_JAGUAR3_8822E`.
-Configure fails on no-chip-selected or 8814-without-JAGUAR1. Each group exports
-a PUBLIC `DEVOURER_HAVE_*` define; sites referencing a dropped group are behind
-`#if defined(DEVOURER_HAVE_*)`, and the factory returns `nullptr` (logs) for a
-chip whose support isn't built.
+libusb-1.0 via `pkg-config` (Linux/macOS) or vcpkg (`VCPKG_ROOT`, Windows).
 
-libusb-1.0 is required: `pkg-config` on Linux/macOS, vcpkg on Windows
-(`VCPKG_ROOT` must be set so the toolchain file resolves). CI matrix builds
-across GCC/Clang/MSVC on Ubuntu/macOS/Windows, plus a separate `build-mingw`
-job (mingw-w64 via MSYS2, libusb from pkg-config) covering the Windows-GCC
-toolchain the MSVC matrix cell doesn't; the `build-configs` matrix builds each
-per-chip subset and `reject-bad-configs` asserts the invalid option combos fail
-(`.github/workflows/cmake-multi-platform.yml`). `ctest` runs in every CI job;
-the one registered test (`stream_stdin_binary`) round-trips the stream demos'
-binary-stdin framing (`examples/common/stream_stdin.h`) headlessly, so a Windows
-text-mode regression fails CI instead of only surfacing on a radio. Hardware
-regression testing happens out-of-band via `tests/regress.py`.
+Per-chip options, all default ON: `DEVOURER_JAGUAR1`, `DEVOURER_8814` (requires
+JAGUAR1), `DEVOURER_JAGUAR2_8822B`, `DEVOURER_JAGUAR2_8821C`,
+`DEVOURER_JAGUAR3_8822C`, `DEVOURER_JAGUAR3_8822E`. Turning groups off drops
+their firmware blobs + PHY tables (an 8812AU-only `rxdemo` is ~1.0 MB vs
+~2.6 MB). Configure fails on no-chip-selected or 8814-without-JAGUAR1. Each
+group exports a PUBLIC `DEVOURER_HAVE_*` define; sites referencing a dropped
+group sit behind `#if defined(DEVOURER_HAVE_*)`, and the factory returns
+`nullptr` (logs) for a chip whose support isn't built.
 
-## Regression testing
+CI (`.github/workflows/cmake-multi-platform.yml`): GCC/Clang/MSVC ×
+Ubuntu/macOS/Windows matrix, a `build-mingw` job, a `build-configs` matrix over
+each per-chip subset, and `reject-bad-configs` for the invalid option combos.
+`ctest` runs in every job (headless selftests — math guards + the
+`stream_stdin_binary` framing round-trip). Hardware testing is out-of-band.
 
-`tests/regress.py` runs a 2x2 TX/RX matrix (devourer vs. kernel driver) using
-two USB Wi-Fi adapters plugged into the host. Run **after** building devourer.
+## Hardware testing
+
+`tests/regress.py` — 2×2 TX/RX matrix (devourer vs. kernel driver) over two
+plugged adapters. Run after building.
 
 ```sh
-# Local mode — kernel cells use whatever driver is bound on the host
-sudo python3 tests/regress.py
-
-# VM mode (recommended for RTL8814AU and other chips whose kernel driver
-# doesn't build on bleeding-edge kernels) — kernel cells run inside a
-# pinned-kernel (Ubuntu 22.04 / 5.15) libvirt VM with aircrack-ng/rtl8812au
-# preloaded. Provision once with tests/setup_vm.sh, then:
+sudo python3 tests/regress.py                 # local kernel cells
 sudo python3 tests/regress.py \
-    --vm-name devourer-testrig --vm-ssh <user>@<VM-IP>
+    --vm-name devourer-testrig --vm-ssh <user>@<VM-IP>   # pinned-kernel VM
 ```
 
-Default channel is `6` (2.4GHz). Pass `--channel 36` / `--channel 100`
-to exercise 5GHz; do not assume a single-band matrix is comprehensive.
-Matrix-interpretation caveat: with the 8814 as TX, the `kernel`-TX cells
-read 0 at every channel — `aircrack-ng/88XXau` host-push *beacon*
-injection (what `inject_beacon.py` does) doesn't emit on that driver,
-even though its probe-request injection does. Judge 8814 TX by the
-devourer-TX cells.
+VM mode (provision once with `tests/setup_vm.sh`) is required for chips whose
+vendor driver doesn't build on bleeding-edge kernels — notably the RTL8814AU.
+Default channel 6; pass `--channel 36` / `--channel 100` for 5 GHz — a
+single-band matrix is not comprehensive. Caveat: with the 8814 as TX, kernel-TX
+cells read 0 on every channel (`aircrack-ng/88XXau` doesn't emit host-pushed
+*beacon* injection) — judge 8814 TX by the devourer-TX cells.
 
-Three specialised modes layered on top of the default 4-cell matrix:
+Layered modes: `--full-matrix` (every ordered DUT pair × 4 driver combos),
+`--encoding-matrix --tx-pid --rx-pid` (radiotap encoding combos; the kernel-TX
+rows are not authoritative for LDPC/STBC — that driver strips those bits),
+`--sniffer-iface IFACE` (3rd-adapter capture, intended for AR9271).
+`--keep-logs` puts per-cell logs at `/tmp/devourer-regress-last/`. Full
+semantics: `tests/README.md`.
 
-- `--full-matrix`: iterates every ordered (TX, RX) pair of plugged DUTs
-  across all four driver-side combinations (N×(N−1)×4 cells; ~16 min for
-  N=3 in VM mode). Use for cross-chipset interop regressions.
-- `--encoding-matrix --tx-pid 0xNNNN --rx-pid 0xNNNN`: for one ordered
-  pair, iterates (driver-mode × radiotap encoding combo) — 4 HT
-  combos (BCC / LDPC / STBC=1 / LDPC+STBC) + 2 VHT combos
-  (BCC / LDPC), 24 cells total.
-- `--sniffer-iface IFACE`: when set, captures on a 3rd monitor-mode
-  adapter alongside every cell and reports decoded radiotap encoding
-  distribution. Intended for AR9271 — vanilla radiotap, no driver-side
-  filtering. NB: `aircrack-ng/88XXau` on the kernel-TX side strips the
-  radiotap LDPC + STBC bits before air, so the `k/k` and `k/d` rows of
-  `--encoding-matrix` are NOT authoritative for LDPC/STBC asymmetries
-  (MCS index + HT/VHT distinction do survive).
+Startup-time benchmarking: `tests/bench_init.py` (per-stage `init-timing:`
+lines from `src/InitTimer.h`; methodology + numbers in `docs/startup-time.md`).
+On-air TX throughput: measure **Mbps via SDR duty × PHY rate**
+(`tests/bench_onair.py`), never monitor-sniffer frame counts — a sensitive
+receiver decodes weak frames and masks a real drop. Keep a known-good control
+adapter, re-check it each session, and take one clean SDR read per session (a
+second back-to-back `sdr_duty` read can fail to reacquire and report ~0).
 
-Init/startup-time benchmarking lives in `tests/bench_init.py`: per-DUT
-cold-init timing of devourer RX (`exec → first RX frame`), devourer TX
-(`exec → first bulk-OUT`), and the kernel driver — with `--kernel-host`
-via the vendor `.ko`s built under `reference/` (`insmod → netdev →
-monitor → first frame`; 88XXau for Jaguar1, rtl88x2bu / 8821cu /
-rtl88x2cu / rtl88x2eu for Jaguar2/3 — all build against the host 6.18
-kernel with local compat patches in those trees), or with
-`--vm-name`/`--vm-ssh` via the pinned-kernel VM (driver-behaviour
-comparisons only — virtualized USB adds latency, don't cite its
-timings). Per-stage
-numbers come from the `init-timing: <scope>.<stage> = N ms` lines the
-library emits (`src/InitTimer.h`); A/B variants isolate libusb log level,
-USB reset, and the TX-power loop. `--traffic-from PID` dedicates a plugged
-non-DUT adapter to a devourer beacon flood on the bench channel — without
-it, every first-frame marker (devourer and kernel tcpdump alike) starves in
-an RF-quiet room. NB the per-rep `authorized`-toggle is warm, not a true
-cold plug (vendor drivers re-init a calibrated chip ~2× faster) —
-first-plug comparisons need a per-rep VBUS cycle (uhubctl). Numbers +
-methodology: `docs/startup-time.md`.
+## Configuration
 
-DUTs are routed between host and VM per cell via `virsh attach-device`.
-Re-run with `--keep-logs` to inspect per-cell logs (and per-cell pcaps
-when `--sniffer-iface` is active) at `/tmp/devourer-regress-last/`. See
-`tests/README.md` for the full matrix semantics and prerequisites.
+**The library reads no environment.** Construction-time knobs live in
+`devourer::DeviceConfig` (`src/DeviceConfig.h` — rx / tx / bf / tuning / debug /
+usb sections, every field doc-tagged with its env-var spelling and value
+grammar), passed as `CreateRtlDevice`'s defaulted fourth argument. Mid-session
+knobs are runtime setters on `IRtlDevice` (`SetTxMode`, `SetTxPowerOffsetQdb`,
+`SetTxPowerIndexOverride`, `SetRxPathMask`, `SetCcaMode`, `FastRetune`, ...).
 
-## Demo env vars
+**Env vars are the demos' interface**: `examples/common/env_config.{h,cpp}`
+maps every library-level `DEVOURER_*` var onto `DeviceConfig`, so the test
+scripts drive everything through env. For the per-var reference, read the
+`env:` tags in `DeviceConfig.h`; demo-local vars (device selection, timing)
+are parsed in each demo's own code. The ones needed daily:
 
-Env vars are the *demos'* interface, not the library's: the library is
-configured through `devourer::DeviceConfig` (src/DeviceConfig.h, passed to
-`CreateRtlDevice`; each field's `env:` tag names its variable) plus the
-runtime setters on `IRtlDevice`, and reads no environment itself. The demos
-translate every library-level `DEVOURER_*` var into a `DeviceConfig` via
-`examples/common/env_config.{h,cpp}` — so the vars below (and the test
-scripts using them) work on every example binary, while a library consumer
-sets the fields directly. Demo-local vars (device selection, timing loops)
-are parsed in each demo's own code.
+- `DEVOURER_PID=0xNNNN` / `DEVOURER_VID=0xNNNN` — restrict the device-open
+  loop (default VID `0x0bda`, all Realtek PIDs). `DEVOURER_USB_BUS=N` +
+  `DEVOURER_USB_PORT=a.b.c` select by USB topology when two adapters share
+  VID:PID **and** serial.
+- `DEVOURER_CHANNEL=N` — monitor channel.
+- `DEVOURER_TX_RATE=<rate>[/<bw>][/SGI][/LDPC][/STBC]` — TX mode for rate-less
+  frames (`MCS7/40/SGI`, `VHT2SS_MCS3/80/LDPC`, `1M`...). Unset = 6M legacy.
+  CCK rates are 2.4 GHz-only; `1M` buys ~9 dB link budget over `6M`. The
+  library itself is radiotap-driven — a frame carrying its own rate radiotap
+  overrides the mode per-packet. Programmatic: `SetTxMode` / `ClearTxMode`.
+- `DEVOURER_SKIP_RESET=1` — skip `libusb_reset_device` before claim (only
+  helps when firmware state is intact).
+- `DEVOURER_TX_GAP_US=N` — txdemo inter-frame gap (default 2000, ~500 fps;
+  `0` = max duty for heating experiments).
+- `DEVOURER_USB_DEBUG=1` — libusb DEBUG log level (~7 MB / 15 s, has filled
+  `/tmp` mid-capture; adds 0.5–0.8 s to init).
 
-Both `rxdemo` and `txdemo` honour:
+Knob-specific facts that aren't obvious from the field docs:
 
-- `DEVOURER_PID=0xNNNN` — restrict the open loop to a single PID (e.g.
-  `0x8813` for RTL8814AU); without it, the demo iterates every Realtek PID.
-- `DEVOURER_VID=0xNNNN` — override VID (default `0x0bda`); needed for
-  OEM-rebadged dongles like the TP-Link Archer T2U Plus (`2357:0120`).
-- `DEVOURER_USB_BUS=N` (+ optional `DEVOURER_USB_PORT=a.b.c`) — select a device
-  by USB topology instead of first-match VID:PID. Needed when two adapters share
-  one VID:PID **and serial** and can't otherwise be told apart (two RTL8814AU
-  dongles, e.g. CF-938AC vs CF-960AC). `DEVOURER_USB_PORT` is the dotted libusb
-  port path (sysfs `devpath` / `lsusb -t`). Unset = the normal VID:PID open loop.
-  Used by `tests/compare_8814_decorrelation.sh`.
-- `DEVOURER_CHANNEL=N` — override monitor channel.
-- `DEVOURER_SKIP_RESET=1` — skip `libusb_reset_device` before claim; useful
-  when picking up a chip whose firmware is already running.
-- `DEVOURER_SKIP_TXPWR=1` — skip the per-rate TX-power loop during channel
-  switch (runs by default on every chip; escape hatch for RX-only
-  experiments).
-- `DEVOURER_RX_KEEP_CORRUPTED=1` — pass frames that fail the 802.11 FCS (CRC32)
-  or decryption-ICV check up to the host instead of dropping them at the WMAC
-  filter (sets RCR `ACRC32|AICV`). They arrive with `crc_err`/`icv_err` set on
-  the RX descriptor; `rxdemo` surfaces them in its `<devourer-stream>`
-  output. This is the entry point for the fused-FEC sub-block-salvage layer
-  (see `docs/fused-fec.md`); opt-in, since a body with a corrupt tail is the
-  worst-case input for an IP-stack consumer that didn't ask for it.
-- `DEVOURER_RX_ALLPATHS=1` — emit a `<devourer-rxpath>` line per canonical-SA
-  frame carrying all four RX chains (A,B,C,D) of per-stream `rssi`/`snr`/`evm`,
-  where the canonical `<devourer-stream>`/`<devourer-body>` lines surface only
-  A,B. Paths C/D are non-zero only on the 8814AU (4T4R); 0 on 2T2R parts.
-  Opt-in and on a distinct tag so the two-path format its regex consumers key on
-  is untouched. Consumed by `tests/antenna_decorrelation.py` to measure
-  inter-chain envelope correlation and realised diversity gain.
-- `DEVOURER_RX_PATHS=0xNN` — (Jaguar1 RX) restrict which RX chains the chip
-  enables/combines by masking the RX-path-enable register (`0x808` byte 0: bits
-  0/4 = path A CCK/OFDM, 1/5 = B, 2/6 = C, 3/7 = D). Default all paths (`0xFF`).
-  `0x11` = A only, `0x33` = A+B, `0x77` = A+B+C. Validated on the 8814: a masked
-  path's per-chain RSSI collapses to the noise floor while the enabled ones stay
-  up. Routes through the runtime `RtlJaguarDevice::SetRxPathMask(mask)` /
-  `GetRxPathMask()` API (the adaptive-link spatial-diversity lever — a
-  controller with a motion/fade signal switches chains live instead of on the
-  toggle's fixed timer); once set, the mask is **sticky** — re-applied after
-  every `SetMonitorChannel` (a channel set runs IQK, which saves/restores
-  `0x808`), so it survives channel hops. The knob for measuring the chip's
-  hardware maximal-ratio-combining gain — compare frame delivery at
-  `0x11`/`0x33`/`0x77`/`0xFF` over a *marginal* link (see
-  `docs/measuring-spatial-diversity.md`); register + stickiness validation in
-  `tests/rx_path_mask_check.sh`. A **toggle spec**
-  `0xAA:0xBB[:0xCC]@<ms>` (e.g. `0x22:0xFF@300`) cycles the mask on a timer
-  thread instead of setting it once, printing a `<devourer-rxpath-mask>0xNN`
-  marker inline with the frame stream on each switch — the stimulus for the
-  mobile/fading combining measurement (alternate a fixed chain vs all-4 fast
-  relative to RX motion so both sample the same fading). Analyse with
-  `tests/mrc_mobility.py`.
-- `DEVOURER_RX_CSI_MASK=<f_lo>[-<f_hi>][/wgt]` — (all generations, RX)
-  de-weight a frequency range (MHz) in the receive equalizer's per-tone CSI
-  mask — the RX half of pseudo preamble puncturing (`src/ToneMask.h`,
-  `docs/pseudo-preamble-puncturing.md`). Masks every 312.5 kHz subcarrier in
-  the range (e.g. `5230-5250` = the top 20 MHz slice of the ch36 80 MHz
-  block); `/wgt` (0..7, default 7) is the Jaguar3 per-tone weight. Applied
-  when the RX loop starts, after the channel set; a channel switch reverts it
-  (same contract as `DEVOURER_RX_PATHS`). Register-landing checked per chip by
-  `tests/tone_mask_regcheck.sh`. NB measured: inert against a *jammed* slice
-  (that loss is pre-FCS sync/AGC, upstream of the equalizer) — it targets
-  in-band spurs riding on decodable frames.
-- `DEVOURER_RX_NBI=<f_mhz>` — (all generations, RX) arm the narrowband-
-  interference notch filter at one in-channel frequency (vendor-parity,
-  LUT-quantized — a single narrow notch, not a slice mask).
-- `DEVOURER_TX_WITH_RX=thread` — (`txdemo`) run the RX worker loop on
-  a `std::thread` alongside the TX loop, on the **same claimed adapter**: one
-  bring-up (`InitWrite`), then `StartRxLoop(packetProcessor)` — the programmatic
-  API for concurrent TX+RX on one handle (all three generations). On Jaguar3 the
-  env must be set **before** `InitWrite` (it keeps the RX filters open and
-  enables the RX path during bring-up — retrofitting RX onto a TX-only bring-up
-  is unreliable), and the coex thread's C2H drain yields bulk-IN to the RX loop;
-  Jaguar2's shared bring-up always enables RX, so it has no such constraint.
-  On the 8822E, TX+RX mode leaves the path-B OFDM TXAGC reference (0x41e8) at
-  its table default — any nonzero value in that one field desenses the EU's RX
-  to near-deaf (hardware-bisected, value-independent; the rest of the per-rate
-  power applies normally). This is the single-radio beamforming self-sounding
-  ground station — pair with `DEVOURER_BF_ARM_SOUNDER`/`DEVOURER_TX_NDPA` and
-  `DEVOURER_BF_DETECT_REPORT` to sound and capture your own reports in one
-  process (`docs/beamforming-self-sounding.md`; hardware-validated on Jaguar1
-  (8814AU), Jaguar2 (8822BU) and both Jaguar3 variants — 50k+ self-captured
-  reports per 20 s at full sounding rate). Any other
-  non-empty value selects the legacy `fork()` RX child — Termux-only
-  (`libusb_wrap_sys_device` keeps the fd shared across fork); on regular Linux
-  the forked bring-ups race and die with `rtw_read: iostream error`.
-- `DEVOURER_USB_DEBUG=1` — raise libusb log level from the default WARNING to
-  DEBUG (produces ~7 MB per 15 s — has filled `/tmp` mid-capture and adds
-  0.5-0.8 s to init even with stderr discarded). `DEVOURER_USB_QUIET` is
-  accepted as a no-op for backwards compatibility.
-- `DEVOURER_THERMAL_POLL_MS=N` — emit periodic `<devourer-thermal>` lines from
-  the chip thermal meter (RF[A][0x42][15:10]) paired with the EFUSE baseline:
-  `raw` (0..63 thermal units, ~1.5-2 °C each, not absolute °C), `baseline`,
-  `delta = raw − baseline`, and a coarse `status` bucket (cool/warm/hot/critical,
-  keyed off delta — the meter has no calibrated °C, so this is deliberately
-  bucketed rather than a fake temperature). Works on every Jaguar chip; read-only (does not
-  alter TX-power tracking). 0/unset = disabled. In `rxdemo` (RX) this
-  spawns a background poller at the given cadence; in `txdemo` it is
-  read inline on the TX thread (no extra USB contention) every `N/2` frames.
-  Jaguar-1 has no hard thermal TX shutdown — a rising `delta` is the early
-  warning that the PA is heating and TX power is being backed off. NB: on the
-  8814 the EFUSE baseline is read at the 8812 offset, so the absolute `delta`
-  may be off there; the raw trend is still valid.
-- `DEVOURER_THERMAL_WARN_DELTA=N` — thermal-units-above-baseline threshold at
-  which a one-shot `warn` fires (default `15`); re-arms once the chip cools
-  back below it.
-- `DEVOURER_LINKHEALTH=1` — (`rxdemo` RX, needs `DEVOURER_RX_ENERGY_MS`)
-  emit a `<devourer-linkhealth>` verdict line per energy window: the RX sensor
-  tuple classified into a plain-language cause + fix (`src/LinkHealth.h`). The
-  point is to tell a **near-field saturation** problem (strong RSSI + poor EVM —
-  *back OFF* TX power, add attenuation/distance) apart from a genuine weak link
-  (*add* power) so a user isn't chasing the wrong remedy — EVM, not SNR, is the
-  saturation tell (SNR looks fine while the constellation collapses). Verdicts:
-  `SATURATED` / `INTERFERENCE` / `WEAK` / `MARGINAL` / `HEALTHY` / `NO_SIGNAL`.
-  Uses `rssi_max` (window peak) as the strength signal since near-field
-  saturation drags the mean down. Thresholds calibrated on-air
-  (`tests/saturation_knee_sweep.sh`, `tests/j3_dig_penalty_sweep.sh`), unit-
-  guarded (`tests/link_health_selftest.cpp`), SAT-vs-HEALTHY verified on-air
-  (`tests/link_health_onair.sh`). See **`docs/bench-testing-near-field.md`**.
+- `DEVOURER_TX_WITH_RX=thread` (concurrent TX+RX on one claimed handle:
+  `InitWrite` once, then `StartRxLoop` on a thread) must be set **before**
+  `InitWrite` on Jaguar3 — the bring-up keeps the RX filters open; retrofitting
+  RX later is unreliable. On the 8822E, TX+RX mode leaves the path-B OFDM TXAGC
+  reference (0x41e8) at table default — any nonzero value there desenses the
+  EU's RX to near-deaf (hardware-bisected, value-independent). This is the
+  single-radio beamforming self-sounding station: pair with
+  `DEVOURER_BF_ARM_SOUNDER` / `DEVOURER_TX_NDPA` / `DEVOURER_BF_DETECT_REPORT`
+  (`docs/beamforming-self-sounding.md`). Non-`thread` values select a
+  `fork()` RX child that only works on Termux; on regular Linux the forked
+  bring-ups race and die.
+- `DEVOURER_RX_PATHS` (Jaguar1 RX-chain mask, `0x808` byte 0) routes through
+  `SetRxPathMask` and is **sticky** across `SetMonitorChannel` (IQK
+  saves/restores `0x808`). Toggle spec `0xAA:0xBB[:0xCC]@<ms>` cycles masks on
+  a timer for mobility/MRC measurements (`docs/measuring-spatial-diversity.md`,
+  `tests/mrc_mobility.py`). `DEVOURER_RX_ALLPATHS=1` emits per-chain
+  RSSI/SNR/EVM on a separate `<devourer-rxpath>` tag (C/D nonzero only on the
+  8814AU).
+- `DEVOURER_RX_CSI_MASK` / `DEVOURER_RX_NBI` (RX per-tone equalizer mask /
+  narrowband notch, `src/ToneMask.h`) apply at RX-loop start and revert on a
+  channel switch. Measured: inert against a *jammed* slice (that loss is
+  pre-FCS sync/AGC, upstream of the equalizer) — they target in-band spurs on
+  decodable frames (`docs/pseudo-preamble-puncturing.md`).
+- `DEVOURER_RX_KEEP_CORRUPTED=1` passes FCS/ICV-failed frames up with
+  `crc_err`/`icv_err` set — the entry point for the fused-FEC salvage layer
+  (`docs/fused-fec.md`). Opt-in: a body with a corrupt tail is the worst-case
+  input for an IP-stack consumer that didn't ask for it.
+- `DEVOURER_THERMAL_POLL_MS=N` emits `<devourer-thermal>` lines from the RF
+  0x42 meter: `raw` is 0..63 thermal units (~1.5–2 °C each, **not** absolute
+  °C — hence bucketed status, not a fake temperature), `delta` = raw −
+  EFUSE baseline. Jaguar1 has no hard thermal TX shutdown — a rising delta is
+  the early warning. On the 8814 the baseline is read at the 8812 offset, so
+  absolute delta may be off; the trend is valid.
+- `DEVOURER_LINKHEALTH=1` (rxdemo, needs `DEVOURER_RX_ENERGY_MS=N` — the RX
+  energy-window cadence in ms) classifies
+  the RX sensor tuple into SATURATED / INTERFERENCE / WEAK / MARGINAL /
+  HEALTHY / NO_SIGNAL (`src/LinkHealth.h`). Its purpose: distinguish
+  near-field saturation (strong RSSI + poor **EVM** — back OFF power) from a
+  weak link (add power). EVM, not SNR, is the saturation tell.
+  `docs/bench-testing-near-field.md`.
 
-`txdemo` selects the on-air TX mode with a single env var that it
-parses into a `devourer::TxMode` and hands to `RtlJaguarDevice::SetTxMode`
-(the canonical runtime API; the demo sends a rate-less beacon so this mode
-applies). The library itself is radiotap-driven — a frame that carries its own
-rate radiotap overrides the mode per-packet — so there is **no** `DEVOURER_TX_HT_MCS`
-gate any more (an HT-MCS radiotap is honoured unconditionally):
+**Runtime TX power** (all generations — the adaptive-link power lever, see
+`src/TxPower.h`): `SetTxPowerOffsetQdb(qdb)` shifts power in quarter-dB
+relative to the efuse per-rate table (shape preserved until rates saturate at
+the rails; flags in `GetTxPowerState`); `SetTxPowerIndexOverride(idx)`
+forces/clears a flat index. Both apply live and stick across
+`SetMonitorChannel` (re-folded on the new channel) and `FastRetune` (never
+rewrites TXAGC). `GetTxPowerCaps` reports the family step: 0.5 dB Jaguar1/2,
+0.25 dB Jaguar3. The Jaguar2 TXAGC block and the 8814A's packed port are
+write-only, so their `GetTxPowerState` reports the software shadow
+(`hw_readback=false`). `txpower` (examples/txpower/) is the reference
+consumer; register-level validation: `tests/txpwr_offset_regcheck.sh`.
 
-- `DEVOURER_TX_RATE=<rate>[/<bw>][/SGI][/LDPC][/STBC]` (case-insensitive). Unset
-  = `6M` legacy. Examples: `MCS7`, `MCS7/40/SGI`, `VHT2SS_MCS3/80/LDPC`, `54M`.
-  - `<rate>`: `1M`/`2M`/`5.5M`/`11M` (CCK, 2.4 GHz only — the chip drops CCK at
-    5 GHz; `1M` is the most robust rate, ~9 dB more link budget than `6M` for a
-    long-range beacon), `6M`/`9M`/`12M`/`18M`/`24M`/`36M`/`48M`/`54M` (legacy
-    OFDM), `MCS0`..`MCS31` (HT), or `VHT1SS_MCS0`..`VHT4SS_MCS9` (VHT).
-  - `<bw>`: `20`|`40`|`80`|`160` (default 20; legacy is always 20).
-  - `SGI` / `LDPC` / `STBC`: optional modifiers.
+**Per-packet TX power is Jaguar2-only**: the 8822B/8821C TX descriptor's
+`TXPWR_OFSET` field is a hardware LUT (0/-3/-7/-11/+3/+6 dB) applied per-frame
+at zero USB cost — `send_packet` quantizes a radiotap `DBM_TX_POWER` delta to
+it (`jaguar2::txpkt_pwr_step_for_db`), and
+`RtlJaguar2Device::SetTxPacketPowerStep` sets a session default. The 8812AU
+has no such field (its per-packet power *is* per-rate selection via radiotap);
+Jaguar3's `TXPWR_OFSET_TYPE` is measured inert.
 
-(Programmatic equivalent: `dev->SetTxMode(devourer::TxMode{...})`;
-`dev->ClearTxMode()` reverts to the built-in default.)
-
-`svctx` is a per-packet-rate showcase: it reads length-prefixed HEVC NALs
-from stdin, classifies each by `temporal_id` / IRAP-or-parameter-set criticality
-(`examples/svctx/svc_tx.h`), and injects each at the PHY rate its SVC-T layer
-deserves — a per-layer unequal-error-protection ladder (robust MCS for base/IDR,
-fast MCS for enhancement), since the radiotap is honoured per-packet. The ladder
-is `DEVOURER_SVC_LADDER="CRIT=<spec>;T0=<spec>;T1=<spec>;..."` where each `<spec>`
-is a `DEVOURER_TX_RATE` string; unset uses the built-in default. On-air check:
-`tests/gen_svc_nals.py` (synthetic 1:4:8:16 layer mix) + `tests/svc_uep_onair.sh`.
-
-The SVC ladder is the PHY-MCS half of cross-layer unequal error protection. The
-application-FEC half — a sub-block-integrity layer that salvages FCS-failed
-frames (`DEVOURER_RX_KEEP_CORRUPTED`) plus a Reed-Solomon outer code with
-per-layer redundancy — lives in `tools/precoder/` and is documented in
-**`docs/fused-fec.md`**. `streamtx` adds `DEVOURER_TX_PWR_OVERRIDE=N`
-(absolute per-rate TXAGC index 0..63, held) for the marginal-SNR bench setups
-that exercise the salvage path.
+Per-packet unequal error protection: `svctx` classifies stdin HEVC NALs by
+temporal layer and injects each at its ladder's rate
+(`DEVOURER_SVC_LADDER="CRIT=<spec>;T0=<spec>;..."`); the application-FEC half
+(RS outer code + corrupt-frame salvage) lives in `tools/precoder/`
+(`docs/fused-fec.md`).
 
 ## Frequency hopping
 
-`IRtlDevice::FastRetune(channel)` is a lean intra-band, same-bandwidth channel
-retune every generation implements (default = the full `SetMonitorChannel`): it
-does the RF channel switch only, skipping the steady-state work a hop doesn't
-need, and runs write-only from a compose cache (full dwords primed once per
-epoch, bit changes composed in memory — a masked register write is otherwise a
-read+write USB round-trip, and hop cost is purely transfer count × the chip's
-EP0 latency). Measured medians: 8812AU ~277→1.6 ms, 8822BU ~65→2.5 ms, 8821CU
-~30→0.55 ms, 8822CU/8812EU ~12→2-2.4 ms — FHSS-grade on every generation
-(soak: 12k consecutive dwell-1 per-packet hops, zero TX stalls; kickless
-hopping RX holds a constant catch rate). `DEVOURER_HOP_PROF=1` emits per-stage
-hop timing. It falls back to the full path on a band change; on Jaguar3 it
-serializes on the coex thread's register mutex (the sanctioned in-session hop)
-and preserves the 5/10 MHz narrowband dividers across hops. `send_packet` on
-all three generations also honours a radiotap `CHANNEL` field, so hopping is
-per-packet and radiotap-driven like rate. Both demos hop via
-`DEVOURER_HOP_CHANNELS="1,6,11"` (SweepSpec grammar — also `36-48/4` channel
-ranges and `5170-5250/5` MHz ranges; + `DEVOURER_HOP_DWELL_FRAMES`,
-`DEVOURER_HOP_ROUNDS`, `DEVOURER_HOP_FAST=0|1|2`, `DEVOURER_HOP_RADIOTAP`,
-`DEVOURER_HOP_BW`/`DEVOURER_HOP_OFFSET`). Per-packet hopping doubles as a
-frequency-diversity interleaver for the outer FEC. Validated by
-`tests/run_hop_validation.sh` (B210 wideband), `tests/hop_parity_check.sh`
-(family-aware register parity — all three generations dump the same canary
-from both paths), and `tools/precoder/hop_diversity_sim.py`. The
-implementation, the in-code techniques, and the per-generation ports are
-documented in **`docs/frequency-hopping.md`**.
+`IRtlDevice::FastRetune(channel)` — lean intra-band, same-bandwidth retune on
+every generation (RF channel switch only, write-only from a compose cache);
+falls back to full `SetMonitorChannel` on a band change. FHSS-grade: ~0.5–2.5 ms
+per hop depending on chip. `send_packet` honours a radiotap `CHANNEL` field, so
+hopping is per-packet and radiotap-driven like rate. Demos hop via
+`DEVOURER_HOP_CHANNELS` (SweepSpec grammar: `1,6,11`, `36-48/4`, `5170-5250/5`
+MHz) + `DEVOURER_HOP_DWELL_FRAMES` / `_ROUNDS` / `_FAST` / `_RADIOTAP` /
+`_BW` / `_OFFSET`; `debug.hop_prof` (env `DEVOURER_HOP_PROF=1`) emits per-stage
+timing. Validation: `tests/run_hop_validation.sh`, `tests/hop_parity_check.sh`
+(register parity full-vs-fast). Implementation + per-generation ports:
+`docs/frequency-hopping.md`.
 
-The hop-driven RX counterpart is the sweep/sounding pair: `DEVOURER_RX_SWEEP`
-dwells FastRetune-cheap bins emitting per-bin energy + frame stats
-(`DEVOURER_RX_SWEEP_FULL=1` forces full retunes; `DEVOURER_RX_AGG_SA=canon`
-filters the frame stats to the canonical probe SA), and
-`tests/sounding_sweep.sh` + `tests/sounding_map.py` run the two-ended active
-sounding that recovers a coarse per-bin H(f) of the link — down to 5 MHz bins
-on Jaguar3 (`docs/rx-spectrum-sensing.md`).
-
-`txdemo` also honours a TX-gain ramp + duty knob for thermal /
-TX-power characterisation (drives `RtlJaguarDevice::SetTxPowerOverride` +
-`ApplyTxPower`):
-
-- `DEVOURER_TX_PWR_START=N` — force an absolute per-rate TXAGC index (0..63),
-  bypassing the EFUSE per-rate table. Unset = normal EFUSE-driven power.
-- `DEVOURER_TX_PWR_STOP=N` / `DEVOURER_TX_PWR_STEP=N` / `DEVOURER_TX_PWR_STEP_MS=N`
-  — step the override from START up to STOP by STEP every STEP_MS, in one
-  uninterrupted TX session, emitting a `<devourer-txpwr>index=N` marker per step.
-  The override only moves on-air power for OFDM/HT/VHT rates — drive HT with
-  `DEVOURER_TX_RATE=MCS1` (the CCK path tracks the index in-register but the
-  SDR-measured swing is dominated by the CCK path).
-- `DEVOURER_TX_GAP_US=N` — inter-frame gap in microseconds (default 2000,
-  ~500 fps). `0` = back-to-back for maximum TX duty (heating experiments).
-- `DEVOURER_TX_PWR_READBACK=1` — after each override apply, print
-  `<devourer-txpwr-rb>` with the read-back TXAGC registers (0xc20 CCK 1M /
-  0xc24 OFDM 6M) to confirm the write landed.
-
-The reusable experiment harness lives in `tests/thermal_gain_sweep.py`
-(orchestrator), `tests/sdr_power_probe.py` (USRP receive-power ground truth),
-and `tests/run_thermal_gain_sweep.sh` (build + uv venv + sudo run).
+RX counterpart: `DEVOURER_RX_SWEEP` dwells FastRetune-cheap bins emitting
+per-bin energy + frame stats; `tests/sounding_sweep.sh` + `tests/sounding_map.py`
+recover a coarse per-bin H(f) — down to 5 MHz bins on Jaguar3
+(`docs/rx-spectrum-sensing.md`).
 
 ## Architecture
 
 **The caller owns libusb.** `WiFiDriver::CreateRtlDevice` is intentionally
-thin — `libusb_init`, device open, kernel driver detach, and
+thin — `libusb_init`, device open, kernel-driver detach, and
 `libusb_claim_interface(handle, 0)` must happen **before** handing the handle
-to the factory. `examples/rx/main.cpp` is the canonical boilerplate.
+to the factory. `examples/rx/main.cpp` is the canonical boilerplate;
+`devourer::claim_interface_then_reset` (src/UsbOpen.h) is the recommended
+open path (advisory per-adapter lock before reset).
 
-**Chip identity is resolved at construction** from SYS_CFG bits + USB PID.
-`CreateRtlDevice` returns an `IRtlDevice` (`Init` / `InitWrite` / `send_packet` /
-`StartRxLoop` — the last is the blocking RX worker loop on an already-brought-up
-chip, so one process can `InitWrite` once and run TX + RX concurrently on the
-same claimed handle; `Init` = bring-up + `StartRxLoop` for RX-only callers)
-and dispatches on chip generation: Jaguar-1 PIDs construct `RtlJaguarDevice`;
-Jaguar2 PIDs construct `RtlJaguar2Device`, with the variant selected from the
-`SYS_CFG2` chip-id (`0x0a` → C8822B, `0x09` → C8821C); Jaguar3 PIDs construct
-`RtlJaguar3Device`, with the generation (`rtl8822c` vs `rtl8822e`) selected from
-the `SYS_CFG2` chip-id (`0x13` → C8822C, `0x17` → C8822E). Each orchestrator
-drives bring-up, RX, and TX through its own HAL.
-`RtlJaguarDevice` was previously named `Rtl8812aDevice` — a deprecated alias
-still exists for one release cycle.
+**Chip identity is resolved at construction** from the `SYS_CFG2` chip-id +
+USB PID. `CreateRtlDevice` returns an `IRtlDevice` (`Init` = bring-up + RX
+loop; `InitWrite` = TX bring-up; `StartRxLoop` = blocking RX worker on an
+already-up chip, enabling TX+RX on one handle; `send_packet`) and constructs
+`RtlJaguarDevice` / `RtlJaguar2Device` / `RtlJaguar3Device` per generation.
+`Rtl8812aDevice` is a deprecated alias of `RtlJaguarDevice`.
 
-Generation-agnostic core in `src/` (always compiled; depends on neither
-generation's HAL):
+Generation-agnostic core in `src/` (always compiled; depends on no HAL):
 
 - `WiFiDriver` — the factory (`CreateRtlDevice`).
-- `DeviceConfig.h` — construction-time configuration struct (rx / tx / bf /
-  tuning / debug / usb sections), the library's replacement for env-var
-  knobs; every component copies the sub-struct it consumes at construction.
-- `RtlUsbAdapter` — libusb wrapper (vendor control + bulk transfers).
-- `Radiotap.c` — radiotap header iterator. TX buffers passed to
-  `send_packet` **must** begin with a radiotap header; rate / MCS / VHT /
-  STBC / LDPC / SGI / bandwidth are read from it.
-- `RateDefinitions.h` (`MGN_RATE`), `RxPacket.h` (`Packet` + RX descriptor
-  types), `TxDescBits.h` (`SET_BITS_TO_LE_4BYTE` + LE bit-field helpers) —
-  the symbols both generations' parsers build on, kept neutral so neither
-  generation's header pulls in the other's.
+- `DeviceConfig.h` — construction-time configuration struct; every component
+  copies the sub-struct it consumes at construction.
+- `RtlUsbAdapter` — libusb wrapper (vendor control + bulk transfers); a
+  copyable value type shared by every component.
+- `Radiotap.c` — radiotap iterator. TX buffers passed to `send_packet` **must**
+  begin with a radiotap header; rate/MCS/VHT/STBC/LDPC/SGI/bandwidth are read
+  from it.
+- `RateDefinitions.h`, `RxPacket.h`, `TxDescBits.h` — symbols all generations'
+  parsers build on, kept neutral so no generation's header pulls in another's.
+- `PhyTableLoader` — runtime walker for Realtek's phydm-format register tables
+  (`check_positive` + opcode state machine, without pulling in phydm itself).
+  Shared by Jaguar1 + Jaguar2; Jaguar3 has its own `PhyTableLoaderJaguar3`.
 
-The Jaguar1 HAL lives under `src/jaguar1/`:
+Per-generation HALs (each self-contained):
 
-- `RtlJaguarDevice` — top-level orchestrator (Init / InitWrite / send_packet /
-  StartRxLoop).
-- `HalModule` — chip bring-up, power sequencing, BB/AGC/RF table application,
-  USB EP priority, FIFO/page-boundary init. Most of the chip-family-specific
-  divergence lives here (`_8812A`, `_8814A`, `_8821A` suffixed methods).
-- `RadioManagementModule` — channel, bandwidth, TX power; supports up to 4
-  RF paths for 8814.
-- `EepromManager` — EFUSE / EEPROM read + autoload state; supplies the
-  `cut_version` / `rfe_type` used by `PhyTableLoader::CheckPositive`.
-- `FirmwareManager` — chip-specific FW download (`FirmwareDownload_8814A`
-  uses the 3081-DDMA path; 8812/8821 use the page-write path).
-- `PhyTableLoader` — runtime walker for Realtek's phydm-format register
-  tables (opcode-encoded conditional blocks). Replicates upstream phydm's
-  `check_positive` + state machine **without pulling in phydm itself**.
-- `FrameParser` — RX parsing and TX descriptor layout (`SET_TX_DESC_*_8812`
-  macros are shared across the Jaguar family).
+- `src/jaguar1/`: `RtlJaguarDevice` (orchestrator), `HalModule` (bring-up,
+  power seq, table apply — most chip-family divergence, `_8812A`/`_8814A`/
+  `_8821A` suffixed methods), `RadioManagementModule` (channel/BW/TX power, up
+  to 4 RF paths), `EepromManager` (EFUSE + `cut_version`/`rfe_type` for
+  `CheckPositive`), `FirmwareManager` (8814 = 3081-DDMA path, 8812/8821 =
+  page-write), `FrameParser` (RX parsing + `SET_TX_DESC_*_8812` descriptors).
+- `src/jaguar2/`: shared core (`RtlJaguar2Device`, `HalJaguar2`,
+  `HalmacJaguar2Fw`/`MacInit`, `FrameParserJaguar2.h`) + per-variant strategy
+  interfaces selected by `ChipVariant`: `Jaguar2PhyTables` →
+  `Phy8822bTables`/`Phy8821cTables`, `Jaguar2Calibration` →
+  `Halrf8822b`/`Halrf8821c`. Every strategy seam defaults to `C8822B`, so the
+  8822B path stays byte-identical when the 8821C variant is compiled out.
+- `src/jaguar3/`: `RtlJaguar3Device`, `HalJaguar3` (power seq, table apply,
+  3-wire RF, bf_init, efuse incl. 8822e OTP burst-mode), `HalmacJaguar3Fw`/
+  `MacInit`, `RadioManagementJaguar3` (channel/BW/per-path power, the
+  `0x9b0`/`0x9b4` narrowband dividers, RF18 encoding), strategy interfaces
+  `Jaguar3Calibration` → `Halrf8822c`/`Halrf8822e` and `Jaguar3PhyTables`.
 
-The Jaguar2 HAL is a parallel, self-contained set under `src/jaguar2/`, structured
-like Jaguar3: a shared core (`RtlJaguar2Device`, `HalJaguar2`,
-`HalmacJaguar2Fw`/`MacInit`, `FrameParserJaguar2.h`) with per-variant behaviour
-behind two strategy interfaces selected by `ChipVariant` (`C8822B` / `C8821C`):
-
-- `Jaguar2PhyTables` (interface) → `Phy8822bTables` / `Phy8821cTables`: the
-  `check_positive`-format MAC/BB/AGC/RF register arrays, walked by the shared core
-  `PhyTableLoader`.
-- `Jaguar2Calibration` (interface) → `Halrf8822b` / `Halrf8821c`: IQK/LOK/TXK/RXK,
-  LCK, and WiFi-only coex/antenna control.
-
-`HalJaguar2::set_channel_bw` does channel + 20/40/80 MHz bandwidth
-(central-channel tune, with the 8821C 1T1R BTG/WLG/WLA RF-set); `apply_tx_power`
-programs the per-rate, bandwidth-aware efuse TXAGC clamped to the variant's
-generated `txpwr_lmt` table. Every strategy seam defaults to `C8822B`, so the
-8822B path stays byte-identical when the 8821C variant is compiled out.
-
-The Jaguar3 HAL is a parallel, self-contained set under `src/jaguar3/`. The core
-uses generation-neutral names; per-generation behaviour is behind two strategy
-interfaces selected by `ChipVariant`:
-
-- `RtlJaguar3Device` — orchestrator (Init / InitWrite / send_packet /
-  StartRxLoop / Stop).
-- `HalJaguar3` — bring-up: power-on/off PWR_SEQ, MAC/USB config, BB/AGC/RF table
-  apply, `config_phydm_parameter_init` (3-wire RF), `bf_init`, `enable_tx_path`,
-  efuse access (incl. the 8822e OTP burst-mode / 2-byte-header decode), RFE pins.
-- `HalmacJaguar3Fw` / `HalmacJaguar3MacInit` — HalMAC firmware download + MAC init.
-- `Jaguar3Calibration` (interface) → `Halrf8822c` / `Halrf8822e`: halrf DACK, IQK,
-  TXGAPK, thermal TX-power tracking, coex/antenna control.
-- `Jaguar3PhyTables` (interface) → `Phy8822cTables` / `Phy8822eTables`.
-- `RadioManagementJaguar3` — channel / bandwidth / per-path TX power, the
-  `0x9b0`/`0x9b4` narrowband divider recipe, and the RF18 channel-tune encoding.
-- `FrameParserJaguar3.h` / `PhyTableLoaderJaguar3` — TX/RX descriptors and the
-  phydm table walker (shared across both generations).
-
-`hal/` holds vendor headers and tables ported from Realtek's tree. The
-8814-specific tables under `hal/phydm/rtl8814a/Hal8814_PhyTables.{c,h}` are
-**generated** from the upstream aircrack-ng/rtl8814au source by
-`tools/extract_8814a_phy_tables.py`; the Jaguar3 tables under
-`hal/phydm/rtl8822{c,e}/` and the Jaguar2 tables under `hal/phydm/rtl8822b/` and
-`hal/phydm/rtl8821c/` by `tools/extract_8822c_phy_tables.py` (`--chip 8822b` /
-`--chip 8821c`); the `Hal8822b_TxpwrLmt.h` / `Hal8821c_TxpwrLmt.h` regulatory
-limits by `tools/extract_8822b_txpwr_lmt.py` / `tools/extract_8821c_txpwr_lmt.py`;
-and the 8821C firmware blob (`hal/hal8821c_fw.{c,h}`) by
-`tools/extract_8821c_fw.py`. Edit the generators, not the output. The runtime
-table walker is the shared `PhyTableLoader` (Jaguar1 + Jaguar2, the latter fed by
-`Jaguar2PhyTables`) / `src/jaguar3/PhyTableLoaderJaguar3` (Jaguar3), not the
-upstream phydm parser.
+`hal/` holds vendor headers and tables. The per-chip PHY/limit tables and the
+8821C firmware blob are **generated** by `tools/extract_*.py` — edit the
+generators, never the output files.
 
 ## Hardware gotchas
 
-- **ZeroCD trap**: some Realtek dongles enumerate first as a USB
-  mass-storage device (`0bda:1a2b` is the canonical offender) exposing the
-  Windows installer, then re-enumerate as the NIC after a mode switch. If
+- **ZeroCD trap**: some Realtek dongles enumerate first as USB mass-storage
+  (`0bda:1a2b`) exposing a Windows installer, then re-enumerate as the NIC. If
   `libusb_open_device_with_vid_pid` returns NULL, check `lsusb` — may need
-  `usb_modeswitch` first.
+  `usb_modeswitch`.
 - **rmmod/sysfs-unbind actively de-inits the chip** (RF off, MAC DMA off).
-  After detaching a kernel driver, expect to re-init from cold, not warm.
-  `DEVOURER_SKIP_RESET=1` only helps when firmware state is still intact.
-- **Bench measurement**: measure TX as on-air **Mbps via SDR duty × PHY rate**
-  (`tests/bench_onair.py`), not monitor-sniffer frame counts — a sensitive
-  receiver decodes weak frames and masks a real drop. Keep a known-good control
-  adapter and re-check it each session; take one clean SDR read per session (a
-  second back-to-back `sdr_duty` read can fail to reacquire and report ~0).
+  After detaching a kernel driver, expect a cold re-init; `DEVOURER_SKIP_RESET`
+  only helps when firmware state is intact.
+- **The chip retains state across soft re-init** — cold-bisect hardware
+  problems with a VBUS power-cycle, not a re-run.
 
 ## TX path
 
@@ -567,7 +293,8 @@ dev->InitWrite(SelectedChannel{ .Channel = 36, .ChannelOffset = 0,
 dev->send_packet(buffer, len);  // buffer[0..] = radiotap header, then 802.11
 ```
 
-The canonical test beacon (`examples/tx/main.cpp`) uses SA `57:42:75:05:d6:00` —
-the same constant is hardcoded into `examples/rx/main.cpp` as the `<devourer-tx-hit>`
-matcher and into `tests/regress.py` (`CANONICAL_SA`). Change all three
-together if it ever moves.
+The canonical test beacon (`examples/tx/main.cpp`) uses SA
+`57:42:75:05:d6:00` — the same constant is hardcoded into
+`examples/rx/main.cpp` as the `<devourer-tx-hit>` matcher and into
+`tests/regress.py` (`CANONICAL_SA`). Change all three together if it ever
+moves.

--- a/README.md
+++ b/README.md
@@ -1,92 +1,79 @@
 # devourer
 
-The Realtek 11ac driver that simply devours its competitors.
+**The Realtek 11ac driver that simply devours its competitors.**
 
-Devourer is a userspace re-implementation of Realtek's RTL88xxAU Wi-Fi
-driver, speaking to the chip directly through libusb. It covers three chip
-generations: the first-generation **Jaguar** 802.11ac family (RTL8812AU,
-RTL8814AU, and RTL8821AU shipping on every band, RTL8811AU via the 8812
-code path); the **Jaguar2** **RTL8822BU** (RTL8812BU via the 8822B code path)
-and the 1T1R + BT **RTL8811CU** (chip **8821C**),
-2.4/5 GHz at 20/40/80 MHz; and
-the **Jaguar3** parts — `rtl8822c` (RTL8812CU / RTL8822CU) and `rtl8822e`
-(RTL8812EU / RTL8822EU) — which additionally reach **5/10 MHz narrowband**
-operation the Jaguar-1 silicon physically can't. No kernel module, no
-`rtl8812au` DKMS tree — just a C++20 static library (`devourer`) plus example
-executables under `examples/`. It is the OpenIPC project's driver of choice
-for long-range video links built on top of cheap Realtek 11ac USB radios.
+Devourer is a userspace Wi-Fi driver for Realtek's 802.11ac USB adapters —
+the cheap, everywhere-available dongles that power most long-range FPV video
+links. It talks to the chip directly over libusb: no kernel module, no DKMS
+tree to patch every time your kernel updates, no root filesystem to taint.
+Build one static library, link it, and you have raw monitor-mode RX and
+packet injection on three generations of Realtek silicon, from a single API.
 
-## Hardware landscape
+It is the [OpenIPC](https://openipc.org) project's driver of choice for
+long-range digital video links.
 
-Devourer targets **RTL8812AU**, **RTL8811AU**, **RTL8814AU**, and
-**RTL8821AU** — all members of Realtek's first-generation 802.11ac
-silicon family, internally codenamed **"Jaguar"**. The HAL,
-register-table layout, firmware-download plumbing, and
-`SET_TX_DESC_*_8812` macros in `src/jaguar1/FrameParser.h` are shared across
-the family; chip-specific EEPROM handling, firmware blobs, and RF tables are
-layered on top.
+## Why devourer
 
-It also targets the **Jaguar2** family through a second self-contained HAL under
-`src/jaguar2/`, dispatched on the `SYS_CFG2` chip-id: the **RTL8822BU** (chip
-**8822B**, 2T2R USB, `2357:012d` / `0bda:b82c`, chip-id `0x0a`) and its 1T1R cut
-**RTL8812BU** (single-path via `REG_SYS_CFG` bit 27 like RTL8811AU on Jaguar1),
-plus the 1T1R + BT **RTL8811CU** (chip **8821C**, `0bda:c811`, chip-id
-`0x09`). The two silicon are selected behind `ChipVariant` strategy interfaces
-(per-generation PHY tables + halrf calibration), mirroring the Jaguar3 split.
-Jaguar2 is a hybrid of the other two: HalMAC firmware download, MAC init and
-power sequencing follow the Jaguar3 path, while the BB/AGC/RF register tables use
-the older phydm `check_positive` format like Jaguar1. Bring-up is ported from the
-vendor rtl88x2bu / rtl8821cu trees and reaches on-air RX + TX across **2.4 and
-5 GHz at 20/40/80 MHz** with per-rate, bandwidth-aware efuse TX power.
+- **No kernel driver, no driver hell.** Everything runs in your process via
+  libusb. The same code works on Linux, macOS, Windows, and Android (Termux)
+  — including platforms the vendor drivers never supported.
+- **Faster on-air than the kernel driver.** Ready-to-receive and
+  ready-to-transmit come up quicker than the vendor `.ko` on every supported
+  chip ([numbers](docs/startup-time.md)).
+- **Per-packet control.** Every injected frame carries its own radiotap
+  header: rate, bandwidth, guard interval, coding, STBC — even TX power and
+  channel — can change frame by frame. That turns one dongle into an
+  adaptive-link engine: unequal error protection for video layers, live
+  power control, per-packet frequency hopping.
+- **Frequency hopping at FHSS speed.** A channel hop costs ~0.5–2.5 ms
+  depending on chip — fast enough to hop on every packet
+  ([how](docs/frequency-hopping.md)).
+- **Narrowband modes the kernel can't do.** 5 and 10 MHz channels on the
+  newest chips — half/quarter the bandwidth, more range from the same power.
+- **A radio lab in a dongle.** Channel sounding, per-antenna signal quality,
+  beamforming report capture (enough to do
+  [motion sensing](docs/beamforming-victim-sensing.md)), spectrum sweeps,
+  link-health diagnosis that tells you whether to add or *back off* power.
+- **Clean library API.** One `DeviceConfig` struct at construction, runtime
+  setters for everything that changes mid-flight, zero environment-variable
+  magic inside the library.
 
-Finally, the **Jaguar3** parts run through a third self-contained HAL under
-`src/jaguar3/`, dispatched at the factory from the `SYS_CFG2` chip-id and USB
-PID: the `rtl8822c` generation (**RTL8812CU** / **RTL8822CU**, `0bda:c812`,
-`0bda:c82c`) and the `rtl8822e` generation (**RTL8812EU** / **RTL8822EU**,
-`0bda:a81a`). These add **5/10 MHz narrowband** operation the Jaguar-1 silicon
-lacks. Bring-up is ported from Realtek's vendor source.
+New to low-level RF? Start with the [visual RF primer](docs/rf-primer.md) —
+eight short animations that make the rest click.
 
-Band cells are **devourer on-air TX throughput** (Mbps, HT MCS7, 20 MHz) via
-USRP channel-occupancy (`tests/bench_onair.py`). `†` = on-air but the reading
-varies run-to-run (bracketed = best clean reading).
+## Supported hardware
+
+Bandwidth cells are devourer's measured on-air TX throughput (Mbps, HT MCS7,
+20 MHz) per band:
 
 | Part                          | RF / streams      | 2.4 GHz (ch6) | UNII-1 (ch36) | UNII-2/3 (ch149) | Notes                                       |
 | ----------------------------- | ----------------- | ------------- | ------------- | ---------------- | ------------------------------------------- |
 | **RTL8812AU**                 | 2T2R              | 56            | 52            | 52               | [CHANEVE CHW50L](https://www.aliexpress.com/item/4000762461362.html) (`0bda:8812`) |
-| **RTL8811AU**                 | 1T1R              | —             | —             | —                | 1T1R cut of 8812 silicon; rides the 8812 code path (`RFType=RF_TYPE_1T1R` from `REG_SYS_CFG` bit 27). Not benchmarked |
-| **RTL8814AU**                 | 4T4R, 3-SS max    | 65            | †(32)         | †(32)            | `0bda:8813`; tested on COMFAST CF-938AC (2 ext antennas) and CF-960AC (4 internal) — effective RX-diversity branches differ (N_eff ≈ 3.8 vs 2.6) despite identical silicon, see [`docs/measuring-spatial-diversity.md`](docs/measuring-spatial-diversity.md) |
+| **RTL8811AU**                 | 1T1R              | —             | —             | —                | 1T1R cut of 8812 silicon; rides the 8812 code path. Not benchmarked |
+| **RTL8814AU**                 | 4T4R, 3-SS max    | 65            | †(32)         | †(32)            | `0bda:8813`; tested on COMFAST CF-938AC and CF-960AC — antenna builds differ in realised [RX diversity](docs/measuring-spatial-diversity.md) |
 | **RTL8821AU**                 | 1T1R AC + BT      | 54            | 32            | 28               | TP-Link Archer T2U Plus (`2357:0120`) |
 | **RTL8822BU**                 | 2T2R + BT         | 52            | 50            | 49               | TP-Link Archer T3U (`2357:012d`) |
-| **RTL8812BU**                 | 1T1R + BT         | —             | —             | —                | 1T1R cut of the 8822B silicon; rides the 8822BU code path (single-path via `REG_SYS_CFG` bit 27). Not benchmarked (`0xb812`) |
+| **RTL8812BU**                 | 1T1R + BT         | —             | —             | —                | 1T1R cut of 8822B silicon; rides the 8822BU code path. Not benchmarked |
 | **RTL8811CU**                 | 1T1R + BT         | 36            | 29            | 28               | COMFAST CF-811AC (`0bda:c811`) |
 | **RTL8812CU**                 | 2T2R              | 65            | 60            | 60               | LB-LINK WDN1300H (`0bda:c812`) |
 | **RTL8822CU**                 | 2T2R + BT         | —             | —             | —                | not benchmarked (`0bda:c82c`) |
-| **RTL8812EU**                 | 2T2R              | 8             | 51            | 47               | LB-LINK BL-M8812EU2 (`0bda:a81a`); bare 5 GHz FPV module |
-| **RTL8822EU**                 | 2T2R + BT         | —             | —             | —                | not benchmarked (`rtl8822e`) |
+| **RTL8812EU**                 | 2T2R              | 8             | 51            | 47               | LB-LINK BL-M8812EU2 (`0bda:a81a`); bare 5 GHz FPV module. 5/10 MHz capable |
+| **RTL8822EU**                 | 2T2R + BT         | —             | —             | —                | not benchmarked. 5/10 MHz capable |
 
-The **8822BE** (the PCIe sibling of the in-scope 8822BU) and the later
-**`Kestrel`** 11ax generation are **out of scope**: they share the Realtek
-"AU" / "BU" branding but the bus or baseband differs enough that they would
-need their own driver. Two naming traps worth calling out: RTL8821AU is
-Jaguar wave 1 (CHIP_8821 = 7 in Realtek's HalVerDef, shares the enum with
-CHIP_8812), **not** Jaguar2; and the RTL8822**B**U (Jaguar2) is a different
-chip from the RTL8822**C**U (Jaguar3, `rtl8822c`) despite the shared "8822"
-number — devourer supports both through separate HALs.
+`†` = works on-air but the reading varies run-to-run (bracketed = best clean
+reading).
 
-> Heads up — some Realtek USB sticks ship in "ZeroCD" mode and enumerate first
-> as a USB mass-storage device exposing the Windows driver installer
-> (`0bda:1a2b` is the canonical offender), then re-enumerate as the NIC after
-> a mode switch. If `libusb_open_device_with_vid_pid(ctx, 0x0bda, 0x8812)`
-> returns NULL, check `lsusb` — you may need `usb_modeswitch` to flip it
-> first.
+Out of scope: the PCIe siblings (e.g. 8822BE) and the 11ax "Kestrel"
+generation — same branding, different bus or baseband.
 
-## Building
+> Heads up — some Realtek sticks ship in "ZeroCD" mode and first enumerate as
+> a USB flash drive holding a Windows installer (`0bda:1a2b` is the canonical
+> offender). If the device won't open, check `lsusb`; `usb_modeswitch` flips
+> it to the real NIC.
 
-Toolchain: CMake ≥ 3.15, a C++20 compiler, and libusb-1.0.
+## Quick start
 
-### Linux / macOS
-
-libusb is located via `pkg-config`:
+Toolchain: CMake ≥ 3.15, a C++20 compiler, libusb-1.0.
 
 ```sh
 # Debian/Ubuntu
@@ -98,185 +85,45 @@ cmake -S . -B build
 cmake --build build -j
 ```
 
-### Windows
+On Windows, install libusb via vcpkg (`vcpkg install libusb`) and set
+`VCPKG_ROOT` before configuring.
 
-Dependencies come from vcpkg. Set `VCPKG_ROOT` so the CMake toolchain file at
-`$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake` resolves:
-
-```powershell
-git clone https://github.com/Microsoft/vcpkg.git
-cd vcpkg
-.\bootstrap-vcpkg.bat
-.\vcpkg integrate install
-.\vcpkg install libusb
-```
-
-Then the same `cmake -S . -B build && cmake --build build` from the project
-root.
-
-### Build artifacts
-
-- `devourer` — static library; link this from your application.
-- `rxdemo` — RX example built from `examples/rx/main.cpp`. Walks every
-  Realtek device under VID `0bda` and tries to open it; sets monitor mode
-  on channel 36 / 20 MHz, runs the read loop.
-- `txdemo` — TX example built from `examples/tx/main.cpp`. Opens the
-  device via `libusb_open_device_with_vid_pid` by default, or wraps a USB
-  fd passed as `argv[1]` (the Termux-on-Android pattern using
-  `libusb_wrap_sys_device`). Forks RX into a child, TX-loops a hardcoded
-  beacon in the parent.
-- `streamtx` / `duplex` / `svctx` / `precoder` / `txpower` / `sense` —
-  specialised examples, one directory each under `examples/`.
-
-### Selecting which chips to build
-
-All chips are compiled in by default. Turn off the ones you don't need to
-drop their firmware blobs and generated PHY tables and shrink the binary —
-an 8812AU-only `rxdemo` is ~1.0 MB versus ~2.6 MB with everything on.
-
-| CMake option | default | chips |
-|---|---|---|
-| `DEVOURER_JAGUAR1` | ON | RTL8812AU / 8811AU / 8821AU |
-| `DEVOURER_8814` | ON | RTL8814AU (requires `DEVOURER_JAGUAR1`) |
-| `DEVOURER_JAGUAR2_8822B` | ON | RTL8822BU / 8812BU |
-| `DEVOURER_JAGUAR2_8821C` | ON | RTL8811CU |
-| `DEVOURER_JAGUAR3_8822C` | ON | RTL8812CU / 8822CU |
-| `DEVOURER_JAGUAR3_8822E` | ON | RTL8812EU / 8822EU |
+Then, with a supported dongle plugged in:
 
 ```sh
-# 8812AU/8811AU/8821AU only
-cmake -S . -B build -DDEVOURER_8814=OFF \
-      -DDEVOURER_JAGUAR2_8822B=OFF -DDEVOURER_JAGUAR2_8821C=OFF \
-      -DDEVOURER_JAGUAR3_8822C=OFF -DDEVOURER_JAGUAR3_8822E=OFF
+sudo ./build/rxdemo                    # receive: monitor mode, prints frames
+sudo ./build/txdemo                    # transmit: injects a test beacon
+DEVOURER_CHANNEL=100 DEVOURER_TX_RATE=MCS7/40 sudo -E ./build/txdemo
 ```
 
-Configure fails if no chip is selected, or if `DEVOURER_8814` is on without
-`DEVOURER_JAGUAR1`. A chip whose support isn't built is rejected at runtime
-(the factory returns `nullptr` and logs which).
+The demos find the first supported adapter automatically; `DEVOURER_PID` /
+`DEVOURER_VID` pin a specific one. Every configuration knob the demos accept
+is an environment variable — the complete catalogue, with value grammar, is
+the `env:` tags in [`src/DeviceConfig.h`](src/DeviceConfig.h).
 
-### Demo env vars
+### Example binaries
 
-Env vars are the demos' interface, not the library's: the library is
-configured through `devourer::DeviceConfig` (`src/DeviceConfig.h`, passed to
-`CreateRtlDevice`) and the runtime setters on `IRtlDevice`, and reads no
-environment itself. The demos map each library-level `DEVOURER_*` var onto a
-`DeviceConfig` field in `examples/common/env_config.{h,cpp}`; each field's
-`env:` tag in `DeviceConfig.h` names its variable and value grammar.
+| binary | what it shows |
+|---|---|
+| `rxdemo` | monitor-mode RX loop with per-frame signal telemetry |
+| `txdemo` | packet injection, rate/power/channel control, hopping |
+| `streamtx` / `duplex` | stdin-driven TX / full-duplex packet link |
+| `svctx` | per-video-layer rate ladders (unequal error protection) |
+| `txpower` | runtime TX-power API walkthrough |
+| `sense` | Wi-Fi motion sensing from beamforming reports |
+| `precoder` | OFDM subcarrier shaping proof-of-concept |
 
-Common to both demos:
-
-- `DEVOURER_PID=0xNNNN` — restrict the device-open loop to a single PID
-  (e.g. `0x8813` for RTL8814AU, `0xc812` for the Jaguar3 RTL8812CU). The
-  factory picks the Jaguar1 or Jaguar3 HAL from the PID automatically.
-- `DEVOURER_VID=0xNNNN` — override VID (default `0x0bda`). Needed for
-  OEM-rebadged dongles like the TP-Link Archer T2U Plus (`2357:0120`).
-- `DEVOURER_CHANNEL=N` — override the demo's monitor channel (e.g. `6`
-  for 2.4 GHz, `36` for 5 GHz).
-- `DEVOURER_SKIP_RESET=1` — skip `libusb_reset_device` before claim. Useful
-  when picking up a chip whose firmware is already running (e.g. after
-  unbinding a kernel driver that left fw state intact).
-- `DEVOURER_SKIP_TXPWR=1` — skip the per-rate TX-power loop entirely on
-  every chip (it runs by default, including 8814). Useful for fast
-  iteration during BB/RF debugging when the per-rate indices aren't
-  relevant to what you're measuring.
-- `DEVOURER_FORCE_IQK=1` — run phydm I/Q calibration on every channel-set,
-  not just band transitions. For 8814, IQK is otherwise off by default —
-  the kernel doesn't run it on `iw set channel` either, and devourer
-  matches that behaviour.
-- `DEVOURER_DISABLE_IQK=1` — never run IQK, even when armed by a band
-  transition. Diagnostic — IQK-output BB regs stay at their BB-init seeds.
-- `DEVOURER_PHYDM_WATCHDOG=1` — start the periodic phydm DM watchdog
-  thread (FA-counter statistics + DIG IGI walk every ~2 s). Off by
-  default because the watchdog's BB reads/writes share libusb's
-  transfer queue with the TX bulk path and measurably drop sustained
-  TX throughput on Jaguar chips. Use for canary-diff workflows and
-  RX-only DIG tuning.
-- `DEVOURER_DUMP_CANARY=1` — emit a canonical post-channel-set dump of
-  BB/MAC/RF anchor registers. Feeds the `tests/canary_diff.py`
-  cross-validation tool against `tools/canary_kernel_dump.sh` output.
-- `DEVOURER_USB_DEBUG=1` — raise libusb log level from the default WARNING
-  to DEBUG (produces ~7 MB per 15 s, can fill `/tmp` mid-capture, and slows
-  init measurably). `DEVOURER_USB_QUIET` is accepted as a no-op.
-
-`rxdemo` (RX)-only knobs:
-
-- `DEVOURER_RX_ENERGY_MS=N` — frame-free RX energy / interferer-detection
-  telemetry (the read side of `DEVOURER_CW_TONE`). Every `N` ms emit a
-  `<devourer-energy>` line combining the chip's phydm false-alarm + CCA
-  (channel-busy) counters and DIG IGI (`IRtlDevice::GetRxEnergy`, frame-free,
-  all three generations) with a rolling per-frame RSSI/SNR aggregate. A second
-  adapter running this detects the first adapter's CW carrier: co-located, a
-  strong tone pushes `cca_ofdm` far out of its ambient band — a large spike (the
-  2T2R 8822CU registers the carrier as busy) or a collapse toward zero (the
-  1T1R parts' AGC saturates and RX goes deaf). No SDR needed. 0 = disabled.
-  Validate with `tests/rx_energy_probe.sh` (+ `tests/rx_energy_check.py`).
-  Reads channel-wide scalars, not per-subcarrier CSI (no Realtek 88xx chip
-  exports CSI to the host); build a coarse spectrum by sweeping channels.
-  Each interval also emits a `<devourer-nhm>` line — the frame-free phydm NHM
-  (noise histogram): a 12-bucket, IGI-referenced in-band power distribution
-  (`peak` = fullest bucket, `busy` = percent above the noise floor, `hist` =
-  the raw counts low→high power). An in-band interferer shifts the histogram's
-  mass into higher buckets (measured: peak bucket 5→8 on the 8822CU under a
-  co-located CW tone). All three generations.
-- `DEVOURER_RX_SWEEP="1,6,11"` — coarse **live spectrum map**. Cycle the listed
-  bins (also accepts channel ranges `36-48/4` and MHz ranges `5170-5250/5`),
-  dwelling `DEVOURER_RX_SWEEP_DWELL_MS` (default 300) on each, and emit one
-  `<devourer-energy>ch=N` line per bin carrying the frame-free counters, the
-  measured `retune_us`, and the dwell's per-frame
-  `frames/rssi_mean/rssi_max/snr_mean/snr_min/evm_mean` aggregate. The RX loop
-  runs on a worker thread while the main thread retunes between reads via the
-  lean `FastRetune` (`DEVOURER_RX_SWEEP_FULL=1` forces the full
-  `SetMonitorChannel` per dwell) — one process, uniform across all three
-  generations. Park a `DEVOURER_CW_TONE` on one channel (another adapter) and
-  the map peaks (or, on the saturating 1T1R parts, dips) at that channel.
-  Resolution = the channel grid (20 MHz), down to ~5 MHz on Jaguar3 with
-  `DEVOURER_NB_BW=5`. Render with `tests/rx_spectrum_sweep.sh` +
-  `tests/rx_spectrum_sweep.py`.
-- `DEVOURER_RX_AGG_SA=canon|<mac>` — restrict the per-frame aggregate (energy
-  telemetry + sweep) to frames whose SA matches (`canon` = the canonical txdemo
-  beacon SA). The active-sounding filter: a prober hopping fixed-rate beacons
-  across the sweep's bins (`tests/sounding_sweep.sh`) turns the sweep into a
-  coarse per-bin H(f) map of the actual link, rendered by
-  `tests/sounding_map.py` (see `docs/rx-spectrum-sensing.md`).
-
-`txdemo`-only knobs:
-
-- `DEVOURER_TX_RATE=<rate>[/<bw>][/SGI][/LDPC][/STBC]` — the on-air TX mode,
-  parsed into a `devourer::TxMode` and applied via `RtlJaguarDevice::SetTxMode`.
-  `<rate>` = `6M`..`54M` (legacy OFDM) | `MCS0`..`MCS31` (HT) |
-  `VHT1SS_MCS0`..`VHT4SS_MCS9` (VHT); `<bw>` = `20|40|80|160`. Unset = `6M`.
-  Examples: `MCS7`, `MCS7/40/SGI`, `VHT2SS_MCS3/80/LDPC`.
-- `DEVOURER_TX_PAYLOAD_BYTES=N` — pad the 802.11 PSDU up to `N` bytes (on-wire
-  `N + 40`). For throughput testing — `N=3993` is wfb-ng's max frame payload.
-- `DEVOURER_CW_TONE=1` — emit a bare RF local-oscillator CW carrier at the
-  `DEVOURER_CHANNEL` center frequency (Realtek MP single-tone, path A). Supported
-  on all USB generations, each via its own vendor recipe: Jaguar-1 (8812AU/8821AU
-  via OFDM/CCK off + RFE pinmux; 8814AU via CCA off + per-path TX-scale zero),
-  Jaguar-2 (8822BU via OFDM/CCK off + RFE pinmux + RFE-inverse; 8811CU/8821CU via
-  the 8821C path-A pinmux + RF 0x75[16] BTG / RF 0x58[1] LO gate), and Jaguar-3
-  (8822CU/8822EU — the halbb generation needs the RF-mode register written through
-  the HSSI 3-wire port and the BB held in continuous TX, else its RF state machine
-  re-drives the mode back to RX). The demo idle-holds the carrier until SIGINT,
-  then restores the chip. `DEVOURER_CW_TONE_GAIN=0..31` sets the RF gain index
-  (`RF 0x00[4:0]`, default 0 = lowest). A controllable narrowband interferer / MP
-  tone source; SDR-validate with `tests/cw_tone_sdr.sh` (+ `tests/cw_tone_probe.py`).
-- `DEVOURER_CONT_TX=1` — the modulated sibling of the CW tone: a true 100%-duty
-  modulated OFDM carrier (Realtek's MP hardware continuous-TX mode) on all three
-  generations, instead of a bare tone. A full-channel active stimulus for
-  spectral / power / thermal characterisation — one of the adaptive-link building
-  blocks. 100% duty is the worst-case PA heat — a debug/characterisation knob, not
-  for sustained use. See
-  [`docs/adaptive-link-building-blocks.md`](docs/adaptive-link-building-blocks.md).
-
-On-air TX throughput vs wfb-ng (SDR-verified parity; how to reproduce) is
-documented in [`docs/wfb-ng-tuning.md`](docs/wfb-ng-tuning.md).
+All chips compile in by default; per-chip CMake options (`DEVOURER_JAGUAR1`,
+`DEVOURER_8814`, `DEVOURER_JAGUAR2_8822B`, `DEVOURER_JAGUAR2_8821C`,
+`DEVOURER_JAGUAR3_8822C`, `DEVOURER_JAGUAR3_8822E`) drop unneeded firmware
+and tables — an 8812AU-only `rxdemo` is ~1.0 MB versus ~2.6 MB with
+everything on.
 
 ## Using the library
 
-The caller owns libusb: you must `libusb_init`, open the device, detach any
-kernel driver, and `libusb_claim_interface(handle, 0)` **before** handing
-the handle to `WiFiDriver::CreateRtlDevice`. The factory is intentionally
-thin — see `examples/rx/main.cpp` for the full boilerplate. A minimal RX path:
+You own libusb: init it, open the device, detach any kernel driver, claim
+interface 0 — then hand the handle to the factory. `examples/rx/main.cpp` is
+the full boilerplate; the minimal RX path is:
 
 ```cpp
 auto logger = std::make_shared<Logger>();
@@ -289,119 +136,47 @@ dev->Init(packetProcessor, SelectedChannel{
 });
 ```
 
-Construction-time knobs (RX filter behaviour, beamforming arming,
-calibration gates, diagnostics) go in a `devourer::DeviceConfig` passed as
-the factory's fourth argument — `src/DeviceConfig.h` documents every field:
+`packetProcessor` is your `void(const Packet&)` callback. For TX, call
+`InitWrite` and then `send_packet(buffer, len)`, where the buffer starts with
+a radiotap header describing how the frame should fly.
+
+Construction-time options travel in a `devourer::DeviceConfig`
+([`src/DeviceConfig.h`](src/DeviceConfig.h) documents every field):
 
 ```cpp
 devourer::DeviceConfig cfg;
-cfg.rx.keep_corrupted = true;                  // FCS-failed frames to host
-cfg.debug.log_writes = true;                   // <wlog> register-write trace
+cfg.rx.keep_corrupted = true;                  // deliver CRC-failed frames too
 auto dev = driver.CreateRtlDevice(handle, ctx, lock, cfg);
 ```
 
-Knobs that change mid-session are runtime setters on the device instead
-(`SetTxMode`, `SetTxPowerOffsetQdb`, `SetRxPathMask`, `SetCcaMode`, ...).
+Anything that changes mid-session is a runtime setter on the device:
+`SetTxMode`, `SetTxPowerOffsetQdb`, `SetRxPathMask`, `FastRetune`, ...
+The device class is chosen automatically from the chip behind the handle;
+one `IRtlDevice` interface covers all three generations.
 
-`packetProcessor` is your `void(const Packet&)` callback. `Init` runs the
-RX loop until `should_stop` is set, then returns. For TX, use `InitWrite`
-on a channel followed by `send_packet(buffer, len)` where the buffer begins
-with a radiotap header (the iterator in `src/Radiotap.c` extracts
-rate/MCS/VHT/STBC/LDPC/SGI/bandwidth from it).
+## Going deeper
+
+- [Visual RF primer](docs/rf-primer.md) — animated intro to the concepts
+  behind everything below.
+- [Adaptive link](docs/adaptive-link.md) — the energy-minimizing video-link
+  controller design, and [its validation](docs/adaptive-link-validation.md).
+- [Fused FEC](docs/fused-fec.md) — the cross-layer error-protection stack:
+  per-layer PHY rates, corrupt-frame salvage, outer erasure code.
+- [Frequency hopping](docs/frequency-hopping.md) — how per-packet hopping
+  works and what it costs on each chip.
+- [Startup time](docs/startup-time.md) — devourer vs. kernel driver,
+  measured on every supported chip.
+- [Spectrum sensing](docs/rx-spectrum-sensing.md),
+  [spatial diversity](docs/measuring-spatial-diversity.md),
+  [bench testing near-field](docs/bench-testing-near-field.md) — measurement
+  guides for the built-in radio instrumentation.
 
 ## Testing
 
-Out-of-band regression rig in `tests/regress.py` — runs a cross-driver
-TX/RX matrix between devourer and the kernel driver across plugged-in
-USB Wi-Fi adapters. Default mode is a 4-cell matrix on one ordered
-pair; `--full-matrix` extends to all ordered pairs; `--encoding-matrix`
-adds radiotap encoding sweeps (HT BCC/LDPC/STBC + VHT BCC/LDPC); and
-`--sniffer-iface IFACE` adds a 3rd-adapter monitor capture for
-verifying what actually flies on-air.
-
-See [`tests/README.md`](tests/README.md) for setup (host + libvirt VM
-modes), per-mode CLI knobs, and the regression matrix's known
-limitations (notably: `aircrack-ng/88XXau` strips radiotap LDPC + STBC
-on the kernel-TX path, so the `kernel`-TX rows of `--encoding-matrix`
-are not authoritative for LDPC/STBC asymmetries — devourer-TX rows
-ARE).
-
-### Video link design
-
-The long-range video link's design documents:
-[`docs/adaptive-link.md`](docs/adaptive-link.md) — the energy-minimizing adaptive
-controller (VTX ↔ VRX), and how it compares to OpenIPC's `alink` and other
-adaptive systems; [`docs/adaptive-link-validation.md`](docs/adaptive-link-validation.md)
-— its simulation + on-air results, the measurement methodology, and the open
-questions, with the [linklab](https://github.com/josephnef/linklab) simulation
-sandbox; and [`docs/fused-fec.md`](docs/fused-fec.md) — the cross-layer
-(PHY-MCS ⊕ sub-block-integrity ⊕ outer erasure) FEC stack the link's per-layer
-quality SLA is stated against.
-
-New to the low-level RF machinery? [`docs/rf-primer.md`](docs/rf-primer.md) is a
-visual primer — eight short animations (the OFDM channel, the constellation, the
-TX pipeline, a tone vs a modulated carrier, AGC saturation, channel sounding,
-antenna diversity, and frequency hopping) that make the rest of the docs click.
-
-### Startup time
-
-Devourer reaches ready-to-RX/TX faster than the kernel driver on every
-supported chip — measured numbers and the benchmark methodology
-(`tests/bench_init.py`) in [`docs/startup-time.md`](docs/startup-time.md).
-
-## Project layout
-
-```
-hal/      Vendor headers and tables ported from Realtek's tree
-          Hal8812PhyReg.h, hal8812a_fw.[ch], rtl8812a_spec.h
-          Hal8814PhyReg.h, hal8814a_fw.[ch], Hal8814PwrSeq.[ch]
-          rtl8814a/Hal8814_PhyTables.[ch]    (8814 BB/AGC/RF tables)
-          Hal8812a_PhyRegPg.h                (per-rate TX-power PG table)
-          Hal8812a_TxpwrLmt.h                (per-region TX-power limit table)
-          Hal8812a_TxPwrTrack.[h,cpp]        (phydm thermal-meter delta-swing tables)
-          hal8822c_fw.[ch], phydm/rtl8822c/  (Jaguar3 firmware blob + BB/AGC/RF tables)
-src/      Driver implementation
-          Generation-agnostic core (always compiled):
-          WiFiDriver             thin factory (dispatches Jaguar1 vs Jaguar3 by chip-id)
-          DeviceConfig.h         construction-time configuration (env-free library)
-          IRtlDevice             chip-family-agnostic device interface
-          RtlUsbAdapter          libusb wrapper (vendor + bulk transfers)
-          Radiotap.c             radiotap header iterator
-          RateDefinitions.h      MGN_* rate enum (shared by both generations)
-          RxPacket.h             RX packet / descriptor types (shared)
-          TxDescBits.h           little-endian TX-descriptor bit-field macros (shared)
-          TxMode                 runtime TX-mode parsing
-
-          jaguar1/               Jaguar1 (8812/8811/8821/8814) HAL
-          RtlJaguarDevice        Jaguar1 orchestrator (RX + TX entry points)
-          HalModule              chip bring-up / power sequencing
-          RadioManagementModule  channel, bandwidth, TX power, up to 4 RF paths
-          EepromManager          EFUSE / EEPROM read + autoload state
-          FirmwareManager        chip-specific firmware download
-          PhyTableLoader         applies chip-cut-conditional BB/AGC tables
-          PowerTracking8812a     phydm thermal-meter TX BB-swing compensation
-          Iqk8812a / Iqk8814a    phydm I/Q calibration (8812/8821; 8814 4-path)
-          PhydmWatchdog          opt-in periodic DM thread (FA stats + DIG)
-          FrameParser            RX parsing, TX descriptor layout
-
-          jaguar3/               Jaguar3 (rtl8822c / rtl8822e) HAL — RtlJaguar3Device,
-                                 HalMAC firmware download, halrf calibration, 5/10 MHz
-                                 narrowband, per-generation PHY/RF tables + TX/RX descriptors
-examples/ Example executables (one directory per demo)
-          rx/        RX example (rxdemo)
-          tx/        TX example (txdemo; Android / Termux pattern)
-          streamtx/  stdin-driven TX (streamtx)
-          duplex/    stdin TX + RX duplex (duplex)
-          svctx/     HEVC SVC-T UEP injector (svctx)
-          precoder/  OFDM subcarrier precoding PoC (precoder)
-          txpower/   runtime TX-power API reference (txpower)
-          sense/     beamforming motion/presence sensor (sense)
-          common/    env_config (DEVOURER_* -> DeviceConfig translator),
-                     stream_stdin.h shared framing + selftest
-```
-
-Each chip generation can be compiled out to shrink the binary — see
-**Selecting which chips to build** below.
+Headless selftests run with `ctest`. Hardware regression is
+`tests/regress.py`: a TX/RX matrix between devourer and the kernel driver
+across plugged-in adapters, with optional full-pair, encoding-sweep, and
+third-adapter-sniffer modes — see [`tests/README.md`](tests/README.md).
 
 ## License
 


### PR DESCRIPTION
## What

Both top-level docs rewritten for their actual audiences. Net: **−873/+375 lines**.

### README (408 → 183) — a product pitch for humans

- Leads with **Why devourer**: no kernel module / no DKMS pain, cross-platform via libusb (incl. Android/Termux), faster-than-kernel startup, per-packet radiotap control (rate/power/channel per frame), FHSS-speed hopping, 5/10 MHz narrowband, built-in radio instrumentation.
- Chip information lives **only in the Supported hardware table** — the HAL genealogy, chip-id dispatch and strategy-interface prose is gone from README (CLAUDE.md keeps it, where the maintainer-agent needs it).
- **Project layout section removed.**
- The 115-line env-var catalogue is a single pointer to the `env:` tags in `src/DeviceConfig.h` — one source of truth, nothing to rot.
- Example binaries become a plain-language table ("Wi-Fi motion sensing from beamforming reports"); register addresses and driver jargon stay out of everything above the library-usage section; curated `docs/` index with the visual RF primer first for newcomers.

### CLAUDE.md (573 → 303) — the agent-facing operational guide

- Cut what duplicates other sources: chip essays (→ README table), per-env-var essays (→ `DeviceConfig.h` field docs), frequency-hopping / bench-init narratives (→ `docs/`).
- Kept every hard-won, non-obvious fact as a compact list: the 8822E 0x41e8 RX-desense quirk, CSI-mask inert-vs-jammed-slice, thermal meter units aren't °C, EVM (not SNR) as the saturation tell, Jaguar3 `TX_WITH_RX`-before-`InitWrite`, the SDR-not-sniffer bench rule, the canonical-SA three-place convention, generated-tables rule.
- Fixed stale claims: TX power ramp described against the live runtime API (the deprecated `SetTxPowerOverride`/`ApplyTxPower` forwarders were still referenced), change-log phrasing ("no ... any more", "previously named ... one release cycle") removed, `DEVOURER_RX_ENERGY_MS` defined where it's referenced (a gap in the old text).

All 13 README links verified to exist; cross-references between the two files updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)