### PR TITLE
Adapter doctor — dying-dongle triage (EFUSE stability / fw-boot / RX smoke)

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -148,7 +148,7 @@ jobs:
           devourer streamtx duplex StreamStdinSelftest
           ToneMaskSelftest BfReportDecodeSelftest SweepSpecSelftest
           TxPowerQuantSelftest LinkHealthSelftest TxCapsSelftest TxPktPwrSelftest
-          RxQualitySelftest
+          RxQualitySelftest AdapterHealthSelftest
 
       - name: Test
         working-directory: build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,17 @@ receiver decodes weak frames and masks a real drop. Keep a known-good control
 adapter, re-check it each session, and take one clean SDR read per session (a
 second back-to-back `sdr_duty` read can fail to reacquire and report ~0).
 
+Suspect a DUT itself (deaf with a green init, chronic FW-boot fails):
+`build/doctor` grades adapter health — EFUSE read-stability ×N, fw-boot,
+RX smoke → HEALTHY/SUSPECT/FAILING in the exit code;
+`tests/adapter_doctor_cold.sh` wraps it in per-rep VBUS cold + a vouched
+flood for a definitive verdict (`docs/adapter-doctor.md`). Two cold-init
+traps it encodes: the in-tree rtw88 modules auto-probe (and fw-download
+into) every Realtek dongle at each enumeration — `modprobe -r` does NOT
+survive re-enumeration, temp-blacklist instead; and `authorized`-toggle
+"cold" leaves chip state (real VBUS cold via `REGRESS_VBUS_MAP` /
+uhubctl — never on xhci root ports on this rig).
+
 ## Configuration
 
 **The library reads no environment.** Construction-time knobs live in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,17 @@ add_executable(sense
 target_link_libraries(sense PUBLIC devourer PRIVATE PkgConfig::libusb)
 target_include_directories(sense PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/examples/common)
 
+# doctor — adapter health triage (src/AdapterHealth.h): EFUSE read-stability
+# probe + firmware-boot outcome + RX smoke, classified into
+# HEALTHY / SUSPECT / FAILING with reasons. Detects dying dongles that
+# enumerate and init green but read stochastic EFUSE garbage / never boot the
+# MCU (the #205 failure mode). Pure CLI; exit code carries the verdict. See
+# docs/adapter-doctor.md.
+add_executable(doctor
+    examples/doctor/main.cpp
+)
+target_link_libraries(doctor PUBLIC devourer PRIVATE PkgConfig::libusb)
+
 # Headless regression guard for the binary-stdin framing shared by the two
 # stream demos above (examples/common/stream_stdin.h). No libusb, no radio — just the
 # set_stdin_binary() + read_exact() path, so a text-mode regression (e.g. the
@@ -367,6 +378,18 @@ add_executable(LinkHealthSelftest
 target_link_libraries(LinkHealthSelftest PRIVATE devourer)
 
 add_test(NAME link_health_classify COMMAND LinkHealthSelftest)
+
+# Headless guard for the adapter-health classifier + EFUSE-stability probe
+# loop (src/AdapterHealth.h) — the verdict mapping behind examples/doctor,
+# with cases encoding the verdicts measured on a real dying unit vs its
+# healthy twin (#205). A misgrade fails `ctest` instead of only surfacing as
+# a wrong retire-or-keep call.
+add_executable(AdapterHealthSelftest
+    tests/adapter_health_selftest.cpp
+)
+target_link_libraries(AdapterHealthSelftest PRIVATE devourer)
+
+add_test(NAME adapter_health_classify COMMAND AdapterHealthSelftest)
 
 # Headless guard for the RX link-quality feed (src/RxQuality.h) — the aggregate
 # math + passive noise-floor formula + verdict fuse behind GetRxQuality().

--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ one `IRtlDevice` interface covers all three generations.
   works and what it costs on each chip.
 - [Startup time](docs/startup-time.md) — devourer vs. kernel driver,
   measured on every supported chip.
+- [Adapter doctor](docs/adapter-doctor.md) — dying-dongle triage: EFUSE
+  read-stability, firmware-boot and RX-smoke probes with a
+  HEALTHY / SUSPECT / FAILING verdict.
 - [Spectrum sensing](docs/rx-spectrum-sensing.md),
   [spatial diversity](docs/measuring-spatial-diversity.md),
   [bench testing near-field](docs/bench-testing-near-field.md) — measurement

--- a/docs/adapter-doctor.md
+++ b/docs/adapter-doctor.md
@@ -1,0 +1,88 @@
+# Adapter doctor: is this dongle dying?
+
+A Realtek adapter can be electrically dead-ish and still *look* fine:
+it enumerates, USB transfers are clean, driver init completes green —
+and the radio is stone-deaf. Measured on a degrading RTL8812AU
+([#205](https://github.com/OpenIPC/devourer/issues/205)), the failure
+lives in places no "did init succeed" check reaches:
+
+- **EFUSE reads return stochastic garbage** — a different EEPROM ID /
+  calibration map on every physical read. The driver then configures
+  the wrong RFE / PA / LNA tables and the radio hears nothing. A
+  healthy chip returns byte-identical maps every read, cold or warm.
+- **The MCU never boots firmware** — the download checksum report
+  never asserts. On Jaguar1 that is deliberately non-fatal (monitor RX
+  runs without the 8051), so nothing aborts.
+- The failure **drifts**: the same unit alternates between garbage
+  EFUSE, stable-but-wrong reads, and valid-ID-but-still-dead phases.
+  Any single-symptom check misses some phase; probing independent
+  subsystems catches every one.
+
+`doctor` (examples/doctor) runs the battery and grades it:
+
+```sh
+build/doctor                       # first Realtek adapter, ambient traffic
+build/doctor --pid 0x8812 --channel 6 --expect-traffic
+build/doctor --bus 3 --port 2.3.3  # topology select (two same-PID adapters)
+```
+
+1. **Bring-up** — `InitWrite`; an abort is an immediate FAILING.
+2. **EFUSE stability** — N fresh *physical* map reads
+   (`IRtlDevice::ProbeEfuseStability`), cross-compared byte-for-byte +
+   EEPROM-ID (0x8129) validated. Any read-to-read mismatch is
+   conclusive by itself. Not probed on the 8822E — its OTP is not
+   reliably readable after bring-up by design, so probing would flag
+   healthy units.
+3. **FW boot** — checksum + MCU-ready outcome of the bring-up's
+   download (`IRtlDevice::GetFwBootStatus`).
+4. **RX smoke** — FCS-clean frame count over `--listen-secs`. Ambient
+   traffic counts. Hearing *nothing* is only SUSPECT unless
+   `--expect-traffic` vouches for a source on the channel — an
+   RF-quiet room is otherwise indistinguishable from a deaf radio
+   (same trap as [startup-time](startup-time.md) benchmarking).
+
+Verdict → exit code: `HEALTHY`=0, `SUSPECT`=1, `FAILING`=2 (3 = tool /
+open error), plus a `<devourer-doctor>` machine line and per-reason
+text. The classifier is pure logic (`src/AdapterHealth.h`, ctest'd in
+`tests/adapter_health_selftest.cpp`); grading rules and their
+rationale live next to the code.
+
+## Getting a definitive verdict
+
+One warm run can miss a cold-only pathology (the #205 unit read valid
+EFUSE on some warm passes while staying deaf). For a hard verdict,
+give the doctor per-rep true cold + vouched traffic:
+
+```sh
+sudo bash tests/adapter_doctor_cold.sh <hub> <hubport> <sysfs> <bus> <portpath> [reps]
+# bench example — suspect unit on nested smart-hub port 3-2.3.3:
+sudo bash tests/adapter_doctor_cold.sh 3-2.3 3 3-2.3.3 3 2.3.3 3
+```
+
+Per rep the wrapper VBUS-cycles the DUT's uhubctl-switchable hub port,
+keeps the in-tree rtw88 module away (temp blacklist — udev reloads it
+on every re-enumeration otherwise, and its probe firmware-download
+would contaminate first-touch), runs a radiation-verified beacon flood,
+and invokes `doctor --expect-traffic`. Exit code is the worst verdict
+across reps.
+
+Validated on the bench pair: the healthy unit grades HEALTHY (stable
+0x8129 EFUSE ×4, FW ready, thousands of frames) and the dying unit
+grades FAILING on every cold rep — regardless of which face the
+sickness shows that day (garbage EFUSE, or valid-ID-with-dead-MCU +
+deaf-to-flood).
+
+## Reading a SUSPECT
+
+- `heard nothing (no traffic guarantee)` — re-run with a known traffic
+  source on the channel and `--expect-traffic`.
+- `EFUSE is blank (autoload fail)` — all-0xFF map. Legitimate on some
+  bare dev boards; on a retail adapter it means the calibration data
+  is gone.
+- `MCU never booted firmware` alone — can be a transient warm-state
+  hang (the vendor drivers retry this too). VBUS power-cycle and
+  re-run; persistent across cold reps = hardware.
+
+A cheap independent cross-check on any modern kernel: the in-tree
+rtw88 driver's probe (dmesg) fails with `failed to validate firmware`
+on a unit with this pathology and binds cleanly on a healthy one.

--- a/examples/doctor/main.cpp
+++ b/examples/doctor/main.cpp
@@ -1,0 +1,344 @@
+/* doctor — adapter health triage: is this dongle dying?
+ *
+ * Motivated by a field failure mode (OpenIPC/devourer#205) where a degrading
+ * RTL8812AU enumerates fine, inits green — and is stone-deaf, because its
+ * EFUSE reads return stochastic garbage (wrong RFE/PA/LNA → wrong PHY tables)
+ * and its 8051 never boots firmware (non-fatal on Jaguar1). Neither shows up
+ * as an init failure.
+ *
+ * What it runs (see src/AdapterHealth.h for the classifier semantics):
+ *   1. bring-up      — InitWrite; an abort is an immediate FAILING.
+ *   2. EFUSE probe   — N fresh physical map reads cross-compared. Any
+ *                      read-to-read mismatch = dying silicon (a healthy chip
+ *                      is byte-identical every read). Also validates the
+ *                      0x8129 EEPROM ID. (8822E: skipped by design — its OTP
+ *                      is not reliably readable post-bring-up.)
+ *   3. FW boot       — checksum + MCU-ready outcome of the bring-up's
+ *                      firmware download.
+ *   4. RX smoke      — count FCS-clean frames for a window. Ambient traffic
+ *                      counts; in an RF-quiet place hearing nothing is only
+ *                      SUSPECT unless --expect-traffic vouches for a source
+ *                      (bench flood / busy AP on the channel).
+ *
+ * Verdict: HEALTHY / SUSPECT / FAILING (+ reasons), exit code 0 / 1 / 2
+ * (3 = tool/open error). Machine-readable summary on one line:
+ *
+ *   <devourer-doctor>verdict=FAILING reasons=0x12 efuse_reads=4 \
+ *       efuse_mismatch=3 efuse_bad_id=4 efuse_id=0x1029 fw_attempted=1 \
+ *       fw_ready=0 rx_ok=0 rx_crc=7 init=1
+ *
+ * CLI (no environment variables — device selection included, since a rig may
+ * hold two same-PID/same-serial adapters where only topology tells them
+ * apart):
+ *
+ *   --vid 0xNNNN --pid 0xNNNN   adapter select (default: first Realtek PID)
+ *   --bus N --port a.b.c        topology select (dotted libusb port path)
+ *   --channel N                 bring-up + listen channel (default 6)
+ *   --reads N                   EFUSE stability passes (default 4)
+ *   --listen-secs N             RX smoke window (default 8; 0 = skip)
+ *   --expect-traffic            operator vouches for on-channel traffic:
+ *                               0 frames heard upgrades to FAILING
+ *
+ * Bench protocol for a definitive verdict on a suspect unit: put it on a
+ * uhubctl-switchable hub port, VBUS-cycle, run doctor with a beacon flood on
+ * the channel and --expect-traffic, and repeat from cold a few times
+ * (tests/adapter_doctor_cold.sh wraps exactly that).
+ */
+#ifdef _WIN32
+#define NOMINMAX
+#endif
+
+#if defined(__ANDROID__) || defined(_MSC_VER) || defined(__APPLE__)
+#include <libusb.h>
+#else
+#include <libusb-1.0/libusb.h>
+#endif
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "AdapterHealth.h"
+#include "RxPacket.h"
+#include "SignalStop.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "logger.h"
+
+namespace {
+
+/* The Realtek PIDs the demos' open loop iterates; --pid narrows to one. */
+const uint16_t kRealtekPids[] = {0x8812, 0x8813, 0x881a, 0x0811, 0xa811,
+                                 0x0820, 0x0821, 0x8822, 0x0120, 0x012d,
+                                 0xb82c, 0xc811, 0xc812, 0xa81a};
+
+struct Args {
+  uint16_t vid = 0x0bda;
+  int pid = -1; /* -1 = iterate kRealtekPids */
+  int bus = -1; /* -1 = no topology filter */
+  std::string port;
+  int channel = 6;
+  int reads = 4;
+  int listen_secs = 8;
+  bool expect_traffic = false;
+};
+
+bool parse_int(const char *s, int &out) {
+  char *end = nullptr;
+  long v = std::strtol(s, &end, 0);
+  if (end == s || *end != '\0')
+    return false;
+  out = static_cast<int>(v);
+  return true;
+}
+
+bool parse_args(int argc, char **argv, Args &a) {
+  for (int i = 1; i < argc; ++i) {
+    const std::string k = argv[i];
+    auto next = [&](int &out) {
+      return i + 1 < argc && parse_int(argv[++i], out);
+    };
+    int v = 0;
+    if (k == "--vid" && next(v))
+      a.vid = static_cast<uint16_t>(v);
+    else if (k == "--pid" && next(v))
+      a.pid = v;
+    else if (k == "--bus" && next(a.bus))
+      ;
+    else if (k == "--port" && i + 1 < argc)
+      a.port = argv[++i];
+    else if (k == "--channel" && next(a.channel))
+      ;
+    else if (k == "--reads" && next(a.reads))
+      ;
+    else if (k == "--listen-secs" && next(a.listen_secs))
+      ;
+    else if (k == "--expect-traffic")
+      a.expect_traffic = true;
+    else {
+      std::fprintf(stderr, "unknown/incomplete arg: %s\n", k.c_str());
+      return false;
+    }
+  }
+  return true;
+}
+
+/* Open by USB topology (bus + dotted port path) when a rig holds several
+ * same-PID/same-serial adapters — the matcher rxdemo uses, CLI-fed. */
+libusb_device_handle *open_by_topology(libusb_context *ctx, const Args &a,
+                                       const std::shared_ptr<Logger> &logger) {
+  libusb_device_handle *handle = nullptr;
+  libusb_device **list = nullptr;
+  ssize_t n = libusb_get_device_list(ctx, &list);
+  for (ssize_t i = 0; i < n && handle == nullptr; ++i) {
+    libusb_device_descriptor dd{};
+    if (libusb_get_device_descriptor(list[i], &dd) != 0)
+      continue;
+    if (dd.idVendor != a.vid)
+      continue;
+    if (a.pid >= 0 && dd.idProduct != static_cast<uint16_t>(a.pid))
+      continue;
+    if (libusb_get_bus_number(list[i]) != a.bus)
+      continue;
+    if (!a.port.empty()) {
+      uint8_t ports[8];
+      int pc = libusb_get_port_numbers(list[i], ports, sizeof(ports));
+      std::string path;
+      for (int p = 0; p < pc; ++p)
+        path += (path.empty() ? "" : ".") + std::to_string(ports[p]);
+      if (path != a.port)
+        continue;
+    }
+    if (libusb_open(list[i], &handle) == 0)
+      logger->info("Opened device {:04x}:{:04x} on bus {} port {}",
+                   dd.idVendor, dd.idProduct, a.bus,
+                   a.port.empty() ? "(any)" : a.port.c_str());
+  }
+  if (list != nullptr)
+    libusb_free_device_list(list, 1);
+  return handle;
+}
+
+const char *yn(bool b) { return b ? "yes" : "NO"; }
+
+} // namespace
+
+int main(int argc, char **argv) {
+  Args a;
+  if (!parse_args(argc, argv, a))
+    return 3;
+
+  auto logger = std::make_shared<Logger>();
+  install_devourer_signal_handlers();
+
+  libusb_context *ctx = nullptr;
+  if (libusb_init(&ctx) < 0) {
+    logger->error("libusb_init failed");
+    return 3;
+  }
+  libusb_device_handle *handle = nullptr;
+  if (a.bus >= 0) {
+    handle = open_by_topology(ctx, a, logger);
+  } else if (a.pid >= 0) {
+    handle = libusb_open_device_with_vid_pid(ctx, a.vid,
+                                             static_cast<uint16_t>(a.pid));
+  } else {
+    for (uint16_t pid : kRealtekPids) {
+      handle = libusb_open_device_with_vid_pid(ctx, a.vid, pid);
+      if (handle)
+        break;
+    }
+  }
+  if (!handle) {
+    logger->error("no adapter found (vid {:04x})", a.vid);
+    libusb_exit(ctx);
+    return 3;
+  }
+
+  std::shared_ptr<devourer::UsbDeviceLock> lock;
+  if (devourer::claim_interface_then_reset(handle, 0, logger, true, lock) !=
+      0) {
+    libusb_close(handle);
+    libusb_exit(ctx);
+    return 3;
+  }
+
+  /* keep_corrupted so the RX smoke can report the corrupt-frame count too
+   * (informational only); enable_with_tx so Jaguar3's InitWrite keeps the RX
+   * filters open for the StartRxLoop smoke window. */
+  devourer::DeviceConfig cfg;
+  cfg.rx.keep_corrupted = true;
+  cfg.rx.enable_with_tx = true;
+
+  WiFiDriver driver(logger);
+  std::unique_ptr<IRtlDevice> dev =
+      driver.CreateRtlDevice(handle, ctx, lock, cfg);
+  if (!dev) {
+    logger->error("CreateRtlDevice failed (chip support not built?)");
+    libusb_close(handle);
+    libusb_exit(ctx);
+    return 3;
+  }
+
+  devourer::AdapterHealthInput in;
+
+  /* 1. bring-up */
+  try {
+    dev->InitWrite(SelectedChannel{.Channel = static_cast<uint8_t>(a.channel),
+                                   .ChannelOffset = 0,
+                                   .ChannelWidth = CHANNEL_WIDTH_20});
+    in.init_completed = true;
+  } catch (const std::exception &e) {
+    logger->error("bring-up FAILED: {}", e.what());
+    in.init_completed = false;
+  }
+
+  /* 3. FW boot outcome — read even after an init abort: on the fatal-DLFW
+   * generations (Jaguar2/3) the throw IS the fw failure, and the status
+   * still says which stage died (checksum vs MCU boot). */
+  in.fw = dev->GetFwBootStatus();
+
+  if (in.init_completed) {
+    /* 2. EFUSE stability */
+    in.efuse = dev->ProbeEfuseStability(a.reads);
+
+    /* 4. RX smoke */
+    if (a.listen_secs > 0 && !g_devourer_should_stop) {
+      std::atomic<uint32_t> ok{0}, crc{0};
+      std::thread rx([&] {
+        dev->StartRxLoop([&](const Packet &p) {
+          if (p.RxAtrib.crc_err || p.RxAtrib.icv_err)
+            crc++;
+          else
+            ok++;
+        });
+      });
+      for (int s = 0; s < a.listen_secs && !g_devourer_should_stop; ++s)
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+      dev->StopRxLoop();
+      rx.join();
+      in.rx_checked = true;
+      in.rx_traffic_expected = a.expect_traffic;
+      in.rx_frames_ok = ok.load();
+      in.rx_frames_crc = crc.load();
+    }
+  }
+
+  uint32_t reasons = 0;
+  const devourer::AdapterVerdict v =
+      devourer::ClassifyAdapterHealth(in, reasons);
+
+  /* ---- report ---- */
+  std::printf("\n== adapter doctor ==\n");
+  std::printf("bring-up:        %s\n", yn(in.init_completed));
+  if (in.efuse.supported) {
+    std::printf("efuse stability: %d reads, %d mismatched, %d bad-id "
+                "(last id 0x%04x%s)\n",
+                in.efuse.reads, in.efuse.mismatched_reads,
+                in.efuse.invalid_id_reads, in.efuse.eeprom_id,
+                in.efuse.eeprom_id == devourer::kRtlEepromId ? "" : " ≠ 0x8129");
+    if (in.efuse.mismatched_reads > 0)
+      std::printf("                 first mismatch at map offset 0x%x\n",
+                  in.efuse.first_mismatch_off);
+  } else {
+    std::printf("efuse stability: not probed (unsupported on this chip or "
+                "bring-up failed)\n");
+  }
+  if (in.fw.supported && in.fw.attempted)
+    std::printf("fw boot:         checksum %s, MCU ready %s\n",
+                yn(in.fw.checksum_ok), yn(in.fw.ready_ok));
+  if (in.rx_checked)
+    std::printf("rx smoke:        %u ok / %u corrupt in %d s%s\n",
+                in.rx_frames_ok, in.rx_frames_crc, a.listen_secs,
+                in.rx_frames_ok == 0 && !a.expect_traffic
+                    ? " (no traffic guarantee — inconclusive if RF-quiet)"
+                    : "");
+
+  std::printf("verdict:         %s\n", devourer::AdapterVerdictName(v));
+  if (reasons & devourer::kAdapterInitFailed)
+    std::printf("  - bring-up aborted\n");
+  if (reasons & devourer::kAdapterEfuseUnstable)
+    std::printf("  - EFUSE reads are unstable — dying silicon; retire this "
+                "adapter\n");
+  if (reasons & devourer::kAdapterEfuseIdInvalid)
+    std::printf("  - EFUSE EEPROM ID is corrupt (calibration untrustworthy)\n");
+  if (reasons & devourer::kAdapterEfuseBlank)
+    std::printf("  - EFUSE is blank (autoload fail) — normal on some dev "
+                "boards, odd on retail adapters\n");
+  if (reasons & devourer::kAdapterFwBootFailed)
+    std::printf("  - MCU never booted firmware\n");
+  if (reasons & devourer::kAdapterRxDeafToTraffic)
+    std::printf("  - deaf to a vouched traffic source\n");
+  if (reasons & devourer::kAdapterRxSilent)
+    std::printf("  - heard nothing (supply known traffic + --expect-traffic "
+                "for a hard verdict)\n");
+
+  std::printf("<devourer-doctor>verdict=%s reasons=0x%x efuse_reads=%d "
+              "efuse_mismatch=%d efuse_bad_id=%d efuse_id=0x%04x "
+              "fw_attempted=%d fw_ready=%d rx_ok=%u rx_crc=%u init=%d\n",
+              devourer::AdapterVerdictName(v), reasons, in.efuse.reads,
+              in.efuse.mismatched_reads, in.efuse.invalid_id_reads,
+              in.efuse.eeprom_id, in.fw.attempted ? 1 : 0,
+              in.fw.ready_ok ? 1 : 0, in.rx_frames_ok, in.rx_frames_crc,
+              in.init_completed ? 1 : 0);
+  std::fflush(stdout);
+
+  dev->Stop();
+  libusb_close(handle);
+  libusb_exit(ctx);
+  switch (v) {
+  case devourer::AdapterVerdict::Healthy:
+    return 0;
+  case devourer::AdapterVerdict::Suspect:
+    return 1;
+  case devourer::AdapterVerdict::Failing:
+    return 2;
+  default:
+    return 3;
+  }
+}

--- a/src/AdapterHealth.h
+++ b/src/AdapterHealth.h
@@ -1,0 +1,220 @@
+/* Adapter-health probes + classifier — the "is my dongle dying" detector.
+ *
+ * Motivated by a field failure mode measured on a degrading RTL8812AU
+ * (OpenIPC/devourer#205): the chip enumerates fine, USB transfers are clean,
+ * init completes green — and the radio is stone-deaf, because
+ *
+ *   (1) the EFUSE read path returns STOCHASTIC garbage — a different
+ *       EEPROM ID / calibration map on every physical read (a healthy chip
+ *       returns byte-identical content every time), so the driver configures
+ *       the wrong RFE type / PA / LNA tables; and
+ *   (2) the 8051 MCU never boots firmware — the download checksum report
+ *       never asserts (non-fatal for Jaguar1 monitor RX, so nothing aborts).
+ *
+ * Both are invisible to "did init succeed" checks. The probes here make them
+ * measurable: N fresh physical EFUSE reads cross-compared for stability +
+ * validity, the firmware-boot outcome of the last bring-up, and an RX smoke
+ * count. The classifier maps those to a plain verdict + reason bits.
+ *
+ * IRtlDevice carries the probe entry points (ProbeEfuseStability,
+ * GetFwBootStatus); examples/doctor is the reference consumer.
+ */
+#ifndef DEVOURER_ADAPTER_HEALTH_H
+#define DEVOURER_ADAPTER_HEALTH_H
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace devourer {
+
+/* Every Realtek WLAN EFUSE logical map opens with this ID; anything else on a
+ * programmed retail adapter means the read is corrupt (a BLANK map — all
+ * 0xFF, id 0xFFFF — is the separate "autoload fail" case: legitimate on
+ * bare dev boards, odd on retail dongles). */
+constexpr uint16_t kRtlEepromId = 0x8129;
+
+/* Result of N back-to-back physical EFUSE logical-map reads (not the cached
+ * shadow — each pass re-runs the efuse controller read sequence). */
+struct EfuseStability {
+  bool supported = false; /* family wired + chip brought up when probed */
+  int reads = 0;          /* passes performed */
+  int mismatched_reads = 0; /* passes whose content != pass #0 */
+  int invalid_id_reads = 0; /* passes with EEPROM ID != kRtlEepromId */
+  uint16_t eeprom_id = 0;   /* ID from the last pass */
+  uint16_t map_len = 0;     /* logical map bytes compared per pass */
+  uint16_t first_mismatch_off = 0xFFFF; /* first differing offset, if any */
+};
+
+/* Shared probe loop behind IRtlDevice::ProbeEfuseStability — each generation
+ * supplies its own fresh-physical-map reader as `read_map(uint8_t *buf)`
+ * (return false on transport failure) and this does the cross-compare. */
+template <typename ReadFn>
+inline EfuseStability ProbeEfuseStabilityImpl(ReadFn &&read_map,
+                                              uint16_t map_len, int reads) {
+  EfuseStability st;
+  if (reads < 1 || map_len < 2)
+    return st;
+  st.supported = true;
+  st.map_len = map_len;
+  std::vector<uint8_t> ref(map_len), cur(map_len);
+  for (int i = 0; i < reads; ++i) {
+    uint8_t *buf = (i == 0) ? ref.data() : cur.data();
+    if (!read_map(buf))
+      break;
+    st.reads++;
+    st.eeprom_id = static_cast<uint16_t>(buf[0] | (buf[1] << 8));
+    if (st.eeprom_id != kRtlEepromId)
+      st.invalid_id_reads++;
+    if (i > 0 && std::memcmp(ref.data(), cur.data(), map_len) != 0) {
+      st.mismatched_reads++;
+      if (st.first_mismatch_off == 0xFFFF) {
+        for (uint16_t off = 0; off < map_len; ++off) {
+          if (ref[off] != cur[off]) {
+            st.first_mismatch_off = off;
+            break;
+          }
+        }
+      }
+    }
+  }
+  return st;
+}
+
+/* Outcome of the most recent firmware download (populated during
+ * Init/InitWrite). On Jaguar1 a failed FW boot does NOT abort init — monitor
+ * RX runs without the 8051 — which is exactly why it needs surfacing. */
+struct FwBootStatus {
+  bool supported = false; /* family records this */
+  bool attempted = false; /* a download ran this bring-up */
+  bool checksum_ok = false;
+  bool ready_ok = false; /* MCU signalled firmware-ready */
+};
+
+enum class AdapterVerdict {
+  Unknown, /* nothing conclusive was checked */
+  Healthy,
+  Suspect, /* one soft anomaly — re-run, or supply known traffic */
+  Failing, /* hard evidence of dying silicon */
+};
+
+/* Reason bits accompanying a verdict. */
+enum : uint32_t {
+  kAdapterInitFailed = 1u << 0,     /* bring-up aborted */
+  kAdapterEfuseUnstable = 1u << 1,  /* reads disagree — the smoking gun */
+  kAdapterEfuseIdInvalid = 1u << 2, /* stable but ID != 0x8129 (not blank) */
+  kAdapterEfuseBlank = 1u << 3,     /* stable all-0xFF map (autoload fail) */
+  kAdapterFwBootFailed = 1u << 4,   /* download attempted, MCU never ready */
+  kAdapterRxDeafToTraffic = 1u << 5, /* 0 frames with a known traffic source */
+  kAdapterRxSilent = 1u << 6, /* 0 frames, no traffic guarantee (soft) */
+};
+
+struct AdapterHealthInput {
+  bool init_completed = false;
+  EfuseStability efuse;
+  FwBootStatus fw;
+  bool rx_checked = false;
+  /* Operator asserts a known traffic source on the listen channel (bench
+   * flood / busy AP) — upgrades "heard nothing" from Suspect to Failing. */
+  bool rx_traffic_expected = false;
+  uint32_t rx_frames_ok = 0;  /* FCS-clean frames heard */
+  uint32_t rx_frames_crc = 0; /* corrupt frames heard (informational) */
+};
+
+inline const char *AdapterVerdictName(AdapterVerdict v) {
+  switch (v) {
+  case AdapterVerdict::Healthy:
+    return "HEALTHY";
+  case AdapterVerdict::Suspect:
+    return "SUSPECT";
+  case AdapterVerdict::Failing:
+    return "FAILING";
+  default:
+    return "UNKNOWN";
+  }
+}
+
+/* Pure classifier — no I/O, unit-tested in tests/adapter_health_selftest.cpp.
+ *
+ * Grading (measured on the #205 dying unit vs its healthy twin):
+ *   - Cross-read EFUSE instability is conclusive by itself: healthy silicon
+ *     returns identical maps every read, cold or warm. → Failing.
+ *   - A stable-but-invalid ID (not blank) is corrupt calibration → Failing
+ *     when the FW also failed, else Suspect (one anomaly, re-run).
+ *   - A blank map (all-0xFF / autoload fail) is legitimate on some dev
+ *     boards → Suspect, look at the adapter's provenance.
+ *   - FW-boot failure alone → Suspect (state can be transient); with any
+ *     EFUSE anomaly → Failing (two independent subsystems = the signature).
+ *   - Deaf RX only counts as Failing when the operator vouched for traffic
+ *     (rx_traffic_expected); otherwise an RF-quiet room is indistinguishable
+ *     → Suspect. High corrupt-frame ratios are NOT graded — distant ambient
+ *     traffic legitimately decodes mostly-corrupt.
+ */
+inline AdapterVerdict ClassifyAdapterHealth(const AdapterHealthInput &in,
+                                            uint32_t &reasons) {
+  reasons = 0;
+  bool checked = false;
+
+  if (!in.init_completed) {
+    reasons |= kAdapterInitFailed;
+    /* Enrich the abort with the fw stage that died (fatal-DLFW generations
+     * throw out of bring-up; the status still says checksum vs boot). */
+    if (in.fw.supported && in.fw.attempted && !in.fw.ready_ok)
+      reasons |= kAdapterFwBootFailed;
+    return AdapterVerdict::Failing;
+  }
+
+  bool efuse_hard = false, efuse_soft = false;
+  if (in.efuse.supported && in.efuse.reads > 0) {
+    checked = true;
+    const bool blank = in.efuse.mismatched_reads == 0 &&
+                       in.efuse.invalid_id_reads == in.efuse.reads &&
+                       in.efuse.eeprom_id == 0xFFFF;
+    if (in.efuse.mismatched_reads > 0) {
+      reasons |= kAdapterEfuseUnstable;
+      efuse_hard = true;
+    } else if (blank) {
+      reasons |= kAdapterEfuseBlank;
+      efuse_soft = true;
+    } else if (in.efuse.invalid_id_reads > 0) {
+      reasons |= kAdapterEfuseIdInvalid;
+      efuse_soft = true;
+    }
+  }
+
+  bool fw_bad = false;
+  if (in.fw.supported && in.fw.attempted) {
+    checked = true;
+    if (!in.fw.ready_ok) {
+      reasons |= kAdapterFwBootFailed;
+      fw_bad = true;
+    }
+  }
+
+  bool rx_hard = false, rx_soft = false;
+  if (in.rx_checked) {
+    checked = true;
+    if (in.rx_frames_ok == 0) {
+      if (in.rx_traffic_expected) {
+        reasons |= kAdapterRxDeafToTraffic;
+        rx_hard = true;
+      } else {
+        reasons |= kAdapterRxSilent;
+        rx_soft = true;
+      }
+    }
+  }
+
+  if (!checked)
+    return AdapterVerdict::Unknown;
+  if (efuse_hard || rx_hard || (fw_bad && (efuse_soft || efuse_hard)) ||
+      ((reasons & kAdapterEfuseIdInvalid) && fw_bad))
+    return AdapterVerdict::Failing;
+  if (efuse_soft || fw_bad || rx_soft)
+    return AdapterVerdict::Suspect;
+  return AdapterVerdict::Healthy;
+}
+
+} // namespace devourer
+
+#endif /* DEVOURER_ADAPTER_HEALTH_H */

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <functional>
 
+#include "AdapterHealth.h"
 #include "RxQuality.h"
 #include "RxSense.h"
 #include "SelectedChannel.h"
@@ -175,6 +176,26 @@ public:
    * poll GetRxEnergy separately on the same cadence). Default is an all-invalid
    * snapshot; each generation overrides. */
   virtual devourer::RxQuality GetRxQuality() { return {}; }
+
+  /* --- Adapter-health probes (see src/AdapterHealth.h; examples/doctor is
+   * the reference consumer) --- */
+
+  /* Perform `reads` fresh PHYSICAL EFUSE logical-map reads (each pass re-runs
+   * the efuse-controller read sequence — not the cached shadow) and
+   * cross-compare them. Dying silicon returns different content per read;
+   * healthy silicon is byte-identical every time. Post-bring-up only: returns
+   * supported=false before Init/InitWrite (on the 8814AU a pre-fwdl EFUSE
+   * read breaks the RSVD-page firmware download). Control-plane threading
+   * contract applies (same as SetMonitorChannel). */
+  virtual devourer::EfuseStability ProbeEfuseStability(int reads = 4) {
+    (void)reads;
+    return {};
+  }
+
+  /* Outcome of the most recent firmware download (populated during
+   * Init/InitWrite). On Jaguar1 a failed FW boot does not abort bring-up —
+   * this is the only place the failure is visible to a caller. */
+  virtual devourer::FwBootStatus GetFwBootStatus() { return {}; }
 };
 
 #endif /* IRTL_DEVICE_H */

--- a/src/jaguar1/EepromManager.cpp
+++ b/src/jaguar1/EepromManager.cpp
@@ -1298,6 +1298,13 @@ void EepromManager::Efuse_ReadAllMap(uint8_t efuseType, uint8_t *Efuse) {
   EfusePowerSwitch8812A(false, false);
 }
 
+bool EepromManager::ReadPhysicalEfuseMap(uint8_t *map, size_t len) {
+  if (map == nullptr || len != EFUSE_MAP_LEN_JAGUAR)
+    return false;
+  Efuse_ReadAllMap(EFUSE_WIFI, map);
+  return true;
+}
+
 enum {
   VOLTAGE_V25 = 0x03,
   LDOE25_SHIFT = 28,

--- a/src/jaguar1/EepromManager.h
+++ b/src/jaguar1/EepromManager.h
@@ -54,6 +54,13 @@ public:
    * fwdl times out). Safe to call once fw is running. */
   void LateInitFor8814A();
 
+  /* One fresh PHYSICAL logical-map read into `map` (health probing — see
+   * src/AdapterHealth.h). Re-runs the efuse power-switch + controller read
+   * sequence; does NOT touch the cached shadow this manager parsed at
+   * construction. `len` must be EFUSE_MAP_LEN_JAGUAR. Post-bring-up only
+   * (8814AU: post-fwdl only, same constraint as LateInitFor8814A). */
+  bool ReadPhysicalEfuseMap(uint8_t *map, size_t len);
+
   /* Build the minimal phydm-context shim PhyTableLoader needs to evaluate
    * card-cut conditionals on the 8814AU BB/AGC/MAC tables. The fields are
    * populated from EFUSE values already read into this manager. */

--- a/src/jaguar1/FirmwareManager.cpp
+++ b/src/jaguar1/FirmwareManager.cpp
@@ -71,6 +71,10 @@ static bool jaguar_fw_header_present(const uint8_t *buf, HAL_IC_TYPE_E ic_type) 
 }
 
 void FirmwareManager::FirmwareDownload(HAL_IC_TYPE_E ic_type) {
+  _boot = {};
+  _boot.supported = true;
+  _boot.attempted = true;
+
   if (ic_type == CHIP_8814A) {
     /* 8814AU uses an entirely different firmware transport (TX-FIFO reserved
      * page + internal DMA controller) than 8812. Hand off to the 8814 path.
@@ -137,11 +141,13 @@ void FirmwareManager::FirmwareDownload(HAL_IC_TYPE_E ic_type) {
   }
 
   _FWDownloadEnable_8812(false);
+  _boot.checksum_ok = (rtStatus == true);
   if (true != rtStatus) {
     return;
   }
 
   rtStatus = _FWFreeToGo8812(10, 200, ic_type);
+  _boot.ready_ok = (rtStatus == true);
   if (true != rtStatus) {
     return;
   }
@@ -641,6 +647,8 @@ void FirmwareManager::_Fwdl8814_Rtw88Path(const uint8_t *fw,
         _device.rtw_read32(REG_MCUFWDL));
     return;
   }
+  _boot.checksum_ok = true;
+  _boot.ready_ok = true;
 
   InitializeFirmwareVars8812();
 }
@@ -828,6 +836,8 @@ void FirmwareManager::_Fwdl8814_KernelPath(const uint8_t *fw,
   _logger->info("8814A firmware boot confirmed: CPU_DL_READY asserted "
                 "(REG_MCUFWDL=0x{:08X})",
                 _device.rtw_read32(REG_MCUFWDL));
+  _boot.checksum_ok = true;
+  _boot.ready_ok = true;
 
   InitializeFirmwareVars8812();
 }

--- a/src/jaguar1/FirmwareManager.h
+++ b/src/jaguar1/FirmwareManager.h
@@ -1,6 +1,7 @@
 #ifndef FIRMWAREMANAGER_H
 #define FIRMWAREMANAGER_H
 
+#include "AdapterHealth.h"
 #include "HalVerDef.h"
 #include "RtlUsbAdapter.h"
 #include "logger.h"
@@ -9,6 +10,7 @@ class FirmwareManager {
   RtlUsbAdapter _device;
   Logger_t _logger;
   devourer::DeviceConfig::Tuning _tuning; /* fwdl_8814 / fwdl_8814_chunk */
+  devourer::FwBootStatus _boot;           /* outcome of the last download */
 
 public:
   FirmwareManager(RtlUsbAdapter device, Logger_t logger,
@@ -17,6 +19,9 @@ public:
    * download protocol are common across Jaguar (8812 / 8811 / 8814) — only the
    * blob and the header-signature check differ. */
   void FirmwareDownload(HAL_IC_TYPE_E ic_type);
+  /* Outcome of the last FirmwareDownload (see src/AdapterHealth.h) — a failed
+   * FW boot is deliberately non-fatal on Jaguar1, so this is where it shows. */
+  const devourer::FwBootStatus &GetBootStatus() const { return _boot; }
 
 private:
   void _FWDownloadEnable_8812(bool enable);

--- a/src/jaguar1/HalModule.cpp
+++ b/src/jaguar1/HalModule.cpp
@@ -187,6 +187,7 @@ bool HalModule::rtl8812au_hal_init(uint8_t init_channel) {
 
   auto fwManager = std::make_unique<FirmwareManager>(_device, _logger, _cfg);
   fwManager->FirmwareDownload(_eepromManager->version_id.ICType);
+  _fwBoot = fwManager->GetBootStatus();
   timer.stage("fwdl");
 
   /* 8814AU: now that fw is running, the chip will accept EFUSE reads

--- a/src/jaguar1/HalModule.h
+++ b/src/jaguar1/HalModule.h
@@ -1,6 +1,7 @@
 #ifndef HALMODULE_H
 #define HALMODULE_H
 
+#include "AdapterHealth.h"
 #include "EepromManager.h"
 extern "C"{
 #include "Hal8812PwrSeq.h"
@@ -56,12 +57,16 @@ class HalModule {
   /* Phydm DM watchdog. Lazily constructed in `rtw_hal_init` after
    * `RadioManagementModule` is fully wired up. */
   std::unique_ptr<PhydmWatchdog> _phydmWatchdog;
+  /* Outcome of the fw download run by the last rtw_hal_init (the
+   * FirmwareManager is a hal-init local; its status is copied out here). */
+  devourer::FwBootStatus _fwBoot;
 
 public:
   HalModule(RtlUsbAdapter device, std::shared_ptr<EepromManager> eepromManager,
             std::shared_ptr<RadioManagementModule> _radioManagementModule,
             Logger_t logger, const devourer::DeviceConfig &cfg = {});
   bool rtw_hal_init(SelectedChannel selectedChannel);
+  const devourer::FwBootStatus &GetFwBootStatus() const { return _fwBoot; }
 
 private:
   bool rtl8812au_hal_init(uint8_t init_channel);

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -902,6 +903,20 @@ void RtlJaguarDevice::ClearTxMode() { _tx_mode_default.reset(); }
 
 uint32_t RtlJaguarDevice::ReadBBReg(uint16_t addr, uint32_t mask) {
   return _radioManagement->phy_query_bb_reg_public(addr, mask);
+}
+
+devourer::EfuseStability RtlJaguarDevice::ProbeEfuseStability(int reads) {
+  if (!_brought_up)
+    return {}; /* supported=false — needs a powered, brought-up chip */
+  auto st = devourer::ProbeEfuseStabilityImpl(
+      [this](uint8_t *buf) {
+        return _eepromManager->ReadPhysicalEfuseMap(buf, EFUSE_MAP_LEN_JAGUAR);
+      },
+      EFUSE_MAP_LEN_JAGUAR, reads);
+  _logger->info(
+      "efuse-stability: reads={} mismatched={} invalid_id={} id=0x{:04x}",
+      st.reads, st.mismatched_reads, st.invalid_id_reads, st.eeprom_id);
+  return st;
 }
 
 bool RtlJaguarDevice::NetDevOpen(SelectedChannel selectedChannel) {

--- a/src/jaguar1/RtlJaguarDevice.h
+++ b/src/jaguar1/RtlJaguarDevice.h
@@ -169,6 +169,15 @@ public:
     return devourer::build_rx_quality(_rxq.snapshot(), GetRxEnergy());
   }
 
+  /* Adapter-health probes (see src/AdapterHealth.h). The EFUSE probe re-runs
+   * the physical map read N times and cross-compares — post-bring-up only
+   * (guarded on _brought_up; on the 8814AU a pre-fwdl EFUSE read breaks the
+   * RSVD-page fwdl transport). */
+  devourer::EfuseStability ProbeEfuseStability(int reads) override;
+  devourer::FwBootStatus GetFwBootStatus() override {
+    return _halModule.GetFwBootStatus();
+  }
+
   /* Runtime TX-mode default. send_packet honours a frame's own radiotap rate
    * fields per-packet; when a frame's radiotap carries no rate, this mode
    * supplies the modulation / MCS / BW / GI / FEC / STBC instead of the

--- a/src/jaguar2/HalmacJaguar2Fw.cpp
+++ b/src/jaguar2/HalmacJaguar2Fw.cpp
@@ -371,6 +371,7 @@ bool HalmacJaguar2Fw::dlfw_end_flow() {
                    fw_ctrl);
     return false;
   }
+  _boot.checksum_ok = true;
   w16(REG_MCUFW_CTRL,
       static_cast<uint16_t>((fw_ctrl | BIT_FW_DW_RDY) & ~0x1));
 
@@ -388,11 +389,16 @@ bool HalmacJaguar2Fw::dlfw_end_flow() {
     cnt--;
     delay_us(50);
   }
+  _boot.ready_ok = true;
   _logger->info("Jaguar2 DLFW: FW ready (0x80 = 0xC078)");
   return true;
 }
 
 bool HalmacJaguar2Fw::download_firmware(const uint8_t *fw_bin, size_t size) {
+  _boot = {};
+  _boot.supported = true;
+  _boot.attempted = true;
+
   if (!chk_fw_size(fw_bin, size))
     return false;
 

--- a/src/jaguar2/HalmacJaguar2Fw.h
+++ b/src/jaguar2/HalmacJaguar2Fw.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "AdapterHealth.h"
 #include "logger.h"
 #include "RtlUsbAdapter.h"
 #include "ChipVariant.h"
@@ -28,6 +29,13 @@ public:
 
   bool download_firmware(const uint8_t *fw_bin, size_t size);
   bool download_default_firmware(); /* bundled per-variant NIC image */
+
+  /* Outcome of the last download_firmware attempt, recorded at the real
+   * hardware boundaries (see src/AdapterHealth.h): checksum_ok = the IMEM/DMEM
+   * checksum-ready bits (MCUFW_CTRL & 0x50), ready_ok = the FW-boot handshake
+   * (MCUFW_CTRL == 0xC078). Distinguishes a transport/checksum failure from a
+   * downloaded-but-never-booted MCU — the dying-adapter signature. */
+  const devourer::FwBootStatus &boot_status() const { return _boot; }
 
   /* The reserved-page boundary FIFOPAGE_CTRL_2 is restored to after each
    * rsvd-page chunk (from the queue/page allocation). Set by MacInit before
@@ -69,6 +77,7 @@ private:
   RtlUsbAdapter _device;
   Logger_t _logger;
   ChipVariant _variant;
+  devourer::FwBootStatus _boot; /* last download_firmware outcome */
   /* Per-chunk DLFW size. The vendor 8822B driver downloads in 4096-byte chunks
    * (4144-byte bulk-OUT incl. the 48-byte TX desc); this fits the HIQ page
    * space allocated by init_trx_cfg (64 pages) with margin. DLFW_PKT_MAX_SIZE is

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -648,6 +648,22 @@ devourer::TxCaps RtlJaguar2Device::GetTxCaps() {
   return devourer::tx_caps_for_chains(chains);
 }
 
+devourer::EfuseStability RtlJaguar2Device::ProbeEfuseStability(int reads) {
+  if (!_brought_up)
+    return {}; /* supported=false — the efuse read needs a powered chip */
+  constexpr uint16_t kMapLen = 0x200;
+  auto st = devourer::ProbeEfuseStabilityImpl(
+      [this](uint8_t *buf) {
+        _hal.read_efuse_logical_map(buf, kMapLen, /*dump=*/false);
+        return true;
+      },
+      kMapLen, reads);
+  _logger->info(
+      "efuse-stability: reads={} mismatched={} invalid_id={} id=0x{:04x}",
+      st.reads, st.mismatched_reads, st.invalid_id_reads, st.eeprom_id);
+  return st;
+}
+
 devourer::ThermalStatus RtlJaguar2Device::GetThermalStatus() {
   devourer::ThermalStatus t;
   if (!_brought_up)

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -128,6 +128,18 @@ public:
     return devourer::build_rx_quality(_rxq.snapshot(), GetRxEnergy());
   }
 
+  /* Adapter-health probes (see src/AdapterHealth.h). EFUSE probe re-reads the
+   * physical logical map N times (~0.5 s per pass over USB control transfers)
+   * and cross-compares; post-bring-up only. FW status comes from the DLFW
+   * state machine's real hardware boundaries (HalmacJaguar2Fw::boot_status:
+   * checksum-ready bits vs the 0xC078 boot handshake) — on Jaguar2 a FW
+   * failure additionally aborts bring_up (throws after retries), but the
+   * status still tells WHICH stage died. */
+  devourer::EfuseStability ProbeEfuseStability(int reads) override;
+  devourer::FwBootStatus GetFwBootStatus() override {
+    return _fw.boot_status();
+  }
+
 private:
   RtlUsbAdapter _device;
   const devourer::DeviceConfig _cfg;

--- a/src/jaguar3/HalJaguar3.cpp
+++ b/src/jaguar3/HalJaguar3.cpp
@@ -597,6 +597,17 @@ void HalJaguar3::config_pa_bias_8822e() {
  * fills 0xFF for gaps). Standard Realtek section format: header (or header+ext)
  * gives a logical block offset + 4-bit word-enable; each enabled 2-byte word
  * follows. */
+bool HalJaguar3::probe_efuse_map(uint8_t *map, size_t len) {
+  /* 8822E OTP reads are not reliable after TX/coex bring-up (by design — see
+   * cache_efuse_8822e); probing there would flag healthy units. 8822C only. */
+  if (_variant != ChipVariant::C8822C)
+    return false;
+  if (map == nullptr || len != sizeof(_efuse_cache))
+    return false;
+  read_efuse_logical_map(map, len, 0xFA);
+  return true;
+}
+
 void HalJaguar3::read_efuse_logical_map(uint8_t *map, size_t len, uint16_t upto) {
   constexpr uint16_t kPhysMax = 1024; /* EFUSE_REAL_CONTENT_LEN_8822C */
   for (size_t i = 0; i < len; ++i) map[i] = 0xFF;

--- a/src/jaguar3/HalJaguar3.h
+++ b/src/jaguar3/HalJaguar3.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 
+#include "AdapterHealth.h"
 #include "logger.h"
 #include "RtlUsbAdapter.h"
 #include "SelectedChannel.h"
@@ -69,6 +70,21 @@ public:
     bool test_chip = false;
   };
   ChipVersion chip_version() const { return _ver; }
+
+  /* One fresh PHYSICAL logical-map read for health probing (see
+   * src/AdapterHealth.h) — same holding-region window the rtw_hal_init cache
+   * read uses; bypasses _efuse_cache. `len` must be sizeof(_efuse_cache).
+   * Post-bring-up only, and 8822C ONLY: the 8822E's OTP is not reliably
+   * readable after TX/coex bring-up by design (see cache_efuse_8822e) — a
+   * stability probe there would flag healthy units. Returns false on 8822E. */
+  bool probe_efuse_map(uint8_t *map, size_t len);
+
+  /* Outcome of the fw download run by the last rtw_hal_init — forwarded from
+   * the DLFW state machine's real hardware boundaries (checksum-ready bits vs
+   * the 0xC078 boot handshake; see HalmacJaguar3Fw::boot_status). */
+  const devourer::FwBootStatus &fw_boot_status() const {
+    return _fw.boot_status();
+  }
 
 private:
   void power_off();           /* card-disable PWR_SEQ — reset from active state */

--- a/src/jaguar3/HalmacJaguar3Fw.cpp
+++ b/src/jaguar3/HalmacJaguar3Fw.cpp
@@ -297,6 +297,7 @@ bool HalmacJaguar3Fw::dlfw_end_flow() {
                    fw_ctrl);
     return false;
   }
+  _boot.checksum_ok = true;
   w16(REG_MCUFW_CTRL,
       static_cast<uint16_t>((fw_ctrl | BIT_FW_DW_RDY) & ~0x1));
 
@@ -314,6 +315,7 @@ bool HalmacJaguar3Fw::dlfw_end_flow() {
     cnt--;
     delay_us(50);
   }
+  _boot.ready_ok = true;
   _logger->info("Jaguar3 DLFW: FW ready (0x80 = 0xC078)");
   return true;
 }
@@ -322,6 +324,10 @@ bool HalmacJaguar3Fw::dlfw_end_flow() {
  * restore around 0x38 is intentionally omitted — no LTE coex in devourer's
  * monitor/inject scope. */
 bool HalmacJaguar3Fw::download_firmware(const uint8_t *fw_bin, size_t size) {
+  _boot = {};
+  _boot.supported = true;
+  _boot.attempted = true;
+
   if (!chk_fw_size(fw_bin, size))
     return false;
 

--- a/src/jaguar3/HalmacJaguar3Fw.h
+++ b/src/jaguar3/HalmacJaguar3Fw.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "AdapterHealth.h"
 #include "logger.h"
 #include "RtlUsbAdapter.h"
 #include "ChipVariant.h"
@@ -38,6 +39,13 @@ public:
    * (hal/hal8822c_fw.c). */
   bool download_default_firmware();
 
+  /* Outcome of the last download_firmware attempt, recorded at the real
+   * hardware boundaries (see src/AdapterHealth.h): checksum_ok = the IMEM/DMEM
+   * checksum-ready bits (MCUFW_CTRL & 0x50), ready_ok = the FW-boot handshake
+   * (MCUFW_CTRL == 0xC078). Distinguishes a transport/checksum failure from a
+   * downloaded-but-never-booted MCU — the dying-adapter signature. */
+  const devourer::FwBootStatus &boot_status() const { return _boot; }
+
 private:
   /* --- ported halmac DLFW steps --- */
   bool start_dlfw(const uint8_t *fw_bin, size_t size);
@@ -67,6 +75,7 @@ private:
   RtlUsbAdapter _device;
   Logger_t _logger;
   ChipVariant _variant; /* selects the firmware blob (8822c vs 8822e) */
+  devourer::FwBootStatus _boot; /* last download_firmware outcome */
   /* halmac adapter->dlfw_pkt_size — the per-chunk DDMA size. */
   uint32_t _dlfw_pkt_size = 4096;
   /* halmac adapter->txff_alloc.rsvd_boundary — the reserved-page boundary the

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -887,6 +887,22 @@ devourer::TxCaps RtlJaguar3Device::GetTxCaps() {
   return devourer::tx_caps_for_chains(2); /* 8822C/8822E are 2T2R */
 }
 
+devourer::EfuseStability RtlJaguar3Device::ProbeEfuseStability(int reads) {
+  if (!_brought_up)
+    return {}; /* supported=false — the efuse read needs a powered chip */
+  std::lock_guard<std::mutex> lk(_reg_mu); /* serialize vs the coex tick */
+  constexpr uint16_t kMapLen = 0x100;      /* sizeof(HalJaguar3::_efuse_cache) */
+  auto st = devourer::ProbeEfuseStabilityImpl(
+      [this](uint8_t *buf) { return _hal.probe_efuse_map(buf, kMapLen); },
+      kMapLen, reads);
+  if (st.reads == 0)
+    return {}; /* 8822E: probe refused (OTP unreliable post-bring-up) */
+  _logger->info(
+      "efuse-stability: reads={} mismatched={} invalid_id={} id=0x{:04x}",
+      st.reads, st.mismatched_reads, st.invalid_id_reads, st.eeprom_id);
+  return st;
+}
+
 devourer::TxPowerState RtlJaguar3Device::GetTxPowerState() {
   devourer::TxPowerState s;
   s.valid = true;

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -141,6 +141,16 @@ public:
    * IRtlDevice until the measurement justifies it. */
   void SetCcaMode(bool disabled);
 
+  /* Adapter-health probes (see src/AdapterHealth.h). EFUSE probe is 8822C
+   * only — the 8822E's OTP is not reliably readable post-bring-up by design
+   * (HalJaguar3::cache_efuse_8822e), so probing it would flag healthy units;
+   * 8822E returns supported=false. Serialized on _reg_mu against the coex
+   * tick like every other register-touching entry point. */
+  devourer::EfuseStability ProbeEfuseStability(int reads) override;
+  devourer::FwBootStatus GetFwBootStatus() override {
+    return _hal.fw_boot_status();
+  }
+
   bool should_stop = false;
 
 private:

--- a/tests/adapter_doctor_cold.sh
+++ b/tests/adapter_doctor_cold.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# adapter_doctor_cold.sh — definitive-verdict wrapper around examples/doctor.
+#
+# A single warm doctor run can miss a cold-start-only pathology (the #205
+# dying unit read valid EFUSE on some warm passes). This wrapper gives the
+# doctor what a hard verdict needs, per rep:
+#   - TRUE cold: uhubctl VBUS off/on on the DUT's smart-hub port
+#   - first-touch: the in-tree rtw88 module temp-blacklisted (udev reloads it
+#     on every re-enumeration otherwise)
+#   - a vouched traffic source: canonical-SA beacon flood, radiation-verified
+#     through a third adapter, so --expect-traffic verdicts are trustworthy
+#
+# Usage:
+#   sudo bash tests/adapter_doctor_cold.sh <hub> <hubport> <sysfs> <bus> <portpath> [reps]
+#     e.g. old bench 8812AU:  ... 3-2.3 3 3-2.3.3 3 2.3.3 3
+#          new bench 8812AU:  ... 3-2   2 3-2.2   3 2.2   3
+#
+# Rig knobs (env, defaults = this bench):
+#   DOCTOR_RTW88_MOD   in-tree module to keep away   (default rtw88_8812au)
+#   DOCTOR_FLOOD_ARGS  txdemo env for the flood      (default 8814AU @ 4/2.3.2)
+#   DOCTOR_VERIFY_ARGS rxdemo env for flood verify   (default 8821CU @ 9/1.3)
+#   DOCTOR_CHANNEL     bench channel                 (default 6)
+#   DOCTOR_DUT_VID     DUT vendor id                 (default 0x0bda)
+#   DOCTOR_SKIP_VBUS=1 no per-rep VBUS cycle — for a DUT on a ROOT port
+#                      (NEVER uhubctl root ports on this rig: a root-port
+#                      cycle once wedged a device past everything but a
+#                      machine power-off). Pass '-' for <hub>/<hubport>.
+#                      Verdicts are then warm/plug-cold, not per-rep cold.
+# The verify runs sequentially before the rep loop, so the DUT itself can
+# double as the verify adapter — but prefer pointing DOCTOR_VERIFY_ARGS at a
+# third adapter so a stone-deaf DUT can't fail the flood check.
+#
+# Exit: worst doctor verdict across reps (0 healthy / 1 suspect / 2 failing).
+
+set -u
+
+HUB="${1:?hub (uhubctl -l)}"; HPORT="${2:?hub port}"; SYSFS="${3:?sysfs id}"
+BUS="${4:?usb bus}"; PP="${5:?dotted port path}"; REPS="${6:-3}"
+
+MOD="${DOCTOR_RTW88_MOD:-rtw88_8812au}"
+CHANNEL="${DOCTOR_CHANNEL:-6}"
+DUT_VID="${DOCTOR_DUT_VID:-0x0bda}"   # e.g. 0x2357 for TP-Link-branded DUTs
+FLOOD_ARGS="${DOCTOR_FLOOD_ARGS:-DEVOURER_PID=0x8813 DEVOURER_USB_BUS=4 DEVOURER_USB_PORT=2.3.2}"
+VERIFY_ARGS="${DOCTOR_VERIFY_ARGS:-DEVOURER_PID=0xc811 DEVOURER_USB_BUS=9 DEVOURER_USB_PORT=1.3}"
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOCTOR="$REPO/build/doctor"
+RXDEMO="$REPO/build/rxdemo"
+TXDEMO="$REPO/build/txdemo"
+BLACKLIST="/etc/modprobe.d/zz-temp-blacklist-doctor.conf"
+
+[ "$(id -u)" = 0 ] || { echo "must run as root"; exit 3; }
+[ -x "$DOCTOR" ] || { echo "build/doctor missing — build first"; exit 3; }
+command -v uhubctl >/dev/null || { echo "uhubctl not installed"; exit 3; }
+
+TS="$(date +%Y%m%d-%H%M%S)"
+LOG="/tmp/devourer-doctor/$TS-$SYSFS"
+mkdir -p "$LOG"
+
+cleanup() {
+  trap - EXIT INT TERM
+  pkill -x txdemo 2>/dev/null
+  pkill -x rxdemo 2>/dev/null
+  pkill -x doctor 2>/dev/null
+  [ "${DOCTOR_SKIP_VBUS:-0}" = 1 ] || uhubctl -l "$HUB" -p "$HPORT" -a on >/dev/null 2>&1
+  rm -f "$BLACKLIST"
+  modprobe "$MOD" 2>/dev/null
+  wait 2>/dev/null
+  echo "[cleanup] done — logs in $LOG"
+}
+trap cleanup EXIT INT TERM
+
+log() { echo "[$(date +%H:%M:%S)] $*" | tee -a "$LOG/session.log"; }
+
+# flood + radiation check (a deaf verdict is only meaningful while this is up)
+env $FLOOD_ARGS DEVOURER_CHANNEL="$CHANNEL" "$TXDEMO" > "$LOG/flood.log" 2>&1 &
+sleep 6
+kill -0 $! 2>/dev/null || { log "FATAL: flood txdemo died"; tail -5 "$LOG/flood.log"; exit 3; }
+timeout -k 5 -s INT 8 env $VERIFY_ARGS DEVOURER_CHANNEL="$CHANNEL" \
+  "$RXDEMO" > "$LOG/verify.log" 2>&1
+hits=$(grep -o 'hits=[0-9]*' "$LOG/verify.log" | tail -1 | cut -d= -f2)
+[ "${hits:-0}" -ge 5 ] || { log "FATAL: flood not radiating (hits=${hits:-0})"; exit 3; }
+log "flood radiating (verify hits=$hits) — deaf verdicts are trustworthy"
+
+echo "blacklist $MOD" > "$BLACKLIST"
+modprobe -r "$MOD" 2>/dev/null
+log "$MOD removed + temp-blacklisted"
+
+worst=0
+for i in $(seq 1 "$REPS"); do
+  if [ "${DOCTOR_SKIP_VBUS:-0}" = 1 ]; then
+    log "--- rep $i/$REPS: no VBUS cycle (root-port DUT) ---"
+  else
+    log "--- rep $i/$REPS: VBUS cycle $HUB port $HPORT ---"
+    uhubctl -l "$HUB" -p "$HPORT" -a off > /dev/null || { log "uhubctl off failed"; exit 3; }
+    sleep 5
+    uhubctl -l "$HUB" -p "$HPORT" -a on > /dev/null
+    t0=$SECONDS
+    while [ $((SECONDS - t0)) -lt 20 ]; do
+      [ -e "/sys/bus/usb/devices/$SYSFS/idProduct" ] && break
+      sleep 0.5
+    done
+    sleep 1.5
+  fi
+
+  "$DOCTOR" --vid "$DUT_VID" --bus "$BUS" --port "$PP" --channel "$CHANNEL" \
+    --expect-traffic > "$LOG/rep$i.log" 2>&1
+  rc=$?
+  [ "$rc" -gt "$worst" ] && [ "$rc" -le 2 ] && worst=$rc
+  log "rep $i: $(grep -o '<devourer-doctor>.*' "$LOG/rep$i.log" | head -1) (rc=$rc)"
+done
+
+log "=== worst verdict across $REPS cold reps: rc=$worst (0=healthy 1=suspect 2=failing) ==="
+exit "$worst"

--- a/tests/adapter_health_selftest.cpp
+++ b/tests/adapter_health_selftest.cpp
@@ -1,0 +1,194 @@
+/* Selftest for the AdapterHealth classifier (src/AdapterHealth.h) — pure
+ * logic, no hardware. The cases encode the verdicts measured on real units
+ * during the #205 investigation: a dying 8812AU (stochastic EFUSE garbage +
+ * 8051 never booting) vs its healthy twin, plus the soft/inconclusive edges
+ * (RF-quiet room, blank dev-board efuse, transient FW hiccup). */
+#include "AdapterHealth.h"
+
+#include <cstdio>
+
+using namespace devourer;
+
+static int failures = 0;
+
+static void expect(bool cond, const char *what) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", what);
+    failures++;
+  }
+}
+
+static AdapterHealthInput healthy_base() {
+  AdapterHealthInput in;
+  in.init_completed = true;
+  in.efuse.supported = true;
+  in.efuse.reads = 4;
+  in.efuse.eeprom_id = kRtlEepromId;
+  in.fw.supported = true;
+  in.fw.attempted = true;
+  in.fw.checksum_ok = true;
+  in.fw.ready_ok = true;
+  in.rx_checked = true;
+  in.rx_frames_ok = 1000;
+  return in;
+}
+
+int main() {
+  uint32_t r = 0;
+
+  /* Healthy twin: everything clean, frames heard. */
+  {
+    auto in = healthy_base();
+    expect(ClassifyAdapterHealth(in, r) == AdapterVerdict::Healthy,
+           "clean unit → Healthy");
+    expect(r == 0, "clean unit → no reasons");
+  }
+
+  /* The dying unit, exactly as measured: unstable EFUSE + FW never ready +
+   * deaf against a vouched flood. */
+  {
+    auto in = healthy_base();
+    in.efuse.mismatched_reads = 3;
+    in.efuse.invalid_id_reads = 4;
+    in.efuse.eeprom_id = 0x1029;
+    in.fw.checksum_ok = false;
+    in.fw.ready_ok = false;
+    in.rx_frames_ok = 0;
+    in.rx_traffic_expected = true;
+    expect(ClassifyAdapterHealth(in, r) == AdapterVerdict::Failing,
+           "dying unit → Failing");
+    expect((r & kAdapterEfuseUnstable) != 0, "dying unit flags EfuseUnstable");
+    expect((r & kAdapterFwBootFailed) != 0, "dying unit flags FwBootFailed");
+    expect((r & kAdapterRxDeafToTraffic) != 0, "dying unit flags DeafToTraffic");
+  }
+
+  /* EFUSE instability ALONE is conclusive (healthy silicon never varies). */
+  {
+    auto in = healthy_base();
+    in.efuse.mismatched_reads = 1;
+    expect(ClassifyAdapterHealth(in, r) == AdapterVerdict::Failing,
+           "any cross-read mismatch → Failing");
+  }
+
+  /* Stable-but-corrupt ID + FW fail = two independent subsystems → Failing.
+   * (The warm phase of the dying unit: ID settles wrong, MCU still dead.) */
+  {
+    auto in = healthy_base();
+    in.efuse.invalid_id_reads = 4;
+    in.efuse.eeprom_id = 0x8100;
+    in.fw.ready_ok = false;
+    expect(ClassifyAdapterHealth(in, r) == AdapterVerdict::Failing,
+           "corrupt-id + fw-dead → Failing");
+  }
+
+  /* Stable corrupt ID alone → Suspect (one anomaly; re-run). */
+  {
+    auto in = healthy_base();
+    in.efuse.invalid_id_reads = 4;
+    in.efuse.eeprom_id = 0x8100;
+    expect(ClassifyAdapterHealth(in, r) == AdapterVerdict::Suspect,
+           "corrupt-id alone → Suspect");
+  }
+
+  /* Blank map (all-0xFF autoload fail) → Suspect, flagged as blank. */
+  {
+    auto in = healthy_base();
+    in.efuse.invalid_id_reads = 4;
+    in.efuse.eeprom_id = 0xFFFF;
+    expect(ClassifyAdapterHealth(in, r) == AdapterVerdict::Suspect,
+           "blank efuse → Suspect");
+    expect((r & kAdapterEfuseBlank) != 0, "blank efuse flags EfuseBlank");
+    expect((r & kAdapterEfuseIdInvalid) == 0,
+           "blank efuse is not also flagged corrupt-id");
+  }
+
+  /* FW hiccup alone → Suspect (could be transient warm state). */
+  {
+    auto in = healthy_base();
+    in.fw.ready_ok = false;
+    expect(ClassifyAdapterHealth(in, r) == AdapterVerdict::Suspect,
+           "fw-fail alone → Suspect");
+  }
+
+  /* Heard nothing in an unvouched (possibly RF-quiet) room → Suspect. */
+  {
+    auto in = healthy_base();
+    in.rx_frames_ok = 0;
+    expect(ClassifyAdapterHealth(in, r) == AdapterVerdict::Suspect,
+           "silent unvouched → Suspect");
+    expect((r & kAdapterRxSilent) != 0, "silent unvouched flags RxSilent");
+  }
+
+  /* Same silence with a vouched traffic source → Failing. */
+  {
+    auto in = healthy_base();
+    in.rx_frames_ok = 0;
+    in.rx_traffic_expected = true;
+    expect(ClassifyAdapterHealth(in, r) == AdapterVerdict::Failing,
+           "deaf to vouched traffic → Failing");
+  }
+
+  /* Bring-up abort short-circuits to Failing. */
+  {
+    AdapterHealthInput in;
+    in.init_completed = false;
+    expect(ClassifyAdapterHealth(in, r) == AdapterVerdict::Failing,
+           "init abort → Failing");
+    expect((r & kAdapterInitFailed) != 0, "init abort flags InitFailed");
+  }
+
+  /* Fatal-DLFW generations (Jaguar2/3): the init abort carries the fw stage
+   * that died — checksum passed, MCU never booted. */
+  {
+    AdapterHealthInput in;
+    in.init_completed = false;
+    in.fw.supported = true;
+    in.fw.attempted = true;
+    in.fw.checksum_ok = true;
+    in.fw.ready_ok = false;
+    expect(ClassifyAdapterHealth(in, r) == AdapterVerdict::Failing,
+           "fatal fw abort → Failing");
+    expect((r & kAdapterInitFailed) != 0 && (r & kAdapterFwBootFailed) != 0,
+           "fatal fw abort flags InitFailed + FwBootFailed");
+  }
+
+  /* Nothing checked (e.g. probes unsupported, rx skipped) → Unknown. */
+  {
+    AdapterHealthInput in;
+    in.init_completed = true;
+    expect(ClassifyAdapterHealth(in, r) == AdapterVerdict::Unknown,
+           "no checks → Unknown");
+  }
+
+  /* Corrupt frames alone never grade the verdict (distant ambient traffic
+   * legitimately decodes mostly-corrupt). */
+  {
+    auto in = healthy_base();
+    in.rx_frames_ok = 3;
+    in.rx_frames_crc = 5000;
+    expect(ClassifyAdapterHealth(in, r) == AdapterVerdict::Healthy,
+           "high corrupt ratio with decodes → still Healthy");
+  }
+
+  /* ProbeEfuseStabilityImpl: mismatch detection + first-diff offset. */
+  {
+    int pass = 0;
+    auto read_map = [&](uint8_t *buf) {
+      buf[0] = 0x29;
+      buf[1] = 0x81;
+      buf[2] = (pass++ == 2) ? 0xAA : 0x55; /* corrupt 3rd read at offset 2 */
+      buf[3] = 0x00;
+      return true;
+    };
+    auto st = ProbeEfuseStabilityImpl(read_map, 4, 4);
+    expect(st.supported && st.reads == 4, "impl runs all reads");
+    expect(st.mismatched_reads == 1, "impl counts the one corrupt read");
+    expect(st.first_mismatch_off == 2, "impl records first mismatch offset");
+    expect(st.invalid_id_reads == 0 && st.eeprom_id == kRtlEepromId,
+           "impl parses the LE eeprom id");
+  }
+
+  if (failures == 0)
+    std::printf("adapter_health_selftest: all OK\n");
+  return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Follow-up to #205. That investigation ended with a dongle that enumerates cleanly, inits green, and is stone-deaf — its EFUSE reads return **stochastic garbage** (wrong RFE/PA/LNA → wrong PHY tables) and its 8051 **never boots firmware** (deliberately non-fatal on Jaguar1). Neither is visible to any "did init succeed" check, on the bench or in the field. This PR makes both measurable and ships a triage tool.

## Library — health probes on `IRtlDevice` (all generations)

- **`ProbeEfuseStability(N)`** — N fresh *physical* EFUSE logical-map reads (not the cached shadow), cross-compared byte-for-byte + `0x8129` EEPROM-ID validation. Healthy silicon is byte-identical on every read, cold or warm — **any mismatch is conclusive dying-silicon evidence**. Wired per generation: J1 (`EepromManager::ReadPhysicalEfuseMap`), J2 (public logical-map reader), J3 **8822C only** — the 8822E's OTP is not reliably readable post-bring-up *by design* (see `cache_efuse_8822e`), so probing it would false-flag healthy units; it reports `supported=false`.
- **`GetFwBootStatus()`** — the firmware-download outcome recorded at the **real hardware boundaries** inside each generation's DLFW machine: `checksum_ok` = IMEM/DMEM checksum-ready (`MCUFW_CTRL & 0x50` on J2/J3, the chksum report on J1), `ready_ok` = the boot handshake (`0xC078` / CPU_DL_READY). Distinguishes a transport/checksum failure from a downloaded-but-never-booted MCU — and survives the fatal bring-up throw on J2/J3, so an init abort still reports *which stage died*.
- **`src/AdapterHealth.h`** — structs, the shared probe loop, and a pure classifier (`HEALTHY / SUSPECT / FAILING` + reason bits). Grading rules documented next to the code; `ctest`'d (`adapter_health_classify`) with cases encoding the verdicts measured on the real dying unit vs its healthy twin — including the edges (blank dev-board EFUSE, RF-quiet silence, corrupt-frame ratios deliberately ungraded).

## Tool + harness

- **`examples/doctor`** — pure-CLI end-user triage: bring-up → EFUSE probe → FW status → RX smoke. Deaf grades FAILING only when `--expect-traffic` vouches for a source (an RF-quiet room is otherwise indistinguishable); verdict in the exit code (0/1/2), `<devourer-doctor>` machine line, `--vid/--bus/--port` topology select for rigs with same-PID/same-serial adapters.
- **`tests/adapter_doctor_cold.sh`** — definitive-verdict wrapper: per-rep VBUS cold via uhubctl, in-tree rtw88 module temp-blacklisted (udev modalias reloads it at every re-enumeration — a bare `modprobe -r` does not survive), radiation-verified canonical-SA flood. `DOCTOR_SKIP_VBUS=1` for DUTs on root ports.
- **`docs/adapter-doctor.md`** + README/CLAUDE.md pointers.

## Hardware validation

| unit | path | protocol | verdict |
|---|---|---|---|
| 8812AU (the #205 dying unit) | J1 | VBUS cold ×2 + vouched flood | **FAILING 2/2** (fw-dead + deaf-to-flood) |
| 8812AU (healthy twin) | J1 | VBUS cold ×2 + vouched flood | HEALTHY 2/2 (EFUSE 4/4 stable, ~3.7k frames) |
| 8821CU | J2 / 8821C | VBUS cold ×2 + vouched flood | HEALTHY 2/2 |
| 8822BU (Archer T3U) | J2 / 8822B | warm ×2 + vouched flood (root-port DUT) | HEALTHY 2/2 |
| 8812CU | J3 / 8822C | warm, ambient | HEALTHY |
| 8812EU | J3 / 8822E | warm, ambient | HEALTHY, probe correctly refused |

The dying unit's EFUSE happened to read *stable* during the validation session — its sickness drifts between faces (garbage EFUSE / valid-ID-with-dead-MCU / deaf RX), which is exactly why the doctor probes independent subsystems: the verdict landed anyway, via the FW and vouched-deaf checks. A cheap external cross-check is also documented: the in-tree rtw88 probe fails `failed to validate firmware` on such a unit and binds cleanly on a healthy one.

11/11 `ctest`; `jaguar1-only` and `jaguar2-only` subset builds verified green (all probe wiring lives inside each generation's own conditionally-compiled directory — no new `#if` guards needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)