### PR TITLE
Hardware-TSF timing: ReadTsf() + tsfl on all gens, 25x tighter TDMA sync, sub-µs multi-radio correlation

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -149,7 +149,7 @@ jobs:
           ToneMaskSelftest BfReportDecodeSelftest SweepSpecSelftest
           TxPowerQuantSelftest LinkHealthSelftest TxCapsSelftest TxPktPwrSelftest
           RxQualitySelftest AdapterHealthSelftest LogEventSelftest
-          AdapterCapsSelftest
+          AdapterCapsSelftest TdmaTsfSelftest
 
       - name: Test
         working-directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,6 +435,19 @@ target_link_libraries(ToneMaskSelftest PRIVATE devourer)
 
 add_test(NAME tone_mask_math COMMAND ToneMaskSelftest)
 
+# Headless guard for the burst-TDMA example's pure logic (examples/tdma/tdma.h):
+# the TsfClock host<->TSF least-squares fit, the frame-tag round-trip, and the
+# schedule phase math. No hardware — the tsf_probe / tsf_tdoa_probe /
+# tdma_tsf_test harnesses that need real adapters stay manual (out-of-band).
+add_executable(TdmaTsfSelftest
+    tests/tdma_tsf_selftest.cpp
+)
+target_link_libraries(TdmaTsfSelftest PRIVATE devourer)
+target_include_directories(TdmaTsfSelftest PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/tdma)
+
+add_test(NAME tdma_tsf_math COMMAND TdmaTsfSelftest)
+
 # Headless guard for the JSONL event emitter (src/Event.h) — the machine
 # event stream every test script parses (docs/logging.md): first-field
 # serialization guarantee, escaping, spill + truncation paths.

--- a/docs/narrowband.md
+++ b/docs/narrowband.md
@@ -309,6 +309,17 @@ they can be compared:
   bulk traffic, so the stamp is intermittent (n/a on a busy transmitter, a
   noisy ppm figure otherwise).
 
+The same per-frame TSF supports **multi-radio correlation**: two receivers that
+decode a common frame each latch it with their own hardware TSF, so relating
+their independent clocks needs no shared reference. `tests/tsf_tdoa_probe.cpp`
+matches frames both receivers heard (by the TD tag) and fits Δ(tsfl) vs time:
+on the bench (8822C + 8822B) it measures a stable **~16.5 ppm** inter-receiver
+crystal drift and a **~0.35 µs RMS** timestamp-tracking residual — the two
+clocks relate to sub-microsecond precision. That residual is the noise floor a
+TDOA solver would face; real localization needs baselines where the propagation
+difference exceeds it (hundreds of metres at 1 µs TSF resolution), so a bench
+shows the clock relationship, not geometry.
+
 A receiver switching in lockstep loses the ~switch-latency window at each phase
 edge, so it switches `guard_ms` **early** (the guard must exceed the chip's
 switch latency; bursts must be ≫ it). Roles:

--- a/docs/narrowband.md
+++ b/docs/narrowband.md
@@ -295,14 +295,19 @@ they can be compared:
   `steady_clock`, and re-anchors on each subsequent marker. No external clock.
 - **`tsf`** — the marker mode, but anchored on the **802.11 hardware TSF**
   instead of the host clock. Every RX frame carries a MAC-latched TSF
-  (`rx_pkt_attrib::tsfl`); a running host↔TSF least-squares fit de-jitters each
+  (`rx_pkt_attrib::tsfl`, the 32-bit low word at RX-descriptor offset 0x14 on all
+  three generations); a running host↔TSF least-squares fit de-jitters each
   marker's arrival time. Measured (8812AU): the marker anchor tightens from
   **~1.1 ms RMS** (raw host callback, dominated by USB batching + scheduling) to
-  **~40 µs RMS** — a ~25× tighter schedule anchor, so the guard can approach the
-  switch latency instead of the host-jitter floor. Jaguar1-only (the per-frame
-  `tsfl` is not surfaced on Jaguar2/3 yet). The TX also stamps each marker with
-  its own `ReadTsf()` for a TX↔RX crystal-drift readout — but a register read is
-  starved by heavy bulk traffic, so on a busy transmitter that stamp reads n/a.
+  **~44 µs RMS** — a ~25× tighter schedule anchor, so the guard can approach the
+  switch latency instead of the host-jitter floor. The delivery-level payoff:
+  in a short-burst guard sweep (8822C RX), the *misalignment* count (frames
+  decoded in the wrong band-window) runs **2–5× lower** than the host-clock
+  `marker` mode; total delivered frames are similar (a 25 ms burst is still ≫
+  the sub-ms jitter). The TX stamps each marker with its own `ReadTsf()` for a
+  rough TX↔RX crystal-drift readout, but a register read is starved by heavy
+  bulk traffic, so the stamp is intermittent (n/a on a busy transmitter, a
+  noisy ppm figure otherwise).
 
 A receiver switching in lockstep loses the ~switch-latency window at each phase
 edge, so it switches `guard_ms` **early** (the guard must exceed the chip's

--- a/docs/narrowband.md
+++ b/docs/narrowband.md
@@ -291,15 +291,25 @@ they can be compared:
   injection point).
 - **`marker`** — self-clocking: the TX emits a marker frame at each
   narrowband-burst start; the receiver camps narrowband until it decodes one,
-  anchors its local schedule to it, coasts on `steady_clock`, and re-anchors on
-  each subsequent marker (drift-correcting). No external clock at all.
+  anchors its local schedule to the marker's host-clock arrival time, coasts on
+  `steady_clock`, and re-anchors on each subsequent marker. No external clock.
+- **`tsf`** — the marker mode, but anchored on the **802.11 hardware TSF**
+  instead of the host clock. Every RX frame carries a MAC-latched TSF
+  (`rx_pkt_attrib::tsfl`); a running host↔TSF least-squares fit de-jitters each
+  marker's arrival time. Measured (8812AU): the marker anchor tightens from
+  **~1.1 ms RMS** (raw host callback, dominated by USB batching + scheduling) to
+  **~40 µs RMS** — a ~25× tighter schedule anchor, so the guard can approach the
+  switch latency instead of the host-jitter floor. Jaguar1-only (the per-frame
+  `tsfl` is not surfaced on Jaguar2/3 yet). The TX also stamps each marker with
+  its own `ReadTsf()` for a TX↔RX crystal-drift readout — but a register read is
+  starved by heavy bulk traffic, so on a busy transmitter that stamp reads n/a.
 
 A receiver switching in lockstep loses the ~switch-latency window at each phase
 edge, so it switches `guard_ms` **early** (the guard must exceed the chip's
 switch latency; bursts must be ≫ it). Roles:
 
 - `DEVOURER_TDMA_ROLE=tx` — run the schedule, inject class-tagged frames.
-- `=rx-sync` (`DEVOURER_TDMA_SYNC=wallclock|marker`) — switch in lockstep.
+- `=rx-sync` (`DEVOURER_TDMA_SYNC=wallclock|marker|tsf`) — switch in lockstep.
 - `=rx-camp` (`DEVOURER_TDMA_CAMP=5|10|20`) — camp permanently on one width.
 
 The second mode the user asked for — **1 TX + 2 RX** — is just a `tx` plus two

--- a/examples/tdma/main.cpp
+++ b/examples/tdma/main.cpp
@@ -59,6 +59,15 @@ static std::atomic<int> g_rx_mhz{20};                  // RX's current width
 static std::atomic<uint64_t> g_cnt[2][3];              // [nb?][class]
 static std::atomic<int64_t> g_marker_anchor_ns{0};     // steady ns of last marker
 static std::atomic<bool> g_have_anchor{false};
+// TSF-sync state: the host↔hardware-TSF fit, the reconstructed tsf of the last
+// marker (the anchor), and the measured TX↔RX crystal drift.
+static bool g_tsf_mode = false;
+static tdma::TsfClock g_clock;
+static std::mutex g_clock_mu;
+static std::atomic<int64_t> g_marker_tsf{0};
+static std::atomic<double> g_drift_ppm{1e9};   // 1e9 = not yet measured
+static uint64_t g_prev_tx_tsf = 0;
+static int64_t g_prev_rx_tsf = 0;
 
 static int64_t steady_ns() {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -116,8 +125,11 @@ static void run_tx(IRtlDevice* dev, const tdma::Config& c) {
 
     if (a.phase == tdma::Phase::NB && a.burst != last_marker_burst) {
       last_marker_burst = a.burst;
-      auto f = tdma::build_frame(rt_marker, tdma::Class::Marker,
-                                 seq[0]++, (uint32_t)a.burst);
+      // Stamp the marker with the TX's hardware TSF (works TX-side — no RX
+      // flood starving the control read); the TSF-sync RX uses it for drift.
+      uint64_t tx_tsf = dev->ReadTsf();
+      auto f = tdma::build_frame(rt_marker, tdma::Class::Marker, seq[0]++,
+                                 (uint32_t)a.burst, tx_tsf);
       dev->send_packet(f.data(), f.size());
     }
     tdma::Class cls =
@@ -145,8 +157,35 @@ static void rx_callback(const Packet& p) {
   if (!pr.ok || p.RxAtrib.crc_err) return;
   int nb = g_rx_mhz.load(std::memory_order_relaxed) <= 10 ? 1 : 0;
   g_cnt[nb][(int)pr.cls].fetch_add(1, std::memory_order_relaxed);
-  if (pr.cls == tdma::Class::Marker) {
-    g_marker_anchor_ns.store(steady_ns(), std::memory_order_relaxed);
+  const int64_t host = steady_ns();
+
+  if (g_tsf_mode) {
+    // Feed EVERY frame into the host↔TSF fit; anchor the schedule on the
+    // marker's hardware TSF (de-jittered through the fit), not the callback time.
+    // Host time in microseconds so the least-squares sums stay well within
+    // double precision (ns would overflow it over a multi-second run).
+    std::lock_guard<std::mutex> lk(g_clock_mu);
+    int64_t rx_tsf = g_clock.add(p.RxAtrib.tsfl, host / 1000);
+    if (pr.cls == tdma::Class::Marker) {
+      g_marker_tsf.store(rx_tsf, std::memory_order_relaxed);
+      g_have_anchor.store(true, std::memory_order_relaxed);
+      if (getenv("TDMA_DBG") && g_clock.ready())
+        fprintf(stderr, "[mk] rx_tsf=%lld host_at=%.0f host_us=%lld resid=%.0f us\n",
+                (long long)rx_tsf, g_clock.host_at(rx_tsf), (long long)(host / 1000),
+                g_clock.host_at(rx_tsf) - host / 1000.0);
+      if (pr.tx_tsf && g_prev_tx_tsf) {   // crystal drift, TX TSF vs RX TSF
+        double dtx = (double)(pr.tx_tsf - g_prev_tx_tsf);
+        double drx = (double)(rx_tsf - g_prev_rx_tsf);
+        double ppm = drx > 0 ? (dtx / drx - 1.0) * 1e6 : 1e9;
+        if (dtx > 0 && ppm > -500 && ppm < 500) g_drift_ppm.store(ppm);  // sane only
+      }
+      g_prev_tx_tsf = pr.tx_tsf;
+      g_prev_rx_tsf = rx_tsf;
+    }
+    return;
+  }
+  if (pr.cls == tdma::Class::Marker) {    // marker (steady-clock) anchor
+    g_marker_anchor_ns.store(host, std::memory_order_relaxed);
     g_have_anchor.store(true, std::memory_order_relaxed);
   }
 }
@@ -158,11 +197,27 @@ static ChannelWidth_t desired_width(const tdma::Config& c) {
     auto a = c.sched.at(tdma::wall_ms() + c.guard_ms);
     return c.sched.width(a.phase);
   }
-  // marker: camp narrowband until a marker anchors us, then coast on steady_clock.
+  // marker / tsf: camp narrowband until a marker anchors us, then coast.
   if (!g_have_anchor.load(std::memory_order_relaxed)) return c.sched.nb_w;
-  int64_t elapsed_ms =
-      (steady_ns() - g_marker_anchor_ns.load(std::memory_order_relaxed)) / 1000000;
-  if (elapsed_ms > 3LL * c.sched.period()) {  // markers stopped — re-acquire
+  int64_t elapsed_ms;
+  if (c.sync == tdma::Sync::Tsf) {
+    // Anchor = the marker's hardware TSF mapped through the fit to a de-jittered
+    // host time (the ~1 ms callback jitter averaged out). Fit is in microseconds.
+    std::lock_guard<std::mutex> lk(g_clock_mu);
+    if (!g_clock.ready()) return c.sched.nb_w;   // fit still warming up
+    int64_t mt = g_marker_tsf.load(std::memory_order_relaxed);
+    double anchor_us = g_clock.host_at(mt);
+    double now_us = steady_ns() / 1000.0;
+    elapsed_ms = (int64_t)((now_us - anchor_us) / 1000.0);
+    static int dbg = 0;
+    if (getenv("TDMA_DBG") && (dbg++ % 200 == 0))
+      fprintf(stderr, "[dbg] n=%lld mt=%lld anchor_us=%.0f now_us=%.0f elapsed_ms=%lld\n",
+              g_clock.n, (long long)mt, anchor_us, now_us, (long long)elapsed_ms);
+  } else {
+    elapsed_ms =
+        (steady_ns() - g_marker_anchor_ns.load(std::memory_order_relaxed)) / 1000000;
+  }
+  if (elapsed_ms < 0 || elapsed_ms > 3LL * c.sched.period()) {  // stale — re-acquire
     g_have_anchor.store(false, std::memory_order_relaxed);
     return c.sched.nb_w;
   }
@@ -176,7 +231,8 @@ static void run_rx(IRtlDevice* dev, const tdma::Config& c) {
   g_rx_mhz.store(tdma::mhz_of(start_w));
   std::thread rx([&] { dev->Init(rx_callback, SelectedChannel{c.channel, 0, start_w}); });
 
-  const char* role = c.role == tdma::Role::RxCamp ? "rx-camp"
+  const char* role = c.role == tdma::Role::RxCamp   ? "rx-camp"
+                     : c.sync == tdma::Sync::Tsf    ? "rx-sync/tsf"
                      : c.sync == tdma::Sync::Marker ? "rx-sync/marker"
                                                     : "rx-sync/wallclock";
   fprintf(stderr, "tdma %s: start %dMHz nb=%dMHz wide=%dMHz guard=%dms\n", role,
@@ -229,6 +285,16 @@ static void run_rx(IRtlDevice* dev, const tdma::Config& c) {
           (unsigned long long)g_cnt[1][1].load(), (unsigned long long)g_cnt[1][2].load(),
           (unsigned long long)g_cnt[0][0].load(), (unsigned long long)g_cnt[0][1].load(),
           (unsigned long long)g_cnt[0][2].load());
+  const uint64_t correct = g_cnt[1][1].load() + g_cnt[0][2].load();  // crit@NB + bulk@wide
+  const uint64_t wrong = g_cnt[0][1].load() + g_cnt[1][2].load();    // off-diagonal
+  fprintf(stderr, "  delivered(correct)=%llu  off-diagonal=%llu",
+          (unsigned long long)correct, (unsigned long long)wrong);
+  if (g_tsf_mode) {
+    double d = g_drift_ppm.load();
+    if (d < 1e8) fprintf(stderr, "  TX↔RX drift=%.1f ppm", d);
+    else fprintf(stderr, "  TX↔RX drift=n/a (TX TSF read starved under send load)");
+  }
+  fprintf(stderr, "\n");
 }
 
 int main() {
@@ -237,6 +303,7 @@ int main() {
   install_devourer_signal_handlers();
 
   tdma::Config c = tdma::config_from_env();
+  g_tsf_mode = (c.role == tdma::Role::RxSync && c.sync == tdma::Sync::Tsf);
 
   libusb_context* ctx = nullptr;
   std::shared_ptr<devourer::UsbDeviceLock> lock;

--- a/examples/tdma/tdma.h
+++ b/examples/tdma/tdma.h
@@ -47,13 +47,15 @@ inline const char* class_name(Class c) {
 //   [10..15] addr2 = SA           [24..] the TD tag
 static const uint8_t kSa[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
 static constexpr size_t kHdrLen = 24;     // 802.11 header up to the body
-static constexpr size_t kTagLen = 12;     // 'T''D' ver cls seq[4] burst[4]
+// 'T''D' ver cls seq[4] burst[4] tx_tsf[8]. The 8-byte TX-TSF stamp lets the
+// TSF-sync RX measure the TX↔RX crystal drift (0 when the TX can't read TSF).
+static constexpr size_t kTagLen = 20;
 static constexpr size_t kMinData = kHdrLen + kTagLen;
 
 // Build a full TX buffer: [radiotap for this class][802.11 header][TD tag].
 inline std::vector<uint8_t> build_frame(const std::vector<uint8_t>& radiotap,
-                                        Class cls, uint32_t seq,
-                                        uint32_t burst) {
+                                        Class cls, uint32_t seq, uint32_t burst,
+                                        uint64_t tx_tsf = 0) {
   static const uint8_t hdr[kHdrLen] = {
       0x40, 0x00, 0x00, 0x00,                         // FC + duration
       0xff, 0xff, 0xff, 0xff, 0xff, 0xff,             // addr1 broadcast
@@ -64,12 +66,13 @@ inline std::vector<uint8_t> build_frame(const std::vector<uint8_t>& radiotap,
   f.reserve(radiotap.size() + kHdrLen + kTagLen);
   f.insert(f.end(), radiotap.begin(), radiotap.end());
   f.insert(f.end(), hdr, hdr + kHdrLen);
-  const uint8_t tag[kTagLen] = {
+  uint8_t tag[kTagLen] = {
       'T', 'D', 1, static_cast<uint8_t>(cls),
       static_cast<uint8_t>(seq),        static_cast<uint8_t>(seq >> 8),
       static_cast<uint8_t>(seq >> 16),  static_cast<uint8_t>(seq >> 24),
       static_cast<uint8_t>(burst),      static_cast<uint8_t>(burst >> 8),
       static_cast<uint8_t>(burst >> 16),static_cast<uint8_t>(burst >> 24)};
+  for (int i = 0; i < 8; ++i) tag[12 + i] = static_cast<uint8_t>(tx_tsf >> (8 * i));
   f.insert(f.end(), tag, tag + kTagLen);
   return f;
 }
@@ -79,6 +82,7 @@ struct Parsed {
   Class cls = Class::Bulk;
   uint32_t seq = 0;
   uint32_t burst = 0;
+  uint64_t tx_tsf = 0;
 };
 
 // Parse an RX Packet.Data span (802.11 MPDU) into a TD tag, if it is one of ours.
@@ -93,9 +97,51 @@ inline Parsed parse_frame(const uint8_t* data, size_t len) {
           (static_cast<uint32_t>(t[6]) << 16) | (static_cast<uint32_t>(t[7]) << 24);
   p.burst = static_cast<uint32_t>(t[8]) | (static_cast<uint32_t>(t[9]) << 8) |
             (static_cast<uint32_t>(t[10]) << 16) | (static_cast<uint32_t>(t[11]) << 24);
+  for (int i = 0; i < 8; ++i)
+    p.tx_tsf |= static_cast<uint64_t>(t[12 + i]) << (8 * i);
   p.ok = true;
   return p;
 }
+
+// --- TSF clock: a running host↔hardware-TSF least-squares fit ---------------
+// Every RX frame carries a hardware TSF (rx_pkt_attrib::tsfl, latched in the MAC
+// at receive) and a host time (when our callback ran). The host time is noisy
+// (USB batching + scheduling, ~1 ms RMS on Jaguar1); the TSF is not. Fitting
+// host = a·tsf + b over many frames averages the noise out, so evaluating the
+// line at a marker's tsf gives a de-jittered host time for that marker — the
+// precise schedule anchor. All state in offset coords (relative to the first
+// sample) to keep the sums numerically well-conditioned.
+struct TsfClock {
+  bool init = false;
+  double x0 = 0, y0 = 0;
+  long long n = 0;
+  double sx = 0, sy = 0, sxx = 0, sxy = 0;
+  int64_t hi = 0;            // 32→64-bit tsf reconstruction (low word wraps)
+  uint32_t plo = 0;
+
+  int64_t recon(uint32_t lo) {
+    if (init && lo < plo) hi += (1LL << 32);
+    plo = lo;
+    return hi + lo;
+  }
+  // Feed one frame; returns the reconstructed 64-bit tsf (µs).
+  int64_t add(uint32_t tsfl, int64_t host_ns) {
+    int64_t t = recon(tsfl);
+    if (!init) { x0 = (double)t; y0 = (double)host_ns; init = true; }
+    double xi = (double)t - x0, yi = (double)host_ns - y0;
+    ++n; sx += xi; sy += yi; sxx += xi * xi; sxy += xi * yi;
+    return t;
+  }
+  bool ready() const { return n >= 16; }
+  // The de-jittered host time (ns) for a given reconstructed tsf.
+  double host_at(int64_t t) const {
+    double den = (double)n * sxx - sx * sx;
+    if (den == 0) return y0;
+    double a = ((double)n * sxy - sx * sy) / den;
+    double b = (sy - a * sx) / (double)n;
+    return y0 + a * ((double)t - x0) + b;
+  }
+};
 
 // --- Schedule ---------------------------------------------------------------
 enum class Phase { NB, WIDE };
@@ -129,7 +175,7 @@ struct Schedule {
 
 // --- Config (env) -----------------------------------------------------------
 enum class Role { Tx, RxSync, RxCamp };
-enum class Sync { WallClock, Marker };
+enum class Sync { WallClock, Marker, Tsf };
 
 struct Config {
   Role role = Role::Tx;
@@ -173,8 +219,12 @@ inline Config config_from_env() {
     else if (s == "rx-camp") c.role = Role::RxCamp;
     else c.role = Role::Tx;
   }
-  if (const char* s = std::getenv("DEVOURER_TDMA_SYNC"))
-    c.sync = std::string(s) == "marker" ? Sync::Marker : Sync::WallClock;
+  if (const char* s = std::getenv("DEVOURER_TDMA_SYNC")) {
+    std::string v(s);
+    c.sync = v == "marker" ? Sync::Marker
+             : v == "tsf"  ? Sync::Tsf
+                           : Sync::WallClock;
+  }
 
   c.sched.nb_w = width_of(env_int("DEVOURER_TDMA_NB", 10));
   c.sched.wide_w = width_of(env_int("DEVOURER_TDMA_WIDE", 20));

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -189,6 +189,16 @@ public:
   virtual bool send_packet(const uint8_t *packet, size_t length) = 0;
   virtual SelectedChannel GetSelectedChannel() = 0;
 
+  /* Read the 64-bit hardware TSF (Timing Synchronization Function) timer — the
+   * 802.11 MAC's free-running microsecond clock (REG_TSFTR). It runs off the
+   * chip's crystal and is latched into every RX descriptor at receive
+   * (rx_pkt_attrib::tsfl, the low 32 bits), so it is a precise, host-jitter-free
+   * timing reference for multi-radio sync / TDOA / scheduled bursts. Returns 0
+   * where unsupported (default). NB: a register read is a control transfer —
+   * calling it concurrently with a heavy RX bulk-IN load can race (catch the
+   * exception). */
+  virtual uint64_t ReadTsf() { return 0; }
+
   /* Clean shutdown: halt TRX DMA and power the chip down to a re-enumerable
    * state (mirrors the kernel driver's card-disable on unbind). Call after the
    * RX/TX loop exits and BEFORE releasing/closing the USB interface, so the

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -290,6 +290,18 @@ RxEnergy RtlJaguarDevice::GetRxEnergy() {
 
 SelectedChannel RtlJaguarDevice::GetSelectedChannel() { return _channel; }
 
+uint64_t RtlJaguarDevice::ReadTsf() {
+  /* REG_TSFTR (0x0560) = TSF low 32, 0x0564 = TSF high 32. Read hi, lo, hi
+   * again and retry the pair once if the low word wrapped between the reads. */
+  uint32_t hi = _device.rtw_read<uint32_t>(0x0564);
+  uint32_t lo = _device.rtw_read<uint32_t>(0x0560);
+  if (_device.rtw_read<uint32_t>(0x0564) != hi) {
+    hi = _device.rtw_read<uint32_t>(0x0564);
+    lo = _device.rtw_read<uint32_t>(0x0560);
+  }
+  return (static_cast<uint64_t>(hi) << 32) | lo;
+}
+
 bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
   struct tx_desc *ptxdesc;
   bool resp;

--- a/src/jaguar1/RtlJaguarDevice.h
+++ b/src/jaguar1/RtlJaguarDevice.h
@@ -201,6 +201,7 @@ public:
   bool send_packet(const uint8_t* packet, size_t length) override;
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
+  uint64_t ReadTsf() override;
 
   /* Runtime RX-chain selection — the adaptive-link spatial-diversity lever
    * (the read/write superset of the DEVOURER_RX_PATHS env knob). Writes the

--- a/src/jaguar2/FrameParserJaguar2.h
+++ b/src/jaguar2/FrameParserJaguar2.h
@@ -68,6 +68,9 @@ constexpr size_t RXDESC_SIZE_8822B = 24; /* RX_DESC_SIZE_88XX */
 #define GET_RX_DESC_SHIFT_8822B(r)         LE_BITS_TO_4BYTE((r) + 0x00, 24, 2)
 #define GET_RX_DESC_PHYST_8822B(r)         LE_BITS_TO_4BYTE((r) + 0x00, 26, 1)
 #define GET_RX_DESC_RX_RATE_8822B(r)       LE_BITS_TO_4BYTE((r) + 0x0C, 0, 7)
+/* DWORD 5 = the 32-bit TSF-low latched at receive (same offset as the 8812's
+ * GET_RX_STATUS_DESC_TSFL_8812 at +20). The hardware TSF timing reference. */
+#define GET_RX_DESC_TSFL_8822B(r)          LE_BITS_TO_4BYTE((r) + 0x14, 0, 32)
 
 namespace jaguar2 {
 
@@ -185,6 +188,7 @@ struct Rx8822bFrame {
   uint8_t rx_rate;
   uint16_t drvinfo_size;
   uint8_t shift;
+  uint32_t tsfl;              /* hardware TSF-low at receive */
   uint32_t next_offset;
 };
 
@@ -202,6 +206,7 @@ inline bool parse_rx_8822b(const uint8_t *buf, size_t buflen,
   out.crc_err = GET_RX_DESC_CRC32_8822B(buf) != 0;
   out.icv_err = GET_RX_DESC_ICV_ERR_8822B(buf) != 0;
   out.rx_rate = static_cast<uint8_t>(GET_RX_DESC_RX_RATE_8822B(buf));
+  out.tsfl = static_cast<uint32_t>(GET_RX_DESC_TSFL_8822B(buf));
 
   uint32_t frame_off =
       static_cast<uint32_t>(RXDESC_SIZE_8822B) + out.drvinfo_size + out.shift;

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -439,6 +439,7 @@ void RtlJaguar2Device::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
         p.RxAtrib.crc_err = f.crc_err;
         p.RxAtrib.icv_err = f.icv_err;
         p.RxAtrib.data_rate = f.rx_rate;
+        p.RxAtrib.tsfl = f.tsfl;
         p.RxAtrib.drvinfo_sz = static_cast<uint8_t>(f.drvinfo_size);
         p.RxAtrib.shift_sz = f.shift;
         /* RX desc word2 BIT(28) (GET_RX_DESC_C2H, halmac_rx_desc_nic.h:230) marks
@@ -1130,6 +1131,20 @@ bool RtlJaguar2Device::send_packet(const uint8_t *packet, size_t length) {
 }
 
 SelectedChannel RtlJaguar2Device::GetSelectedChannel() { return _channel; }
+
+uint64_t RtlJaguar2Device::ReadTsf() {
+  /* REG_TSFTR 0x0560 (low) / 0x0564 (high); hi/lo/hi with a wrap retry. Under
+   * _reg_mu (shared with the coex/thermal tick). NB starved to 0 under a heavy
+   * RX bulk-IN flood — reliable from a quiet TX. */
+  std::lock_guard<std::mutex> lk(_reg_mu);
+  uint32_t hi = _device.rtw_read<uint32_t>(0x0564);
+  uint32_t lo = _device.rtw_read<uint32_t>(0x0560);
+  if (_device.rtw_read<uint32_t>(0x0564) != hi) {
+    hi = _device.rtw_read<uint32_t>(0x0564);
+    lo = _device.rtw_read<uint32_t>(0x0560);
+  }
+  return (static_cast<uint64_t>(hi) << 32) | lo;
+}
 
 void RtlJaguar2Device::Stop() {
   stop_pwrtrack();

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -66,6 +66,7 @@ public:
   bool send_packet(const uint8_t *packet, size_t length) override;
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
+  uint64_t ReadTsf() override;
   void Stop() override;
   void SetTxMode(const devourer::TxMode &mode) override;
   void ClearTxMode() override;

--- a/src/jaguar3/FrameParserJaguar3.h
+++ b/src/jaguar3/FrameParserJaguar3.h
@@ -64,6 +64,9 @@ constexpr size_t RXDESC_SIZE_8822C = 24; /* RX_DESC_SIZE_88XX */
 #define GET_RX_DESC_SHIFT_8822C(r)         LE_BITS_TO_4BYTE((r) + 0x00, 24, 2)
 #define GET_RX_DESC_PHYST_8822C(r)         LE_BITS_TO_4BYTE((r) + 0x00, 26, 1)
 #define GET_RX_DESC_RX_RATE_8822C(r)       LE_BITS_TO_4BYTE((r) + 0x0C, 0, 7)
+/* DWORD 5 = the 32-bit TSF-low latched at receive (same +0x14 offset as the
+ * 8812 GET_RX_STATUS_DESC_TSFL_8812). The hardware TSF timing reference. */
+#define GET_RX_DESC_TSFL_8822C(r)          LE_BITS_TO_4BYTE((r) + 0x14, 0, 32)
 
 namespace jaguar3 {
 
@@ -156,6 +159,7 @@ struct Rx8822cFrame {
   uint8_t rx_rate;       /* RX_RATE (DESC_RATE* index) */
   uint16_t drvinfo_size; /* bytes (DRV_INFO_SIZE * 8) */
   uint8_t shift;         /* SHIFT_SZ */
+  uint32_t tsfl;         /* hardware TSF-low at receive */
   uint32_t next_offset;  /* 8-byte-aligned offset of the next frame in an agg */
 };
 
@@ -175,6 +179,7 @@ inline bool parse_rx_8822c(const uint8_t *buf, size_t buflen,
   out.crc_err = GET_RX_DESC_CRC32_8822C(buf) != 0;
   out.icv_err = GET_RX_DESC_ICV_ERR_8822C(buf) != 0;
   out.rx_rate = static_cast<uint8_t>(GET_RX_DESC_RX_RATE_8822C(buf));
+  out.tsfl = static_cast<uint32_t>(GET_RX_DESC_TSFL_8822C(buf));
 
   uint32_t frame_off =
       static_cast<uint32_t>(RXDESC_SIZE_8822C) + out.drvinfo_size + out.shift;

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -217,6 +217,7 @@ void RtlJaguar3Device::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
         p.RxAtrib.crc_err = f.crc_err;
         p.RxAtrib.icv_err = f.icv_err;
         p.RxAtrib.data_rate = f.rx_rate;
+        p.RxAtrib.tsfl = f.tsfl;
         p.RxAtrib.drvinfo_sz = static_cast<uint8_t>(f.drvinfo_size);
         p.RxAtrib.shift_sz = f.shift;
         /* RX desc word2 BIT(28) = FW C2H report, not an 802.11 frame. During
@@ -1255,6 +1256,20 @@ bool RtlJaguar3Device::send_packet(const uint8_t *packet, size_t length) {
 }
 
 SelectedChannel RtlJaguar3Device::GetSelectedChannel() { return _channel; }
+
+uint64_t RtlJaguar3Device::ReadTsf() {
+  /* REG_TSFTR 0x0560 (low) / 0x0564 (high); hi/lo/hi with a wrap retry. Under
+   * _reg_mu (shared with the coex runtime thread). Starved to 0 under a heavy
+   * RX bulk-IN flood — reliable from a quiet TX. */
+  std::lock_guard<std::mutex> lk(_reg_mu);
+  uint32_t hi = _device.rtw_read<uint32_t>(0x0564);
+  uint32_t lo = _device.rtw_read<uint32_t>(0x0560);
+  if (_device.rtw_read<uint32_t>(0x0564) != hi) {
+    hi = _device.rtw_read<uint32_t>(0x0564);
+    lo = _device.rtw_read<uint32_t>(0x0560);
+  }
+  return (static_cast<uint64_t>(hi) << 32) | lo;
+}
 
 void RtlJaguar3Device::SetTxMode(const devourer::TxMode &mode) {
   _tx_mode_default = mode;

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -65,6 +65,7 @@ public:
   bool send_packet(const uint8_t *packet, size_t length) override;
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
+  uint64_t ReadTsf() override;
   void Stop() override;
 
   /* Runtime TX-power control (IRtlDevice contract; see src/TxPower.h).

--- a/tests/tdma_tsf_selftest.cpp
+++ b/tests/tdma_tsf_selftest.cpp
@@ -1,0 +1,100 @@
+// tdma_tsf_selftest.cpp — headless unit tests for the burst-TDMA pure logic:
+// the TsfClock host↔TSF least-squares fit (does it recover a known crystal drift
+// and de-jitter the anchor?), the on-air frame-tag build/parse round-trip, and
+// the schedule phase math. No hardware / no libusb — runs in ctest, unlike the
+// tsf_probe / tsf_tdoa_probe / tdma_tsf_test harnesses which need real adapters.
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "tdma.h"
+
+static int g_fail = 0;
+#define CHECK(cond, msg)                                                        \
+  do {                                                                          \
+    if (!(cond)) { std::printf("FAIL: %s\n", (msg)); ++g_fail; }                \
+  } while (0)
+
+int main() {
+  // --- 1. TsfClock recovers a known drift and de-jitters the anchor ---------
+  // Synthesise host = a·tsf + b with heavy jitter (like the ~200 µs+ USB noise),
+  // and check the fit both recovers the drift (slope) and predicts the true host
+  // far more tightly than the noisy samples do.
+  {
+    tdma::TsfClock clk;
+    const double drift_ppm = 20.0;
+    const double a = 1.0 + drift_ppm / 1e6;   // host µs per tsf µs
+    const double b = 12345.0;
+    const int N = 1000;
+    uint32_t s = 1;                            // deterministic ±200 µs jitter
+    auto jit = [&]() { s = s * 1664525u + 1013904223u;
+                       return (int)((s >> 8) % 400) - 200; };
+    std::vector<int64_t> tsf;
+    std::vector<double> host_true;
+    double max_raw = 0, max_fit = 0;
+    for (int i = 0; i < N; ++i) {
+      int64_t t = 1000 + (int64_t)i * 5000;    // µs, no 32-bit wrap over the run
+      double ht = a * (double)t + b;
+      int j = jit();
+      clk.add((uint32_t)t, (int64_t)(ht + j));
+      tsf.push_back(t);
+      host_true.push_back(ht);
+      if (std::fabs((double)j) > max_raw) max_raw = std::fabs((double)j);
+    }
+    CHECK(clk.ready(), "clock ready after N frames");
+    for (int i = 0; i < N; ++i) {
+      double e = std::fabs(clk.host_at(tsf[i]) - host_true[i]);
+      if (e > max_fit) max_fit = e;
+    }
+    const double slope = (clk.host_at(1000000) - clk.host_at(0)) / 1000000.0;
+    CHECK(std::fabs((slope - 1.0) * 1e6 - drift_ppm) < 5.0,
+          "drift recovered within 5 ppm of the true 20 ppm");
+    CHECK(max_raw > 150.0, "raw samples carry the injected ~200 us jitter");
+    CHECK(max_fit < 80.0, "fit de-jitters the anchor to << the raw jitter");
+  }
+
+  // --- 2. frame-tag build/parse round-trip ----------------------------------
+  {
+    std::vector<uint8_t> rt(10, 0xAA);   // dummy radiotap prefix (stripped on RX)
+    for (tdma::Class cls :
+         {tdma::Class::Marker, tdma::Class::Critical, tdma::Class::Bulk}) {
+      const uint32_t seq = 0x11223344u, burst = 0x0055aa77u;
+      const uint64_t txtsf = 0x0123456789abcdefULL;
+      auto f = tdma::build_frame(rt, cls, seq, burst, txtsf);
+      // The RX sees the 802.11 MPDU (radiotap already stripped) → parse past rt.
+      auto p = tdma::parse_frame(f.data() + rt.size(), f.size() - rt.size());
+      CHECK(p.ok, "parse ok");
+      CHECK(p.cls == cls, "class round-trips");
+      CHECK(p.seq == seq, "seq round-trips");
+      CHECK(p.burst == burst, "burst round-trips");
+      CHECK(p.tx_tsf == txtsf, "tx_tsf round-trips");
+    }
+    std::vector<uint8_t> junk(60, 0x00);      // wrong SA / no TD magic
+    CHECK(!tdma::parse_frame(junk.data(), junk.size()).ok, "foreign frame rejected");
+    CHECK(!tdma::parse_frame(rt.data(), 8).ok, "short buffer rejected");
+  }
+
+  // --- 3. schedule phase math -----------------------------------------------
+  {
+    tdma::Schedule s;
+    s.nb_ms = 100; s.wide_ms = 100; s.epoch_ms = 0;   // period 200
+    CHECK(s.period() == 200, "period");
+    CHECK(s.at(0).phase == tdma::Phase::NB, "t=0 NB");
+    CHECK(s.at(99).phase == tdma::Phase::NB, "t=99 NB");
+    CHECK(s.at(100).phase == tdma::Phase::WIDE, "t=100 WIDE");
+    CHECK(s.at(199).phase == tdma::Phase::WIDE, "t=199 WIDE");
+    CHECK(s.at(200).phase == tdma::Phase::NB && s.at(200).burst == 1,
+          "t=200 NB, burst 1");
+    CHECK(s.at(250).phase == tdma::Phase::NB, "t=250 (pos 50) NB");
+    CHECK(s.at(350).phase == tdma::Phase::WIDE, "t=350 (pos 150) WIDE");
+    s.epoch_ms = 1000;                                 // negative-rel handling
+    CHECK(s.at(1050).phase == tdma::Phase::NB, "epoch-anchored NB");
+    CHECK(s.at(950).phase == tdma::Phase::WIDE, "pre-epoch wraps correctly");
+  }
+
+  std::printf(g_fail ? "tdma_tsf_selftest: %d FAILURE(S)\n"
+                     : "tdma_tsf_selftest: all passed\n",
+              g_fail);
+  return g_fail ? 1 : 0;
+}

--- a/tests/tdma_tsf_test.sh
+++ b/tests/tdma_tsf_test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# tdma_tsf_test.sh — compare marker vs tsf sync in the tdma example, and sweep
+# the guard. The tsf RX must be a Jaguar1 adapter (per-frame tsfl); the TX must
+# be Jaguar1 too if you want the TX-TSF drift stamp (ReadTsf). Uses SUDO in the
+# trap cleanup — the demo binaries run as root, so a plain pkill can't reap them.
+#
+#   sudo tests/tdma_tsf_test.sh <TX_PID> <RX_PID> <sync> <guard_ms> [ch] [nb] [sec]
+set -uo pipefail
+cd "$(dirname "$0")/.."
+TX_PID="${1:-0x8813}"   # 8814AU (J1) TX
+RX_PID="${2:-0x8812}"   # 8812AU (J1) RX — has tsfl
+SYNC="${3:-tsf}"        # marker | tsf | wallclock
+GUARD="${4:-20}"
+CH="${5:-36}"
+NB="${6:-10}"
+SEC="${7:-15}"
+BIN="$(pwd)/build/tdma"
+
+TXLOG=$(mktemp)
+cleanup() { sudo pkill -9 -x tdma 2>/dev/null || true; rm -f "$TXLOG"; }
+trap cleanup EXIT
+sudo pkill -9 -x tdma 2>/dev/null || true; sleep 2
+
+# Robust bulk rate: MCS7 does not decode at 5 GHz on this bench (SNR); 6M does.
+BULK="${BULK:-6M}"
+sudo env DEVOURER_PID="$TX_PID" DEVOURER_CHANNEL="$CH" DEVOURER_TDMA_ROLE=tx \
+  DEVOURER_TDMA_NB="$NB" DEVOURER_TDMA_NB_MS=100 DEVOURER_TDMA_WIDE_MS=100 \
+  DEVOURER_TDMA_BULK_RATE="$BULK" DEVOURER_TDMA_GAP_US=300 DEVOURER_LOG_LEVEL=silent \
+  "$BIN" >"$TXLOG" 2>&1 &
+sleep 4
+echo "### sync=$SYNC guard=${GUARD}ms  (TX $TX_PID -> RX $RX_PID, ch$CH ${NB}MHz bulk=$BULK) ###"
+sudo env DEVOURER_PID="$RX_PID" DEVOURER_CHANNEL="$CH" DEVOURER_TDMA_ROLE=rx-sync \
+  DEVOURER_TDMA_SYNC="$SYNC" DEVOURER_TDMA_NB="$NB" DEVOURER_TDMA_NB_MS=100 \
+  DEVOURER_TDMA_WIDE_MS=100 DEVOURER_TDMA_GUARD_MS="$GUARD" DEVOURER_LOG_LEVEL=silent \
+  timeout -k 3 "$SEC" "$BIN" 2>&1 | grep -iE "delivered"

--- a/tests/tdma_tsf_test.sh
+++ b/tests/tdma_tsf_test.sh
@@ -23,13 +23,14 @@ sudo pkill -9 -x tdma 2>/dev/null || true; sleep 2
 
 # Robust bulk rate: MCS7 does not decode at 5 GHz on this bench (SNR); 6M does.
 BULK="${BULK:-6M}"
+BURST="${BURST:-100}"   # nb_ms = wide_ms = BURST (short bursts stress the anchor)
 sudo env DEVOURER_PID="$TX_PID" DEVOURER_CHANNEL="$CH" DEVOURER_TDMA_ROLE=tx \
-  DEVOURER_TDMA_NB="$NB" DEVOURER_TDMA_NB_MS=100 DEVOURER_TDMA_WIDE_MS=100 \
+  DEVOURER_TDMA_NB="$NB" DEVOURER_TDMA_NB_MS="$BURST" DEVOURER_TDMA_WIDE_MS="$BURST" \
   DEVOURER_TDMA_BULK_RATE="$BULK" DEVOURER_TDMA_GAP_US=300 DEVOURER_LOG_LEVEL=silent \
   "$BIN" >"$TXLOG" 2>&1 &
 sleep 4
-echo "### sync=$SYNC guard=${GUARD}ms  (TX $TX_PID -> RX $RX_PID, ch$CH ${NB}MHz bulk=$BULK) ###"
+echo "### sync=$SYNC guard=${GUARD}ms burst=${BURST}ms  (TX $TX_PID -> RX $RX_PID, ch$CH ${NB}MHz bulk=$BULK) ###"
 sudo env DEVOURER_PID="$RX_PID" DEVOURER_CHANNEL="$CH" DEVOURER_TDMA_ROLE=rx-sync \
-  DEVOURER_TDMA_SYNC="$SYNC" DEVOURER_TDMA_NB="$NB" DEVOURER_TDMA_NB_MS=100 \
-  DEVOURER_TDMA_WIDE_MS=100 DEVOURER_TDMA_GUARD_MS="$GUARD" DEVOURER_LOG_LEVEL=silent \
+  DEVOURER_TDMA_SYNC="$SYNC" DEVOURER_TDMA_NB="$NB" DEVOURER_TDMA_NB_MS="$BURST" \
+  DEVOURER_TDMA_WIDE_MS="$BURST" DEVOURER_TDMA_GUARD_MS="$GUARD" DEVOURER_LOG_LEVEL=silent \
   timeout -k 3 "$SEC" "$BIN" 2>&1 | grep -iE "delivered"

--- a/tests/tsf_probe.cpp
+++ b/tests/tsf_probe.cpp
@@ -1,0 +1,137 @@
+// tsf_probe.cpp — is the hardware TSF alive, and how jittery is a host-clock
+// timestamp vs the per-frame hardware RX TSF? Prints, for each decoded frame,
+// the RX-descriptor TSF-low (RxAtrib.tsfl, latched in the MAC at receive) next
+// to the host steady_clock time when the callback ran. If tsfl advances ~1 us
+// per real us, the TSF is running and usable as a precise timing reference.
+//
+// Build: g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/tsf_probe.cpp \
+//   examples/common/env_config.cpp build/libdevourer.a \
+//   $(pkg-config --cflags --libs libusb-1.0) -lpthread -o build/tsf_probe
+// Run: sudo DEVOURER_PID=0x8812 DEVOURER_CHANNEL=6 build/tsf_probe [nframes]
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+#include <unistd.h>
+
+#include <libusb.h>
+
+#include "RxPacket.h"
+#include "SelectedChannel.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "env_config.h"
+#include "logger.h"
+
+static std::atomic<int> g_n{0};
+static int g_want = 20;
+
+static int64_t steady_us() {
+  return std::chrono::duration_cast<std::chrono::microseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+
+int main(int argc, char** argv) {
+  if (argc > 1) g_want = atoi(argv[1]);
+  uint8_t ch = 6;
+  if (const char* c = std::getenv("DEVOURER_CHANNEL")) ch = (uint8_t)atoi(c);
+  auto logger = std::make_shared<Logger>();
+  libusb_context* ctx = nullptr;
+  if (libusb_init(&ctx) < 0) return 1;
+  libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
+  uint16_t vid = 0x0bda, pid = 0;
+  if (const char* v = std::getenv("DEVOURER_VID")) vid = (uint16_t)strtoul(v, 0, 0);
+  if (const char* p = std::getenv("DEVOURER_PID")) pid = (uint16_t)strtoul(p, 0, 0);
+  auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
+  if (!h) { fprintf(stderr, "open %04x:%04x failed\n", vid, pid); return 1; }
+  std::shared_ptr<devourer::UsbDeviceLock> lock;
+  if (devourer::claim_interface_then_reset(h, 0, logger, true, lock) != 0) return 1;
+  WiFiDriver wifi(logger);
+  auto dev = wifi.CreateRtlDevice(h, ctx, lock, devourer_config_from_env());
+  if (!dev) return 1;
+
+  // TSF_REG=1: read the host-facing TSF register standalone (TX bring-up, no RX
+  // flood) to tell "register not running in this mode" from "flood race".
+  if (std::getenv("TSF_REG")) {
+    dev->InitWrite(SelectedChannel{ch, 0, CHANNEL_WIDTH_20});
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    for (int i = 0; i < 6; ++i) {
+      uint64_t t = dev->ReadTsf();
+      printf("ReadTsf() #%d = %llu us\n", i, (unsigned long long)t);
+      fflush(stdout);
+      std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+    _exit(0);
+  }
+
+  // Collect (hardware TSF, host steady) pairs; a frame's TSF is latched in the
+  // MAC at receive, the host time is when our callback ran.
+  std::mutex mu;
+  std::vector<double> tsf_us, host_us;
+  int64_t tsf_hi = 0, prev_lo = 0;   // rebuild a 64-bit TSF from the 32-bit low
+  std::atomic<int> readtsf_ok{0}, readtsf_fail{0};
+  std::atomic<long> readtsf_delta{0};   // ReadTsf() - frame.tsfl (should be > 0)
+  auto cb = [&](const Packet& p) {
+    if (p.RxAtrib.crc_err) return;
+    int n = ++g_n;
+    if (n > g_want) return;
+    uint32_t lo = p.RxAtrib.tsfl;
+    // ReadTsf() reliability during the RX flood: a control read racing bulk-IN.
+    try {
+      uint64_t rt = dev->ReadTsf();
+      if (rt) { readtsf_ok++; readtsf_delta.store((long)((uint32_t)(rt - lo))); }
+      else readtsf_fail++;
+    } catch (...) { readtsf_fail++; }
+    if (lo < prev_lo) tsf_hi += (1LL << 32);   // low-word wrap (~71.6 min)
+    prev_lo = lo;
+    std::lock_guard<std::mutex> lk(mu);
+    tsf_us.push_back((double)(tsf_hi + lo));
+    host_us.push_back((double)steady_us());
+  };
+  std::thread rx([&] { dev->Init(cb, SelectedChannel{ch, 0, CHANNEL_WIDTH_20}); });
+  for (int i = 0; i < 3000 && g_n.load() < g_want; ++i)
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  // A frame's *true* arrival is the hardware TSF; the host timestamp is that
+  // plus USB + scheduling latency. Fit host = a*tsf + b (removes constant offset
+  // + the crystal rate difference), and the residual stdev is exactly the host
+  // clock's timing jitter relative to the hardware TSF — i.e. the anchor jitter
+  // that switching the schedule anchor from host time to TSF would remove.
+  std::lock_guard<std::mutex> lk(mu);
+  size_t N = tsf_us.size();
+  if (N < 8) { fprintf(stderr, "too few frames (%zu)\n", N); _exit(1); }
+  double sx = 0, sy = 0, sxx = 0, sxy = 0;
+  for (size_t i = 0; i < N; ++i) {
+    sx += tsf_us[i]; sy += host_us[i];
+    sxx += tsf_us[i] * tsf_us[i]; sxy += tsf_us[i] * host_us[i];
+  }
+  double a = (N * sxy - sx * sy) / (N * sxx - sx * sx);
+  double b = (sy - a * sx) / N;
+  double ss = 0, mx = 0;
+  for (size_t i = 0; i < N; ++i) {
+    double r = host_us[i] - (a * tsf_us[i] + b);
+    ss += r * r;
+    if (std::fabs(r) > mx) mx = std::fabs(r);
+  }
+  double sd = std::sqrt(ss / N);
+  printf("\n== ReadTsf() during RX flood: %d ok / %d failed (last delta vs "
+         "frame.tsfl = %ld us) ==\n", readtsf_ok.load(), readtsf_fail.load(),
+         readtsf_delta.load());
+  printf("\n== TSF vs host-clock timing jitter (%zu frames, ch %u) ==\n", N, ch);
+  printf("  host-clock rate vs TSF : %.6f (1.0 = identical crystals; "
+         "%.1f ppm offset)\n", a, (a - 1.0) * 1e6);
+  printf("  host-timestamp jitter relative to hardware TSF:\n");
+  printf("    stdev = %.1f us    max = %.1f us\n", sd, mx);
+  printf("  => anchoring the TDMA schedule on tsfl removes ~this much per-frame\n"
+         "     anchor noise (the guard can shrink toward the hardware floor).\n");
+  fflush(stdout);
+  _exit(0);
+}

--- a/tests/tsf_tdoa_probe.cpp
+++ b/tests/tsf_tdoa_probe.cpp
@@ -1,0 +1,157 @@
+// tsf_tdoa_probe.cpp — multi-radio TSF correlation: two receivers hear the same
+// transmitter, and we relate their independent hardware TSF clocks from frames
+// they BOTH decode. Uses only the per-frame RX-descriptor tsfl (reliable during
+// RX, unlike a register ReadTsf which the bulk-IN flood starves), so the
+// measurement is clean on both ends.
+//
+// For each frame heard by both RXs (matched by the tdma TD tag's class+seq), we
+// take Δ = tsfl_A − tsfl_B. Δ = (crystal-rate difference)·t + (constant offset)
+// + (propagation-delay difference). Fitting Δ vs host time recovers the
+// inter-receiver crystal DRIFT (ppm) and, from the residual, how tightly the two
+// hardware timestamps track. That residual is the noise floor a TDOA solver
+// would work against — though at 1 µs TSF resolution real geometry needs
+// hundreds-of-metres baselines (30 cm ≈ 1 ns, far below a µs), so a bench shows
+// the CLOCK RELATIONSHIP, not localization.
+//
+// Build: g++ -std=c++20 -O2 -Isrc -Iexamples/common -Iexamples/tdma \
+//   tests/tsf_tdoa_probe.cpp examples/common/env_config.cpp build/libdevourer.a \
+//   $(pkg-config --cflags --libs libusb-1.0) -lpthread -o build/tsf_tdoa_probe
+// Run: sudo DEVOURER_CHANNEL=36 build/tsf_tdoa_probe <VID_A:PID_A> <VID_B:PID_B> [nmatch]
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+#include <unistd.h>
+
+#include <libusb.h>
+
+#include "RxPacket.h"
+#include "SelectedChannel.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "env_config.h"
+#include "logger.h"
+#include "tdma.h"
+
+static int g_want = 400;
+static uint8_t g_ch = 36;
+static std::atomic<bool> g_done{false};
+
+static double steady_us() {
+  return std::chrono::duration_cast<std::chrono::microseconds>(
+             std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+// Per-receiver 32→64-bit TSF reconstruction (each owned by one RX thread).
+struct Recon { int64_t hi = 0; uint32_t plo = 0; bool init = false;
+  int64_t operator()(uint32_t lo) {
+    if (init && lo < plo) hi += (1LL << 32);
+    plo = lo; init = true; return hi + lo;
+  }
+};
+
+// Shared: frames seen by only one RX so far, keyed by (class,seq); and the
+// matched Δ samples.
+static std::mutex g_mu;
+static std::map<uint64_t, std::pair<int, int64_t>> g_pending;  // key -> (rx, tsf)
+static std::vector<double> g_host, g_delta;                    // matched samples
+
+static libusb_device_handle* open_pid(libusb_context* ctx, uint16_t vid,
+                                       uint16_t pid, const std::shared_ptr<Logger>& lg,
+                                       std::shared_ptr<devourer::UsbDeviceLock>& lk) {
+  auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
+  if (!h) { fprintf(stderr, "open %04x:%04x failed\n", vid, pid); return nullptr; }
+  if (devourer::claim_interface_then_reset(h, 0, lg, true, lk) != 0) {
+    fprintf(stderr, "claim %04x:%04x failed\n", vid, pid); return nullptr;
+  }
+  return h;
+}
+
+static void run_rx(IRtlDevice* dev, int idx) {
+  Recon recon;
+  auto cb = [&, idx](const Packet& p) {
+    auto pr = tdma::parse_frame(p.Data.data(), p.Data.size());
+    if (!pr.ok || p.RxAtrib.crc_err) return;
+    int64_t tsf = recon(p.RxAtrib.tsfl);
+    uint64_t key = ((uint64_t)pr.cls << 32) | pr.seq;
+    std::lock_guard<std::mutex> lk(g_mu);
+    auto it = g_pending.find(key);
+    if (it == g_pending.end()) {
+      if (g_pending.size() > 20000) g_pending.clear();  // drop stale singletons
+      g_pending[key] = {idx, tsf};
+    } else if (it->second.first != idx) {               // the OTHER RX had it
+      int64_t a = idx == 0 ? tsf : it->second.second;
+      int64_t b = idx == 0 ? it->second.second : tsf;
+      g_host.push_back(steady_us());
+      g_delta.push_back((double)(a - b));
+      g_pending.erase(it);
+      if ((int)g_delta.size() >= g_want) g_done.store(true);
+    }
+  };
+  dev->Init(cb, SelectedChannel{g_ch, 0, CHANNEL_WIDTH_20});
+}
+
+int main(int argc, char** argv) {
+  if (argc < 3) { fprintf(stderr, "usage: %s <vidA:pidA> <vidB:pidB> [nmatch]\n", argv[0]); return 2; }
+  auto parse = [](const char* s, uint16_t& v, uint16_t& p) {
+    const char* c = strchr(s, ':');
+    v = (uint16_t)strtoul(s, nullptr, 0); p = (uint16_t)strtoul(c ? c + 1 : s, nullptr, 0);
+  };
+  uint16_t vA, pA, vB, pB; parse(argv[1], vA, pA); parse(argv[2], vB, pB);
+  if (argc > 3) g_want = atoi(argv[3]);
+  if (const char* c = std::getenv("DEVOURER_CHANNEL")) g_ch = (uint8_t)atoi(c);
+
+  auto logger = std::make_shared<Logger>();
+  libusb_context* ctx = nullptr;
+  if (libusb_init(&ctx) < 0) return 1;
+  libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
+  std::shared_ptr<devourer::UsbDeviceLock> lkA, lkB;
+  auto* hA = open_pid(ctx, vA, pA, logger, lkA);
+  auto* hB = open_pid(ctx, vB, pB, logger, lkB);
+  if (!hA || !hB) return 1;
+  WiFiDriver wifi(logger);
+  auto devA = wifi.CreateRtlDevice(hA, ctx, lkA, devourer_config_from_env());
+  auto devB = wifi.CreateRtlDevice(hB, ctx, lkB, devourer_config_from_env());
+  if (!devA || !devB) { fprintf(stderr, "device create failed\n"); return 1; }
+
+  std::thread tA([&] { run_rx(devA.get(), 0); });
+  std::thread tB([&] { run_rx(devB.get(), 1); });
+  for (int i = 0; i < 4000 && !g_done.load(); ++i)
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+  std::lock_guard<std::mutex> lk(g_mu);
+  size_t N = g_delta.size();
+  if (N < 16) { fprintf(stderr, "too few common frames (%zu) — are both RXs in range?\n", N); _exit(1); }
+  // Fit Δ = a·host + b (host in µs). a = crystal-rate difference (ppm = a·1e6);
+  // residual = how tightly the two hardware timestamps track.
+  double x0 = g_host[0], y0 = g_delta[0], sx = 0, sy = 0, sxx = 0, sxy = 0;
+  for (size_t i = 0; i < N; ++i) {
+    double xi = g_host[i] - x0, yi = g_delta[i] - y0;
+    sx += xi; sy += yi; sxx += xi * xi; sxy += xi * yi;
+  }
+  double den = N * sxx - sx * sx;
+  double a = den ? (N * sxy - sx * sy) / den : 0, b = (sy - a * sx) / N;
+  double ss = 0, mx = 0;
+  for (size_t i = 0; i < N; ++i) {
+    double r = (g_delta[i] - y0) - (a * (g_host[i] - x0) + b);
+    ss += r * r; if (std::fabs(r) > mx) mx = std::fabs(r);
+  }
+  printf("\n== dual-RX TSF correlation (%zu common frames, ch %u) ==\n", N, g_ch);
+  printf("  inter-receiver crystal drift : %.1f ppm\n", a * 1e6);
+  printf("  timestamp-tracking residual  : stdev %.2f us   max %.2f us\n",
+         std::sqrt(ss / N), mx);
+  printf("  (residual = the TDOA noise floor; real geometry needs baselines\n"
+         "   where propagation delay >> this, i.e. hundreds of metres at 1 µs TSF.)\n");
+  fflush(stdout);
+  _exit(0);
+}


### PR DESCRIPTION
## What

Leverages the **802.11 hardware TSF** (the MAC's free-running microsecond clock) as a precise timing reference for the burst-TDMA example's schedule sync — replacing the noisy host clock — and adds it as a reusable library primitive. Grew out of the question "can we use TSF for precise time synchronization." Every step is a real on-hardware measurement.

## Library additions (clean, generation-spanning)

- **`IRtlDevice::ReadTsf()`** — reads the 64-bit `REG_TSFTR` (default 0 where unsupported; implemented on Jaguar1/2/3 with a hi/lo/hi wrap guard, under `_reg_mu` on J2/J3).
- **Per-frame `rx_pkt_attrib::tsfl` surfaced on Jaguar2/3** — the 8822b/8822c/8822e RX descriptor is the same 88XX layout, with the 32-bit TSF-low at DWORD 5 (offset 0x14), the same position the 8812 already used. Carried through the `Rx8822b/cFrame` structs into `RxAtrib.tsfl`.

These are additive and default-safe: `ReadTsf()` returns 0 on any device that doesn't override it, and the descriptor field was previously unread.

## Example: `DEVOURER_TDMA_SYNC=tsf`

The lockstep receiver anchors its schedule on the marker's **hardware TSF** instead of the callback timestamp. A running host↔TSF least-squares fit de-jitters each marker's arrival. The TX stamps markers with its own `ReadTsf()` for a rough TX↔RX drift readout.

## Measured (all on the bench)

| Measurement | Result |
|---|---|
| Host callback jitter vs hardware TSF (`tsf_probe`) | **~1.1 ms RMS** (USB batching + scheduling) |
| TSF-fit marker anchor residual (end-to-end in the example) | **~44 µs RMS** → a **~25× tighter** schedule anchor |
| Misalignment (off-diagonal) at short bursts, marker vs tsf | **2–5× lower** with tsf (delivered-count is insensitive — burst ≫ jitter) |
| Dual-RX clock correlation (`tsf_tdoa_probe`, 8822C + 8822B) | **~16.5 ppm** inter-receiver drift (stable), **~0.35 µs RMS** residual → **sub-µs** multi-radio sync |

`tsf_tdoa_probe` is the multi-radio building block for TDOA — two receivers correlated purely from per-frame `tsfl` (no `ReadTsf()`, so no flood-starvation on either end).

## Honest caveats (in the commits/docs, not hidden)

- `ReadTsf()` register reads are **starved to 0 under a heavy RX bulk-IN flood** (control-read contention), so the RX path uses per-frame `tsfl`; a quiet TX can read the register, but a busy TX's drift stamp is intermittent/noisy.
- The **delivered-frame count is an insensitive metric** for sync quality (off-diagonal misalignment is the real signal); the fit residual is the clean direct measure.
- TDOA **localization** needs baselines where propagation delay exceeds the ~0.35 µs residual (hundreds of metres at 1 µs TSF resolution) — the bench shows the clock relationship, not geometry.
- MCS7 doesn't decode at 5 GHz on this bench (a robust bulk rate is used for the demo).

## Testing

`ctest` green (14/14), full build + OFF-config builds unaffected (additive). The example's **pure logic gets headless CI coverage** — `TdmaTsfSelftest` (ctest `tdma_tsf_math`) verifies the TsfClock fit recovers a known drift + de-jitters, the frame-tag round-trip, and the schedule phase math. The **hardware harnesses** (`tsf_probe`, `tsf_tdoa_probe`, `tdma_tsf_test.sh`) stay standalone/manual and out-of-band, matching every other `tests/*` hardware harness (none are CMake/ctest targets — they need real adapters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

