### PR TITLE
README: surface hardware-TSF timing in "Why devourer"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ long-range digital video links.
   supported generation — including the decade-old RTL8812AU and RTL8814AU the
   vendor never gave narrowband — half/quarter the bandwidth, more range from
   the same power ([how](docs/narrowband.md)).
+- **Hardware time, for coordinating radios.** Every received frame is stamped
+  with the chip's microsecond MAC clock (TSF) on all three generations, and the
+  64-bit timer reads back directly — the primitive multi-radio setups need.
+  Independent receivers correlate their clocks to sub-microsecond, and a
+  time-division burst schedule locks to a transmitter ~25× tighter than the host
+  clock manages — enough to interleave a robust narrowband link and a wide
+  high-throughput one on one shared channel
+  ([bandwidth TDMA](docs/narrowband.md)).
 - **A radio lab in a dongle.** Channel sounding, per-antenna signal quality,
   beamforming report capture (enough to do
   [motion sensing](docs/beamforming-victim-sensing.md)), spectrum sweeps,

--- a/docs/narrowband.md
+++ b/docs/narrowband.md
@@ -280,10 +280,9 @@ protection class are grouped into a burst, both ends switch, then the next
 burst. Rate-UEP is layered on top (critical frames also ride a robust rate, bulk
 a fast MCS — reusing the `svctx` per-frame-rate mechanism).
 
-The interesting hard part is **schedule synchronization**, and devourer exposes
-no hardware time primitive (no host TSF read, no PPS/GPS hook — only a per-frame
-read-only `tsfl`). The example ships two receiver sync strategies, selectable so
-they can be compared:
+The interesting hard part is **schedule synchronization**, and the example ships
+three receiver sync strategies — spanning no shared hardware to full
+hardware-time — selectable so they can be compared:
 
 - **`wallclock`** — both ends compute the phase from `system_clock` (a shared
   Unix-epoch anchor). Trivially aligned on one machine; across machines it needs


### PR DESCRIPTION
## What

Adds a **"Hardware time, for coordinating radios"** bullet to the `Why devourer`
feature list, surfacing the capability class that landed in #225:

- per-frame TSF stamp on all three generations,
- the directly-readable 64-bit MAC timer,
- sub-microsecond multi-radio clock correlation,
- and the ~25× tighter TDMA schedule anchor.

## Also

Fixes a now-stale sentence in `docs/narrowband.md`'s burst-TDMA section that
still claimed devourer *"exposes no hardware time primitive (no host TSF
read...)"* — the `tsf` sync strategy documented immediately below it **is** that
primitive. The intro now frames the three sync strategies (`wallclock` /
`marker` / `tsf`) as spanning no-shared-hardware to full-hardware-time.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)