### PR TITLE
Over-the-air time distribution + infrastructure AP mode (hardware beacon)

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -149,7 +149,7 @@ jobs:
           ToneMaskSelftest BfReportDecodeSelftest SweepSpecSelftest
           TxPowerQuantSelftest LinkHealthSelftest TxCapsSelftest TxPktPwrSelftest
           RxQualitySelftest AdapterHealthSelftest LogEventSelftest
-          AdapterCapsSelftest TdmaTsfSelftest
+          AdapterCapsSelftest TdmaTsfSelftest TimesyncSelftest
 
       - name: Test
         working-directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,6 +358,19 @@ target_include_directories(tdma PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/examples/common
     ${CMAKE_CURRENT_SOURCE_DIR}/examples/tdma)
 
+# timesync — LTE-eNB-style over-the-air time distribution. One MASTER broadcasts
+# its hardware TSF; SLAVES lock to it from the beacons alone (no GPS at the
+# slaves). Reuses the tdma TD frame tag. timesync.h is header-only.
+add_executable(timesync
+    examples/timesync/main.cpp
+    examples/common/env_config.cpp
+)
+target_link_libraries(timesync PUBLIC devourer PRIVATE PkgConfig::libusb)
+target_include_directories(timesync PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/common
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/tdma
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/timesync)
+
 # Stream-link DUPLEX: one binary, one chip, both directions. Combines the RX
 # loop from rxdemo and the stdin-driven TX from streamtx —
 # stdin = length-prefixed PSDU bodies, stdout = <devourer-stream> lines.
@@ -447,6 +460,21 @@ target_include_directories(TdmaTsfSelftest PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/examples/tdma)
 
 add_test(NAME tdma_tsf_math COMMAND TdmaTsfSelftest)
+
+# Headless guard for the timesync example's pure logic (examples/timesync/
+# timesync.h): the LinFit master<->local fit (ppm recovery + prediction), the
+# inter-slave agreement bound, and the 32->64-bit TSF Recon wrap. No hardware —
+# the master/slave demo that needs real adapters stays manual (out-of-band).
+add_executable(TimesyncSelftest
+    tests/timesync_selftest.cpp
+)
+target_link_libraries(TimesyncSelftest PRIVATE devourer)
+target_include_directories(TimesyncSelftest PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/common
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/tdma
+    ${CMAKE_CURRENT_SOURCE_DIR}/examples/timesync)
+
+add_test(NAME timesync_math COMMAND TimesyncSelftest)
 
 # Headless guard for the JSONL event emitter (src/Event.h) — the machine
 # event stream every test script parses (docs/logging.md): first-field

--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ one `IRtlDevice` interface covers all three generations.
   [spatial diversity](docs/measuring-spatial-diversity.md),
   [bench testing near-field](docs/bench-testing-near-field.md) — measurement
   guides for the built-in radio instrumentation.
+- [Time distribution](docs/time-distribution.md) — LTE-eNB-style over-the-air
+  clock distribution off the hardware beacon TSF: sub-µs downlink, TSF adoption,
+  µs-fine TBTT steering and a converging closed-loop uplink timing advance.
+- [AP mode](docs/ap-mode.md) — devourer as an infrastructure access point a real
+  Linux station associates with: beacon → probe/auth/assoc → DHCP/ARP/ICMP → ping,
+  open or WPA2-PSK (4-way handshake + software CCMP), validated against rtw88.
 
 ## Testing
 

--- a/docs/ap-mode.md
+++ b/docs/ap-mode.md
@@ -1,0 +1,95 @@
+# Infrastructure AP mode — devourer as a Wi-Fi access point
+
+devourer's hardware-beacon path (`StartBeacon`, see `docs/time-distribution.md`)
+is the foundation for acting as a real infrastructure **access point**: a Linux
+station discovers devourer, authenticates, associates, gets an IP, and exchanges
+IP traffic with it — open or WPA2-PSK encrypted. These are experimental example
+harnesses under `tests/`, not a library API — the pieces (beacon, RX callback,
+`send_packet`) are the same ones the demos use; the AP logic (probe/auth/assoc
+responses, DHCP/ARP/ICMP, the WPA2 4-way handshake, software CCMP) lives in the
+harness. All bench-validated against the real Linux `rtw88`/`mac80211` stack.
+
+A dense beacon interval (`DEVOURER_BCN_TU=25`) is needed throughout, so a
+supplicant's fast channel-hopping scan catches the AP. The AP adapter must be a
+full-duplex J2/J3 (`StartBeacon` + `StartRxLoop`); the station is a second
+Realtek adapter bound to the kernel (rtw88 auto-probes a VBUS-cold dongle to a
+`wlp*` interface). `send_packet` must run **off** the RX event thread (queue the
+requester, TX from another thread — libusb returns BUSY from the RX callback).
+
+## The beacon is accepted by a real kernel scan
+
+`tests/beacon_wire_check.cpp` checks the on-wire beacon: right frame control
+(0x0080), an 802.11 sequence number that **increments by 1 per beacon** (the
+hardware sequence numbering a kernel AP does via `EN_HWSEQ`), and the live TSF —
+on both HalMAC generations. `tests/beacon_kernel_scan.sh` goes further: a real
+station bound to `rtw88` runs `iw scan` and lists devourer, parsing every element:
+
+    BSS 57:42:75:05:d6:00   TSF <live>   freq 2437   beacon interval 25 TUs
+    capability: ESS   SSID: devourerAP
+    Supported rates: 1.0* 2.0* 5.5* 11.0* 18.0 24.0 36.0 54.0
+    DS Parameter set: channel 6   TIM: DTIM Count 0 Period 1   ERP: <no flags>
+
+Confirmed on **both bands** — ch6 (2437 MHz) and ch36 (5180 MHz).
+
+## Active scans — probe response
+
+`tests/probe_responder.cpp` runs full-duplex, matches probe-requests in the RX
+callback and `send_packet`s a probe-response to the requester. With **no beacon
+aired**, a real station's `iw scan` still lists `devourerAP` — discovery via the
+probe response. This works because management-frame timing is tens of ms (the
+userspace RX→TX round-trip is a few ms), unlike SIFS-timed ACKs.
+
+## Open-network association + data plane
+
+`tests/ap_responder.cpp` completes the whole open handshake (probe → auth →
+assoc): a real station authenticates, associates, and stays `Connected`
+(wpa_supplicant `CTRL-EVENT-CONNECTED`), with auth/assoc requests arriving at
+**retry=0** — devourer hardware-ACKs them (the ACK engine matches `REG_MACID`,
+which `StartBeacon` sets to the BSSID).
+
+The one non-obvious requirement: **the BSSID must be unicast**. The canonical test
+SA `57:42:75:05:d6:00` has the I/G (multicast) bit set in `0x57`; a station cannot
+unicast-auth to a multicast address, so rtw88 silently drops the auth before it
+hits the air (bench-proven across two station chips — `0x57` → no auth on air,
+`0x02` → auth on air and association completes). Use a locally-administered unicast
+BSSID (`0x02..`).
+
+It then answers the data plane over 802.11 from-DS data frames: a minimal **DHCP
+server** (leasing 192.168.99.2), **ARP** replies for the AP IP, and **ICMP** echo
+replies. So a station associates, `dhcpcd` **auto-leases 192.168.99.2**, and
+`ping 192.168.99.1` returns **0% packet loss, ~2 ms RTT** — the full self-service
+chain (beacon → auth → assoc → DHCP → ARP/ICMP → ping), like a hostapd+dnsmasq AP
+in one userspace process. `tests/ap_ping_demo.sh` runs it end to end.
+
+## WPA2-PSK (4-way handshake + CCMP)
+
+`tests/ap_wpa2.cpp` advertises an RSN IE and runs the WPA2 **4-way handshake**
+authenticator — msg1→4 with PMK/PTK (PBKDF2+PRF), HMAC-SHA1 MIC and an
+AES-key-wrapped GTK (openssl in userspace). A real station completes it:
+`WPA: Key negotiation completed … [PTK=CCMP GTK=CCMP]` + `CTRL-EVENT-CONNECTED`.
+The handshake needs no CCMP (EAPOL-Key frames are cleartext, MIC-protected), so it
+works without the chip crypto engine.
+
+The **data plane is encrypted too**: the AP decrypts the station's CCMP frames
+(software AES-CCM with the TK) and answers ARP + ICMP + DHCP encrypted, so a real
+station **leases 192.168.99.2 over encrypted DHCP** and **pings over WPA2/CCMP at
+0% loss, ~2.5 ms RTT**. The station runs hardware CCMP, the AP software CCMP — they
+interoperate. So devourer is a complete zero-config WPA2-PSK AP: associate → 4-way
+→ encrypted DHCP → encrypted IP.
+
+CCMP framing detail: the AAD masks the FC subtype/retry/pwr-mgmt/more-data bits and
+sets protected, and masks the sequence number (keeping the fragment number); the
+nonce is `0 | A2 | PN(6, big-endian)`; the CCMP header carries the 48-bit PN + the
+ext-IV key id. A hardware CCMP offload would instead need the J3 security TX/RX
+descriptor fields, which are absent in devourer (only Jaguar1 has
+`SET_TX_DESC_SEC_TYPE_8812`) — software CCMP sidesteps that.
+
+## Scope
+
+These harnesses implement enough AP-side logic to interoperate with a real station
+end to end. What is intentionally out of scope (AP-*stack* breadth, not driver
+parity): multiple concurrent clients, GTK broadcast/rekey, routing/NAT, and a real
+DHCP address pool. The bench caveat is that a single clean end-to-end run of the
+whole WPA2 chain is flaky after many cycles when the AP adapter has no VBUS reset
+(an xhci root-hub port) — cold-cycle the station between runs, and prefer a
+VBUS-cyclable AP adapter.

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -92,9 +92,14 @@ So the master↔slave clocks track to sub-µs on any channel — the offset move
 only with the crystal drift. `DEVOURER_TSYNC_HWBEACON=1` on both master and
 slave; `tests/beacon_ts_check.cpp` reads the raw beacon TSF for validation.
 
-Note: the beacon body must stay minimal (a long SSID / extra IEs was observed to
-break the hardware TSF insertion — the MAC wrote a per-beacon counter instead);
-`build_std_beacon` uses the validated minimal layout.
+Note: the beacon body may carry full kernel-AP content. A well-formed 70-byte
+body (10-char SSID + 8 supported rates + DS param + TIM + ERP IEs) inserts the
+live hardware TSF correctly — bench-verified on an 8822C, the timestamp field
+steps ~102400 µs per beacon exactly as the minimal body does
+(`tests/beacon_fullbody.cpp`). An earlier report that an extended body broke the
+TSF insertion was a *malformed* test frame (bad IE lengths), not a hardware
+limit; there is no minimal-body requirement. `build_std_beacon` keeps a compact
+layout only because the timesync demo needs no more.
 
 ## Uplink timing advance (experimental)
 

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -118,8 +118,20 @@ Jaguar2/3 adapter; the RTL8822EU desenses its RX in TX+RX mode, adding jitter.)
 The measurement, feedback, and math are in place; closing the loop needs
 hardware-timed TX departure, which `send_packet` does not have — but the beacon
 path now does. A UE that transmits its uplink as a **TBTT-scheduled beacon**
-(`StartBeacon`) and advances by shifting its own TSF gets exactly the sub-slot
-air-departure control this loop was missing; that is the natural next iteration.
+(`StartBeacon`) gets the sub-slot air-departure control this loop was missing.
+
+**Steering the TBTT.** The actuator is `AdjustBeaconTiming(microseconds)`, not a
+TSF write: `WriteTsf` moves the reported TSF (and the beacon-body timestamp) but
+NOT the TBTT air-time — a separate per-port timer drives the beacon, so the TBTT
+is deaf to `REG_TSFTR`. A one-shot beacon-interval tweak *does* steer it: running
+one interval at (nominal ± Δ) TU then restoring advances/retards the next TBTT —
+and the cadence thereafter — by Δ TU. Bench-proven to the microsecond on an
+8822C: `AdjustBeaconTiming(-20480)` advanced the TBTT by exactly 20 TU
+(observer arrival phase stepped 88018 → 67565 µs at the tweak). This is the
+802.11 IBSS/TSF-merge mechanism. Granularity is **1 TU = 1.024 ms** (the
+`REG_BCN_INTERVAL` field is integer TU) — a coarse slot/guard-alignment lever,
+not a µs-fine advance; the timesync uplink loop quantizes its correction to it.
+Actuator characterization: `tests/beacon_interval_shift.sh <short_TU>`.
 
 Harness: `tests/timesync_ta_demo.sh` (+ `tests/timesync_ta_analyze.py`).
 

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -109,65 +109,11 @@ generations (J3 8822C and J2 8812BU). A frozen sequence number indicates a
 degraded engine (e.g. a J2 beacon left in the post-drop state after an
 `AdjustBeaconTiming` tweak, which J2 does not survive), not a healthy beacon.
 
-**End-to-end interop.** The strongest check is that a *real* Linux 802.11 station
-accepts the beacon: `tests/beacon_kernel_scan.sh` airs a full-content beacon from
-devourer and scans for it with a second Realtek adapter bound to `rtw88`
-(`iw dev <if> scan`). Proven — the kernel lists it and parses every element:
-
-    BSS 57:42:75:05:d6:00   TSF <live>   freq 2437   beacon interval 25 TUs
-    capability: ESS   SSID: devourerAP
-    Supported rates: 1.0* 2.0* 5.5* 11.0* 18.0 24.0 36.0 54.0
-    DS Parameter set: channel 6   TIM: DTIM Count 0 Period 1   ERP: <no flags>
-
-So devourer's beacon is not just wire-correct but accepted as a legitimate AP by
-the mac80211/rtw88 BSS parser — live TSF, capability, SSID, rates (with basic-rate
-flags), DS param, TIM/DTIM and ERP all interpreted correctly. Confirmed on **both
-bands** — ch6 (2437 MHz) and ch36 (5180 MHz). A dense beacon interval (e.g. 25 TU,
-`DEVOURER_BCN_TU`) is needed so the scan's per-channel dwell catches it.
-
-devourer also answers **active scans** like a kernel AP: `tests/probe_responder.cpp`
-runs full-duplex, matches probe-requests in the RX callback and `send_packet`s a
-probe-response addressed to the requester — with **no beacon aired**, a real rtw88
-station's `iw scan` still lists `devourerAP` (discovery via the probe response).
-send_packet must run off the RX event thread (queue the requester, TX from another
-thread — libusb returns BUSY otherwise). This works because management-frame timing
-is tens of ms (the userspace RX→TX round-trip is a few ms), unlike SIFS ACKs.
-
-**A real kernel station fully associates.** `tests/ap_responder.cpp` completes the
-whole open-network handshake (probe → auth → assoc): a real rtw88 station
-authenticates, associates, and stays `Connected` (wpa_supplicant
-`CTRL-EVENT-CONNECTED`, `iw link` Connected, stable). The station's auth/assoc
-requests arrive with **retry=0** — devourer hardware-ACKs them (the ACK engine
-matches `REG_MACID`, which `StartBeacon` sets to the BSSID). The one non-obvious
-requirement: **the BSSID must be unicast**. The canonical test SA `57:42:75:05:d6:00`
-has the I/G (multicast) bit set in `0x57`; a station cannot unicast-auth to a
-multicast address, so rtw88 silently drops the auth before it hits the air
-(bench-proven across two station chips — `0x57` → no auth on air, `0x02` → auth on
-air and association completes). Use a locally-administered unicast BSSID (`0x02..`).
-
-**Data plane — a real station gets an IP and pings devourer's AP.** `ap_responder`
-answers the post-association data plane over 802.11 from-DS data frames: a minimal
-**DHCP server** (DISCOVER→OFFER, REQUEST→ACK leasing 192.168.99.2), **ARP**
-replies for the AP IP, and **ICMP** echo replies. So a Linux station associates,
-`dhcpcd` **automatically leases 192.168.99.2** from it, and `ping 192.168.99.1`
-returns **0% packet loss, ~2 ms RTT** — the full self-service chain (beacon → auth
-→ assoc → DHCP → ARP/ICMP → ping), like a hostapd+dnsmasq AP, in one userspace
-process. `tests/ap_ping_demo.sh` runs it end to end.
-
-**WPA2-PSK.** `tests/ap_wpa2.cpp` runs the WPA2 **4-way handshake** authenticator —
-the beacon/assoc advertise an RSN IE and the AP does msg1→4 with PMK/PTK
-(PBKDF2+PRF), HMAC-SHA1 MIC and an AES-key-wrapped GTK (openssl in userspace). A
-real station completes it: wpa_supplicant reports `WPA: Key negotiation completed …
-[PTK=CCMP GTK=CCMP]` + `CTRL-EVENT-CONNECTED`. The handshake needs no CCMP
-(EAPOL-Key frames are cleartext, MIC-protected), so it works without the chip
-crypto engine. And the **data plane is encrypted too**: the AP decrypts the
-station's CCMP frames (software AES-CCM with the TK) and answers ARP + ICMP + DHCP
-encrypted, so a real station **leases 192.168.99.2 over encrypted DHCP** and
-**pings the AP over WPA2/CCMP at 0% loss, ~2.5 ms RTT**. The station runs hardware
-CCMP, the AP software CCMP — they interoperate. So devourer is a complete
-zero-config WPA2-PSK AP: associate → 4-way → encrypted DHCP → **encrypted** IP.
-(Hardware CCMP offload would need porting the J3 security TX/RX descriptor fields,
-absent in devourer; software CCMP sidesteps that.)
+The same hardware beacon is also the foundation for full **infrastructure AP
+mode** — a real Linux station discovers devourer, associates, gets an IP, and
+pings it (open or WPA2-PSK encrypted). That is a distinct feature with its own
+write-up: see **`docs/ap-mode.md`** (`tests/beacon_kernel_scan.sh`,
+`probe_responder`, `ap_responder`, `ap_wpa2`, `ap_ping_demo.sh`).
 
 ## Uplink timing advance (experimental)
 

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -145,15 +145,15 @@ multicast address, so rtw88 silently drops the auth before it hits the air
 (bench-proven across two station chips — `0x57` → no auth on air, `0x02` → auth on
 air and association completes). Use a locally-administered unicast BSSID (`0x02..`).
 
-**Data plane — a real station pings devourer's AP.** `ap_responder` also answers
-the post-association data plane (ARP requests for the AP IP → ARP replies, ICMP
-echo requests → echo replies, over 802.11 from-DS data frames), so an associated
-station running `ping 192.168.99.1` gets **0% packet loss, ~1.8 ms RTT**
-(`tests/ap_ping_demo.sh`; the station needs a static IP — there is no DHCP
-server). So devourer is a real, associable, pingable AP — a Linux station
-discovers it, authenticates, associates, and exchanges IP traffic with it over the
-air, exactly like a kernel-driven AP. (A full data path — DHCP, forwarding — is an
-AP *stack* concern beyond the driver.)
+**Data plane — a real station gets an IP and pings devourer's AP.** `ap_responder`
+answers the post-association data plane over 802.11 from-DS data frames: a minimal
+**DHCP server** (DISCOVER→OFFER, REQUEST→ACK leasing 192.168.99.2), **ARP**
+replies for the AP IP, and **ICMP** echo replies. So a Linux station associates,
+`dhcpcd` **automatically leases 192.168.99.2** from it, and `ping 192.168.99.1`
+returns **0% packet loss, ~2 ms RTT** — the full self-service chain (beacon → auth
+→ assoc → DHCP → ARP/ICMP → ping), like a hostapd+dnsmasq AP, in one userspace
+process. `tests/ap_ping_demo.sh` runs it end to end. (Beyond this — routing/NAT,
+WPA2 — is AP-stack scope, not driver parity.)
 
 ## Uplink timing advance (experimental)
 

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -152,8 +152,18 @@ replies for the AP IP, and **ICMP** echo replies. So a Linux station associates,
 `dhcpcd` **automatically leases 192.168.99.2** from it, and `ping 192.168.99.1`
 returns **0% packet loss, ~2 ms RTT** — the full self-service chain (beacon → auth
 → assoc → DHCP → ARP/ICMP → ping), like a hostapd+dnsmasq AP, in one userspace
-process. `tests/ap_ping_demo.sh` runs it end to end. (Beyond this — routing/NAT,
-WPA2 — is AP-stack scope, not driver parity.)
+process. `tests/ap_ping_demo.sh` runs it end to end.
+
+**WPA2-PSK.** `tests/ap_wpa2.cpp` runs the WPA2 **4-way handshake** authenticator —
+the beacon/assoc advertise an RSN IE and the AP does msg1→4 with PMK/PTK
+(PBKDF2+PRF), HMAC-SHA1 MIC and an AES-key-wrapped GTK (openssl in userspace). A
+real station completes it: wpa_supplicant reports `WPA: Key negotiation completed …
+[PTK=CCMP GTK=CCMP]` + `CTRL-EVENT-CONNECTED`. The handshake needs no CCMP
+(EAPOL-Key frames are cleartext, MIC-protected), so it works without the chip
+crypto engine. Encrypted CCMP *data* is the remaining follow-on (software AES-CCM
+on the data path); the station disconnects after the handshake because data isn't
+yet encrypted. (Routing/NAT and hardware CCMP offload are AP-stack / chip-descriptor
+scope beyond this.)
 
 ## Uplink timing advance (experimental)
 

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -1,0 +1,98 @@
+# Over-the-air time distribution (LTE-eNB style)
+
+devourer exposes the chip's hardware TSF (the 802.11 MAC's free-running 64-bit
+microsecond clock) two ways: a per-frame receive stamp (`rx_pkt_attrib::tsfl`,
+the low 32 bits latched in the MAC at reception, on all three generations) and a
+direct `IRtlDevice::ReadTsf()`. Together they are the primitive an LTE eNB uses
+to give its UEs a common timebase — one node holds a reference and distributes it
+over the air, and every other node slaves to it with no GPS of its own. The
+`timesync` example (`examples/timesync/`) is a worked demonstration.
+
+## The idea
+
+An LTE eNB broadcasts its frame timing; UEs acquire it from the downlink and run
+their whole schedule in the eNB's timebase. Only the eNB needs an absolute
+reference (typically GPS); a UE derives everything from the signal it hears. The
+802.11 analog:
+
+- the **master** (eNB) periodically broadcasts a beacon carrying its hardware
+  TSF — the SFN,
+- each **slave** (UE) relates that broadcast TSF to its *own* per-frame hardware
+  TSF with a running least-squares fit, and predicts the master clock from it.
+
+Both the broadcast TSF and the local `tsfl` are clean MAC-latched microsecond
+clocks, so the fit residual is the true lock quality — not the ~1 ms host-callback
+jitter a wall-clock scheme would carry. The distribution costs one node a
+reference and the rest nothing but reception.
+
+## Downlink: distributing the clock
+
+`DEVOURER_TSYNC_ROLE=master` brings the chip up TX-only and broadcasts a beacon
+every `DEVOURER_TSYNC_INTERVAL_MS` (default 100), each stamped with `ReadTsf()` —
+reliable on a transmitter, where no bulk-IN flood starves the control read.
+
+`DEVOURER_TSYNC_ROLE=slave` brings the chip up RX-only. For every beacon it
+decodes it feeds the pair (broadcast master TSF, local `tsfl`) into the fit, then
+*predicts* the beacon's master TSF from the fit built on prior beacons — the
+prediction error is how tightly this UE tracks the eNB. A slave never reads a
+host or wall clock.
+
+Two slaves predicting the **same** beacon (matched by its sequence number) agree
+far more tightly than either's absolute lock. Each slave's absolute lock is
+bounded by the master's *software* stamp→air jitter (it calls `ReadTsf()` then
+sends), but that jitter is common to every slave — it is the same frame, aired
+once — so it cancels in the difference. What survives is only the independent
+per-slave MAC-latch noise: the sub-microsecond floor of a two-receiver TSF
+correlation.
+
+Bench (master RTL8812AU, slaves RTL8822CU + RTL8822EU, ch36, 50 ms beacons):
+
+| metric | value |
+|--------|-------|
+| per-slave absolute lock | ~94 µs RMS (master stamp-jitter bound) |
+| inter-slave (inter-UE) agreement | 4.7 µs RMS, mean +1.7 µs |
+
+The inter-slave agreement tightens with beacon rate (≈18 µs at 100 ms → ≈5 µs at
+50 ms) as the fits densify and balance. Slaves must be Jaguar2/3 (per-frame
+`tsfl`); the master can be any transmitter (`ReadTsf()`, including Jaguar1).
+
+Run it with `tests/timesync_demo.sh` (one master + two slaves; joins the two
+`{"ev":"timesync.lock"}` streams by beacon seq into the inter-UE error). A
+hardware-timed master beacon (a MAC-transmitted beacon at TBTT, rather than a
+software-stamped injection) would drop the absolute-lock floor toward the
+inter-slave sub-µs, but that is a separate reserved-page/beacon-queue build.
+
+## Uplink timing advance (experimental)
+
+`DEVOURER_TSYNC_UPLINK=1` adds the LTE closed-loop half: a full-duplex master
+phase-measures each UE uplink against its own TSF slot grid (the arrival `tsfl`
+mod the slot period — reliable per-frame, needing no `ReadTsf()` the RX loop
+would starve) and integrates a timing advance it broadcasts back in the beacon; a
+full-duplex UE transmits one uplink per beacon, advanced by that correction, so
+its frames should land on the master's slot boundary. Both nodes come up
+full-duplex (`DEVOURER_TX_WITH_RX=thread`, InitWrite + StartRxLoop).
+
+The control loop converges in the headless selftest and the full-duplex plumbing
+works on-air — with a **fixed** advance the uplinks arrive tightly clustered
+(~±0.2 ms). But the closed loop does **not** converge on the bench, and a
+fixed-advance authority test shows why: changing the advance shifts the UE's
+send-*call* time but not the master-measured *arrival* phase. Under full-duplex,
+`send_packet` queues the frame and the chip airs it on its own schedule, so
+userspace call-timing has no sub-slot control over air departure — the loop has
+nothing fine to actuate. (The bench also has only one clean full-duplex
+Jaguar2/3 adapter; the RTL8822EU desenses its RX in TX+RX mode, adding jitter.)
+The measurement, feedback, and math are in place; closing the loop needs
+hardware-timed TX departure, which this path does not have.
+
+Harness: `tests/timesync_ta_demo.sh` (+ `tests/timesync_ta_analyze.py`).
+
+## Env knobs
+
+- `DEVOURER_TSYNC_ROLE=master|slave|ue`
+- `DEVOURER_TSYNC_INTERVAL_MS=N` — master beacon period (default 100)
+- `DEVOURER_TSYNC_RATE=<spec>` — beacon TX rate (default 6M; must be heard)
+- `DEVOURER_TSYNC_SECS=N` — run duration (0 = until signalled)
+- `DEVOURER_TSYNC_UPLINK=1` — enable the uplink timing-advance loop (experimental)
+- `DEVOURER_TSYNC_SLOT_MS=N` — uplink slot grid on the master TSF (default 20)
+- `DEVOURER_TSYNC_TA_GAIN=g` — TA integrator gain (default 0.3)
+- `DEVOURER_CHANNEL=N`, `DEVOURER_PID` / `DEVOURER_VID` — as elsewhere

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -101,6 +101,14 @@ TSF insertion was a *malformed* test frame (bad IE lengths), not a hardware
 limit; there is no minimal-body requirement. `build_std_beacon` keeps a compact
 layout only because the timesync demo needs no more.
 
+On-wire kernel-equivalence is verifiable with `tests/beacon_wire_check.cpp`: the
+beacon carries the right frame control (0x0080), an 802.11 sequence number that
+**increments by 1 per beacon** (the hardware sequence numbering a kernel AP does
+via `EN_HWSEQ`), and the live hardware TSF — bench-confirmed on both HalMAC
+generations (J3 8822C and J2 8812BU). A frozen sequence number indicates a
+degraded engine (e.g. a J2 beacon left in the post-drop state after an
+`AdjustBeaconTiming` tweak, which J2 does not survive), not a healthy beacon.
+
 ## Uplink timing advance (experimental)
 
 `DEVOURER_TSYNC_UPLINK=1` adds the LTE closed-loop half: a full-duplex master

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -119,19 +119,28 @@ full-duplex UE transmits one uplink per beacon, advanced by that correction, so
 its frames should land on the master's slot boundary. Both nodes come up
 full-duplex (`DEVOURER_TX_WITH_RX=thread`, InitWrite + StartRxLoop).
 
-The control loop converges in the headless selftest and the full-duplex plumbing
-works on-air — with a **fixed** advance the uplinks arrive tightly clustered
-(~±0.2 ms). But the closed loop does **not** converge on the bench, and a
+With the default `send_packet` uplink the loop does **not** converge, and a
 fixed-advance authority test shows why: changing the advance shifts the UE's
 send-*call* time but not the master-measured *arrival* phase. Under full-duplex,
 `send_packet` queues the frame and the chip airs it on its own schedule, so
 userspace call-timing has no sub-slot control over air departure — the loop has
-nothing fine to actuate. (The bench also has only one clean full-duplex
-Jaguar2/3 adapter; the RTL8822EU desenses its RX in TX+RX mode, adding jitter.)
-The measurement, feedback, and math are in place; closing the loop needs
-hardware-timed TX departure, which `send_packet` does not have — but the beacon
-path now does. A UE that transmits its uplink as a **TBTT-scheduled beacon**
-(`StartBeacon`) gets the sub-slot air-departure control this loop was missing.
+nothing fine to actuate (bench baseline: arrival phase RMS ~5.4 ms, drifting
+across the whole slot).
+
+**Closed loop (`DEVOURER_TSYNC_HWBEACON=1` on the UE).** The fix is a
+hardware-timed uplink: the UE airs its uplink from the **beacon engine**
+(`StartBeacon` stores a tdma Uplink frame in the rsvd page; the engine airs it at
+the UE's TBTT) and steers that TBTT with `AdjustBeaconTimingFine` per the master's
+TA — the sub-slot air-departure control `send_packet` lacked. The master's
+measurement path is unchanged (it matches the Uplink frame by class). Bench-proven
+to converge: master = 8812AU (Jaguar1, full-duplex — the master needs no fine
+steering, so it need not be J3), UE = 8822CU (J3, HW-beacon + µs-fine steer), ch36
+slot 20 ms. The arrival phase drops from ~6 ms to a bounded oscillation around
+zero at **~1.25 ms RMS steady-state** (gain 0.30) — a 4× improvement over the
+non-converging `send_packet` baseline. The residual is the fine actuator's USB
+read→write jitter (~0.5–1.2 ms per correction, §Microsecond-fine steering); it is
+the floor for a userspace-USB TSF write (a kernel PCIe driver with MMIO would be
+tighter). Harness: `tests/timesync_ta_demo.sh` with `HWBEACON=1`.
 
 **Steering the TBTT.** The actuator is `AdjustBeaconTiming(microseconds)`, not a
 TSF write: `WriteTsf` moves the reported TSF (and the beacon-body timestamp) but
@@ -178,7 +187,9 @@ Harness: `tests/timesync_ta_demo.sh` (+ `tests/timesync_ta_analyze.py`).
 - `DEVOURER_TSYNC_RATE=<spec>` — beacon TX rate (default 6M; must be heard)
 - `DEVOURER_TSYNC_SECS=N` — run duration (0 = until signalled)
 - `DEVOURER_TSYNC_HWBEACON=1` — hardware-timed beacon downlink (StartBeacon) →
-  sub-µs; set on both master and slave
+  sub-µs; set on both master and slave. On the **UE** (role=ue) it instead
+  selects the hardware-beacon uplink fine-steered by `AdjustBeaconTimingFine` —
+  the converging closed loop (J3 UE required for µs steering)
 - `DEVOURER_TSYNC_CSMA=1` — keep CSMA on the HW-beacon master (default: EDCCA
   off so the beacon airs exactly at TBTT — the master owns the channel)
 - `DEVOURER_TSYNC_UPLINK=1` — enable the uplink timing-advance loop (experimental)

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -125,6 +125,15 @@ flags), DS param, TIM/DTIM and ERP all interpreted correctly. Confirmed on **bot
 bands** — ch6 (2437 MHz) and ch36 (5180 MHz). A dense beacon interval (e.g. 25 TU,
 `DEVOURER_BCN_TU`) is needed so the scan's per-channel dwell catches it.
 
+devourer also answers **active scans** like a kernel AP: `tests/probe_responder.cpp`
+runs full-duplex, matches probe-requests in the RX callback and `send_packet`s a
+probe-response addressed to the requester — with **no beacon aired**, a real rtw88
+station's `iw scan` still lists `devourerAP` (discovery via the probe response).
+send_packet must run off the RX event thread (queue the requester, TX from another
+thread — libusb returns BUSY otherwise). This works because management-frame timing
+is tens of ms (the userspace RX→TX round-trip is a few ms), unlike SIFS ACKs — and
+it de-risks the AP-side handshake (probe-resp → auth → assoc).
+
 ## Uplink timing advance (experimental)
 
 `DEVOURER_TSYNC_UPLINK=1` adds the LTE closed-loop half: a full-duplex master

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -121,7 +121,9 @@ devourer and scans for it with a second Realtek adapter bound to `rtw88`
 
 So devourer's beacon is not just wire-correct but accepted as a legitimate AP by
 the mac80211/rtw88 BSS parser — live TSF, capability, SSID, rates (with basic-rate
-flags), DS param, TIM/DTIM and ERP all interpreted correctly.
+flags), DS param, TIM/DTIM and ERP all interpreted correctly. Confirmed on **both
+bands** — ch6 (2437 MHz) and ch36 (5180 MHz). A dense beacon interval (e.g. 25 TU,
+`DEVOURER_BCN_TU`) is needed so the scan's per-channel dwell catches it.
 
 ## Uplink timing advance (experimental)
 

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -109,6 +109,20 @@ generations (J3 8822C and J2 8812BU). A frozen sequence number indicates a
 degraded engine (e.g. a J2 beacon left in the post-drop state after an
 `AdjustBeaconTiming` tweak, which J2 does not survive), not a healthy beacon.
 
+**End-to-end interop.** The strongest check is that a *real* Linux 802.11 station
+accepts the beacon: `tests/beacon_kernel_scan.sh` airs a full-content beacon from
+devourer and scans for it with a second Realtek adapter bound to `rtw88`
+(`iw dev <if> scan`). Proven — the kernel lists it and parses every element:
+
+    BSS 57:42:75:05:d6:00   TSF <live>   freq 2437   beacon interval 25 TUs
+    capability: ESS   SSID: devourerAP
+    Supported rates: 1.0* 2.0* 5.5* 11.0* 18.0 24.0 36.0 54.0
+    DS Parameter set: channel 6   TIM: DTIM Count 0 Period 1   ERP: <no flags>
+
+So devourer's beacon is not just wire-correct but accepted as a legitimate AP by
+the mac80211/rtw88 BSS parser — live TSF, capability, SSID, rates (with basic-rate
+flags), DS param, TIM/DTIM and ERP all interpreted correctly.
+
 ## Uplink timing advance (experimental)
 
 `DEVOURER_TSYNC_UPLINK=1` adds the LTE closed-loop half: a full-duplex master

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -57,10 +57,44 @@ The inter-slave agreement tightens with beacon rate (≈18 µs at 100 ms → ≈
 `tsfl`); the master can be any transmitter (`ReadTsf()`, including Jaguar1).
 
 Run it with `tests/timesync_demo.sh` (one master + two slaves; joins the two
-`{"ev":"timesync.lock"}` streams by beacon seq into the inter-UE error). A
-hardware-timed master beacon (a MAC-transmitted beacon at TBTT, rather than a
-software-stamped injection) would drop the absolute-lock floor toward the
-inter-slave sub-µs, but that is a separate reserved-page/beacon-queue build.
+`{"ev":"timesync.lock"}` streams by beacon seq into the inter-UE error).
+
+## Hardware beacon — sub-µs downlink (`DEVOURER_TSYNC_HWBEACON`)
+
+The software downlink above is bounded by the master's stamp→air jitter. The
+hardware path removes it entirely: `IRtlDevice::StartBeacon` loads a beacon into
+the MAC's beacon reserved-page and lets the chip **auto-transmit it at each
+TBTT** — hardware-timed, and the MAC inserts the live 64-bit TSF into the
+beacon's timestamp field at the transmit instant. No `ReadTsf()`, no
+`send_packet`, no software in the timing path. One call suffices; the chip
+beacons indefinitely. Implemented on both HalMAC generations (Jaguar2 8822B/
+8812BU/8821C and Jaguar3 8822C/8822E); Jaguar1 has no reserved-page path.
+
+The slave then reads the *standard 802.11 beacon timestamp* (the master's live
+TSF) instead of a software tag, and fits it against its own arrival `tsfl`.
+
+The last limit is CSMA: a TBTT beacon still defers to carrier-sense and airs
+after a variable backoff, so its scheduled-TSF stamp and delayed air time
+diverge by ~hundreds of µs on a shared channel. In a time-distribution setup the
+master **owns** the channel, so that backoff is pure loss — the master disables
+EDCCA (`SetCcaMode`, on by default here; opt out with `DEVOURER_TSYNC_CSMA=1`)
+and the beacon airs exactly on schedule.
+
+Bench (HW-beacon master + slave, **crowded** ch6, 100 ms beacons):
+
+| config | downlink residual |
+|--------|-------------------|
+| software stamp | ~94 µs RMS |
+| HW beacon, CSMA on | ~470 µs RMS (backoff jitter) |
+| HW beacon + no-CSMA (default) | **0.31 µs RMS** (8822C) / 0.39 µs (8812BU) |
+
+So the master↔slave clocks track to sub-µs on any channel — the offset moves
+only with the crystal drift. `DEVOURER_TSYNC_HWBEACON=1` on both master and
+slave; `tests/beacon_ts_check.cpp` reads the raw beacon TSF for validation.
+
+Note: the beacon body must stay minimal (a long SSID / extra IEs was observed to
+break the hardware TSF insertion — the MAC wrote a per-beacon counter instead);
+`build_std_beacon` uses the validated minimal layout.
 
 ## Uplink timing advance (experimental)
 
@@ -82,7 +116,10 @@ userspace call-timing has no sub-slot control over air departure — the loop ha
 nothing fine to actuate. (The bench also has only one clean full-duplex
 Jaguar2/3 adapter; the RTL8822EU desenses its RX in TX+RX mode, adding jitter.)
 The measurement, feedback, and math are in place; closing the loop needs
-hardware-timed TX departure, which this path does not have.
+hardware-timed TX departure, which `send_packet` does not have — but the beacon
+path now does. A UE that transmits its uplink as a **TBTT-scheduled beacon**
+(`StartBeacon`) and advances by shifting its own TSF gets exactly the sub-slot
+air-departure control this loop was missing; that is the natural next iteration.
 
 Harness: `tests/timesync_ta_demo.sh` (+ `tests/timesync_ta_analyze.py`).
 
@@ -92,6 +129,10 @@ Harness: `tests/timesync_ta_demo.sh` (+ `tests/timesync_ta_analyze.py`).
 - `DEVOURER_TSYNC_INTERVAL_MS=N` — master beacon period (default 100)
 - `DEVOURER_TSYNC_RATE=<spec>` — beacon TX rate (default 6M; must be heard)
 - `DEVOURER_TSYNC_SECS=N` — run duration (0 = until signalled)
+- `DEVOURER_TSYNC_HWBEACON=1` — hardware-timed beacon downlink (StartBeacon) →
+  sub-µs; set on both master and slave
+- `DEVOURER_TSYNC_CSMA=1` — keep CSMA on the HW-beacon master (default: EDCCA
+  off so the beacon airs exactly at TBTT — the master owns the channel)
 - `DEVOURER_TSYNC_UPLINK=1` — enable the uplink timing-advance loop (experimental)
 - `DEVOURER_TSYNC_SLOT_MS=N` — uplink slot grid on the master TSF (default 20)
 - `DEVOURER_TSYNC_TA_GAIN=g` — TA integrator gain (default 0.3)

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -160,10 +160,13 @@ the beacon/assoc advertise an RSN IE and the AP does msg1→4 with PMK/PTK
 real station completes it: wpa_supplicant reports `WPA: Key negotiation completed …
 [PTK=CCMP GTK=CCMP]` + `CTRL-EVENT-CONNECTED`. The handshake needs no CCMP
 (EAPOL-Key frames are cleartext, MIC-protected), so it works without the chip
-crypto engine. Encrypted CCMP *data* is the remaining follow-on (software AES-CCM
-on the data path); the station disconnects after the handshake because data isn't
-yet encrypted. (Routing/NAT and hardware CCMP offload are AP-stack / chip-descriptor
-scope beyond this.)
+crypto engine. And the **data plane is encrypted too**: the AP decrypts the
+station's CCMP frames (software AES-CCM with the TK) and answers ARP + ICMP
+encrypted, so a real station **pings the AP over WPA2/CCMP at 0% loss, ~2.5 ms
+RTT**. The station runs hardware CCMP, the AP software CCMP — they interoperate. So
+devourer is a complete WPA2-PSK AP: associate → 4-way → **encrypted** IP. (Hardware
+CCMP offload would need porting the J3 security TX/RX descriptor fields, absent in
+devourer; software CCMP sidesteps that.)
 
 ## Uplink timing advance (experimental)
 

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -144,7 +144,16 @@ has the I/G (multicast) bit set in `0x57`; a station cannot unicast-auth to a
 multicast address, so rtw88 silently drops the auth before it hits the air
 (bench-proven across two station chips — `0x57` → no auth on air, `0x02` → auth on
 air and association completes). Use a locally-administered unicast BSSID (`0x02..`).
-So devourer is a real, associable AP — not just a beacon source.
+
+**Data plane — a real station pings devourer's AP.** `ap_responder` also answers
+the post-association data plane (ARP requests for the AP IP → ARP replies, ICMP
+echo requests → echo replies, over 802.11 from-DS data frames), so an associated
+station running `ping 192.168.99.1` gets **0% packet loss, ~1.8 ms RTT**
+(`tests/ap_ping_demo.sh`; the station needs a static IP — there is no DHCP
+server). So devourer is a real, associable, pingable AP — a Linux station
+discovers it, authenticates, associates, and exchanges IP traffic with it over the
+air, exactly like a kernel-driven AP. (A full data path — DHCP, forwarding — is an
+AP *stack* concern beyond the driver.)
 
 ## Uplink timing advance (experimental)
 

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -129,9 +129,32 @@ and the cadence thereafter — by Δ TU. Bench-proven to the microsecond on an
 8822C: `AdjustBeaconTiming(-20480)` advanced the TBTT by exactly 20 TU
 (observer arrival phase stepped 88018 → 67565 µs at the tweak). This is the
 802.11 IBSS/TSF-merge mechanism. Granularity is **1 TU = 1.024 ms** (the
-`REG_BCN_INTERVAL` field is integer TU) — a coarse slot/guard-alignment lever,
-not a µs-fine advance; the timesync uplink loop quantizes its correction to it.
-Actuator characterization: `tests/beacon_interval_shift.sh <short_TU>`.
+`REG_BCN_INTERVAL` field is integer TU) — a coarse slot/guard-alignment lever.
+
+**Microsecond-fine steering** (`AdjustBeaconTimingFine`, Jaguar3): the reason a
+bare `WriteTsf` doesn't move the TBTT is that the counter is latched while the
+beacon function runs — the vendor `reset_tsf` path clears `EN_BCN_FUNCTION`
+first. Toggling the beacon function off, shifting the port-0 TSF by the desired
+µs, and toggling it back on makes the TBTT re-derive from the shifted TSF at
+**microsecond resolution**. Bench-proven on an 8822C (arrival-phase steps, all
+sub-TU): `-5000 → -4479 µs`, `-10000 → -8997 µs`, `+6000 (retard) → +7172 µs`.
+The magnitude undershoots/overshoots the request by a **sub-ms USB
+read→write latency** (~0.5–1.2 ms, the real TSF advances during the register
+sequence) — a systematic offset a closed timing-advance loop absorbs; the
+resolution is what matters. It also shifts this port's TSF + beacon-body
+timestamp by the same amount, which is the intended UE-advances-its-own-timebase
+behaviour.
+
+Beacon-TBTT steering is **Jaguar3-only**. The Jaguar2 8822B beacon engine drops
+the beacon on *any* TBTT re-latch — bench-proven on the 8812BU, the beacon stops
+airing after both the interval tweak and the beacon-function toggle (the
+bcn-valid latch is lost, and J2 does not retain the beacon bytes to re-download).
+So `AdjustBeaconTiming` / `AdjustBeaconTimingFine` refuse on J2 (return 0) rather
+than silently kill the beacon; the downlink (`StartBeacon` + `SetCcaMode`) is
+unaffected.
+
+Actuator characterization: `tests/beacon_interval_shift.sh <short_TU>` (TU tweak),
+or `FINE_US=<µs> tests/beacon_interval_shift.sh` (µs-fine, Jaguar3).
 
 Harness: `tests/timesync_ta_demo.sh` (+ `tests/timesync_ta_analyze.py`).
 

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -131,8 +131,20 @@ probe-response addressed to the requester — with **no beacon aired**, a real r
 station's `iw scan` still lists `devourerAP` (discovery via the probe response).
 send_packet must run off the RX event thread (queue the requester, TX from another
 thread — libusb returns BUSY otherwise). This works because management-frame timing
-is tens of ms (the userspace RX→TX round-trip is a few ms), unlike SIFS ACKs — and
-it de-risks the AP-side handshake (probe-resp → auth → assoc).
+is tens of ms (the userspace RX→TX round-trip is a few ms), unlike SIFS ACKs.
+
+**A real kernel station fully associates.** `tests/ap_responder.cpp` completes the
+whole open-network handshake (probe → auth → assoc): a real rtw88 station
+authenticates, associates, and stays `Connected` (wpa_supplicant
+`CTRL-EVENT-CONNECTED`, `iw link` Connected, stable). The station's auth/assoc
+requests arrive with **retry=0** — devourer hardware-ACKs them (the ACK engine
+matches `REG_MACID`, which `StartBeacon` sets to the BSSID). The one non-obvious
+requirement: **the BSSID must be unicast**. The canonical test SA `57:42:75:05:d6:00`
+has the I/G (multicast) bit set in `0x57`; a station cannot unicast-auth to a
+multicast address, so rtw88 silently drops the auth before it hits the air
+(bench-proven across two station chips — `0x57` → no auth on air, `0x02` → auth on
+air and association completes). Use a locally-administered unicast BSSID (`0x02..`).
+So devourer is a real, associable AP — not just a beacon source.
 
 ## Uplink timing advance (experimental)
 

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -161,12 +161,13 @@ real station completes it: wpa_supplicant reports `WPA: Key negotiation complete
 [PTK=CCMP GTK=CCMP]` + `CTRL-EVENT-CONNECTED`. The handshake needs no CCMP
 (EAPOL-Key frames are cleartext, MIC-protected), so it works without the chip
 crypto engine. And the **data plane is encrypted too**: the AP decrypts the
-station's CCMP frames (software AES-CCM with the TK) and answers ARP + ICMP
-encrypted, so a real station **pings the AP over WPA2/CCMP at 0% loss, ~2.5 ms
-RTT**. The station runs hardware CCMP, the AP software CCMP — they interoperate. So
-devourer is a complete WPA2-PSK AP: associate → 4-way → **encrypted** IP. (Hardware
-CCMP offload would need porting the J3 security TX/RX descriptor fields, absent in
-devourer; software CCMP sidesteps that.)
+station's CCMP frames (software AES-CCM with the TK) and answers ARP + ICMP + DHCP
+encrypted, so a real station **leases 192.168.99.2 over encrypted DHCP** and
+**pings the AP over WPA2/CCMP at 0% loss, ~2.5 ms RTT**. The station runs hardware
+CCMP, the AP software CCMP — they interoperate. So devourer is a complete
+zero-config WPA2-PSK AP: associate → 4-way → encrypted DHCP → **encrypted** IP.
+(Hardware CCMP offload would need porting the J3 security TX/RX descriptor fields,
+absent in devourer; software CCMP sidesteps that.)
 
 ## Uplink timing advance (experimental)
 

--- a/examples/timesync/main.cpp
+++ b/examples/timesync/main.cpp
@@ -98,11 +98,12 @@ static libusb_device_handle* open_device(
 }
 
 // --- MASTER (eNB): broadcast the hardware TSF -------------------------------
-// A minimal raw 802.11 beacon MPDU (canonical SA/BSSID) — byte-identical to the
-// bench-validated tests/beacon_tbtt.cpp beacon (which the MAC fills with a clean
-// live TSF). The 8-byte timestamp is left zero; the MAC inserts the hardware TSF
-// at each TBTT. (An extended body — longer SSID / more rate IEs — broke the
-// hardware TSF insertion in testing, so keep this exact layout.)
+// A compact raw 802.11 beacon MPDU (canonical SA/BSSID) matching the
+// bench-validated tests/beacon_tbtt.cpp beacon. The 8-byte timestamp is left
+// zero; the MAC inserts the hardware TSF at each TBTT. A full kernel-AP body
+// (SSID + rates + DS + TIM + ...) also inserts the TSF correctly
+// (tests/beacon_fullbody.cpp) — this stays compact only because the timesync
+// demo needs no extra IEs.
 static std::vector<uint8_t> build_std_beacon(int interval_tu) {
   return {
       0x80, 0x00, 0x00, 0x00,                          // FC beacon + dur

--- a/examples/timesync/main.cpp
+++ b/examples/timesync/main.cpp
@@ -124,6 +124,13 @@ static void run_master(IRtlDevice* dev, const timesync::Config& c) {
   if (c.hwbeacon) {
     // Hardware-timed, hardware-TSF-stamped beacon at TBTT — no software send loop,
     // no ReadTsf jitter. The MAC inserts the live TSF into the beacon at TX.
+    if (c.no_csma) {
+      // The master owns the channel: disable EDCCA so the beacon airs exactly on
+      // the TBTT schedule (no CSMA backoff). Collapses the downlink residual from
+      // ~hundreds of µs to sub-µs even on a crowded channel.
+      dev->SetCcaMode(true);
+      fprintf(stderr, "timesync master: CSMA/EDCCA disabled (master owns channel)\n");
+    }
     auto b = build_std_beacon(c.interval_ms > 0 ? c.interval_ms * 1000 / 1024 : 100);
     bool ok = dev->StartBeacon(b.data(), b.size(),
                                c.interval_ms > 0 ? c.interval_ms * 1000 / 1024 : 100);

--- a/examples/timesync/main.cpp
+++ b/examples/timesync/main.cpp
@@ -363,6 +363,66 @@ static void run_ue(IRtlDevice* dev, const timesync::Config& c) {
   sleep_ms(2000);
   const auto rt = devourer::build_stream_radiotap(c.rate);
   const int64_t slot_us = (int64_t)c.slot_ms * 1000;
+
+  // --- Hardware-beacon uplink (fine-steered) — DEVOURER_TSYNC_HWBEACON --------
+  // The send_packet uplink below has no sub-slot air-departure control (the chip
+  // airs the queued frame on its own schedule), so the TA loop cannot converge
+  // (the doc's fixed-TA authority test: TA shifts the send-CALL time, not the
+  // measured arrival). Instead air the uplink from the BEACON engine —
+  // hardware-timed at the UE's TBTT — and steer that TBTT with
+  // AdjustBeaconTimingFine per the master's TA. The uplink is a tdma Uplink frame
+  // (not a beacon FC), which StartBeacon stores in the rsvd page and the engine
+  // airs verbatim at each TBTT, so the master's existing Uplink measurement path
+  // sees it unchanged. The UE owns its slot too, so drop EDCCA (like the master)
+  // for a crisp TBTT departure. This is the closed-loop LTE timing advance.
+  if (c.hwbeacon) {
+    dev->SetCcaMode(true);
+    int interval_tu = c.interval_ms * 1000 / 1024;
+    if (interval_tu < 1) interval_tu = 1;
+    auto up = tdma::build_frame(rt, static_cast<tdma::Class>(timesync::kClassUplink),
+                                0, 0, 0);
+    bool ok = dev->StartBeacon(up.data(), up.size(), interval_tu);
+    fprintf(stderr, "timesync ue(HW-beacon uplink): StartBeacon(%d TU) -> %s; "
+                    "steering via AdjustBeaconTimingFine\n",
+            interval_tu, ok ? "OK" : "FAILED");
+    if (!ok) { dev->StopRxLoop(); rx.join(); return; }
+    double applied_ta = 0;   // TA already actuated into the TBTT (cumulative)
+    uint64_t steers = 0;
+    auto nstat = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    auto deadline2 = std::chrono::steady_clock::now() + std::chrono::seconds(c.secs);
+    while (!g_devourer_should_stop) {
+      // Apply the TA increment: more TA => UE transmits earlier => advance (<0 µs).
+      double ta = g_ue_ta_us.load(std::memory_order_relaxed);
+      double delta = ta - applied_ta;
+      if (std::fabs(delta) >= 3.0) {
+        dev->AdjustBeaconTimingFine(-(int32_t)std::llround(delta));
+        applied_ta = ta;     // integrating loop: master measures the real arrival
+        ++steers; g_ue_tx.fetch_add(1, std::memory_order_relaxed);
+      }
+      if (std::chrono::steady_clock::now() >= nstat) {
+        nstat += std::chrono::seconds(1);
+        char buf[192];
+        std::snprintf(buf, sizeof(buf),
+                      "{\"ev\":\"timesync.ue\",\"beacons\":%llu,\"steers\":%llu,"
+                      "\"ta_us\":%.1f}\n",
+                      (unsigned long long)g_ue_beacons.load(),
+                      (unsigned long long)steers, ta);
+        emit(buf);
+      }
+      if (c.secs && std::chrono::steady_clock::now() >= deadline2) break;
+      sleep_ms(50);   // rate-limit fine steers (each toggles EN_BCN_FUNCTION)
+    }
+    dev->StopRxLoop(); rx.join();
+    fprintf(stderr,
+            "\n=== timesync ue(HW-beacon) summary ===\n"
+            "  beacons heard : %llu\n"
+            "  fine steers   : %llu\n"
+            "  final TA      : %.2f us\n",
+            (unsigned long long)g_ue_beacons.load(), (unsigned long long)steers,
+            g_ue_ta_us.load());
+    return;
+  }
+
   fprintf(stderr, "timesync ue: ch%d, uplink one frame per beacon (TA-corrected)\n",
           c.channel);
 

--- a/examples/timesync/main.cpp
+++ b/examples/timesync/main.cpp
@@ -1,0 +1,203 @@
+// timesync — LTE-eNB-style over-the-air time distribution. One binary, one
+// adapter, one role (compose scenarios by running instances):
+//
+//   DEVOURER_TSYNC_ROLE=master   TX-only. Every DEVOURER_TSYNC_INTERVAL_MS,
+//                                broadcast a sync beacon stamped with the chip's
+//                                hardware TSF (ReadTsf(), reliable TX-side — no
+//                                RX flood starving the control read). This is the
+//                                eNB distributing its SFN.
+//   DEVOURER_TSYNC_ROLE=slave    RX-only. Lock a running fit of the master's
+//                                broadcast TSF against this slave's own per-frame
+//                                hardware TSF, PREDICT each beacon before it
+//                                arrives, and emit the prediction error — how
+//                                tightly this UE tracks the eNB. No host clock,
+//                                no GPS.
+//
+// Run a master + two slaves and join the slaves' {"ev":"timesync.lock"} streams
+// on `seq`: pred_master_A vs pred_master_B is the inter-UE sync error, measured
+// without either slave touching a wall clock (tests/timesync_demo.sh).
+//
+// See timesync.h for the fit + env knobs. Metrics are JSONL on stdout.
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#if defined(_MSC_VER)
+  #include <libusb.h>
+#elif defined(__MINGW32__) || defined(__MINGW64__)
+  #include <libusb-1.0/libusb.h>
+#elif defined(__APPLE__) || defined(__ANDROID__)
+  #include <libusb.h>
+#else
+  #include <libusb-1.0/libusb.h>
+#endif
+
+#include "RadiotapBuilder.h"
+#include "RxPacket.h"
+#include "SignalStop.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "env_config.h"
+#include "logger.h"
+#include "timesync.h"
+
+#define USB_VENDOR_ID 0x0bda
+static constexpr uint16_t kRealtekProductIds[] = {
+    0x8812, 0x0811, 0xa811, 0xb811, 0x8813,
+};
+
+static inline void sleep_ms(long ms) {
+  std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+}
+static void emit(const char* json) { std::fputs(json, stdout); std::fflush(stdout); }
+
+// --- device open (mirrors examples/tdma/main.cpp) ---------------------------
+static libusb_device_handle* open_device(
+    const std::shared_ptr<Logger>& logger, libusb_context** ctx,
+    std::shared_ptr<devourer::UsbDeviceLock>& lock) {
+  if (libusb_init(ctx) < 0) return nullptr;
+  libusb_set_option(*ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
+  uint16_t vid = USB_VENDOR_ID, pid = 0;
+  if (const char* v = std::getenv("DEVOURER_VID")) vid = (uint16_t)strtoul(v, 0, 0);
+  if (const char* p = std::getenv("DEVOURER_PID")) pid = (uint16_t)strtoul(p, 0, 0);
+  libusb_device_handle* h = nullptr;
+  for (uint16_t p : kRealtekProductIds) {
+    if (pid != 0 && p != pid) continue;
+    h = libusb_open_device_with_vid_pid(*ctx, vid, p);
+    if (h) break;
+  }
+  if (!h && pid != 0) h = libusb_open_device_with_vid_pid(*ctx, vid, pid);
+  if (!h) { logger->error("no device {:04x}:{:04x}", vid, pid); return nullptr; }
+  if (devourer::claim_interface_then_reset(
+          h, 0, logger, std::getenv("DEVOURER_SKIP_RESET") == nullptr, lock) != 0) {
+    logger->error("claim failed (busy?)");
+    return nullptr;
+  }
+  return h;
+}
+
+// --- MASTER (eNB): broadcast the hardware TSF -------------------------------
+static void run_master(IRtlDevice* dev, const timesync::Config& c) {
+  dev->InitWrite(SelectedChannel{c.channel, 0, CHANNEL_WIDTH_20});
+  sleep_ms(2000);
+  const auto rt = devourer::build_stream_radiotap(c.rate);
+  fprintf(stderr, "timesync master: ch%d, sync beacon every %d ms\n", c.channel,
+          c.interval_ms);
+
+  uint32_t seq = 0;
+  auto next_stat = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(c.secs);
+  while (!g_devourer_should_stop) {
+    // Stamp with the master's hardware TSF at send time. TX-side ReadTsf() is
+    // reliable (no bulk-IN flood), unlike on a busy receiver.
+    uint64_t tsf = dev->ReadTsf();
+    auto f = tdma::build_frame(rt, tdma::Class::Marker, seq++, 0, tsf);
+    dev->send_packet(f.data(), f.size());
+
+    if (std::chrono::steady_clock::now() >= next_stat) {
+      next_stat += std::chrono::seconds(1);
+      char buf[160];
+      std::snprintf(buf, sizeof(buf),
+                    "{\"ev\":\"timesync.master\",\"beacons\":%u,\"tsf\":%llu}\n",
+                    seq, (unsigned long long)tsf);
+      emit(buf);
+    }
+    if (c.secs && std::chrono::steady_clock::now() >= deadline) break;
+    sleep_ms(c.interval_ms);
+  }
+  fprintf(stderr, "timesync master: %u beacons sent\n", seq);
+}
+
+// --- SLAVE (UE): lock to the master, predict each beacon --------------------
+static timesync::Recon g_recon;
+static timesync::LinFit g_fit;
+static std::mutex g_mu;
+static uint64_t g_beacons = 0;       // master frames heard
+static uint64_t g_predicted = 0;     // frames predicted (fit was ready)
+static double g_resid_ss = 0;        // Σ resid² (µs²), for RMS
+static double g_resid_max = 0;
+
+static void slave_cb(const Packet& p) {
+  auto pr = tdma::parse_frame(p.Data.data(), p.Data.size());
+  if (!pr.ok || p.RxAtrib.crc_err) return;
+  if (pr.cls != tdma::Class::Marker || pr.tx_tsf == 0) return;  // sync beacons only
+
+  std::lock_guard<std::mutex> lk(g_mu);
+  double local_us = (double)g_recon(p.RxAtrib.tsfl);
+  double master_us = (double)pr.tx_tsf;
+  ++g_beacons;
+
+  // Predict this beacon's master TSF from the fit built on PRIOR beacons,
+  // evaluated at this beacon's clean local hardware TSF. resid = lock error.
+  if (g_fit.ready()) {
+    double pred = g_fit.at(local_us);
+    double resid = master_us - pred;
+    ++g_predicted;
+    g_resid_ss += resid * resid;
+    if (std::fabs(resid) > g_resid_max) g_resid_max = std::fabs(resid);
+    char buf[256];
+    std::snprintf(buf, sizeof(buf),
+                  "{\"ev\":\"timesync.lock\",\"seq\":%u,\"master_tsf\":%llu,"
+                  "\"local_tsf\":%llu,\"pred_master\":%.1f,\"resid_us\":%.2f,"
+                  "\"ppm\":%.2f}\n",
+                  pr.seq, (unsigned long long)pr.tx_tsf,
+                  (unsigned long long)(int64_t)local_us, pred, resid, g_fit.ppm());
+    emit(buf);
+  }
+  g_fit.add(local_us, master_us);
+}
+
+static void run_slave(IRtlDevice* dev, const timesync::Config& c) {
+  std::thread rx([&] {
+    dev->Init(slave_cb, SelectedChannel{c.channel, 0, CHANNEL_WIDTH_20});
+  });
+  fprintf(stderr, "timesync slave: ch%d, locking to master beacons\n", c.channel);
+
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(c.secs);
+  while (!g_devourer_should_stop) {
+    sleep_ms(100);
+    if (c.secs && std::chrono::steady_clock::now() >= deadline) break;
+  }
+  dev->StopRxLoop();
+  rx.join();
+
+  std::lock_guard<std::mutex> lk(g_mu);
+  double rms = g_predicted ? std::sqrt(g_resid_ss / (double)g_predicted) : 0;
+  fprintf(stderr,
+          "\n=== timesync slave summary ===\n"
+          "  beacons heard      : %llu\n"
+          "  predicted          : %llu\n"
+          "  lock error (RMS)   : %.2f us    max %.2f us\n"
+          "  master-vs-slave ppm: %.2f\n",
+          (unsigned long long)g_beacons, (unsigned long long)g_predicted, rms,
+          g_resid_max, g_fit.ppm());
+}
+
+int main() {
+  auto logger = std::make_shared<Logger>();
+  apply_logging_env(*logger);
+  install_devourer_signal_handlers();
+
+  timesync::Config c = timesync::config_from_env();
+
+  libusb_context* ctx = nullptr;
+  std::shared_ptr<devourer::UsbDeviceLock> lock;
+  auto* handle = open_device(logger, &ctx, lock);
+  if (!handle) { if (ctx) libusb_exit(ctx); return 1; }
+
+  WiFiDriver wifi(logger);
+  auto dev = wifi.CreateRtlDevice(handle, ctx, lock, devourer_config_from_env());
+  if (!dev) { logger->error("no driver for this chip"); return 1; }
+
+  if (c.role == timesync::Role::Master) run_master(dev.get(), c);
+  else run_slave(dev.get(), c);
+  return 0;
+}

--- a/examples/timesync/main.cpp
+++ b/examples/timesync/main.cpp
@@ -17,6 +17,19 @@
 // on `seq`: pred_master_A vs pred_master_B is the inter-UE sync error, measured
 // without either slave touching a wall clock (tests/timesync_demo.sh).
 //
+// UPLINK TIMING ADVANCE (DEVOURER_TSYNC_UPLINK=1, roles master + ue) is the LTE
+// closed-loop extension — a full-duplex master phase-measures each UE uplink
+// against its TSF slot grid and feeds back a timing advance. It is EXPERIMENTAL:
+// the control math converges in the headless selftest and the full-duplex
+// plumbing works on-air (arrivals cluster tightly, ~±0.2 ms with a FIXED TA),
+// but the closed loop does NOT converge on the bench — a fixed-TA authority test
+// shows the TA shifts the UE's send-CALL time yet not the master-measured
+// arrival phase. Root cause: under full-duplex, send_packet queues the frame and
+// the chip airs it on its own schedule, so userspace call-timing has no
+// sub-slot control over air departure (plus this bench has only one clean
+// full-duplex Jaguar2/3 adapter; the 8822E desenses its RX in TX+RX). See
+// docs and tests/timesync_ta_demo.sh.
+//
 // See timesync.h for the fit + env knobs. Metrics are JSONL on stdout.
 #include <atomic>
 #include <chrono>
@@ -181,6 +194,162 @@ static void run_slave(IRtlDevice* dev, const timesync::Config& c) {
           g_resid_max, g_fit.ppm());
 }
 
+// --- UPLINK TIMING ADVANCE (LTE TA), full-duplex ---------------------------
+// The master broadcasts beacons AND phase-measures each UE uplink against its
+// own TSF slot grid (arrival tsfl mod slot_us — reliable per-frame, no ReadTsf
+// which the RX loop would starve), integrating a per-UE timing-advance it feeds
+// back. The UE schedules its uplinks off the beacon-arrival cadence (a seq↔host
+// fit — rate-locked to the master) minus the TA. The loop drives each uplink's
+// arrival onto the master's slot boundary; open-loop it drifts across the slot
+// at the crystal offset. Both nodes are full-duplex (InitWrite + StartRxLoop).
+static int64_t steady_us() {
+  return std::chrono::duration_cast<std::chrono::microseconds>(
+             std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+// Master TA state.
+static timesync::Recon g_m_recon;
+static std::atomic<double> g_ta_us{0};
+static std::mutex g_m_mu;
+static uint64_t g_uplinks = 0;
+static double g_phase_ss = 0, g_phase_max = 0;
+static uint64_t g_phase_n = 0;
+static double g_slot_us = 20000, g_ta_gain = 0.3;
+static bool g_ta_fixed = false;   // DEVOURER_TSYNC_TA_FIXED: hold TA constant (authority test)
+
+static void master_ta_cb(const Packet& p) {
+  auto pr = tdma::parse_frame(p.Data.data(), p.Data.size());
+  if (!pr.ok || p.RxAtrib.crc_err) return;
+  if (static_cast<uint8_t>(pr.cls) != timesync::kClassUplink) return;
+  std::lock_guard<std::mutex> lk(g_m_mu);
+  double arrival = (double)g_m_recon(p.RxAtrib.tsfl);
+  double phase = arrival - std::round(arrival / g_slot_us) * g_slot_us;  // (-slot/2, slot/2]
+  double ta = g_ta_us.load();
+  if (!g_ta_fixed) {
+    ta += g_ta_gain * phase;                       // late (phase>0) → more TA → UE earlier
+    if (ta > g_slot_us) ta = g_slot_us;            // clamp to one slot (no wrap — a hard
+    if (ta < -g_slot_us) ta = -g_slot_us;          // mod jump kicks the loop)
+    g_ta_us.store(ta);
+  }
+  ++g_uplinks; g_phase_ss += phase * phase; ++g_phase_n;
+  if (std::fabs(phase) > g_phase_max) g_phase_max = std::fabs(phase);
+  char buf[224];
+  std::snprintf(buf, sizeof(buf),
+                "{\"ev\":\"timesync.ta\",\"seq\":%u,\"n\":%llu,\"phase_us\":%.2f,"
+                "\"ta_us\":%.2f}\n",
+                pr.seq, (unsigned long long)g_uplinks, phase, ta);
+  emit(buf);
+}
+
+static void run_master_ta(IRtlDevice* dev, const timesync::Config& c) {
+  g_slot_us = c.slot_ms * 1000.0; g_ta_gain = c.ta_gain;
+  if (const char* f = std::getenv("DEVOURER_TSYNC_TA_FIXED")) {
+    g_ta_fixed = true; g_ta_us.store(std::atof(f));   // authority test: hold TA constant
+  }
+  dev->InitWrite(SelectedChannel{c.channel, 0, CHANNEL_WIDTH_20});
+  std::thread rx([&] { dev->StartRxLoop(master_ta_cb); });
+  sleep_ms(2000);
+  const auto rt = devourer::build_stream_radiotap(c.rate);
+  fprintf(stderr, "timesync master(TA): ch%d beacons=%dms slot=%dms gain=%.2f\n",
+          c.channel, c.interval_ms, c.slot_ms, c.ta_gain);
+
+  uint32_t seq = 0;
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(c.secs);
+  while (!g_devourer_should_stop) {
+    // The beacon carries the current TA in its tx_tsf field (unused for cadence),
+    // so every beacon the UE decodes delivers the latest TA — one send per slot,
+    // no separate frame to drop.
+    int64_t ta_i = (int64_t)std::llround(g_ta_us.load());  // signed µs → 8-byte tag
+    uint64_t ta_b; std::memcpy(&ta_b, &ta_i, 8);
+    auto b = tdma::build_frame(rt, tdma::Class::Marker, seq++, 0, ta_b);
+    dev->send_packet(b.data(), b.size());
+    if (c.secs && std::chrono::steady_clock::now() >= deadline) break;
+    sleep_ms(c.interval_ms);
+  }
+  dev->StopRxLoop(); rx.join();
+  std::lock_guard<std::mutex> lk(g_m_mu);
+  double rms = g_phase_n ? std::sqrt(g_phase_ss / (double)g_phase_n) : 0;
+  fprintf(stderr,
+          "\n=== timesync master(TA) summary ===\n"
+          "  uplinks measured   : %llu\n"
+          "  arrival phase (all): RMS %.2f us   max %.2f us\n"
+          "  final TA           : %.2f us\n",
+          (unsigned long long)g_uplinks, rms, g_phase_max, g_ta_us.load());
+}
+
+// UE state. Event-driven off actual beacon arrivals (rate-locked to the master),
+// so the TA directly and unambiguously shifts the uplink's arrival phase.
+static std::atomic<int64_t> g_ue_beacon_us{0};   // steady_us of the last beacon
+static std::atomic<uint32_t> g_ue_beacon_seq{0};
+static std::atomic<bool> g_ue_have{false};
+static std::atomic<double> g_ue_ta_us{0};
+static std::atomic<uint64_t> g_ue_beacons{0}, g_ue_tx{0};
+
+static void ue_cb(const Packet& p) {
+  auto pr = tdma::parse_frame(p.Data.data(), p.Data.size());
+  if (!pr.ok || p.RxAtrib.crc_err) return;
+  if (pr.cls == tdma::Class::Marker) {
+    g_ue_beacon_us.store(steady_us(), std::memory_order_relaxed);
+    g_ue_beacon_seq.store(pr.seq, std::memory_order_relaxed);
+    g_ue_have.store(true, std::memory_order_relaxed);
+    g_ue_beacons.fetch_add(1, std::memory_order_relaxed);
+    int64_t ta_i; uint64_t ta_b = pr.tx_tsf; std::memcpy(&ta_i, &ta_b, 8);  // TA rides the beacon
+    g_ue_ta_us.store((double)ta_i, std::memory_order_relaxed);
+  }
+}
+
+static void run_ue(IRtlDevice* dev, const timesync::Config& c) {
+  dev->InitWrite(SelectedChannel{c.channel, 0, CHANNEL_WIDTH_20});
+  std::thread rx([&] { dev->StartRxLoop(ue_cb); });
+  sleep_ms(2000);
+  const auto rt = devourer::build_stream_radiotap(c.rate);
+  const int64_t slot_us = (int64_t)c.slot_ms * 1000;
+  fprintf(stderr, "timesync ue: ch%d, uplink one frame per beacon (TA-corrected)\n",
+          c.channel);
+
+  uint32_t done = 0;   // last beacon seq we've already answered with an uplink
+  auto next_stat = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(c.secs);
+  while (!g_devourer_should_stop) {
+    if (std::chrono::steady_clock::now() >= next_stat) {
+      next_stat += std::chrono::seconds(1);
+      char buf[160];
+      std::snprintf(buf, sizeof(buf),
+                    "{\"ev\":\"timesync.ue\",\"beacons\":%llu,\"tx\":%llu,\"ta_us\":%.1f}\n",
+                    (unsigned long long)g_ue_beacons.load(),
+                    (unsigned long long)g_ue_tx.load(), g_ue_ta_us.load());
+      emit(buf);
+    }
+    if (!g_ue_have.load(std::memory_order_relaxed)) { sleep_ms(5); continue; }
+    uint32_t s = g_ue_beacon_seq.load(std::memory_order_relaxed);
+    if (s == done) { sleep_ms(1); continue; }   // wait for the next beacon (a slot tick)
+    done = s;
+    // Aim the uplink to ARRIVE one slot after this beacon (the next boundary),
+    // advanced by the master's TA. TA authority is direct: earlier send → earlier
+    // arrival → smaller measured phase.
+    int64_t send_at = g_ue_beacon_us.load(std::memory_order_relaxed) + slot_us -
+                      (int64_t)g_ue_ta_us.load(std::memory_order_relaxed);
+    int64_t wait = send_at - steady_us();
+    if (wait > 0 && wait < 2 * slot_us)
+      std::this_thread::sleep_for(std::chrono::microseconds(wait));
+    else if (wait >= 2 * slot_us)
+      continue;   // absurd — skip this slot
+    auto f = tdma::build_frame(rt, static_cast<tdma::Class>(timesync::kClassUplink),
+                               s, 0, 0);
+    dev->send_packet(f.data(), f.size());
+    g_ue_tx.fetch_add(1, std::memory_order_relaxed);
+    if (c.secs && std::chrono::steady_clock::now() >= deadline) break;
+  }
+  dev->StopRxLoop(); rx.join();
+  fprintf(stderr,
+          "\n=== timesync ue summary ===\n"
+          "  beacons heard : %llu\n"
+          "  uplinks sent  : %llu\n"
+          "  final TA      : %.2f us\n",
+          (unsigned long long)g_ue_beacons.load(),
+          (unsigned long long)g_ue_tx.load(), g_ue_ta_us.load());
+}
+
 int main() {
   auto logger = std::make_shared<Logger>();
   apply_logging_env(*logger);
@@ -197,7 +366,9 @@ int main() {
   auto dev = wifi.CreateRtlDevice(handle, ctx, lock, devourer_config_from_env());
   if (!dev) { logger->error("no driver for this chip"); return 1; }
 
-  if (c.role == timesync::Role::Master) run_master(dev.get(), c);
+  if (c.role == timesync::Role::Ue) run_ue(dev.get(), c);
+  else if (c.role == timesync::Role::Master && c.uplink) run_master_ta(dev.get(), c);
+  else if (c.role == timesync::Role::Master) run_master(dev.get(), c);
   else run_slave(dev.get(), c);
   return 0;
 }

--- a/examples/timesync/main.cpp
+++ b/examples/timesync/main.cpp
@@ -98,9 +98,44 @@ static libusb_device_handle* open_device(
 }
 
 // --- MASTER (eNB): broadcast the hardware TSF -------------------------------
+// A minimal raw 802.11 beacon MPDU (canonical SA/BSSID) — byte-identical to the
+// bench-validated tests/beacon_tbtt.cpp beacon (which the MAC fills with a clean
+// live TSF). The 8-byte timestamp is left zero; the MAC inserts the hardware TSF
+// at each TBTT. (An extended body — longer SSID / more rate IEs — broke the
+// hardware TSF insertion in testing, so keep this exact layout.)
+static std::vector<uint8_t> build_std_beacon(int interval_tu) {
+  return {
+      0x80, 0x00, 0x00, 0x00,                          // FC beacon + dur
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff,              // addr1 broadcast
+      0x57, 0x42, 0x75, 0x05, 0xd6, 0x00,             // addr2 = SA (canonical)
+      0x57, 0x42, 0x75, 0x05, 0xd6, 0x00,             // addr3 = BSSID
+      0x00, 0x00,                                      // seq
+      0, 0, 0, 0, 0, 0, 0, 0,                          // timestamp (HW fills)
+      static_cast<uint8_t>(interval_tu & 0xff),
+      static_cast<uint8_t>((interval_tu >> 8) & 0xff), // beacon interval
+      0x00, 0x00,                                      // capability
+      0x00, 0x03, 'T', 'B', 'T',                       // SSID IE
+      0x01, 0x01, 0x82};                               // supported rates (1M)
+}
+
 static void run_master(IRtlDevice* dev, const timesync::Config& c) {
   dev->InitWrite(SelectedChannel{c.channel, 0, CHANNEL_WIDTH_20});
   sleep_ms(2000);
+  if (c.hwbeacon) {
+    // Hardware-timed, hardware-TSF-stamped beacon at TBTT — no software send loop,
+    // no ReadTsf jitter. The MAC inserts the live TSF into the beacon at TX.
+    auto b = build_std_beacon(c.interval_ms > 0 ? c.interval_ms * 1000 / 1024 : 100);
+    bool ok = dev->StartBeacon(b.data(), b.size(),
+                               c.interval_ms > 0 ? c.interval_ms * 1000 / 1024 : 100);
+    fprintf(stderr, "timesync master(HW beacon): StartBeacon -> %s, ch%d\n",
+            ok ? "OK" : "UNSUPPORTED", c.channel);
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(c.secs);
+    while (!g_devourer_should_stop) {
+      sleep_ms(200);
+      if (c.secs && std::chrono::steady_clock::now() >= deadline) break;
+    }
+    return;
+  }
   const auto rt = devourer::build_stream_radiotap(c.rate);
   fprintf(stderr, "timesync master: ch%d, sync beacon every %d ms\n", c.channel,
           c.interval_ms);
@@ -138,14 +173,30 @@ static uint64_t g_predicted = 0;     // frames predicted (fit was ready)
 static double g_resid_ss = 0;        // Σ resid² (µs²), for RMS
 static double g_resid_max = 0;
 
+static bool g_hwbeacon = false;
+
 static void slave_cb(const Packet& p) {
-  auto pr = tdma::parse_frame(p.Data.data(), p.Data.size());
-  if (!pr.ok || p.RxAtrib.crc_err) return;
-  if (pr.cls != tdma::Class::Marker || pr.tx_tsf == 0) return;  // sync beacons only
+  uint64_t master_tsf; uint32_t seq;
+  if (g_hwbeacon) {
+    // Standard 802.11 beacon: canonical SA at addr2, and the master's LIVE
+    // hardware TSF is the 8-byte timestamp field (MPDU offset 24). No TD tag.
+    static const uint8_t kSa[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
+    if (p.Data.size() < 32 || p.RxAtrib.crc_err) return;
+    if ((p.Data[0] & 0xfc) != 0x80) return;                        // beacon subtype
+    if (std::memcmp(p.Data.data() + 10, kSa, 6) != 0) return;      // our master
+    master_tsf = 0;
+    for (int i = 0; i < 8; ++i) master_tsf |= (uint64_t)p.Data[24 + i] << (8 * i);
+    seq = (uint32_t)(p.RxAtrib.seq_num);
+  } else {
+    auto pr = tdma::parse_frame(p.Data.data(), p.Data.size());
+    if (!pr.ok || p.RxAtrib.crc_err) return;
+    if (pr.cls != tdma::Class::Marker || pr.tx_tsf == 0) return;   // sync beacons only
+    master_tsf = pr.tx_tsf; seq = pr.seq;
+  }
 
   std::lock_guard<std::mutex> lk(g_mu);
   double local_us = (double)g_recon(p.RxAtrib.tsfl);
-  double master_us = (double)pr.tx_tsf;
+  double master_us = (double)master_tsf;
   ++g_beacons;
 
   // Predict this beacon's master TSF from the fit built on PRIOR beacons,
@@ -161,7 +212,7 @@ static void slave_cb(const Packet& p) {
                   "{\"ev\":\"timesync.lock\",\"seq\":%u,\"master_tsf\":%llu,"
                   "\"local_tsf\":%llu,\"pred_master\":%.1f,\"resid_us\":%.2f,"
                   "\"ppm\":%.2f}\n",
-                  pr.seq, (unsigned long long)pr.tx_tsf,
+                  seq, (unsigned long long)master_tsf,
                   (unsigned long long)(int64_t)local_us, pred, resid, g_fit.ppm());
     emit(buf);
   }
@@ -356,6 +407,7 @@ int main() {
   install_devourer_signal_handlers();
 
   timesync::Config c = timesync::config_from_env();
+  g_hwbeacon = c.hwbeacon;   // slave reads the standard 802.11 beacon timestamp
 
   libusb_context* ctx = nullptr;
   std::shared_ptr<devourer::UsbDeviceLock> lock;

--- a/examples/timesync/timesync.h
+++ b/examples/timesync/timesync.h
@@ -91,7 +91,8 @@ struct Config {
   // Uplink timing-advance (full-duplex, DEVOURER_TSYNC_UPLINK=1):
   bool uplink = false;     // master: measure UE uplinks + feed back TA. ue: TX uplinks
   bool hwbeacon = false;  // master: HW-TBTT beacon (StartBeacon); slave: read 802.11 TS
-  bool no_csma = false;   // master: disable EDCCA so the beacon airs exactly at TBTT
+  bool no_csma = true;    // master: disable EDCCA by DEFAULT (master owns the channel,
+                          // beacon airs exactly at TBTT -> sub-µs); DEVOURER_TSYNC_CSMA=1 keeps CSMA
   int slot_ms = 20;        // uplink slot grid on the master TSF (a TDMA slot)
   double ta_gain = 0.3;    // master TA integrator gain (0..1; error fraction/step)
 };
@@ -112,7 +113,7 @@ inline Config config_from_env() {
   c.channel = static_cast<uint8_t>(env_int("DEVOURER_CHANNEL", 36));
   c.uplink = std::getenv("DEVOURER_TSYNC_UPLINK") != nullptr;
   c.hwbeacon = std::getenv("DEVOURER_TSYNC_HWBEACON") != nullptr;
-  c.no_csma = std::getenv("DEVOURER_TSYNC_NO_CSMA") != nullptr;
+  c.no_csma = std::getenv("DEVOURER_TSYNC_CSMA") == nullptr;  // on by default; opt out to keep CSMA
   c.slot_ms = env_int("DEVOURER_TSYNC_SLOT_MS", 20);
   if (const char* g = std::getenv("DEVOURER_TSYNC_TA_GAIN")) c.ta_gain = std::atof(g);
   const char* rt = std::getenv("DEVOURER_TSYNC_RATE");

--- a/examples/timesync/timesync.h
+++ b/examples/timesync/timesync.h
@@ -60,18 +60,27 @@ struct LinFit {
     double den = (double)n * sxx - sx * sx;
     return den == 0 ? 1.0 : ((double)n * sxy - sx * sy) / den;
   }
-  // Predicted master TSF (µs) at local TSF x (µs).
-  double at(double x) const {
+  double intercept() const { return (sy - slope() * sx) / (double)n; }
+  // Predicted y at x.
+  double at(double x) const { return y0 + slope() * (x - x0) + intercept(); }
+  // Inverse: the x that yields a given y (for scheduling in the fitted domain).
+  double inverse(double y) const {
     double a = slope();
-    double b = (sy - a * sx) / (double)n;
-    return y0 + a * (x - x0) + b;
+    return x0 + (a == 0 ? 0 : (y - y0 - intercept()) / a);
   }
-  // Master-vs-slave crystal offset in ppm (slope = dmaster/dlocal).
+  // Fitted crystal offset in ppm (slope = dy/dx).
   double ppm() const { return (slope() - 1.0) * 1e6; }
 };
 
+// Uplink extends the downlink beacon with two more TD-tag class codes (reusing
+// tdma::build_frame; parse_frame round-trips any class value, so tdma.h is
+// untouched). Uplink = UE→master frame the master phase-measures; Ta = the
+// master→UE timing-advance correction.
+static constexpr uint8_t kClassUplink = 3;
+static constexpr uint8_t kClassTa = 4;
+
 // --- Config (env) -----------------------------------------------------------
-enum class Role { Master, Slave };
+enum class Role { Master, Slave, Ue };
 
 struct Config {
   Role role = Role::Slave;
@@ -79,6 +88,10 @@ struct Config {
   int secs = 0;            // 0 = run until signalled
   uint8_t channel = 36;
   devourer::TxMode rate;   // master beacon rate (default 6M — must be heard)
+  // Uplink timing-advance (full-duplex, DEVOURER_TSYNC_UPLINK=1):
+  bool uplink = false;     // master: measure UE uplinks + feed back TA. ue: TX uplinks
+  int slot_ms = 20;        // uplink slot grid on the master TSF (a TDMA slot)
+  double ta_gain = 0.3;    // master TA integrator gain (0..1; error fraction/step)
 };
 
 inline int env_int(const char* n, int dflt) {
@@ -90,11 +103,14 @@ inline Config config_from_env() {
   Config c;
   if (const char* r = std::getenv("DEVOURER_TSYNC_ROLE")) {
     std::string s(r);
-    c.role = (s == "master") ? Role::Master : Role::Slave;
+    c.role = (s == "master") ? Role::Master : (s == "ue") ? Role::Ue : Role::Slave;
   }
   c.interval_ms = env_int("DEVOURER_TSYNC_INTERVAL_MS", 100);
   c.secs = env_int("DEVOURER_TSYNC_SECS", 0);
   c.channel = static_cast<uint8_t>(env_int("DEVOURER_CHANNEL", 36));
+  c.uplink = std::getenv("DEVOURER_TSYNC_UPLINK") != nullptr;
+  c.slot_ms = env_int("DEVOURER_TSYNC_SLOT_MS", 20);
+  if (const char* g = std::getenv("DEVOURER_TSYNC_TA_GAIN")) c.ta_gain = std::atof(g);
   const char* rt = std::getenv("DEVOURER_TSYNC_RATE");
   c.rate = devourer::parse_tx_mode_str(rt && *rt ? rt : "6M");
   return c;

--- a/examples/timesync/timesync.h
+++ b/examples/timesync/timesync.h
@@ -90,6 +90,7 @@ struct Config {
   devourer::TxMode rate;   // master beacon rate (default 6M — must be heard)
   // Uplink timing-advance (full-duplex, DEVOURER_TSYNC_UPLINK=1):
   bool uplink = false;     // master: measure UE uplinks + feed back TA. ue: TX uplinks
+  bool hwbeacon = false;  // master: HW-TBTT beacon (StartBeacon); slave: read 802.11 TS
   int slot_ms = 20;        // uplink slot grid on the master TSF (a TDMA slot)
   double ta_gain = 0.3;    // master TA integrator gain (0..1; error fraction/step)
 };
@@ -109,6 +110,7 @@ inline Config config_from_env() {
   c.secs = env_int("DEVOURER_TSYNC_SECS", 0);
   c.channel = static_cast<uint8_t>(env_int("DEVOURER_CHANNEL", 36));
   c.uplink = std::getenv("DEVOURER_TSYNC_UPLINK") != nullptr;
+  c.hwbeacon = std::getenv("DEVOURER_TSYNC_HWBEACON") != nullptr;
   c.slot_ms = env_int("DEVOURER_TSYNC_SLOT_MS", 20);
   if (const char* g = std::getenv("DEVOURER_TSYNC_TA_GAIN")) c.ta_gain = std::atof(g);
   const char* rt = std::getenv("DEVOURER_TSYNC_RATE");

--- a/examples/timesync/timesync.h
+++ b/examples/timesync/timesync.h
@@ -91,6 +91,7 @@ struct Config {
   // Uplink timing-advance (full-duplex, DEVOURER_TSYNC_UPLINK=1):
   bool uplink = false;     // master: measure UE uplinks + feed back TA. ue: TX uplinks
   bool hwbeacon = false;  // master: HW-TBTT beacon (StartBeacon); slave: read 802.11 TS
+  bool no_csma = false;   // master: disable EDCCA so the beacon airs exactly at TBTT
   int slot_ms = 20;        // uplink slot grid on the master TSF (a TDMA slot)
   double ta_gain = 0.3;    // master TA integrator gain (0..1; error fraction/step)
 };
@@ -111,6 +112,7 @@ inline Config config_from_env() {
   c.channel = static_cast<uint8_t>(env_int("DEVOURER_CHANNEL", 36));
   c.uplink = std::getenv("DEVOURER_TSYNC_UPLINK") != nullptr;
   c.hwbeacon = std::getenv("DEVOURER_TSYNC_HWBEACON") != nullptr;
+  c.no_csma = std::getenv("DEVOURER_TSYNC_NO_CSMA") != nullptr;
   c.slot_ms = env_int("DEVOURER_TSYNC_SLOT_MS", 20);
   if (const char* g = std::getenv("DEVOURER_TSYNC_TA_GAIN")) c.ta_gain = std::atof(g);
   const char* rt = std::getenv("DEVOURER_TSYNC_RATE");

--- a/examples/timesync/timesync.h
+++ b/examples/timesync/timesync.h
@@ -1,0 +1,103 @@
+// timesync — LTE-eNB-style over-the-air time distribution: one MASTER broadcasts
+// its hardware TSF periodically (a "sync beacon"), and any number of SLAVES lock
+// their notion of the master clock to it from the beacons alone — no GPS at the
+// slaves, only the master holds a reference. This is the 802.11 analog of an eNB
+// distributing frame timing to UEs: the master's TSF is the SFN, each slave a UE
+// slaving to it.
+//
+// A slave relates the master's broadcast TSF to its OWN per-frame hardware TSF
+// (rx_pkt_attrib::tsfl) with a running least-squares fit — both are clean
+// MAC-latched microsecond clocks, so the fit residual is the true lock quality
+// (the ~sub-µs floor of the dual-RX TSF correlation), NOT the ~1 ms host-callback
+// jitter. Each slave PREDICTS the next beacon's master TSF from its fit; the
+// prediction error is how tightly it tracks the eNB. Two slaves predicting the
+// SAME beacon (matched by seq) agree to within their combined residual — the
+// inter-UE sync error, measured without either slave reading a host clock.
+//
+// App-level only (no WiFiDriver core changes); reuses the TD frame tag + SA from
+// the tdma example (examples/tdma/tdma.h) so one marker layout serves both.
+#pragma once
+
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+
+#include "RadiotapBuilder.h"  // devourer::TxMode / parse_tx_mode_str
+#include "tdma.h"             // tdma::build_frame / parse_frame / kSa / Class
+
+namespace timesync {
+
+// 32→64-bit TSF reconstruction (the MAC latches only the low 32 bits per frame;
+// it wraps every ~71 min). One per clock source.
+struct Recon {
+  int64_t hi = 0;
+  uint32_t plo = 0;
+  bool init = false;
+  int64_t operator()(uint32_t lo) {
+    if (init && lo < plo) hi += (1LL << 32);
+    plo = lo;
+    init = true;
+    return hi + lo;
+  }
+};
+
+// Incremental ordinary-least-squares fit y = a·x + b, offset-normalized to the
+// first sample so the sums stay well within double precision over a long run.
+// Here x = the slave's local TSF (µs), y = the master's broadcast TSF (µs).
+struct LinFit {
+  bool init = false;
+  double x0 = 0, y0 = 0;
+  long long n = 0;
+  double sx = 0, sy = 0, sxx = 0, sxy = 0;
+
+  void add(double x, double y) {
+    if (!init) { x0 = x; y0 = y; init = true; }
+    double xi = x - x0, yi = y - y0;
+    ++n; sx += xi; sy += yi; sxx += xi * xi; sxy += xi * yi;
+  }
+  bool ready() const { return n >= 16; }
+  double slope() const {
+    double den = (double)n * sxx - sx * sx;
+    return den == 0 ? 1.0 : ((double)n * sxy - sx * sy) / den;
+  }
+  // Predicted master TSF (µs) at local TSF x (µs).
+  double at(double x) const {
+    double a = slope();
+    double b = (sy - a * sx) / (double)n;
+    return y0 + a * (x - x0) + b;
+  }
+  // Master-vs-slave crystal offset in ppm (slope = dmaster/dlocal).
+  double ppm() const { return (slope() - 1.0) * 1e6; }
+};
+
+// --- Config (env) -----------------------------------------------------------
+enum class Role { Master, Slave };
+
+struct Config {
+  Role role = Role::Slave;
+  int interval_ms = 100;   // master: sync-beacon period (LTE beacon ≈ 100 ms)
+  int secs = 0;            // 0 = run until signalled
+  uint8_t channel = 36;
+  devourer::TxMode rate;   // master beacon rate (default 6M — must be heard)
+};
+
+inline int env_int(const char* n, int dflt) {
+  const char* e = std::getenv(n);
+  return (e && *e) ? std::atoi(e) : dflt;
+}
+
+inline Config config_from_env() {
+  Config c;
+  if (const char* r = std::getenv("DEVOURER_TSYNC_ROLE")) {
+    std::string s(r);
+    c.role = (s == "master") ? Role::Master : Role::Slave;
+  }
+  c.interval_ms = env_int("DEVOURER_TSYNC_INTERVAL_MS", 100);
+  c.secs = env_int("DEVOURER_TSYNC_SECS", 0);
+  c.channel = static_cast<uint8_t>(env_int("DEVOURER_CHANNEL", 36));
+  const char* rt = std::getenv("DEVOURER_TSYNC_RATE");
+  c.rate = devourer::parse_tx_mode_str(rt && *rt ? rt : "6M");
+  return c;
+}
+
+}  // namespace timesync

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -199,11 +199,17 @@ public:
    * exception). */
   virtual uint64_t ReadTsf() { return 0; }
 
-  /* EXPERIMENTAL: load a beacon into the beacon queue + enable the MAC beacon
-   * function, so the chip auto-transmits it at each TBTT (hardware-timed,
-   * host-jitter-free). Returns false where unsupported (default). */
-  virtual bool BeaconTbttSpike(const uint8_t *beacon, size_t len,
-                               int interval_tu) {
+  /* Load a beacon into the beacon reserved-page + enable the MAC beacon function,
+   * so the chip AUTO-TRANSMITS it at each TBTT — hardware-timed and
+   * hardware-TSF-stamped (the MAC inserts the live 64-bit TSF into the beacon
+   * timestamp at TX), fully host-jitter-free. `beacon` is a full 802.11 beacon
+   * MPDU (a leading radiotap header, if present, is stripped); addr2/addr3 set
+   * the port MAC/BSSID. `interval_tu` is the beacon interval in TU (1 TU =
+   * 1024 µs). One call suffices — the hardware beacons indefinitely. Implemented
+   * on Jaguar2/3 (HalMAC reserved-page download); returns false where unsupported
+   * (Jaguar1 has no reserved-page path). See docs/time-distribution.md. */
+  virtual bool StartBeacon(const uint8_t *beacon, size_t len,
+                           int interval_tu) {
     (void)beacon; (void)len; (void)interval_tu;
     return false;
   }

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -199,6 +199,14 @@ public:
    * exception). */
   virtual uint64_t ReadTsf() { return 0; }
 
+  /* Write the 64-bit MAC TSF (REG_TSFTR). Sets the free-running microsecond clock
+   * — the primitive for TSF *adoption* (a slave slewing its clock onto the
+   * master's) and for the LTE-style uplink timing-advance (shift the port TSF so
+   * a TBTT-scheduled uplink lands in its slot). The counter keeps running, so a
+   * read-add-write shifts by an approximate delta (a control loop absorbs the
+   * read→write latency). No-op where unsupported. */
+  virtual void WriteTsf(uint64_t tsf) { (void)tsf; }
+
   /* Load a beacon into the beacon reserved-page + enable the MAC beacon function,
    * so the chip AUTO-TRANSMITS it at each TBTT — hardware-timed and
    * hardware-TSF-stamped (the MAC inserts the live 64-bit TSF into the beacon

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -244,8 +244,29 @@ public:
    * microsecond). Requires an active StartBeacon. BLOCKS the caller ~one beacon
    * interval (the tweaked interval must latch and fire once before restore).
    * Returns the actual applied shift in µs (TU-quantized); 0 if no active beacon
-   * or |microseconds| < 512. Jaguar2/3 only; the base is a no-op. */
+   * or |microseconds| < 512. Jaguar3 only in practice: the Jaguar2 8822B beacon
+   * engine drops the beacon on any TBTT re-latch (bench-proven), so J2 refuses
+   * (returns 0) rather than silently kill it. Base is a no-op. */
   virtual int32_t AdjustBeaconTiming(int32_t microseconds) {
+    (void)microseconds;
+    return 0;
+  }
+
+  /* Fine (sub-TU, microsecond-granular) variant of AdjustBeaconTiming. Shifts the
+   * next beacon TBTT by `microseconds` (>0 = later/retard, <0 = earlier/advance)
+   * by toggling the MAC beacon function off, shifting the port-0 TSF, and toggling
+   * it back on so the TBTT counter re-derives from the shifted TSF. Unlike the
+   * interval-tweak AdjustBeaconTiming (quantized to whole TU), this steers at
+   * microsecond resolution — the µs-fine uplink timing-advance actuator. Note it
+   * also shifts this port's reported TSF (and the beacon-body timestamp) by the
+   * same amount, which is the intended behaviour for a UE advancing its own
+   * timebase. The USB read→write latency adds a sub-ms offset (~0.5–1.2 ms) that
+   * a closed timing-advance loop absorbs — the *resolution* is microseconds.
+   * Requires an active StartBeacon; returns the applied shift in µs. Jaguar3 only:
+   * the Jaguar2 beacon engine survives neither the beacon-function toggle nor the
+   * interval tweak (both drop the beacon), so J2 refuses (returns 0). Base is a
+   * no-op. */
+  virtual int32_t AdjustBeaconTimingFine(int32_t microseconds) {
     (void)microseconds;
     return 0;
   }

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -199,6 +199,15 @@ public:
    * exception). */
   virtual uint64_t ReadTsf() { return 0; }
 
+  /* EXPERIMENTAL: load a beacon into the beacon queue + enable the MAC beacon
+   * function, so the chip auto-transmits it at each TBTT (hardware-timed,
+   * host-jitter-free). Returns false where unsupported (default). */
+  virtual bool BeaconTbttSpike(const uint8_t *beacon, size_t len,
+                               int interval_tu) {
+    (void)beacon; (void)len; (void)interval_tu;
+    return false;
+  }
+
   /* Clean shutdown: halt TRX DMA and power the chip down to a re-enumerable
    * state (mirrors the kernel driver's card-disable on unbind). Call after the
    * RX/TX loop exits and BEFORE releasing/closing the USB interface, so the

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -201,10 +201,13 @@ public:
 
   /* Write the 64-bit MAC TSF (REG_TSFTR). Sets the free-running microsecond clock
    * — the primitive for TSF *adoption* (a slave slewing its clock onto the
-   * master's) and for the LTE-style uplink timing-advance (shift the port TSF so
-   * a TBTT-scheduled uplink lands in its slot). The counter keeps running, so a
-   * read-add-write shifts by an approximate delta (a control loop absorbs the
-   * read→write latency). No-op where unsupported. */
+   * master's, so its per-frame `tsfl` reads in the master's timebase). The
+   * counter keeps running, so a read-add-write shifts by an approximate delta (a
+   * control loop absorbs the read→write latency). NOTE: this moves the reported
+   * TSF (and the beacon-body timestamp) but NOT the beacon TBTT air-time — a
+   * separate per-port timer drives the TBTT (bench-proven). To steer the
+   * hardware-timed beacon (the uplink timing-advance actuator) use
+   * AdjustBeaconTiming. No-op where unsupported. */
   virtual void WriteTsf(uint64_t tsf) { (void)tsf; }
 
   /* Load a beacon into the beacon reserved-page + enable the MAC beacon function,
@@ -229,6 +232,23 @@ public:
    * shared channel (the master owns the channel). Also DEVOURER_DIS_CCA at
    * construction. No-op where unimplemented. */
   virtual void SetCcaMode(bool disabled) { (void)disabled; }
+
+  /* Shift the next hardware beacon TBTT by `microseconds` (>0 = later/retard,
+   * <0 = earlier/advance), quantized to whole TU (1 TU = 1024 µs). One-shot
+   * REG_BCN_INTERVAL tweak: runs one beacon interval at (nominal + round(µs/1024))
+   * TU then restores nominal, so the next TBTT — and the cadence thereafter —
+   * shifts by that many TU. This is the beacon-timing / uplink timing-advance
+   * actuator: WriteTsf moves the reported TSF but NOT the TBTT air-time (a
+   * separate per-port timer drives it), whereas the interval tweak steers it
+   * deterministically (the 802.11 IBSS/TSF-merge mechanism; bench-proven to the
+   * microsecond). Requires an active StartBeacon. BLOCKS the caller ~one beacon
+   * interval (the tweaked interval must latch and fire once before restore).
+   * Returns the actual applied shift in µs (TU-quantized); 0 if no active beacon
+   * or |microseconds| < 512. Jaguar2/3 only; the base is a no-op. */
+  virtual int32_t AdjustBeaconTiming(int32_t microseconds) {
+    (void)microseconds;
+    return 0;
+  }
 
   /* Clean shutdown: halt TRX DMA and power the chip down to a re-enumerable
    * state (mirrors the kernel driver's card-disable on unbind). Call after the

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -214,6 +214,14 @@ public:
     return false;
   }
 
+  /* Disable / restore the MAC EDCCA energy-detect gate (the vendor dis_cca
+   * recipe). With EDCCA off the MAC does not defer TX to carrier-sense, so a
+   * TBTT beacon airs exactly on schedule instead of after a CSMA backoff — the
+   * lever that collapses the hardware-beacon downlink residual to sub-µs on a
+   * shared channel (the master owns the channel). Also DEVOURER_DIS_CCA at
+   * construction. No-op where unimplemented. */
+  virtual void SetCcaMode(bool disabled) { (void)disabled; }
+
   /* Clean shutdown: halt TRX DMA and power the chip down to a re-enumerable
    * state (mirrors the kernel driver's card-disable on unbind). Call after the
    * RX/TX loop exits and BEFORE releasing/closing the USB interface, so the

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -302,44 +302,16 @@ uint64_t RtlJaguarDevice::ReadTsf() {
   return (static_cast<uint64_t>(hi) << 32) | lo;
 }
 
-bool RtlJaguarDevice::BeaconTbttSpike(const uint8_t *beacon, size_t len,
-                                     int interval_tu) {
-  if (_eepromManager->version_id.ICType == CHIP_8814A)
-    return false; /* 8814 beacon path (IDDMA rsvd-page) differs — not spiked */
-
-  /* 1. Load the frame into the beacon queue (QSEL_BEACON = 0x10) via the normal
-   * TX path. NB: this is the OPEN QUESTION — whether a QSEL-beacon bulk-OUT
-   * loads the persistent beacon buffer (for TBTT re-TX) or transmits once. */
-  _tx_qsel = 0x10;
-  const bool loaded = send_packet(beacon, len);
-  _tx_qsel = 0x12;
-  if (!loaded) {
-    _logger->error("beacon-tbtt: beacon-queue load (bulk-OUT) failed");
-    return false;
-  }
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
-
-  /* 2. Beacon-timing registers (mirrors the reference
-   * SetBeaconRelatedRegisters8812A): interval + ATIM window, then a TSF reset
-   * (REG_TCR TSFRST 0x0604[0], clear→set) so the beacon fires on an aligned
-   * TSF boundary. */
-  _device.rtw_write16(0x0554 /* REG_BCN_INTERVAL */,
-                      static_cast<uint16_t>(interval_tu));
-  _device.rtw_write8(0x055A /* REG_ATIMWND */, 0x02);
-  uint32_t tcr = _device.rtw_read<uint32_t>(0x0604);
-  _device.rtw_write<uint32_t>(0x0604, tcr & ~0x1u);
-  _device.rtw_write<uint32_t>(0x0604, tcr | 0x1u);
-
-  /* 3. Enable the MAC beacon function: REG_BCN_CTRL 0x0550 EN_BCN_FUNCTION
-   * BIT3 (+ DIS_BCNQ_SUB BIT1). From here the chip should auto-transmit the
-   * beacon buffer at each TBTT. */
-  uint8_t bcn = _device.rtw_read8(0x0550);
-  _device.rtw_write8(0x0550,
-                     static_cast<uint8_t>(bcn | (1u << 3) | (1u << 1)));
-  _logger->info("beacon-tbtt: beacon loaded + BCN function enabled "
-                "(interval {} TU, BCN_CTRL 0x{:02x}->0x{:02x})",
-                interval_tu, bcn, _device.rtw_read8(0x0550));
-  return true;
+bool RtlJaguarDevice::StartBeacon(const uint8_t *beacon, size_t len,
+                                  int interval_tu) {
+  (void)beacon; (void)len; (void)interval_tu;
+  /* Unsupported on Jaguar1: the 8812/8821 have no HalMAC reserved-page download
+   * (a QSEL-beacon bulk-OUT transmits once, it does not load a persistent
+   * TBTT-retransmitted beacon buffer — bench-confirmed negative). The 8814's
+   * IDDMA rsvd-page path differs and is not ported. Hardware-timed beaconing is
+   * a Jaguar2/3 feature (see RtlJaguar3Device::StartBeacon). */
+  _logger->warn("StartBeacon: unsupported on Jaguar1 (no reserved-page download)");
+  return false;
 }
 
 bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -302,6 +302,46 @@ uint64_t RtlJaguarDevice::ReadTsf() {
   return (static_cast<uint64_t>(hi) << 32) | lo;
 }
 
+bool RtlJaguarDevice::BeaconTbttSpike(const uint8_t *beacon, size_t len,
+                                     int interval_tu) {
+  if (_eepromManager->version_id.ICType == CHIP_8814A)
+    return false; /* 8814 beacon path (IDDMA rsvd-page) differs — not spiked */
+
+  /* 1. Load the frame into the beacon queue (QSEL_BEACON = 0x10) via the normal
+   * TX path. NB: this is the OPEN QUESTION — whether a QSEL-beacon bulk-OUT
+   * loads the persistent beacon buffer (for TBTT re-TX) or transmits once. */
+  _tx_qsel = 0x10;
+  const bool loaded = send_packet(beacon, len);
+  _tx_qsel = 0x12;
+  if (!loaded) {
+    _logger->error("beacon-tbtt: beacon-queue load (bulk-OUT) failed");
+    return false;
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+  /* 2. Beacon-timing registers (mirrors the reference
+   * SetBeaconRelatedRegisters8812A): interval + ATIM window, then a TSF reset
+   * (REG_TCR TSFRST 0x0604[0], clear→set) so the beacon fires on an aligned
+   * TSF boundary. */
+  _device.rtw_write16(0x0554 /* REG_BCN_INTERVAL */,
+                      static_cast<uint16_t>(interval_tu));
+  _device.rtw_write8(0x055A /* REG_ATIMWND */, 0x02);
+  uint32_t tcr = _device.rtw_read<uint32_t>(0x0604);
+  _device.rtw_write<uint32_t>(0x0604, tcr & ~0x1u);
+  _device.rtw_write<uint32_t>(0x0604, tcr | 0x1u);
+
+  /* 3. Enable the MAC beacon function: REG_BCN_CTRL 0x0550 EN_BCN_FUNCTION
+   * BIT3 (+ DIS_BCNQ_SUB BIT1). From here the chip should auto-transmit the
+   * beacon buffer at each TBTT. */
+  uint8_t bcn = _device.rtw_read8(0x0550);
+  _device.rtw_write8(0x0550,
+                     static_cast<uint8_t>(bcn | (1u << 3) | (1u << 1)));
+  _logger->info("beacon-tbtt: beacon loaded + BCN function enabled "
+                "(interval {} TU, BCN_CTRL 0x{:02x}->0x{:02x})",
+                interval_tu, bcn, _device.rtw_read8(0x0550));
+  return true;
+}
+
 bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
   struct tx_desc *ptxdesc;
   bool resp;
@@ -586,7 +626,7 @@ bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
   SET_TX_DESC_BMC_8812(usb_frame, 1);
   SET_TX_DESC_RATE_ID_8812(usb_frame, static_cast<uint8_t>(rate_id));
 
-  SET_TX_DESC_QUEUE_SEL_8812(usb_frame, 0x12);
+  SET_TX_DESC_QUEUE_SEL_8812(usb_frame, _tx_qsel);
   SET_TX_DESC_HWSEQ_EN_8812(usb_frame, static_cast<uint8_t>(1));
   if (!is_8814a) {
     /* 88XXau leaves GID=0 for monitor injection on 8814A. */

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -598,7 +598,7 @@ bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
   SET_TX_DESC_BMC_8812(usb_frame, 1);
   SET_TX_DESC_RATE_ID_8812(usb_frame, static_cast<uint8_t>(rate_id));
 
-  SET_TX_DESC_QUEUE_SEL_8812(usb_frame, _tx_qsel);
+  SET_TX_DESC_QUEUE_SEL_8812(usb_frame, 0x12);
   SET_TX_DESC_HWSEQ_EN_8812(usb_frame, static_cast<uint8_t>(1));
   if (!is_8814a) {
     /* 88XXau leaves GID=0 for monitor injection on 8814A. */

--- a/src/jaguar1/RtlJaguarDevice.h
+++ b/src/jaguar1/RtlJaguarDevice.h
@@ -290,7 +290,6 @@ private:
    * thread and a control-plane SetMonitorChannel see a consistent value. */
   std::atomic<int> _rx_path_mask{-1};
   int _xtal_cap = -1; /* current crystal-cap code (SetXtalCap) */
-  uint8_t _tx_qsel = 0x12; /* TX-desc QUEUE_SEL (0x12 mgmt; 0x10 = beacon) */
   devourer::CfoTracker _cfo; /* closed-loop CFO tracker (#217) */
 
   std::thread _therm_thread;

--- a/src/jaguar1/RtlJaguarDevice.h
+++ b/src/jaguar1/RtlJaguarDevice.h
@@ -203,6 +203,12 @@ public:
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;
 
+  /* EXPERIMENTAL (idea 6 spike): load a beacon into the beacon queue and enable
+   * the MAC beacon function so the chip auto-transmits it at each TBTT — a
+   * hardware-timed, host-jitter-free TX. Returns false if unsupported.
+   * `interval_tu` is the beacon interval in TU (1024 µs). */
+  bool BeaconTbttSpike(const uint8_t* beacon, size_t len, int interval_tu);
+
   /* Runtime RX-chain selection — the adaptive-link spatial-diversity lever
    * (the read/write superset of the DEVOURER_RX_PATHS env knob). Writes the
    * RX-path-enable mask 0x808[7:0] (bits 0/4 = path A CCK/OFDM, 1/5 = B,
@@ -284,6 +290,7 @@ private:
    * thread and a control-plane SetMonitorChannel see a consistent value. */
   std::atomic<int> _rx_path_mask{-1};
   int _xtal_cap = -1; /* current crystal-cap code (SetXtalCap) */
+  uint8_t _tx_qsel = 0x12; /* TX-desc QUEUE_SEL (0x12 mgmt; 0x10 = beacon) */
   devourer::CfoTracker _cfo; /* closed-loop CFO tracker (#217) */
 
   std::thread _therm_thread;

--- a/src/jaguar1/RtlJaguarDevice.h
+++ b/src/jaguar1/RtlJaguarDevice.h
@@ -207,7 +207,7 @@ public:
    * the MAC beacon function so the chip auto-transmits it at each TBTT — a
    * hardware-timed, host-jitter-free TX. Returns false if unsupported.
    * `interval_tu` is the beacon interval in TU (1024 µs). */
-  bool BeaconTbttSpike(const uint8_t* beacon, size_t len, int interval_tu);
+  bool StartBeacon(const uint8_t* beacon, size_t len, int interval_tu);
 
   /* Runtime RX-chain selection — the adaptive-link spatial-diversity lever
    * (the read/write superset of the DEVOURER_RX_PATHS env knob). Writes the

--- a/src/jaguar2/HalmacJaguar2Fw.cpp
+++ b/src/jaguar2/HalmacJaguar2Fw.cpp
@@ -222,7 +222,7 @@ bool HalmacJaguar2Fw::check_fw_chksum(uint32_t mem_addr) {
 }
 
 bool HalmacJaguar2Fw::send_fw_page(uint16_t pg_addr, const uint8_t *chunk,
-                                   uint32_t size) {
+                                   uint32_t size, bool beacon_desc) {
   if (size == 0)
     return false;
 
@@ -232,7 +232,10 @@ bool HalmacJaguar2Fw::send_fw_page(uint16_t pg_addr, const uint8_t *chunk,
   uint8_t cr1 = r8(REG_CR + 1);
   w8(REG_CR + 1, static_cast<uint8_t>(cr1 | 0x1));
   uint8_t txq2 = r8(REG_FWHW_TXQ_CTRL + 2);
-  w8(REG_FWHW_TXQ_CTRL + 2, static_cast<uint8_t>(txq2 & ~(1u << 6)));
+  /* rtw88 clears BIT_EN_BCNQ_DL during download only for PCIe; on USB keep it
+   * set so a TBTT-overlapping beacon refresh isn't suppressed (mirrors J3). */
+  if (!beacon_desc)
+    w8(REG_FWHW_TXQ_CTRL + 2, static_cast<uint8_t>(txq2 & ~(1u << 6)));
 
   /* Minimal rsvd-page TX descriptor, matching the vendor rtl88x2bu DLFW golden
    * (and the in-tree rtw88_8822bu) exactly: TXPKTSIZE + OFFSET + QSEL_BEACON.
@@ -272,6 +275,14 @@ bool HalmacJaguar2Fw::send_fw_page(uint16_t pg_addr, const uint8_t *chunk,
     SET_TX_DESC_OFFSET_8822B(d, desclen);
   }
   SET_TX_DESC_QSEL_8822B(d, QSEL_BEACON);
+  if (beacon_desc) {
+    /* Real beacon-TX descriptor (rtw_tx_rsvd_page_pkt_info_update RSVD_BEACON):
+     * broadcast + hardware sequence + qsel-seq disabled, or the TBTT engine won't
+     * transmit the stored page (mirrors the J3 fix). */
+    SET_TX_DESC_BMC_8822B(d, 1);
+    SET_TX_DESC_EN_HWSEQ_8822B(d, 1);
+    SET_TX_DESC_DISQSELSEQ_8822B(d, 1);
+  }
   cal_txdesc_chksum_8822b(d);
 
   /* Submit the rsvd-page bulk. The vendor (usb_write_data_not_xmitframe ->

--- a/src/jaguar2/HalmacJaguar2Fw.h
+++ b/src/jaguar2/HalmacJaguar2Fw.h
@@ -48,7 +48,7 @@ public:
    * before it enables the MAC TX scheduler; without it RX works but TX frames
    * never leave the MAC. */
   bool download_rsvd_page(uint16_t pg_addr, const uint8_t *buf, uint32_t size) {
-    return send_fw_page(pg_addr, buf, size);
+    return send_fw_page(pg_addr, buf, size, /*beacon_desc=*/true);
   }
 
 private:
@@ -64,7 +64,8 @@ private:
   bool ltecoex_read(uint16_t offset, uint32_t &val);
   bool ltecoex_write(uint16_t offset, uint32_t val);
   bool chk_fw_size(const uint8_t *fw_bin, size_t size);
-  bool send_fw_page(uint16_t pg_addr, const uint8_t *chunk, uint32_t size);
+  bool send_fw_page(uint16_t pg_addr, const uint8_t *chunk, uint32_t size,
+                    bool beacon_desc = false);
 
   uint8_t r8(uint16_t reg);
   uint16_t r16(uint16_t reg);

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -1174,7 +1174,6 @@ bool RtlJaguar2Device::StartBeacon(const uint8_t *beacon, size_t len,
   _device.rtw_write8(0x0550 /* REG_BCN_CTRL */, (1u << 3) | (1u << 4));
   uint32_t txq = _device.rtw_read<uint32_t>(0x0420 /* REG_FWHW_TXQ_CTRL */);
   _device.rtw_write<uint32_t>(0x0420, txq | (1u << 22) /* BIT_EN_BCNQ_DL */);
-  _bcn_interval_tu = interval_tu > 0 ? interval_tu : 100;
   _logger->info("beacon(J2): beacon@rsvd_boundary, net_type->AP, BCN_CTRL=0x18, "
                 "EN_BCNQ_DL (interval {} TU)", interval_tu);
   return true;

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -1205,6 +1205,14 @@ uint64_t RtlJaguar2Device::ReadTsf() {
   return (static_cast<uint64_t>(hi) << 32) | lo;
 }
 
+void RtlJaguar2Device::WriteTsf(uint64_t tsf) {
+  /* REG_TSFTR 0x0560 (low) / 0x0564 (high). Serialized on _reg_mu against the
+   * coex/thermal tick. The counter keeps running, so this sets it to ~tsf. */
+  std::lock_guard<std::mutex> lk(_reg_mu);
+  _device.rtw_write<uint32_t>(0x0560, static_cast<uint32_t>(tsf));
+  _device.rtw_write<uint32_t>(0x0564, static_cast<uint32_t>(tsf >> 32));
+}
+
 void RtlJaguar2Device::Stop() {
   stop_pwrtrack();
   stop_dig();

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -1142,6 +1142,11 @@ bool RtlJaguar2Device::BeaconTbttSpike(const uint8_t *beacon, size_t len,
     _logger->error("beacon-tbtt(J2): rsvd-page beacon download failed");
     return false;
   }
+  /* The TBTT engine only pulls the beacon queue when the port's network type is
+   * AP (or Ad-hoc); monitor-mode bring-up leaves REG_MSR (0x0102) port-0 at
+   * NoLink, so a validly-downloaded beacon never airs. Set port-0 = AP. */
+  uint8_t msr = _device.rtw_read8(0x0102 /* REG_MSR */);
+  _device.rtw_write8(0x0102, static_cast<uint8_t>((msr & ~0x03u) | 0x03u));
   /* Enable the MAC beacon function + interval + a TSF reset (REG_TCR TSFRST). */
   _device.rtw_write16(0x0554 /* REG_BCN_INTERVAL */,
                       static_cast<uint16_t>(interval_tu));
@@ -1152,9 +1157,9 @@ bool RtlJaguar2Device::BeaconTbttSpike(const uint8_t *beacon, size_t len,
   uint8_t bcn = _device.rtw_read8(0x0550 /* REG_BCN_CTRL */);
   _device.rtw_write8(0x0550,
                      static_cast<uint8_t>(bcn | (1u << 3) | (1u << 1)));
-  _logger->info("beacon-tbtt(J2): rsvd-page beacon loaded + BCN function "
-                "enabled (interval {} TU, BCN_CTRL 0x{:02x}->0x{:02x})",
-                interval_tu, bcn, _device.rtw_read8(0x0550));
+  _logger->info("beacon-tbtt(J2): rsvd-page beacon loaded, MSR 0x{:02x}->AP, "
+                "BCN function enabled (interval {} TU, BCN_CTRL 0x{:02x}->0x{:02x})",
+                msr, interval_tu, bcn, _device.rtw_read8(0x0550));
   return true;
 }
 

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -1140,9 +1140,9 @@ bool RtlJaguar2Device::StartBeacon(const uint8_t *beacon, size_t len,
                                    int interval_tu) {
   std::lock_guard<std::mutex> lk(_reg_mu);
   /* Mirrors the working Jaguar3 path (RtlJaguar3Device::StartBeacon) — the same
-   * two bugs (beacon at page 0, radiotap-in-rsvd-page) applied here. NOTE: this
-   * Jaguar2 port is by-construction identical to the validated J3 flow but is
-   * UNTESTED (no 8822B/8821C on the bench when it was written). */
+   * two bugs (beacon at page 0, radiotap-in-rsvd-page) applied here. Validated on
+   * hardware: RTL8812BU (2357:012d, Jaguar2) auto-transmits the beacon at TBTT,
+   * decoded by an 8822E RX (~100 beacons / 12 s). */
   size_t rt = (len >= 4) ? (size_t)(beacon[2] | (beacon[3] << 8)) : 0;
   if (rt > len) rt = 0;
   const uint8_t *mpdu = beacon + rt;
@@ -1175,9 +1175,20 @@ bool RtlJaguar2Device::StartBeacon(const uint8_t *beacon, size_t len,
   uint32_t txq = _device.rtw_read<uint32_t>(0x0420 /* REG_FWHW_TXQ_CTRL */);
   _device.rtw_write<uint32_t>(0x0420, txq | (1u << 22) /* BIT_EN_BCNQ_DL */);
   _logger->info("beacon(J2): beacon@rsvd_boundary, net_type->AP, BCN_CTRL=0x18, "
-                "EN_BCNQ_DL (interval {} TU) — UNTESTED port of the J3 fix",
-                interval_tu);
+                "EN_BCNQ_DL (interval {} TU)", interval_tu);
   return true;
+}
+
+void RtlJaguar2Device::SetCcaMode(bool disabled) {
+  std::lock_guard<std::mutex> lk(_reg_mu);
+  uint32_t v520 = _device.rtw_read<uint32_t>(0x0520);
+  uint32_t v524 = _device.rtw_read<uint32_t>(0x0524);
+  if (disabled) { v520 |= (1u << 15); v524 &= ~(1u << 11); }
+  else          { v520 &= ~(1u << 15); v524 |= (1u << 11); }
+  _device.rtw_write<uint32_t>(0x0520, v520);
+  _device.rtw_write<uint32_t>(0x0524, v524);
+  _logger->info("Jaguar2: MAC EDCCA {}", disabled ? "DISABLED (dis_cca)"
+                                                  : "enabled (default)");
 }
 
 uint64_t RtlJaguar2Device::ReadTsf() {

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -91,6 +91,10 @@ void RtlJaguar2Device::bring_up(SelectedChannel channel) {
 
   if (!_macinit.init_mac_cfg(channel.ChannelWidth))
     throw std::runtime_error("RtlJaguar2Device: init_mac_cfg failed");
+  /* Propagate the queue-init reserved-page boundary to the FW downloader (0 during
+   * the pre-queue-init FW stage) so a beacon rsvd-page download targets the real
+   * boundary, not page 0 — the page-0 bug fixed on J3. */
+  _fw.set_rsvd_boundary(_macinit.rsvd_boundary());
   if (_device.is_usb())
     _macinit.init_usb_cfg(); /* PCIe RX = the BD ring, no RX-DMA agg cfg */
   _macinit.enable_bb_rf(true);
@@ -1132,34 +1136,47 @@ bool RtlJaguar2Device::send_packet(const uint8_t *packet, size_t length) {
 
 SelectedChannel RtlJaguar2Device::GetSelectedChannel() { return _channel; }
 
-bool RtlJaguar2Device::BeaconTbttSpike(const uint8_t *beacon, size_t len,
-                                      int interval_tu) {
+bool RtlJaguar2Device::StartBeacon(const uint8_t *beacon, size_t len,
+                                   int interval_tu) {
   std::lock_guard<std::mutex> lk(_reg_mu);
-  /* J2/J3 have a real halmac reserved-page download (unlike the 8812) — the
-   * blocker on Jaguar1. Load the beacon into the page-0 beacon rsvd-page
-   * (send_fw_page: QSEL_BEACON bulk-OUT + bcn-valid latch, BCN_CTRL gated). */
-  if (!_fw.download_rsvd_page(0, beacon, static_cast<uint32_t>(len))) {
-    _logger->error("beacon-tbtt(J2): rsvd-page beacon download failed");
+  /* Mirrors the working Jaguar3 path (RtlJaguar3Device::StartBeacon) — the same
+   * two bugs (beacon at page 0, radiotap-in-rsvd-page) applied here. NOTE: this
+   * Jaguar2 port is by-construction identical to the validated J3 flow but is
+   * UNTESTED (no 8822B/8821C on the bench when it was written). */
+  size_t rt = (len >= 4) ? (size_t)(beacon[2] | (beacon[3] << 8)) : 0;
+  if (rt > len) rt = 0;
+  const uint8_t *mpdu = beacon + rt;
+  size_t mpdu_len = len - rt;
+  /* Download to the real reserved-page boundary (send_fw_page beacon descriptor:
+   * QSEL_BEACON + BMC/HWSEQ/DISQSELSEQ + bcn-valid latch). */
+  if (!_fw.download_rsvd_page(_fw.rsvd_boundary(), mpdu,
+                              static_cast<uint32_t>(mpdu_len))) {
+    _logger->error("beacon(J2): rsvd-page beacon download failed");
     return false;
   }
-  /* The TBTT engine only pulls the beacon queue when the port's network type is
-   * AP (or Ad-hoc); monitor-mode bring-up leaves REG_MSR (0x0102) port-0 at
-   * NoLink, so a validly-downloaded beacon never airs. Set port-0 = AP. */
-  uint8_t msr = _device.rtw_read8(0x0102 /* REG_MSR */);
-  _device.rtw_write8(0x0102, static_cast<uint8_t>((msr & ~0x03u) | 0x03u));
-  /* Enable the MAC beacon function + interval + a TSF reset (REG_TCR TSFRST). */
+  /* Port identity: MAC (REG_MACID 0x0610) + BSSID (REG_BSSID 0x0618) from the
+   * MPDU's addr2/addr3 (rtw_vif_port_config). */
+  if (mpdu_len >= 24) {
+    const uint8_t *sa = mpdu + 10, *bs = mpdu + 16;
+    _device.rtw_write<uint32_t>(0x0610, (uint32_t)sa[0] | (sa[1] << 8) |
+                                            (sa[2] << 16) | ((uint32_t)sa[3] << 24));
+    _device.rtw_write16(0x0614, (uint16_t)(sa[4] | (sa[5] << 8)));
+    _device.rtw_write<uint32_t>(0x0618, (uint32_t)bs[0] | (bs[1] << 8) |
+                                            (bs[2] << 16) | ((uint32_t)bs[3] << 24));
+    _device.rtw_write16(0x061c, (uint16_t)(bs[4] | (bs[5] << 8)));
+  }
+  /* net_type = AP (REG_CR+2 0x0102 [1:0]); interval; BCN_CTRL = EN_BCN_FUNCTION |
+   * DIS_TSF_UDT (0x18); EN_BCNQ_DL (BIT22 REG_FWHW_TXQ_CTRL). */
+  uint8_t nt = _device.rtw_read8(0x0102);
+  _device.rtw_write8(0x0102, static_cast<uint8_t>((nt & ~0x03u) | 0x03u));
   _device.rtw_write16(0x0554 /* REG_BCN_INTERVAL */,
                       static_cast<uint16_t>(interval_tu));
-  _device.rtw_write8(0x055A /* REG_ATIMWND */, 0x02);
-  uint32_t tcr = _device.rtw_read<uint32_t>(0x0604 /* REG_TCR */);
-  _device.rtw_write<uint32_t>(0x0604, tcr & ~0x1u);
-  _device.rtw_write<uint32_t>(0x0604, tcr | 0x1u);
-  uint8_t bcn = _device.rtw_read8(0x0550 /* REG_BCN_CTRL */);
-  _device.rtw_write8(0x0550,
-                     static_cast<uint8_t>(bcn | (1u << 3) | (1u << 1)));
-  _logger->info("beacon-tbtt(J2): rsvd-page beacon loaded, MSR 0x{:02x}->AP, "
-                "BCN function enabled (interval {} TU, BCN_CTRL 0x{:02x}->0x{:02x})",
-                msr, interval_tu, bcn, _device.rtw_read8(0x0550));
+  _device.rtw_write8(0x0550 /* REG_BCN_CTRL */, (1u << 3) | (1u << 4));
+  uint32_t txq = _device.rtw_read<uint32_t>(0x0420 /* REG_FWHW_TXQ_CTRL */);
+  _device.rtw_write<uint32_t>(0x0420, txq | (1u << 22) /* BIT_EN_BCNQ_DL */);
+  _logger->info("beacon(J2): beacon@rsvd_boundary, net_type->AP, BCN_CTRL=0x18, "
+                "EN_BCNQ_DL (interval {} TU) — UNTESTED port of the J3 fix",
+                interval_tu);
   return true;
 }
 

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -1181,38 +1181,28 @@ bool RtlJaguar2Device::StartBeacon(const uint8_t *beacon, size_t len,
 }
 
 int32_t RtlJaguar2Device::AdjustBeaconTiming(int32_t microseconds) {
-  int nominal;
-  {
-    std::lock_guard<std::mutex> lk(_reg_mu);
-    nominal = _bcn_interval_tu;
+  (void)microseconds;
+  /* Beacon-TBTT STEERING IS NOT SUPPORTED ON JAGUAR2. Both mechanisms that work
+   * on Jaguar3 drop the beacon on the 8822B engine (bench-proven on the 8812BU,
+   * the beacon stops airing after the tweak): the one-shot REG_BCN_INTERVAL
+   * (0x0554) tweak AND the EN_BCN_FUNCTION-toggle + TSF-shift both lose the
+   * bcn-valid latch, and J2 does not retain the beacon bytes to re-download and
+   * re-assert it. So refuse rather than silently kill the beacon. (A fix would
+   * store the beacon bytes in StartBeacon and re-download after the tweak — the
+   * Jaguar3 store-bytes path — but that needs its own hardware validation.) The
+   * downlink (StartBeacon + SetCcaMode) is unaffected; only the uplink-TA
+   * actuator is J3-only. */
+  static bool warned = false;
+  if (!warned) {
+    warned = true;
+    _logger->warn("beacon(J2): TBTT steering not supported (8822B beacon engine "
+                  "drops the beacon on a TBTT re-latch) — uplink-TA is Jaguar3-only");
   }
-  if (nominal <= 0) return 0;  // no active beacon
-  /* Round to whole TU (REG_BCN_INTERVAL is integer TU); sign follows the request
-   * (>0 = later/retard => longer one-shot interval, <0 = earlier/advance). */
-  int delta_tu = (microseconds >= 0 ? microseconds + 512 : microseconds - 512) / 1024;
-  if (delta_tu == 0) return 0;  // below 1-TU resolution
-  int one = nominal + delta_tu;
-  if (one < 1) {  // can't shorten below one TU
-    one = 1;
-    delta_tu = one - nominal;
-  }
-  /* Latch one interval at the tweaked length; after exactly one TBTT fires under
-   * it the phase has shifted by delta_tu TU, so restore nominal. Steers the
-   * beacon-engine TBTT counter, not the TSF (WriteTsf can't; bench-proven).
-   * Release _reg_mu across the wait so the pwrtrack tick isn't starved. */
-  {
-    std::lock_guard<std::mutex> lk(_reg_mu);
-    _device.rtw_write16(0x0554 /* REG_BCN_INTERVAL */, static_cast<uint16_t>(one));
-  }
-  std::this_thread::sleep_for(std::chrono::microseconds(one * 1024 + 2000));
-  {
-    std::lock_guard<std::mutex> lk(_reg_mu);
-    _device.rtw_write16(0x0554, static_cast<uint16_t>(nominal));
-  }
-  _logger->info("beacon(J2): TBTT shift {} TU ({} us) via one-shot interval "
-                "{}->{}->{} TU",
-                delta_tu, delta_tu * 1024, nominal, one, nominal);
-  return delta_tu * 1024;
+  return 0;
+}
+
+int32_t RtlJaguar2Device::AdjustBeaconTimingFine(int32_t microseconds) {
+  return AdjustBeaconTiming(microseconds);  // both unsupported on J2 (beacon drops)
 }
 
 void RtlJaguar2Device::SetCcaMode(bool disabled) {

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -1174,9 +1174,45 @@ bool RtlJaguar2Device::StartBeacon(const uint8_t *beacon, size_t len,
   _device.rtw_write8(0x0550 /* REG_BCN_CTRL */, (1u << 3) | (1u << 4));
   uint32_t txq = _device.rtw_read<uint32_t>(0x0420 /* REG_FWHW_TXQ_CTRL */);
   _device.rtw_write<uint32_t>(0x0420, txq | (1u << 22) /* BIT_EN_BCNQ_DL */);
+  _bcn_interval_tu = interval_tu > 0 ? interval_tu : 100;
   _logger->info("beacon(J2): beacon@rsvd_boundary, net_type->AP, BCN_CTRL=0x18, "
                 "EN_BCNQ_DL (interval {} TU)", interval_tu);
   return true;
+}
+
+int32_t RtlJaguar2Device::AdjustBeaconTiming(int32_t microseconds) {
+  int nominal;
+  {
+    std::lock_guard<std::mutex> lk(_reg_mu);
+    nominal = _bcn_interval_tu;
+  }
+  if (nominal <= 0) return 0;  // no active beacon
+  /* Round to whole TU (REG_BCN_INTERVAL is integer TU); sign follows the request
+   * (>0 = later/retard => longer one-shot interval, <0 = earlier/advance). */
+  int delta_tu = (microseconds >= 0 ? microseconds + 512 : microseconds - 512) / 1024;
+  if (delta_tu == 0) return 0;  // below 1-TU resolution
+  int one = nominal + delta_tu;
+  if (one < 1) {  // can't shorten below one TU
+    one = 1;
+    delta_tu = one - nominal;
+  }
+  /* Latch one interval at the tweaked length; after exactly one TBTT fires under
+   * it the phase has shifted by delta_tu TU, so restore nominal. Steers the
+   * beacon-engine TBTT counter, not the TSF (WriteTsf can't; bench-proven).
+   * Release _reg_mu across the wait so the pwrtrack tick isn't starved. */
+  {
+    std::lock_guard<std::mutex> lk(_reg_mu);
+    _device.rtw_write16(0x0554 /* REG_BCN_INTERVAL */, static_cast<uint16_t>(one));
+  }
+  std::this_thread::sleep_for(std::chrono::microseconds(one * 1024 + 2000));
+  {
+    std::lock_guard<std::mutex> lk(_reg_mu);
+    _device.rtw_write16(0x0554, static_cast<uint16_t>(nominal));
+  }
+  _logger->info("beacon(J2): TBTT shift {} TU ({} us) via one-shot interval "
+                "{}->{}->{} TU",
+                delta_tu, delta_tu * 1024, nominal, one, nominal);
+  return delta_tu * 1024;
 }
 
 void RtlJaguar2Device::SetCcaMode(bool disabled) {

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -1132,6 +1132,32 @@ bool RtlJaguar2Device::send_packet(const uint8_t *packet, size_t length) {
 
 SelectedChannel RtlJaguar2Device::GetSelectedChannel() { return _channel; }
 
+bool RtlJaguar2Device::BeaconTbttSpike(const uint8_t *beacon, size_t len,
+                                      int interval_tu) {
+  std::lock_guard<std::mutex> lk(_reg_mu);
+  /* J2/J3 have a real halmac reserved-page download (unlike the 8812) — the
+   * blocker on Jaguar1. Load the beacon into the page-0 beacon rsvd-page
+   * (send_fw_page: QSEL_BEACON bulk-OUT + bcn-valid latch, BCN_CTRL gated). */
+  if (!_fw.download_rsvd_page(0, beacon, static_cast<uint32_t>(len))) {
+    _logger->error("beacon-tbtt(J2): rsvd-page beacon download failed");
+    return false;
+  }
+  /* Enable the MAC beacon function + interval + a TSF reset (REG_TCR TSFRST). */
+  _device.rtw_write16(0x0554 /* REG_BCN_INTERVAL */,
+                      static_cast<uint16_t>(interval_tu));
+  _device.rtw_write8(0x055A /* REG_ATIMWND */, 0x02);
+  uint32_t tcr = _device.rtw_read<uint32_t>(0x0604 /* REG_TCR */);
+  _device.rtw_write<uint32_t>(0x0604, tcr & ~0x1u);
+  _device.rtw_write<uint32_t>(0x0604, tcr | 0x1u);
+  uint8_t bcn = _device.rtw_read8(0x0550 /* REG_BCN_CTRL */);
+  _device.rtw_write8(0x0550,
+                     static_cast<uint8_t>(bcn | (1u << 3) | (1u << 1)));
+  _logger->info("beacon-tbtt(J2): rsvd-page beacon loaded + BCN function "
+                "enabled (interval {} TU, BCN_CTRL 0x{:02x}->0x{:02x})",
+                interval_tu, bcn, _device.rtw_read8(0x0550));
+  return true;
+}
+
 uint64_t RtlJaguar2Device::ReadTsf() {
   /* REG_TSFTR 0x0560 (low) / 0x0564 (high); hi/lo/hi with a wrap retry. Under
    * _reg_mu (shared with the coex/thermal tick). NB starved to 0 under a heavy

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -67,6 +67,7 @@ public:
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;
+  void WriteTsf(uint64_t tsf) override;
   bool StartBeacon(const uint8_t *beacon, size_t len, int interval_tu) override;
   /* Disable/restore the MAC EDCCA gate (BIT_DIS_EDCCA 0x520[15] + EDCCA-mask
    * 0x524[11] — HalMAC-common with J3) so a TBTT beacon airs on schedule. */

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -67,6 +67,7 @@ public:
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;
+  bool BeaconTbttSpike(const uint8_t *beacon, size_t len, int interval_tu) override;
   void Stop() override;
   void SetTxMode(const devourer::TxMode &mode) override;
   void ClearTxMode() override;

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -72,6 +72,7 @@ public:
   /* Disable/restore the MAC EDCCA gate (BIT_DIS_EDCCA 0x520[15] + EDCCA-mask
    * 0x524[11] — HalMAC-common with J3) so a TBTT beacon airs on schedule. */
   void SetCcaMode(bool disabled) override;
+  int32_t AdjustBeaconTiming(int32_t microseconds) override;
   void Stop() override;
   void SetTxMode(const devourer::TxMode &mode) override;
   void ClearTxMode() override;
@@ -228,6 +229,9 @@ private:
    * FastRetune / the TX-power setters / GetThermalStatus by _reg_mu (the RF
    * read window is a multi-transfer sequence that must not tear). */
   std::mutex _reg_mu;
+  /* Nominal beacon interval in TU while a beacon is active (0 = none); the
+   * AdjustBeaconTiming one-shot tweak restores to this. */
+  int _bcn_interval_tu = 0;
   std::thread _pwrtrack_thread;
   std::atomic<bool> _pwrtrack_stop{false};
   void start_pwrtrack();

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -73,6 +73,7 @@ public:
    * 0x524[11] — HalMAC-common with J3) so a TBTT beacon airs on schedule. */
   void SetCcaMode(bool disabled) override;
   int32_t AdjustBeaconTiming(int32_t microseconds) override;
+  int32_t AdjustBeaconTimingFine(int32_t microseconds) override;
   void Stop() override;
   void SetTxMode(const devourer::TxMode &mode) override;
   void ClearTxMode() override;

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -230,9 +230,6 @@ private:
    * FastRetune / the TX-power setters / GetThermalStatus by _reg_mu (the RF
    * read window is a multi-transfer sequence that must not tear). */
   std::mutex _reg_mu;
-  /* Nominal beacon interval in TU while a beacon is active (0 = none); the
-   * AdjustBeaconTiming one-shot tweak restores to this. */
-  int _bcn_interval_tu = 0;
   std::thread _pwrtrack_thread;
   std::atomic<bool> _pwrtrack_stop{false};
   void start_pwrtrack();

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -67,7 +67,7 @@ public:
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;
-  bool BeaconTbttSpike(const uint8_t *beacon, size_t len, int interval_tu) override;
+  bool StartBeacon(const uint8_t *beacon, size_t len, int interval_tu) override;
   void Stop() override;
   void SetTxMode(const devourer::TxMode &mode) override;
   void ClearTxMode() override;

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -68,6 +68,9 @@ public:
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;
   bool StartBeacon(const uint8_t *beacon, size_t len, int interval_tu) override;
+  /* Disable/restore the MAC EDCCA gate (BIT_DIS_EDCCA 0x520[15] + EDCCA-mask
+   * 0x524[11] — HalMAC-common with J3) so a TBTT beacon airs on schedule. */
+  void SetCcaMode(bool disabled) override;
   void Stop() override;
   void SetTxMode(const devourer::TxMode &mode) override;
   void ClearTxMode() override;

--- a/src/jaguar3/HalJaguar3.cpp
+++ b/src/jaguar3/HalJaguar3.cpp
@@ -120,6 +120,10 @@ void HalJaguar3::rtw_hal_init(SelectedChannel channel) {
     _logger->error("Jaguar3: init_mac_cfg FAILED (structured)");
     return;
   }
+  /* Propagate the queue-init reserved-page boundary to the FW downloader — it
+   * was 0 during the pre-queue-init FW stage, so a beacon rsvd-page download
+   * would otherwise target page 0 instead of the real boundary. */
+  _fw.set_rsvd_boundary(_macinit.rsvd_boundary());
   _macinit.init_usb_cfg();         /* USB RX-DMA mode — RX delivery to bulk-IN */
   _macinit.enable_bb_rf(true);     /* set_hw_value(EN_BB_RF) */
   apply_bb_rf_agc_tables();        /* init_phy: BB + AGC + RF tables */

--- a/src/jaguar3/HalJaguar3.h
+++ b/src/jaguar3/HalJaguar3.h
@@ -163,7 +163,7 @@ public:
   void send_h2c_raw(uint32_t msg, uint32_t msg_ext);
 
   /* Load a beacon into the page-0 beacon rsvd-page for TBTT auto-TX
-   * (experimental — see RtlJaguar3Device::BeaconTbttSpike). */
+   * (experimental — see RtlJaguar3Device::StartBeacon). */
   bool download_beacon_page(const uint8_t *buf, uint32_t size) {
     return _fw.download_rsvd_page(_fw.rsvd_boundary(), buf, size);
   }

--- a/src/jaguar3/HalJaguar3.h
+++ b/src/jaguar3/HalJaguar3.h
@@ -162,6 +162,12 @@ public:
    * rtw_fw_send_h2c_command): 8-byte command, round-robin across 4 boxes. */
   void send_h2c_raw(uint32_t msg, uint32_t msg_ext);
 
+  /* Load a beacon into the page-0 beacon rsvd-page for TBTT auto-TX
+   * (experimental — see RtlJaguar3Device::BeaconTbttSpike). */
+  bool download_beacon_page(const uint8_t *buf, uint32_t size) {
+    return _fw.download_rsvd_page(_fw.rsvd_boundary(), buf, size);
+  }
+
   /* WL_PHY_INFO heartbeat (H2C 0x58, port of rtw_fw_update_wl_phy_info). The
    * firmware's idle detection relies on the host reporting WL PHY activity every
    * ~2 s; without it the FW powers the RF down after ~30 s. Call periodically

--- a/src/jaguar3/HalmacJaguar3Fw.cpp
+++ b/src/jaguar3/HalmacJaguar3Fw.cpp
@@ -174,7 +174,7 @@ bool HalmacJaguar3Fw::check_fw_chksum(uint32_t mem_addr) {
  * HIQ/beacon endpoint come from the queue allocation; QSEL_BEACON and OFFSET
  * match the rsvd-page download convention. */
 bool HalmacJaguar3Fw::send_fw_page(uint16_t pg_addr, const uint8_t *chunk,
-                                 uint32_t size) {
+                                 uint32_t size, bool beacon_desc) {
   if (size == 0)
     return false;
 
@@ -197,6 +197,14 @@ bool HalmacJaguar3Fw::send_fw_page(uint16_t pg_addr, const uint8_t *chunk,
   SET_TX_DESC_DATARATE_8822C(d, 0); /* lowest rate */
   SET_TX_DESC_DISDATAFB_8822C(d, 1);
   SET_TX_DESC_LS_8822C(d, 1);
+  if (beacon_desc) {
+    /* A real beacon-TX descriptor (rtw_tx_rsvd_page_pkt_info_update, RSVD_BEACON):
+     * broadcast, hardware sequence numbering, qsel-seq disabled — without these
+     * the TBTT engine won't transmit the stored page. */
+    SET_TX_DESC_BMC_8822C(d, 1);
+    SET_TX_DESC_EN_HWSEQ_8822C(d, 1);
+    SET_TX_DESC_DISQSELSEQ_8822C(d, 1);
+  }
   std::memcpy(d + TXDESC_SIZE_8822C, chunk, size);
   cal_txdesc_chksum_8822c(d);
 

--- a/src/jaguar3/HalmacJaguar3Fw.cpp
+++ b/src/jaguar3/HalmacJaguar3Fw.cpp
@@ -184,8 +184,13 @@ bool HalmacJaguar3Fw::send_fw_page(uint16_t pg_addr, const uint8_t *chunk,
 
   uint8_t cr1 = r8(REG_CR + 1);
   w8(REG_CR + 1, static_cast<uint8_t>(cr1 | 0x1));
+  /* Clear BIT_EN_BCNQ_DL during the download — but rtw88 does this ONLY for PCIe
+   * (rtw_fw_write_data_rsvd_page). On USB it leaves it set; clearing it here means
+   * a beacon refresh that overlaps a TBTT suppresses that beacon. Keep it set for
+   * the beacon path. */
   uint8_t txq2 = r8(REG_FWHW_TXQ_CTRL + 2);
-  w8(REG_FWHW_TXQ_CTRL + 2, static_cast<uint8_t>(txq2 & ~(1u << 6)));
+  if (!beacon_desc)
+    w8(REG_FWHW_TXQ_CTRL + 2, static_cast<uint8_t>(txq2 & ~(1u << 6)));
 
   /* Build [48-byte TX desc][chunk] and bulk-OUT (PLTFM_SEND_RSVD_PAGE). */
   std::vector<uint8_t> frame(TXDESC_SIZE_8822C + size, 0);

--- a/src/jaguar3/HalmacJaguar3Fw.h
+++ b/src/jaguar3/HalmacJaguar3Fw.h
@@ -50,7 +50,7 @@ public:
    * (experimental — reuses the DLFW send_fw_page: QSEL_BEACON bulk-OUT +
    * bcn-valid latch). */
   bool download_rsvd_page(uint16_t pg_addr, const uint8_t *buf, uint32_t size) {
-    return send_fw_page(pg_addr, buf, size);
+    return send_fw_page(pg_addr, buf, size, /*beacon_desc=*/true);
   }
   /* The reserved-page boundary (halmac txff_alloc.rsvd_boundary) — the head page
    * of the reserved region, where the beacon lives and BCN_HEAD points. Valid
@@ -72,7 +72,8 @@ private:
 
   /* Per-chunk transport (halmac send_fwpkt_88xx/dl_rsvd_page_88xx): build the
    * 8822C rsvd-page TX descriptor and bulk-OUT the chunk. */
-  bool send_fw_page(uint16_t pg_addr, const uint8_t *chunk, uint32_t size);
+  bool send_fw_page(uint16_t pg_addr, const uint8_t *chunk, uint32_t size,
+                    bool beacon_desc = false);
 
   /* --- register helpers (HALMAC_REG_R/W*) --- */
   uint8_t r8(uint16_t reg);

--- a/src/jaguar3/HalmacJaguar3Fw.h
+++ b/src/jaguar3/HalmacJaguar3Fw.h
@@ -46,6 +46,17 @@ public:
    * downloaded-but-never-booted MCU — the dying-adapter signature. */
   const devourer::FwBootStatus &boot_status() const { return _boot; }
 
+  /* Load an arbitrary beacon into the page-0 beacon rsvd-page for TBTT auto-TX
+   * (experimental — reuses the DLFW send_fw_page: QSEL_BEACON bulk-OUT +
+   * bcn-valid latch). */
+  bool download_rsvd_page(uint16_t pg_addr, const uint8_t *buf, uint32_t size) {
+    return send_fw_page(pg_addr, buf, size);
+  }
+  /* The reserved-page boundary (halmac txff_alloc.rsvd_boundary) — the head page
+   * of the reserved region, where the beacon lives and BCN_HEAD points. Valid
+   * after the firmware download. */
+  uint16_t rsvd_boundary() const { return _rsvd_boundary; }
+
 private:
   /* --- ported halmac DLFW steps --- */
   bool start_dlfw(const uint8_t *fw_bin, size_t size);

--- a/src/jaguar3/HalmacJaguar3Fw.h
+++ b/src/jaguar3/HalmacJaguar3Fw.h
@@ -56,6 +56,12 @@ public:
    * of the reserved region, where the beacon lives and BCN_HEAD points. Valid
    * after the firmware download. */
   uint16_t rsvd_boundary() const { return _rsvd_boundary; }
+  /* Set the reserved-page boundary from MacInit's priority_queue_cfg. The FW
+   * download stages chunks BEFORE the queue init runs, so _rsvd_boundary defaults
+   * to 0 and send_fw_page's restore points BCN_HEAD at page 0; the caller must
+   * set the real boundary post-queue-init so the beacon downloads to the right
+   * page AND the head is restored there (where the TBTT engine reads). */
+  void set_rsvd_boundary(uint16_t b) { _rsvd_boundary = b; }
 
 private:
   /* --- ported halmac DLFW steps --- */

--- a/src/jaguar3/HalmacJaguar3MacInit.cpp
+++ b/src/jaguar3/HalmacJaguar3MacInit.cpp
@@ -534,6 +534,7 @@ bool HalmacJaguar3MacInit::priority_queue_cfg() {
       RSVD_PG_CSIBUF_NUM; /* 110 */
   const uint16_t acq_pg_num = tx_fifo_pg_num - rsvd_pg_num; /* 1938 */
   const uint16_t rsvd_boundary = acq_pg_num;                /* 1938 */
+  _rsvd_boundary = rsvd_boundary;  /* propagate to the beacon/rsvd-page download */
 
   uint16_t cur = tx_fifo_pg_num;
   cur -= RSVD_PG_CSIBUF_NUM;

--- a/src/jaguar3/HalmacJaguar3MacInit.h
+++ b/src/jaguar3/HalmacJaguar3MacInit.h
@@ -40,6 +40,11 @@ public:
    * LLT auto-init timeout (the only failure path in the ported flow). */
   bool init_mac_cfg(ChannelWidth_t bw);
 
+  /* Reserved-page boundary computed by priority_queue_cfg (txff_pg_num -
+   * rsvd_pg_num) — the head page of the beacon/rsvd region, where the beacon is
+   * downloaded and BCN_HEAD points. Valid after init_mac_cfg. */
+  uint16_t rsvd_boundary() const { return _rsvd_boundary; }
+
 private:
   bool init_trx_cfg();
   bool priority_queue_cfg();
@@ -52,6 +57,7 @@ private:
   void init_rate_fallback_ctrl();
   void cfg_mac_clk();
 
+  uint16_t _rsvd_boundary = 0;
   RtlAdapter _device;
   Logger_t _logger;
 };

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -1394,6 +1394,30 @@ int32_t RtlJaguar3Device::AdjustBeaconTiming(int32_t microseconds) {
   return delta_tu * 1024;
 }
 
+int32_t RtlJaguar3Device::AdjustBeaconTimingFine(int32_t microseconds) {
+  std::lock_guard<std::mutex> lk(_reg_mu);
+  if (_bcn_interval_tu <= 0) return 0;  // no active beacon
+  /* A bare TSF write with the beacon function running leaves the TBTT latched
+   * (bench-proven: WriteTsf moved the reported TSF but not the air-time). The
+   * vendor reset_tsf path clears EN_BCN_FUNCTION first, so do the same: toggle
+   * the beacon function off, shift the port-0 TSF, toggle on — the TBTT counter
+   * re-derives from the shifted TSF at microsecond resolution. TBTT fires at
+   * TSF % interval, so subtracting `microseconds` advances (<0) / retards (>0)
+   * the next boundary by that many µs. */
+  uint32_t hi = _device.rtw_read<uint32_t>(0x0564);
+  uint32_t lo = _device.rtw_read<uint32_t>(0x0560);
+  uint64_t tsf = (static_cast<uint64_t>(hi) << 32) | lo;
+  uint64_t nt = tsf - static_cast<uint64_t>(static_cast<int64_t>(microseconds));
+  uint8_t bc = _device.rtw_read8(0x0550 /* REG_BCN_CTRL */);
+  _device.rtw_write8(0x0550, static_cast<uint8_t>(bc & ~(1u << 3)));  // clear EN_BCN_FUNCTION
+  _device.rtw_write<uint32_t>(0x0560, static_cast<uint32_t>(nt));
+  _device.rtw_write<uint32_t>(0x0564, static_cast<uint32_t>(nt >> 32));
+  _device.rtw_write8(0x0550, static_cast<uint8_t>(bc | (1u << 3)));   // set EN_BCN_FUNCTION
+  _logger->info("beacon(J3): fine TBTT shift {} us (TSF toggle: EN_BCN off/shift/on)",
+                microseconds);
+  return microseconds;
+}
+
 void RtlJaguar3Device::SetTxMode(const devourer::TxMode &mode) {
   _tx_mode_default = mode;
 }

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -1343,6 +1343,7 @@ bool RtlJaguar3Device::StartBeacon(const uint8_t *beacon, size_t len,
    * (BEACON_REFRESH=1) for content updates; the default is the clean HW-TBTT path. */
   _bcn_bytes.assign(mpdu, mpdu + mpdu_len);
   _bcn_interval_ms = interval_tu > 0 ? interval_tu * 1024 / 1000 : 100;
+  _bcn_interval_tu = interval_tu > 0 ? interval_tu : 100;
   if (std::getenv("BEACON_REFRESH") && !_bcn_run.exchange(true)) {
     _bcn_thread = std::thread([this] {
       while (_bcn_run.load()) {
@@ -1355,6 +1356,42 @@ bool RtlJaguar3Device::StartBeacon(const uint8_t *beacon, size_t len,
     });
   }
   return true;
+}
+
+int32_t RtlJaguar3Device::AdjustBeaconTiming(int32_t microseconds) {
+  int nominal;
+  {
+    std::lock_guard<std::mutex> lk(_reg_mu);
+    nominal = _bcn_interval_tu;
+  }
+  if (nominal <= 0) return 0;  // no active beacon
+  /* Round to whole TU (REG_BCN_INTERVAL is integer TU); sign follows the request
+   * (>0 = later/retard => longer one-shot interval, <0 = earlier/advance). */
+  int delta_tu = (microseconds >= 0 ? microseconds + 512 : microseconds - 512) / 1024;
+  if (delta_tu == 0) return 0;  // below 1-TU resolution
+  int one = nominal + delta_tu;
+  if (one < 1) {  // can't shorten below one TU
+    one = 1;
+    delta_tu = one - nominal;
+  }
+  /* Latch one interval at the tweaked length; after exactly one TBTT fires under
+   * it the phase has advanced/retarded by delta_tu TU, so restore nominal. The
+   * TSF free-runs — this steers the beacon-engine TBTT counter, not the TSF
+   * (WriteTsf can't; bench-proven). Serialize the two writes on _reg_mu, but
+   * release it across the wait so the coex tick / other setters aren't starved. */
+  {
+    std::lock_guard<std::mutex> lk(_reg_mu);
+    _device.rtw_write16(0x0554 /* REG_BCN_INTERVAL */, static_cast<uint16_t>(one));
+  }
+  std::this_thread::sleep_for(std::chrono::microseconds(one * 1024 + 2000));
+  {
+    std::lock_guard<std::mutex> lk(_reg_mu);
+    _device.rtw_write16(0x0554, static_cast<uint16_t>(nominal));
+  }
+  _logger->info("beacon(J3): TBTT shift {} TU ({} us) via one-shot interval "
+                "{}->{}->{} TU",
+                delta_tu, delta_tu * 1024, nominal, one, nominal);
+  return delta_tu * 1024;
 }
 
 void RtlJaguar3Device::SetTxMode(const devourer::TxMode &mode) {

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -1274,7 +1274,7 @@ uint64_t RtlJaguar3Device::ReadTsf() {
   return (static_cast<uint64_t>(hi) << 32) | lo;
 }
 
-bool RtlJaguar3Device::BeaconTbttSpike(const uint8_t *beacon, size_t len,
+bool RtlJaguar3Device::StartBeacon(const uint8_t *beacon, size_t len,
                                       int interval_tu) {
   std::lock_guard<std::mutex> lk(_reg_mu);
   /* The caller may pass [radiotap][802.11 MPDU]; the rsvd-page beacon must be the

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -1271,6 +1271,36 @@ uint64_t RtlJaguar3Device::ReadTsf() {
   return (static_cast<uint64_t>(hi) << 32) | lo;
 }
 
+bool RtlJaguar3Device::BeaconTbttSpike(const uint8_t *beacon, size_t len,
+                                      int interval_tu) {
+  std::lock_guard<std::mutex> lk(_reg_mu);
+  /* Load the beacon into the page-0 beacon rsvd-page (halmac send_fw_page:
+   * QSEL_BEACON bulk-OUT + bcn-valid latch), same mechanism as J2. */
+  if (!_hal.download_beacon_page(beacon, static_cast<uint32_t>(len))) {
+    _logger->error("beacon-tbtt(J3): rsvd-page beacon download failed");
+    return false;
+  }
+  /* The beacon is downloaded to the rsvd_boundary head page, where BCN_HEAD
+   * already points (send_fw_page restores it) — the TBTT engine DMAs from there.
+   * The TBTT engine only pulls the beacon queue when the port's network type is
+   * AP (or Ad-hoc); monitor bring-up leaves REG_MSR (0x0102) port-0 at NoLink,
+   * so a validly-downloaded beacon never airs. Set port-0 = AP. */
+  uint8_t msr = _device.rtw_read8(0x0102 /* REG_MSR */);
+  _device.rtw_write8(0x0102, static_cast<uint8_t>((msr & ~0x03u) | 0x03u));
+  /* Beacon interval; the TSF free-runs from init so TBTT fires on TSF % interval
+   * (no reset needed — REG_DUAL_TSF_RST 0x0553 bit0 would be the port-0 reset,
+   * NOT REG_TCR). */
+  _device.rtw_write16(0x0554 /* REG_BCN_INTERVAL */,
+                      static_cast<uint16_t>(interval_tu));
+  uint8_t bcn = _device.rtw_read8(0x0550 /* REG_BCN_CTRL */);
+  _device.rtw_write8(0x0550,
+                     static_cast<uint8_t>(bcn | (1u << 3) | (1u << 1)));
+  _logger->info("beacon-tbtt(J3): rsvd-page beacon loaded, MSR 0x{:02x}->AP, "
+                "BCN function enabled (interval {} TU, BCN_CTRL 0x{:02x}->0x{:02x})",
+                msr, interval_tu, bcn, _device.rtw_read8(0x0550));
+  return true;
+}
+
 void RtlJaguar3Device::SetTxMode(const devourer::TxMode &mode) {
   _tx_mode_default = mode;
 }

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -1274,6 +1274,14 @@ uint64_t RtlJaguar3Device::ReadTsf() {
   return (static_cast<uint64_t>(hi) << 32) | lo;
 }
 
+void RtlJaguar3Device::WriteTsf(uint64_t tsf) {
+  /* REG_TSFTR 0x0560 (low) / 0x0564 (high). Serialized on _reg_mu against the
+   * coex tick. The counter keeps running, so this sets it to ~tsf. */
+  std::lock_guard<std::mutex> lk(_reg_mu);
+  _device.rtw_write<uint32_t>(0x0560, static_cast<uint32_t>(tsf));
+  _device.rtw_write<uint32_t>(0x0564, static_cast<uint32_t>(tsf >> 32));
+}
+
 bool RtlJaguar3Device::StartBeacon(const uint8_t *beacon, size_t len,
                                       int interval_tu) {
   std::lock_guard<std::mutex> lk(_reg_mu);

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -1298,9 +1298,14 @@ bool RtlJaguar3Device::BeaconTbttSpike(const uint8_t *beacon, size_t len,
    * queue no matter what BCN_CTRL / net_type say. */
   uint32_t txq = _device.rtw_read<uint32_t>(0x0420 /* REG_FWHW_TXQ_CTRL */);
   _device.rtw_write<uint32_t>(0x0420, txq | (1u << 22) /* BIT_EN_BCNQ_DL */);
+  /* H2C RSVD_PAGE (cmd 0x00): rtw88 sends this after each beacon download to tell
+   * the FW the rsvd-page locations. The combo FW gates beacon TX, so it may need
+   * this to start beaconing. Payload from the golden dump (probe/pspoll/null page
+   * offsets) — approximate for the beacon-only layout, a probe of the hypothesis. */
+  _hal.send_h2c_raw(0x690c0100u, 0x00000000u);
   _logger->info("beacon-tbtt(J3): beacon loaded, net_type->AP, BCN_CTRL=0x18, "
-                "EN_BCNQ_DL set (TXQ 0x{:08x}->0x{:08x}, interval {} TU)",
-                txq, _device.rtw_read<uint32_t>(0x0420), interval_tu);
+                "EN_BCNQ_DL set + H2C RSVD_PAGE (TXQ 0x{:08x}, interval {} TU)",
+                _device.rtw_read<uint32_t>(0x0420), interval_tu);
 
   /* Periodic beacon refresh: rtw88 re-downloads the beacon every beacon interval
    * (~94 ms observed) rather than relying on a one-shot HW-TBTT auto-TX. Spawn a

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -1283,6 +1283,20 @@ bool RtlJaguar3Device::BeaconTbttSpike(const uint8_t *beacon, size_t len,
     _logger->error("beacon-tbtt(J3): rsvd-page beacon download failed");
     return false;
   }
+  /* Port identity (rtw88 rtw_vif_port_config) — the beaconing port needs its own
+   * MAC address (REG_MACID 0x0610) and BSSID (REG_BSSID 0x0618). devourer's
+   * monitor bring-up sets NEITHER (usbmon diff vs the kernel IBSS), so the port
+   * has no identity and the MAC won't transmit its beacon. Take them from the
+   * beacon's own addr2 (SA) / addr3 (BSSID). */
+  if (len >= 24) {
+    const uint8_t *sa = beacon + 10, *bs = beacon + 16;
+    _device.rtw_write<uint32_t>(0x0610, (uint32_t)sa[0] | (sa[1] << 8) |
+                                            (sa[2] << 16) | ((uint32_t)sa[3] << 24));
+    _device.rtw_write16(0x0614, (uint16_t)(sa[4] | (sa[5] << 8)));
+    _device.rtw_write<uint32_t>(0x0618, (uint32_t)bs[0] | (bs[1] << 8) |
+                                            (bs[2] << 16) | ((uint32_t)bs[3] << 24));
+    _device.rtw_write16(0x061c, (uint16_t)(bs[4] | (bs[5] << 8)));
+  }
   /* Port-0 network type = AP (rtw88 rtw_vif_port_config: net_type at REG_CR
    * [17:16] = REG_CR+2 byte [1:0]); a beacon airs only in AP/Ad-hoc mode. */
   uint8_t nt = _device.rtw_read8(0x0102 /* REG_CR+2 */);

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -1328,12 +1328,14 @@ bool RtlJaguar3Device::BeaconTbttSpike(const uint8_t *beacon, size_t len,
                 "EN_BCNQ_DL set + H2C RSVD_PAGE (TXQ 0x{:08x}, interval {} TU)",
                 _device.rtw_read<uint32_t>(0x0420), interval_tu);
 
-  /* Periodic beacon refresh: rtw88 re-downloads the beacon every beacon interval
-   * (~94 ms observed) rather than relying on a one-shot HW-TBTT auto-TX. Spawn a
-   * thread that re-downloads on the interval, serialized on _reg_mu. */
+  /* A SINGLE download is enough — the hardware auto-transmits the beacon at every
+   * TBTT (bench-verified: one download airs ~8 beacons/s indefinitely on both
+   * bands). rtw88 re-downloads each interval only to refresh the beacon CONTENT
+   * (TSF/TIM), not to keep it airing. So the periodic refresh is opt-in
+   * (BEACON_REFRESH=1) for content updates; the default is the clean HW-TBTT path. */
   _bcn_bytes.assign(mpdu, mpdu + mpdu_len);
   _bcn_interval_ms = interval_tu > 0 ? interval_tu * 1024 / 1000 : 100;
-  if (!_bcn_run.exchange(true)) {
+  if (std::getenv("BEACON_REFRESH") && !_bcn_run.exchange(true)) {
     _bcn_thread = std::thread([this] {
       while (_bcn_run.load()) {
         std::this_thread::sleep_for(std::chrono::milliseconds(_bcn_interval_ms));

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -293,9 +293,6 @@ RtlJaguar3Device::~RtlJaguar3Device() {
   /* Safety net: restore the chip if a CW tone is still armed (before the coex
    * thread is joined — StopCwTone serializes on _reg_mu with it). */
   StopCwTone();
-  _bcn_run.store(false);
-  if (_bcn_thread.joinable())
-    _bcn_thread.join();
   _coex_stop = true;
   if (_coex_thread.joinable())
     _coex_thread.join();
@@ -1338,23 +1335,11 @@ bool RtlJaguar3Device::StartBeacon(const uint8_t *beacon, size_t len,
 
   /* A SINGLE download is enough — the hardware auto-transmits the beacon at every
    * TBTT (bench-verified: one download airs ~8 beacons/s indefinitely on both
-   * bands). rtw88 re-downloads each interval only to refresh the beacon CONTENT
-   * (TSF/TIM), not to keep it airing. So the periodic refresh is opt-in
-   * (BEACON_REFRESH=1) for content updates; the default is the clean HW-TBTT path. */
-  _bcn_bytes.assign(mpdu, mpdu + mpdu_len);
-  _bcn_interval_ms = interval_tu > 0 ? interval_tu * 1024 / 1000 : 100;
+   * bands), so there is no periodic re-download. rtw88 re-downloads each interval
+   * only to refresh dynamic beacon CONTENT (TSF/TIM); that would need a
+   * content-update path (not this static beacon) and belongs behind a
+   * DeviceConfig knob, not env — the library reads no environment. */
   _bcn_interval_tu = interval_tu > 0 ? interval_tu : 100;
-  if (std::getenv("BEACON_REFRESH") && !_bcn_run.exchange(true)) {
-    _bcn_thread = std::thread([this] {
-      while (_bcn_run.load()) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(_bcn_interval_ms));
-        if (!_bcn_run.load()) break;
-        std::lock_guard<std::mutex> lk(_reg_mu);
-        _hal.download_beacon_page(_bcn_bytes.data(),
-                                  static_cast<uint32_t>(_bcn_bytes.size()));
-      }
-    });
-  }
   return true;
 }
 

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -293,6 +293,9 @@ RtlJaguar3Device::~RtlJaguar3Device() {
   /* Safety net: restore the chip if a CW tone is still armed (before the coex
    * thread is joined — StopCwTone serializes on _reg_mu with it). */
   StopCwTone();
+  _bcn_run.store(false);
+  if (_bcn_thread.joinable())
+    _bcn_thread.join();
   _coex_stop = true;
   if (_coex_thread.joinable())
     _coex_thread.join();
@@ -1280,24 +1283,41 @@ bool RtlJaguar3Device::BeaconTbttSpike(const uint8_t *beacon, size_t len,
     _logger->error("beacon-tbtt(J3): rsvd-page beacon download failed");
     return false;
   }
-  /* The beacon is downloaded to the rsvd_boundary head page, where BCN_HEAD
-   * already points (send_fw_page restores it) — the TBTT engine DMAs from there.
-   * The TBTT engine only pulls the beacon queue when the port's network type is
-   * AP (or Ad-hoc); monitor bring-up leaves REG_MSR (0x0102) port-0 at NoLink,
-   * so a validly-downloaded beacon never airs. Set port-0 = AP. */
-  uint8_t msr = _device.rtw_read8(0x0102 /* REG_MSR */);
-  _device.rtw_write8(0x0102, static_cast<uint8_t>((msr & ~0x03u) | 0x03u));
-  /* Beacon interval; the TSF free-runs from init so TBTT fires on TSF % interval
-   * (no reset needed — REG_DUAL_TSF_RST 0x0553 bit0 would be the port-0 reset,
-   * NOT REG_TCR). */
+  /* Port-0 network type = AP (rtw88 rtw_vif_port_config: net_type at REG_CR
+   * [17:16] = REG_CR+2 byte [1:0]); a beacon airs only in AP/Ad-hoc mode. */
+  uint8_t nt = _device.rtw_read8(0x0102 /* REG_CR+2 */);
+  _device.rtw_write8(0x0102, static_cast<uint8_t>((nt & ~0x03u) | 0x03u));
+  /* Beacon interval; the TSF free-runs from init so TBTT fires on TSF % interval. */
   _device.rtw_write16(0x0554 /* REG_BCN_INTERVAL */,
                       static_cast<uint16_t>(interval_tu));
-  uint8_t bcn = _device.rtw_read8(0x0550 /* REG_BCN_CTRL */);
-  _device.rtw_write8(0x0550,
-                     static_cast<uint8_t>(bcn | (1u << 3) | (1u << 1)));
-  _logger->info("beacon-tbtt(J3): rsvd-page beacon loaded, MSR 0x{:02x}->AP, "
-                "BCN function enabled (interval {} TU, BCN_CTRL 0x{:02x}->0x{:02x})",
-                msr, interval_tu, bcn, _device.rtw_read8(0x0550));
+  /* BCN_CTRL = EN_BCN_FUNCTION | DIS_TSF_UDT (rtw88 bcn_ctrl for AP/Ad-hoc). */
+  _device.rtw_write8(0x0550 /* REG_BCN_CTRL */, (1u << 3) | (1u << 4));
+  /* THE enable: BIT_EN_BCNQ_DL (BIT22) in REG_FWHW_TXQ_CTRL — rtw88 turns
+   * beaconing on here (mac80211 BSS_CHANGED_BEACON_ENABLED: rtw_write32_set(
+   * REG_FWHW_TXQ_CTRL, BIT_EN_BCNQ_DL)). Without it the beacon never leaves the
+   * queue no matter what BCN_CTRL / net_type say. */
+  uint32_t txq = _device.rtw_read<uint32_t>(0x0420 /* REG_FWHW_TXQ_CTRL */);
+  _device.rtw_write<uint32_t>(0x0420, txq | (1u << 22) /* BIT_EN_BCNQ_DL */);
+  _logger->info("beacon-tbtt(J3): beacon loaded, net_type->AP, BCN_CTRL=0x18, "
+                "EN_BCNQ_DL set (TXQ 0x{:08x}->0x{:08x}, interval {} TU)",
+                txq, _device.rtw_read<uint32_t>(0x0420), interval_tu);
+
+  /* Periodic beacon refresh: rtw88 re-downloads the beacon every beacon interval
+   * (~94 ms observed) rather than relying on a one-shot HW-TBTT auto-TX. Spawn a
+   * thread that re-downloads on the interval, serialized on _reg_mu. */
+  _bcn_bytes.assign(beacon, beacon + len);
+  _bcn_interval_ms = interval_tu > 0 ? interval_tu * 1024 / 1000 : 100;
+  if (!_bcn_run.exchange(true)) {
+    _bcn_thread = std::thread([this] {
+      while (_bcn_run.load()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(_bcn_interval_ms));
+        if (!_bcn_run.load()) break;
+        std::lock_guard<std::mutex> lk(_reg_mu);
+        _hal.download_beacon_page(_bcn_bytes.data(),
+                                  static_cast<uint32_t>(_bcn_bytes.size()));
+      }
+    });
+  }
   return true;
 }
 

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -1277,9 +1277,16 @@ uint64_t RtlJaguar3Device::ReadTsf() {
 bool RtlJaguar3Device::BeaconTbttSpike(const uint8_t *beacon, size_t len,
                                       int interval_tu) {
   std::lock_guard<std::mutex> lk(_reg_mu);
-  /* Load the beacon into the page-0 beacon rsvd-page (halmac send_fw_page:
-   * QSEL_BEACON bulk-OUT + bcn-valid latch), same mechanism as J2. */
-  if (!_hal.download_beacon_page(beacon, static_cast<uint32_t>(len))) {
+  /* The caller may pass [radiotap][802.11 MPDU]; the rsvd-page beacon must be the
+   * RAW 802.11 MPDU (the TX descriptor carries the PHY, not a radiotap header).
+   * radiotap it_len is bytes [2:3] LE. Strip it. */
+  size_t rt = (len >= 4) ? (size_t)(beacon[2] | (beacon[3] << 8)) : 0;
+  if (rt > len) rt = 0;
+  const uint8_t *mpdu = beacon + rt;
+  size_t mpdu_len = len - rt;
+  /* Load the beacon into the beacon rsvd-page (halmac send_fw_page: QSEL_BEACON
+   * bulk-OUT + bcn-valid latch), same mechanism as J2. */
+  if (!_hal.download_beacon_page(mpdu, static_cast<uint32_t>(mpdu_len))) {
     _logger->error("beacon-tbtt(J3): rsvd-page beacon download failed");
     return false;
   }
@@ -1287,9 +1294,9 @@ bool RtlJaguar3Device::BeaconTbttSpike(const uint8_t *beacon, size_t len,
    * MAC address (REG_MACID 0x0610) and BSSID (REG_BSSID 0x0618). devourer's
    * monitor bring-up sets NEITHER (usbmon diff vs the kernel IBSS), so the port
    * has no identity and the MAC won't transmit its beacon. Take them from the
-   * beacon's own addr2 (SA) / addr3 (BSSID). */
-  if (len >= 24) {
-    const uint8_t *sa = beacon + 10, *bs = beacon + 16;
+   * MPDU's addr2 (SA) / addr3 (BSSID). */
+  if (mpdu_len >= 24) {
+    const uint8_t *sa = mpdu + 10, *bs = mpdu + 16;
     _device.rtw_write<uint32_t>(0x0610, (uint32_t)sa[0] | (sa[1] << 8) |
                                             (sa[2] << 16) | ((uint32_t)sa[3] << 24));
     _device.rtw_write16(0x0614, (uint16_t)(sa[4] | (sa[5] << 8)));
@@ -1324,7 +1331,7 @@ bool RtlJaguar3Device::BeaconTbttSpike(const uint8_t *beacon, size_t len,
   /* Periodic beacon refresh: rtw88 re-downloads the beacon every beacon interval
    * (~94 ms observed) rather than relying on a one-shot HW-TBTT auto-TX. Spawn a
    * thread that re-downloads on the interval, serialized on _reg_mu. */
-  _bcn_bytes.assign(beacon, beacon + len);
+  _bcn_bytes.assign(mpdu, mpdu + mpdu_len);
   _bcn_interval_ms = interval_tu > 0 ? interval_tu * 1024 / 1000 : 100;
   if (!_bcn_run.exchange(true)) {
     _bcn_thread = std::thread([this] {

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -66,6 +66,7 @@ public:
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;
+  bool BeaconTbttSpike(const uint8_t *beacon, size_t len, int interval_tu) override;
   void Stop() override;
 
   /* Runtime TX-power control (IRtlDevice contract; see src/TxPower.h).

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -253,6 +253,12 @@ private:
   std::thread _coex_thread;
   volatile bool _coex_stop = false;
   void coex_runtime_loop();
+  /* Beacon-TBTT (experimental): periodic beacon re-download thread — rtw88
+   * refreshes the beacon rsvd page every beacon interval. */
+  std::thread _bcn_thread;
+  std::atomic<bool> _bcn_run{false};
+  std::vector<uint8_t> _bcn_bytes;
+  int _bcn_interval_ms = 100;
   /* StartRxLoop stop request (StopRxLoop). */
   volatile bool _rx_stop = false;
   /* True while StartRxLoop owns bulk-IN (gates the coex thread's drain). */

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -68,6 +68,7 @@ public:
   uint64_t ReadTsf() override;
   void WriteTsf(uint64_t tsf) override;
   bool StartBeacon(const uint8_t *beacon, size_t len, int interval_tu) override;
+  int32_t AdjustBeaconTiming(int32_t microseconds) override;
   void Stop() override;
 
   /* Runtime TX-power control (IRtlDevice contract; see src/TxPower.h).
@@ -261,6 +262,9 @@ private:
   std::atomic<bool> _bcn_run{false};
   std::vector<uint8_t> _bcn_bytes;
   int _bcn_interval_ms = 100;
+  /* Nominal beacon interval in TU while a beacon is active (0 = none); the
+   * AdjustBeaconTiming one-shot tweak restores to this. */
+  int _bcn_interval_tu = 0;
   /* StartRxLoop stop request (StopRxLoop). */
   volatile bool _rx_stop = false;
   /* True while StartRxLoop owns bulk-IN (gates the coex thread's drain). */

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -69,6 +69,7 @@ public:
   void WriteTsf(uint64_t tsf) override;
   bool StartBeacon(const uint8_t *beacon, size_t len, int interval_tu) override;
   int32_t AdjustBeaconTiming(int32_t microseconds) override;
+  int32_t AdjustBeaconTimingFine(int32_t microseconds) override;
   void Stop() override;
 
   /* Runtime TX-power control (IRtlDevice contract; see src/TxPower.h).

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -257,12 +257,6 @@ private:
   std::thread _coex_thread;
   volatile bool _coex_stop = false;
   void coex_runtime_loop();
-  /* Beacon-TBTT (experimental): periodic beacon re-download thread — rtw88
-   * refreshes the beacon rsvd page every beacon interval. */
-  std::thread _bcn_thread;
-  std::atomic<bool> _bcn_run{false};
-  std::vector<uint8_t> _bcn_bytes;
-  int _bcn_interval_ms = 100;
   /* Nominal beacon interval in TU while a beacon is active (0 = none); the
    * AdjustBeaconTiming one-shot tweak restores to this. */
   int _bcn_interval_tu = 0;

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -66,7 +66,7 @@ public:
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;
-  bool BeaconTbttSpike(const uint8_t *beacon, size_t len, int interval_tu) override;
+  bool StartBeacon(const uint8_t *beacon, size_t len, int interval_tu) override;
   void Stop() override;
 
   /* Runtime TX-power control (IRtlDevice contract; see src/TxPower.h).

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -150,9 +150,10 @@ public:
    * vendor rtw_proc.c dis_cca recipe (MAC BIT_DIS_EDCCA 0x520[15] + EDCCA-mask
    * countdown 0x524[11], BB 0x1a9c[20]/0x1a14[9:8]/0x1d58[0xff8]); disabled=false
    * restores the inverse. Sticky across SetMonitorChannel; serialized on _reg_mu
-   * against the coex tick. Measure-first — kept for the swept-AWGN A/B; not on
-   * IRtlDevice until the measurement justifies it. */
-  void SetCcaMode(bool disabled);
+   * against the coex tick. On IRtlDevice: measured to collapse the hardware-beacon
+   * downlink residual from ~472 µs to 0.39 µs on a crowded channel (the TBTT
+   * beacon airs on schedule instead of after a CSMA backoff). */
+  void SetCcaMode(bool disabled) override;
 
   /* Adapter-health probes (see src/AdapterHealth.h). EFUSE probe is 8822C
    * only — the 8822E's OTP is not reliably readable post-bring-up by design

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -66,6 +66,7 @@ public:
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;
+  void WriteTsf(uint64_t tsf) override;
   bool StartBeacon(const uint8_t *beacon, size_t len, int interval_tu) override;
   void Stop() override;
 

--- a/tests/ap_ping_demo.sh
+++ b/tests/ap_ping_demo.sh
@@ -37,9 +37,17 @@ for i in $(seq 1 15); do
   L=$(sudo iw dev "$STA_IF" link 2>&1 | grep -oE 'Connected to [0-9a-f:]+') && { echo "-- link: $L (after ${i}s)"; break; }
   sleep 1
 done
-sudo ip addr flush dev "$STA_IF" 2>/dev/null; sudo ip addr add "$STAIP/24" dev "$STA_IF"
+# Get an IP from devourer's built-in DHCP server (no manual static config).
+sudo ip addr flush dev "$STA_IF" 2>/dev/null
+if command -v dhcpcd >/dev/null; then
+  sudo timeout 20 dhcpcd -4 -1 -t 18 "$STA_IF" 2>&1 | grep -iE "offered|leased" | sed 's/^/-- /'
+else
+  echo "-- (no dhcpcd; static IP fallback)"; sudo ip addr add "$STAIP/24" dev "$STA_IF"
+fi
+echo "-- station IP: $(ip -4 -o addr show "$STA_IF" | grep -oE '192\.168\.99\.[0-9]+' | head -1)"
 sudo ping -c 1 -W 2 -I "$STA_IF" "$APIP" >/dev/null 2>&1   # warm ARP
 echo "-- ping $APIP from $STA_IF --"
 sudo ping -c 6 -W 1 -I "$STA_IF" "$APIP" | tail -6
+sudo dhcpcd -x "$STA_IF" 2>/dev/null || true
 echo "-- AP handshake+data log --"
 grep -iE "AUTH req|ASSOC req|data\(" "$LOG" | tail -4

--- a/tests/ap_ping_demo.sh
+++ b/tests/ap_ping_demo.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# ap_ping_demo.sh — the full "devourer behaves like a kernel AP" demo: bring
+# devourer up as an open AP (tests/ap_responder.cpp), associate a REAL Linux
+# station (rtw88) to it, and PING the AP over the air. Proven: 0% loss, ~2 ms RTT.
+#
+# Needs a second Realtek adapter bound to the kernel as a station (rtw88
+# auto-probes a VBUS-cold dongle -> e.g. wlp4s0u2u4). AP adapter = a DIFFERENT
+# J2/J3 devourer adapter (StartBeacon + full-duplex; 8812BU/8822CU work).
+#
+#   sudo STA_IF=wlp4s0u2u4 AP_VID=0x2357 AP_PID=0x012d tests/ap_ping_demo.sh
+set -uo pipefail
+cd "$(dirname "$0")/.."
+STA_IF=${STA_IF:-wlp4s0u2u4}
+AP_VID=${AP_VID:-0x2357}; AP_PID=${AP_PID:-0x012d}
+CH=${CH:-6}; TU=${TU:-25}; APIP=192.168.99.1; STAIP=192.168.99.2
+
+BIN=$(mktemp); WPA=$(mktemp); LOG=$(mktemp)
+cleanup(){ sudo pkill -9 -x apr_ping wpa_supplicant 2>/dev/null
+  sudo ip addr flush dev "$STA_IF" 2>/dev/null; sudo iw dev "$STA_IF" disconnect 2>/dev/null
+  rm -f "$BIN" "$WPA" "$LOG"; }
+trap cleanup EXIT
+
+g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/ap_responder.cpp \
+    examples/common/env_config.cpp build/libdevourer.a \
+    $(pkg-config --cflags --libs libusb-1.0) -lpthread -o "$BIN" || exit 1
+cp "$BIN" /tmp/apr_ping
+printf 'network={\n\tssid="devourerAP"\n\tkey_mgmt=NONE\n\tscan_ssid=1\n}\n' > "$WPA"
+
+sudo pkill -9 -x apr_ping wpa_supplicant 2>/dev/null; sudo iw dev "$STA_IF" disconnect 2>/dev/null; sleep 2
+echo "AP: $AP_VID:$AP_PID ch$CH ${TU}TU (BSSID 02:42:75:05:d6:00)   station: $STA_IF"
+sudo env DEVOURER_VID=$AP_VID DEVOURER_PID=$AP_PID DEVOURER_CHANNEL=$CH DEVOURER_BCN_TU=$TU \
+    DEVOURER_TX_WITH_RX=thread /tmp/apr_ping 45 2>"$LOG" &
+sleep 5
+sudo wpa_supplicant -i "$STA_IF" -c "$WPA" -B >/dev/null 2>&1
+# poll until associated (up to ~15 s) before pinging
+for i in $(seq 1 15); do
+  L=$(sudo iw dev "$STA_IF" link 2>&1 | grep -oE 'Connected to [0-9a-f:]+') && { echo "-- link: $L (after ${i}s)"; break; }
+  sleep 1
+done
+sudo ip addr flush dev "$STA_IF" 2>/dev/null; sudo ip addr add "$STAIP/24" dev "$STA_IF"
+sudo ping -c 1 -W 2 -I "$STA_IF" "$APIP" >/dev/null 2>&1   # warm ARP
+echo "-- ping $APIP from $STA_IF --"
+sudo ping -c 6 -W 1 -I "$STA_IF" "$APIP" | tail -6
+echo "-- AP handshake+data log --"
+grep -iE "AUTH req|ASSOC req|data\(" "$LOG" | tail -4

--- a/tests/ap_responder.cpp
+++ b/tests/ap_responder.cpp
@@ -7,19 +7,22 @@
 // returns libusb BUSY). Management-frame timeouts are tens of ms, so the ~few-ms
 // userspace RX->TX round-trip fits.
 //
-// STATUS (bench): the AP side works — with a DENSE beacon (DEVOURER_BCN_TU=25,
-// so a fast channel-hopping scan catches it) wpa_supplicant discovers devourerAP,
-// selects it and reaches "SME: Trying to authenticate". Probe-response is proven
-// (station discovers the AP via it, tests/probe_responder.cpp). Full association
-// was NOT completed on this rig: the test station's rtw88 (2357:0120) never puts
-// the auth frame on air — two independent promiscuous monitors (this AP's RX +
-// an 8812AU sniffer) saw ZERO auth-to-BSSID, and this device's monitor RX is
-// promiscuous (sees ambient unicast to other MACs), so a present auth would be
-// seen. So the auth/assoc responder paths below are built but unexercised end to
-// end, pending a station that actually transmits auth. Not a devourer-side gap.
+// STATUS (bench): FULL ASSOCIATION ACHIEVED. A real Linux station (rtw88 8822cu,
+// wlp4s0u2u4) authenticates, associates, and stays "Connected to 02:42:75:05:d6:00"
+// (wpa_supplicant CTRL-EVENT-CONNECTED, iw link Connected, stable for 8 s+). The
+// AP sees the AUTH and ASSOC requests with retry=0 — devourer HARDWARE-ACKs them
+// (MACID = the BSSID, set by StartBeacon), so the responses land and the handshake
+// completes. Run with a DENSE beacon (DEVOURER_BCN_TU=25 — a fast channel-hopping
+// supplicant scan misses a 100 TU beacon).
 //
-// The log prints each auth/assoc request with its retry bit (a no-ACK stall,
-// once auth reaches us, would show as repeated retries).
+// THE FIX that unblocked it: the BSSID must be UNICAST. The canonical test SA
+// 0x57.. has the I/G bit set (multicast); a station cannot unicast-auth to a
+// multicast address, so rtw88 silently drops the auth before air (confirmed:
+// 0x57 -> no auth on air across two station chips; 0x02 -> auth on air +
+// association completes). kBssid below is 0x02.. (locally-administered unicast).
+//
+// The log prints each auth/assoc request with its retry bit (a no-ACK stall would
+// show as repeated retries; here retry=0).
 //
 // Build: g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/ap_responder.cpp \
 //   examples/common/env_config.cpp build/libdevourer.a \
@@ -49,7 +52,12 @@
 #include "env_config.h"
 #include "logger.h"
 
-static const uint8_t kBssid[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
+// BSSID MUST be UNICAST — the first octet's I/G bit (bit 0) must be 0. The
+// canonical test SA 0x57... has that bit SET (multicast), which is invalid as a
+// BSSID: a station cannot unicast-auth to a multicast address, so rtw88 silently
+// refuses to emit the auth (bench-proven — flipping 0x57->0x02 made the station
+// transmit auth). Use 0x02 (locally-administered unicast).
+static const uint8_t kBssid[6] = {0x02, 0x42, 0x75, 0x05, 0xd6, 0x00};
 static IRtlDevice* g_dev = nullptr;
 static std::vector<uint8_t> g_rt;
 static uint8_t g_chan = 6;

--- a/tests/ap_responder.cpp
+++ b/tests/ap_responder.cpp
@@ -1,0 +1,166 @@
+// ap_responder.cpp — devourer as a minimal OPEN-network AP that answers the full
+// 802.11 handshake, toward the ultimate "behaves like a kernel AP": a real
+// station associating. It beacons (StartBeacon, discoverable + MACID set) and,
+// full-duplex, answers from its RX callback: probe-req -> probe-resp, auth-req
+// (open) -> auth-resp, (re)assoc-req -> assoc-resp. Responses are BUILT in the
+// callback but SENT from the main thread (send_packet from the RX event thread
+// returns libusb BUSY). Management-frame timeouts are tens of ms, so the ~few-ms
+// userspace RX->TX round-trip fits.
+//
+// STATUS (bench): the AP side works — with a DENSE beacon (DEVOURER_BCN_TU=25,
+// so a fast channel-hopping scan catches it) wpa_supplicant discovers devourerAP,
+// selects it and reaches "SME: Trying to authenticate". Probe-response is proven
+// (station discovers the AP via it, tests/probe_responder.cpp). Full association
+// was NOT completed on this rig: the test station's rtw88 (2357:0120) never puts
+// the auth frame on air — two independent promiscuous monitors (this AP's RX +
+// an 8812AU sniffer) saw ZERO auth-to-BSSID, and this device's monitor RX is
+// promiscuous (sees ambient unicast to other MACs), so a present auth would be
+// seen. So the auth/assoc responder paths below are built but unexercised end to
+// end, pending a station that actually transmits auth. Not a devourer-side gap.
+//
+// The log prints each auth/assoc request with its retry bit (a no-ACK stall,
+// once auth reaches us, would show as repeated retries).
+//
+// Build: g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/ap_responder.cpp \
+//   examples/common/env_config.cpp build/libdevourer.a \
+//   $(pkg-config --cflags --libs libusb-1.0) -lpthread -o build/ap_responder
+// Run: sudo DEVOURER_PID=0xc812 DEVOURER_CHANNEL=6 DEVOURER_TX_WITH_RX=thread \
+//   build/ap_responder [sec]
+//   then on a kernel station: iw dev <if> connect -w devourerAP   (open network)
+#include <atomic>
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+#include <unistd.h>
+#include <libusb.h>
+#include "RadiotapBuilder.h"
+#include "RxPacket.h"
+#include "SelectedChannel.h"
+#include "TxMode.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "env_config.h"
+#include "logger.h"
+
+static const uint8_t kBssid[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
+static IRtlDevice* g_dev = nullptr;
+static std::vector<uint8_t> g_rt;
+static uint8_t g_chan = 6;
+static std::atomic<uint64_t> g_probe{0}, g_auth{0}, g_assoc{0}, g_sent{0};
+static std::mutex g_q_mu;
+static std::vector<std::vector<uint8_t>> g_q;      // pre-built radiotap+MPDU frames
+
+// Common: [SSID + rates + DS] IE tail for probe/assoc responses.
+static void append_ies(std::vector<uint8_t>& m, bool with_ssid) {
+  if (with_ssid) { const char* s = "devourerAP";
+    m.insert(m.end(), {0x00, 0x0a}); m.insert(m.end(), s, s + 10); }
+  m.insert(m.end(), {0x01, 0x08, 0x82, 0x84, 0x8b, 0x96, 0x24, 0x30, 0x48, 0x6c});
+  m.insert(m.end(), {0x03, 0x01, g_chan});
+}
+static void enqueue(std::vector<uint8_t> mpdu) {
+  std::vector<uint8_t> f; f.reserve(g_rt.size() + mpdu.size());
+  f.insert(f.end(), g_rt.begin(), g_rt.end());
+  f.insert(f.end(), mpdu.begin(), mpdu.end());
+  std::lock_guard<std::mutex> lk(g_q_mu);
+  if (g_q.size() < 128) g_q.push_back(std::move(f));
+}
+static std::vector<uint8_t> mgmt_hdr(uint8_t subtype_fc, const uint8_t* sta) {
+  return {subtype_fc, 0x00, 0x00, 0x00,
+          sta[0],sta[1],sta[2],sta[3],sta[4],sta[5],
+          kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],
+          kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],
+          0x00, 0x00};
+}
+
+static void on_rx(const Packet& p) {
+  if (p.Data.size() < 24 || p.RxAtrib.crc_err) return;
+  const uint8_t fc0 = p.Data[0], fc1 = p.Data[1];
+  const uint8_t* a1 = p.Data.data() + 4;             // addr1 (RA)
+  const uint8_t* sta = p.Data.data() + 10;           // addr2 (TA = station)
+  bool to_us = std::memcmp(a1, kBssid, 6) == 0;
+  bool bcast = (a1[0] & 0x01) != 0;
+  bool retry = (fc1 & 0x08) != 0;
+
+  if (fc0 == 0x40) {                                 // probe-request
+    if (!bcast && !to_us) return;
+    g_probe.fetch_add(1);
+    auto m = mgmt_hdr(0x50, sta);                    // probe-response
+    m.insert(m.end(), {0,0,0,0,0,0,0,0, 0x64,0x00, 0x01,0x00});  // ts, bcn int, cap
+    append_ies(m, true);
+    enqueue(std::move(m));
+  } else if (fc0 == 0xb0 && to_us) {                 // authentication
+    g_auth.fetch_add(1);
+    uint16_t alg = p.Data[24] | (p.Data[25] << 8), seq = p.Data[26] | (p.Data[27] << 8);
+    fprintf(stderr, "  AUTH req from %02x:%02x:%02x:%02x:%02x:%02x alg=%u seq=%u retry=%d\n",
+            sta[0],sta[1],sta[2],sta[3],sta[4],sta[5], alg, seq, retry);
+    auto m = mgmt_hdr(0xb0, sta);                    // auth response
+    m.insert(m.end(), {0x00,0x00, 0x02,0x00, 0x00,0x00});  // open, seq 2, status 0
+    enqueue(std::move(m));
+  } else if ((fc0 == 0x00 || fc0 == 0x20) && to_us) {  // (re)assoc request
+    g_assoc.fetch_add(1);
+    fprintf(stderr, "  ASSOC req from %02x:%02x:%02x:%02x:%02x:%02x retry=%d\n",
+            sta[0],sta[1],sta[2],sta[3],sta[4],sta[5], retry);
+    auto m = mgmt_hdr(0x10, sta);                    // assoc response
+    m.insert(m.end(), {0x01,0x00, 0x00,0x00, 0x01,0xc0});   // cap, status 0, AID 1
+    append_ies(m, false);
+    enqueue(std::move(m));
+  }
+}
+
+int main(int argc, char** argv) {
+  int sec = argc > 1 ? atoi(argv[1]) : 60;
+  if (const char* c = std::getenv("DEVOURER_CHANNEL")) g_chan = (uint8_t)atoi(c);
+  auto logger = std::make_shared<Logger>();
+  apply_logging_env(*logger);
+  libusb_context* ctx = nullptr; libusb_init(&ctx);
+  libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
+  uint16_t vid = 0x0bda, pid = 0xc812;
+  if (const char* v = std::getenv("DEVOURER_VID")) vid = (uint16_t)strtoul(v, 0, 0);
+  if (const char* p = std::getenv("DEVOURER_PID")) pid = (uint16_t)strtoul(p, 0, 0);
+  auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
+  if (!h) { fprintf(stderr, "open %04x:%04x fail\n", vid, pid); return 1; }
+  std::shared_ptr<devourer::UsbDeviceLock> lk;
+  if (devourer::claim_interface_then_reset(h, 0, logger, true, lk) != 0) return 1;
+  WiFiDriver wifi(logger);
+  auto dev = wifi.CreateRtlDevice(h, ctx, lk, devourer_config_from_env());
+  g_dev = dev.get();
+  if (!g_dev) return 1;
+  g_rt = devourer::build_stream_radiotap(devourer::parse_tx_mode_str("6M"));
+  g_dev->InitWrite(SelectedChannel{g_chan, 0, CHANNEL_WIDTH_20});
+  // Beacon so the AP is discoverable + MACID/BSSID set (the ACK filter needs it).
+  std::vector<uint8_t> bcn = {
+      0x00,0x00,0x0a,0x00,0x00,0x80,0x00,0x00,0x08,0x00,   // radiotap
+      0x80,0x00,0x00,0x00, 0xff,0xff,0xff,0xff,0xff,0xff,
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],
+      0x00,0x00, 0,0,0,0,0,0,0,0, 0x64,0x00, 0x01,0x00};
+  { const char* s = "devourerAP"; bcn.insert(bcn.end(), {0x00,0x0a});
+    bcn.insert(bcn.end(), s, s + 10);
+    bcn.insert(bcn.end(), {0x01,0x08,0x82,0x84,0x8b,0x96,0x24,0x30,0x48,0x6c});
+    bcn.insert(bcn.end(), {0x03,0x01,g_chan}); }
+  int bcn_tu = 100;
+  if (const char* iv = std::getenv("DEVOURER_BCN_TU")) bcn_tu = atoi(iv);
+  bool bok = g_dev->StartBeacon(bcn.data(), bcn.size(), bcn_tu);
+  std::thread rx([&]{ g_dev->StartRxLoop(on_rx); });
+  fprintf(stderr, "ap_responder up on ch%d SSID devourerAP (beacon %s). %ds. "
+                  "Connect a station: iw dev <if> connect -w devourerAP\n",
+          g_chan, bok ? "OK" : "FAIL", sec);
+  auto end = std::chrono::steady_clock::now() + std::chrono::seconds(sec);
+  while (std::chrono::steady_clock::now() < end) {
+    std::vector<std::vector<uint8_t>> batch;
+    { std::lock_guard<std::mutex> lk2(g_q_mu); batch.swap(g_q); }
+    for (auto& f : batch) if (g_dev->send_packet(f.data(), f.size())) g_sent.fetch_add(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  fprintf(stderr, "probe=%llu auth=%llu assoc=%llu  responses_sent=%llu\n",
+          (unsigned long long)g_probe.load(), (unsigned long long)g_auth.load(),
+          (unsigned long long)g_assoc.load(), (unsigned long long)g_sent.load());
+  _exit(0);
+}

--- a/tests/ap_responder.cpp
+++ b/tests/ap_responder.cpp
@@ -7,13 +7,16 @@
 // returns libusb BUSY). Management-frame timeouts are tens of ms, so the ~few-ms
 // userspace RX->TX round-trip fits.
 //
-// STATUS (bench): FULL ASSOCIATION ACHIEVED. A real Linux station (rtw88 8822cu,
-// wlp4s0u2u4) authenticates, associates, and stays "Connected to 02:42:75:05:d6:00"
-// (wpa_supplicant CTRL-EVENT-CONNECTED, iw link Connected, stable for 8 s+). The
-// AP sees the AUTH and ASSOC requests with retry=0 — devourer HARDWARE-ACKs them
-// (MACID = the BSSID, set by StartBeacon), so the responses land and the handshake
-// completes. Run with a DENSE beacon (DEVOURER_BCN_TU=25 — a fast channel-hopping
-// supplicant scan misses a 100 TU beacon).
+// STATUS (bench): FULL ASSOCIATION + DATA PLANE — a real Linux station (rtw88
+// 8822cu, wlp4s0u2u4) authenticates, associates, stays "Connected to
+// 02:42:75:05:d6:00", AND PINGS the AP: `ping 192.168.99.1` returns 0% loss,
+// ~2 ms RTT. The AP sees AUTH/ASSOC with retry=0 (devourer HARDWARE-ACKs them —
+// MACID = BSSID, set by StartBeacon) and answers the data plane below: ARP
+// requests for the AP IP -> ARP replies, ICMP echo requests -> echo replies, over
+// 802.11 from-DS data frames. Run with a DENSE beacon (DEVOURER_BCN_TU=25 — a fast
+// channel-hopping supplicant scan misses a 100 TU beacon). The station needs a
+// static IP (192.168.99.2/24; the AP answers for .1) — there is no DHCP server.
+// See tests/ap_ping_demo.sh.
 //
 // THE FIX that unblocked it: the BSSID must be UNICAST. The canonical test SA
 // 0x57.. has the I/G bit set (multicast); a station cannot unicast-auth to a
@@ -61,9 +64,32 @@ static const uint8_t kBssid[6] = {0x02, 0x42, 0x75, 0x05, 0xd6, 0x00};
 static IRtlDevice* g_dev = nullptr;
 static std::vector<uint8_t> g_rt;
 static uint8_t g_chan = 6;
-static std::atomic<uint64_t> g_probe{0}, g_auth{0}, g_assoc{0}, g_sent{0};
+static std::atomic<uint64_t> g_probe{0}, g_auth{0}, g_assoc{0}, g_sent{0}, g_data{0};
 static std::mutex g_q_mu;
 static std::vector<std::vector<uint8_t>> g_q;      // pre-built radiotap+MPDU frames
+static const uint8_t kApIp[4] = {192, 168, 99, 1}; // the AP's IP (station uses a static .2)
+
+// 16-bit one's-complement checksum (IP / ICMP), returned host-order big-endian.
+static uint16_t csum16(const uint8_t* d, int len) {
+  uint32_t s = 0;
+  for (int i = 0; i + 1 < len; i += 2) s += (uint32_t)(d[i] << 8) | d[i + 1];
+  if (len & 1) s += (uint32_t)d[len - 1] << 8;
+  while (s >> 16) s = (s & 0xffff) + (s >> 16);
+  return (uint16_t)~s;
+}
+// Build an AP->STA data frame (from-DS): 802.11 data hdr + LLC/SNAP + payload.
+static std::vector<uint8_t> build_data(const uint8_t* sta, uint16_t eth,
+                                       const uint8_t* pl, int plen) {
+  std::vector<uint8_t> m = {0x08, 0x02, 0x00, 0x00,      // data, from-DS
+      sta[0],sta[1],sta[2],sta[3],sta[4],sta[5],          // addr1 = STA (DA)
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],  // addr2 = BSSID (TA)
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],  // addr3 = SA
+      0x00, 0x00,
+      0xaa, 0xaa, 0x03, 0x00, 0x00, 0x00,                 // LLC/SNAP
+      (uint8_t)(eth >> 8), (uint8_t)(eth & 0xff)};
+  m.insert(m.end(), pl, pl + plen);
+  return m;
+}
 
 // Common: [SSID + rates + DS] IE tail for probe/assoc responses.
 static void append_ies(std::vector<uint8_t>& m, bool with_ssid) {
@@ -119,6 +145,43 @@ static void on_rx(const Packet& p) {
     m.insert(m.end(), {0x01,0x00, 0x00,0x00, 0x01,0xc0});   // cap, status 0, AID 1
     append_ies(m, false);
     enqueue(std::move(m));
+  } else if ((fc0 == 0x08 || fc0 == 0x88) && (fc1 & 0x01) && to_us) {  // data, to-DS
+    // Data plane: answer ARP + ICMP echo so an associated station can ping the AP.
+    int hlen = 24 + (fc0 == 0x88 ? 2 : 0);               // QoS data adds 2 bytes
+    if ((int)p.Data.size() < hlen + 8) return;
+    const uint8_t* llc = p.Data.data() + hlen;
+    if (!(llc[0] == 0xaa && llc[1] == 0xaa && llc[2] == 0x03)) return;
+    uint16_t eth = (llc[6] << 8) | llc[7];
+    const uint8_t* pl = llc + 8;
+    int pllen = (int)p.Data.size() - (hlen + 8);
+    if (eth == 0x0806 && pllen >= 28) {                  // ARP
+      uint16_t oper = (pl[6] << 8) | pl[7];
+      const uint8_t* sha = pl + 8; const uint8_t* spa = pl + 14; const uint8_t* tpa = pl + 24;
+      if (oper == 1 && std::memcmp(tpa, kApIp, 4) == 0) {  // request for the AP IP
+        uint8_t a[28] = {0,1, 8,0, 6,4, 0,2,
+            kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],
+            kApIp[0],kApIp[1],kApIp[2],kApIp[3],
+            sha[0],sha[1],sha[2],sha[3],sha[4],sha[5], spa[0],spa[1],spa[2],spa[3]};
+        enqueue(build_data(sta, 0x0806, a, 28)); g_data.fetch_add(1);
+      }
+    } else if (eth == 0x0800 && pllen >= 28) {           // IPv4
+      const uint8_t* ip = pl; int ihl = (ip[0] & 0x0f) * 4;
+      if (ip[9] == 1 && (int)pllen >= ihl + 8 && std::memcmp(ip + 16, kApIp, 4) == 0) {
+        const uint8_t* icmp = ip + ihl;
+        if (icmp[0] == 8) {                              // ICMP echo request -> reply
+          std::vector<uint8_t> r(pl, pl + pllen);
+          std::memcpy(r.data() + 12, kApIp, 4);          // IP src = AP
+          std::memcpy(r.data() + 16, ip + 12, 4);        // IP dst = original src
+          r[10] = r[11] = 0;
+          uint16_t ic = csum16(r.data(), ihl); r[10] = ic >> 8; r[11] = ic & 0xff;
+          r[ihl] = 0;                                    // ICMP type 0 (reply)
+          r[ihl + 2] = r[ihl + 3] = 0;
+          uint16_t cc = csum16(r.data() + ihl, pllen - ihl);
+          r[ihl + 2] = cc >> 8; r[ihl + 3] = cc & 0xff;
+          enqueue(build_data(sta, 0x0800, r.data(), pllen)); g_data.fetch_add(1);
+        }
+      }
+    }
   }
 }
 
@@ -167,8 +230,9 @@ int main(int argc, char** argv) {
     for (auto& f : batch) if (g_dev->send_packet(f.data(), f.size())) g_sent.fetch_add(1);
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
-  fprintf(stderr, "probe=%llu auth=%llu assoc=%llu  responses_sent=%llu\n",
+  fprintf(stderr, "probe=%llu auth=%llu assoc=%llu data(arp/icmp)=%llu  responses_sent=%llu\n",
           (unsigned long long)g_probe.load(), (unsigned long long)g_auth.load(),
-          (unsigned long long)g_assoc.load(), (unsigned long long)g_sent.load());
+          (unsigned long long)g_assoc.load(), (unsigned long long)g_data.load(),
+          (unsigned long long)g_sent.load());
   _exit(0);
 }

--- a/tests/ap_responder.cpp
+++ b/tests/ap_responder.cpp
@@ -13,9 +13,11 @@
 // ~2 ms RTT. The AP sees AUTH/ASSOC with retry=0 (devourer HARDWARE-ACKs them —
 // MACID = BSSID, set by StartBeacon) and answers the data plane below: ARP
 // requests for the AP IP -> ARP replies, ICMP echo requests -> echo replies, over
-// 802.11 from-DS data frames. Run with a DENSE beacon (DEVOURER_BCN_TU=25 — a fast
-// channel-hopping supplicant scan misses a 100 TU beacon). The station needs a
-// static IP (192.168.99.2/24; the AP answers for .1) — there is no DHCP server.
+// 802.11 from-DS data frames — plus a minimal DHCP server, so the station gets
+// 192.168.99.2 AUTOMATICALLY (dhcpcd: offered/leased) with no manual IP. Run with
+// a DENSE beacon (DEVOURER_BCN_TU=25 — a fast channel-hopping supplicant scan
+// misses a 100 TU beacon). The whole chain (beacon -> auth -> assoc -> DHCP ->
+// ARP/ICMP -> ping 0% loss) is a self-service AP like hostapd+dnsmasq.
 // See tests/ap_ping_demo.sh.
 //
 // THE FIX that unblocked it: the BSSID must be UNICAST. The canonical test SA
@@ -89,6 +91,37 @@ static std::vector<uint8_t> build_data(const uint8_t* sta, uint16_t eth,
       (uint8_t)(eth >> 8), (uint8_t)(eth & 0xff)};
   m.insert(m.end(), pl, pl + plen);
   return m;
+}
+// Build a DHCP OFFER (msgtype 2) / ACK (5) leasing 192.168.99.2 to the station,
+// wrapped in UDP(67->68)/IP(AP->broadcast)/802.11-data. So the station gets an IP
+// automatically — no manual static config.
+static const uint8_t kLeaseIp[4] = {192, 168, 99, 2};
+static std::vector<uint8_t> build_dhcp_reply(const uint8_t* sta, const uint8_t* xid,
+                                             uint8_t msgtype) {
+  std::vector<uint8_t> b(236, 0);                      // BOOTP fixed area
+  b[0] = 2; b[1] = 1; b[2] = 6;                        // op=reply, htype=eth, hlen=6
+  std::memcpy(&b[4], xid, 4);                          // xid
+  std::memcpy(&b[16], kLeaseIp, 4);                    // yiaddr (offered IP)
+  std::memcpy(&b[20], kApIp, 4);                       // siaddr (server)
+  std::memcpy(&b[28], sta, 6);                         // chaddr (client MAC)
+  const uint8_t opt[] = {0x63,0x82,0x53,0x63,          // DHCP magic
+      53,1,msgtype, 54,4,kApIp[0],kApIp[1],kApIp[2],kApIp[3],
+      51,4,0,1,0x51,0x80,                              // lease 86400 s
+      1,4,255,255,255,0,                               // subnet /24
+      3,4,kApIp[0],kApIp[1],kApIp[2],kApIp[3],         // router
+      6,4,kApIp[0],kApIp[1],kApIp[2],kApIp[3], 255};   // DNS, end
+  b.insert(b.end(), opt, opt + sizeof(opt));
+  int ul = 8 + (int)b.size();                          // UDP len
+  std::vector<uint8_t> pl(28, 0);                      // IP(20)+UDP(8)
+  pl[0] = 0x45; int tot = 20 + ul; pl[2] = tot >> 8; pl[3] = tot & 0xff;
+  pl[8] = 64; pl[9] = 17;                              // TTL, proto UDP
+  std::memcpy(&pl[12], kApIp, 4);                      // src = AP
+  pl[16]=pl[17]=pl[18]=pl[19]=0xff;                    // dst = 255.255.255.255
+  uint16_t ic = csum16(pl.data(), 20); pl[10] = ic >> 8; pl[11] = ic & 0xff;
+  pl[20]=0; pl[21]=67; pl[22]=0; pl[23]=68;            // UDP sport 67 dport 68
+  pl[24] = ul >> 8; pl[25] = ul & 0xff;                // UDP len (csum 0 = allowed)
+  pl.insert(pl.end(), b.begin(), b.end());
+  return build_data(sta, 0x0800, pl.data(), (int)pl.size());
 }
 
 // Common: [SSID + rates + DS] IE tail for probe/assoc responses.
@@ -179,6 +212,19 @@ static void on_rx(const Packet& p) {
           uint16_t cc = csum16(r.data() + ihl, pllen - ihl);
           r[ihl + 2] = cc >> 8; r[ihl + 3] = cc & 0xff;
           enqueue(build_data(sta, 0x0800, r.data(), pllen)); g_data.fetch_add(1);
+        }
+      } else if (ip[9] == 17 && (int)pllen >= ihl + 8 + 240) {  // UDP -> DHCP
+        const uint8_t* udp = ip + ihl;
+        if (((udp[2] << 8) | udp[3]) == 67) {          // DHCP server port
+          const uint8_t* dh = udp + 8; const uint8_t* end = pl + pllen;
+          uint8_t mt = 0;                              // option 53 = message type
+          for (const uint8_t* o = dh + 240; o + 1 < end && *o != 0xff; ) {
+            if (*o == 0) { o++; continue; }
+            if (*o == 53 && o + 2 < end) mt = o[2];
+            o += 2 + o[1];
+          }
+          uint8_t reply = (mt == 1) ? 2 : (mt == 3) ? 5 : 0;  // DISCOVER->OFFER, REQUEST->ACK
+          if (reply) { enqueue(build_dhcp_reply(sta, dh + 4, reply)); g_data.fetch_add(1); }
         }
       }
     }

--- a/tests/ap_wpa2.cpp
+++ b/tests/ap_wpa2.cpp
@@ -1,0 +1,282 @@
+// ap_wpa2.cpp — devourer as a WPA2-PSK AP. STATUS: the RSN 4-way handshake
+// COMPLETES with a real Linux station — wpa_supplicant reports "WPA: Key
+// negotiation completed ... [PTK=CCMP GTK=CCMP]" + CTRL-EVENT-CONNECTED, and the
+// AP logs msg2-MIC-verified -> msg3 -> msg4-OK. This is the deepest driver-protocol
+// milestone (WPA2 key negotiation). It needs no CCMP (EAPOL-Key frames are
+// cleartext, MIC-protected), so it works WITHOUT the hardware crypto engine — the
+// crypto (PBKDF2/PRF/HMAC-MIC/AES-key-wrap) is openssl in userspace. Association
+// reuses the open-AP path (probe/auth/assoc); the beacon/probe/assoc carry an RSN
+// IE (WPA2-PSK-CCMP); after assoc the AP runs the authenticator: msg1(ANonce) ->
+// msg2(SNonce,MIC) -> derive PTK, verify MIC -> msg3(GTK,MIC) -> msg4.
+//
+// After the handshake the station disconnects: encrypted CCMP *data* is the
+// follow-on (needs software AES-CCM on the data path), not implemented here. Two
+// details that mattered: (1) msg3 key-data pad is 0xDD then 0x00s (a 2nd 0xDD
+// mis-parses as a KDE and the station rejects msg3); (2) a prior WRONG_KEY failure
+// temp-disables the SSID in wpa_supplicant — cold-cycle the station for a clean run.
+//
+// Build: g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/ap_wpa2.cpp \
+//   examples/common/env_config.cpp build/libdevourer.a \
+//   $(pkg-config --cflags --libs libusb-1.0) -lcrypto -lpthread -o build/ap_wpa2
+// Run: sudo DEVOURER_VID=0x2357 DEVOURER_PID=0x012d DEVOURER_CHANNEL=6 \
+//   DEVOURER_WPA2_PSK=devourer123 DEVOURER_BCN_TU=25 DEVOURER_TX_WITH_RX=thread \
+//   build/ap_wpa2 [sec]
+#include <atomic>
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+#include <unistd.h>
+#include <libusb.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/rand.h>
+#include "RadiotapBuilder.h"
+#include "RxPacket.h"
+#include "SelectedChannel.h"
+#include "TxMode.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "env_config.h"
+#include "logger.h"
+
+static const uint8_t kBssid[6] = {0x02, 0x42, 0x75, 0x05, 0xd6, 0x00};
+static const char* kSsid = "devourerAP";
+static IRtlDevice* g_dev = nullptr;
+static std::vector<uint8_t> g_rt;
+static uint8_t g_chan = 6;
+static const char* g_psk = "devourer123";
+static std::atomic<uint64_t> g_sent{0};
+static std::mutex g_q_mu;
+static std::vector<std::vector<uint8_t>> g_q;
+
+// WPA2-PSK / CCMP RSN IE (group=CCMP, pairwise=CCMP, akm=PSK).
+static const uint8_t kRsn[] = {0x30, 0x14, 0x01,0x00,
+    0x00,0x0f,0xac,0x04, 0x01,0x00, 0x00,0x0f,0xac,0x04,
+    0x01,0x00, 0x00,0x0f,0xac,0x02, 0x00,0x00};
+
+// Per-station 4-way state (single client for the demo).
+static uint8_t g_anonce[32], g_snonce[32], g_ptk[48], g_gtk[16];
+static uint8_t g_replay[8];
+static uint8_t g_sta[6];
+static int g_state = 0;  // 0 idle, 1 sent msg1, 2 done
+
+static void enqueue(std::vector<uint8_t> mpdu) {
+  std::vector<uint8_t> f; f.reserve(g_rt.size() + mpdu.size());
+  f.insert(f.end(), g_rt.begin(), g_rt.end());
+  f.insert(f.end(), mpdu.begin(), mpdu.end());
+  std::lock_guard<std::mutex> lk(g_q_mu);
+  if (g_q.size() < 128) g_q.push_back(std::move(f));
+}
+static std::vector<uint8_t> mgmt_hdr(uint8_t fc, const uint8_t* sta) {
+  return {fc,0,0,0, sta[0],sta[1],sta[2],sta[3],sta[4],sta[5],
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5], 0,0};
+}
+static void append_ies(std::vector<uint8_t>& m, bool ssid) {
+  if (ssid) { m.insert(m.end(), {0x00,(uint8_t)strlen(kSsid)});
+    m.insert(m.end(), kSsid, kSsid+strlen(kSsid)); }
+  m.insert(m.end(), {0x01,0x08,0x82,0x84,0x8b,0x96,0x24,0x30,0x48,0x6c});
+  m.insert(m.end(), {0x03,0x01,g_chan});
+  m.insert(m.end(), kRsn, kRsn+sizeof(kRsn));           // RSN IE -> advertise WPA2
+}
+
+// --- WPA2 crypto (openssl) --------------------------------------------------
+static void prf(const uint8_t* key, int klen, const char* label,
+                const uint8_t* data, int dlen, uint8_t* out, int olen) {
+  int ll = (int)strlen(label);
+  for (int i = 0, gen = 0; gen < olen; ++i, gen += 20) {
+    std::vector<uint8_t> b(ll + 1 + dlen + 1);
+    memcpy(b.data(), label, ll); b[ll] = 0;
+    memcpy(b.data()+ll+1, data, dlen); b[ll+1+dlen] = (uint8_t)i;
+    unsigned int l; uint8_t d[20];
+    HMAC(EVP_sha1(), key, klen, b.data(), b.size(), d, &l);
+    int c = (olen-gen < 20) ? olen-gen : 20; memcpy(out+gen, d, c);
+  }
+}
+static void compute_ptk() {
+  const uint8_t *aa = kBssid, *sa = g_sta;
+  uint8_t b[76]; int p = 0;
+  const uint8_t* mn = memcmp(aa,sa,6) < 0 ? aa : sa;
+  const uint8_t* mx = memcmp(aa,sa,6) < 0 ? sa : aa;
+  memcpy(b+p, mn, 6); p+=6; memcpy(b+p, mx, 6); p+=6;
+  const uint8_t* nn = memcmp(g_anonce,g_snonce,32) < 0 ? g_anonce : g_snonce;
+  const uint8_t* nx = memcmp(g_anonce,g_snonce,32) < 0 ? g_snonce : g_anonce;
+  memcpy(b+p, nn, 32); p+=32; memcpy(b+p, nx, 32); p+=32;
+  uint8_t pmk[32];
+  PKCS5_PBKDF2_HMAC(g_psk, strlen(g_psk), (const unsigned char*)kSsid,
+                    strlen(kSsid), 4096, EVP_sha1(), 32, pmk);
+  prf(pmk, 32, "Pairwise key expansion", b, p, g_ptk, 48);
+}
+// MIC over the EAPOL frame with the MIC field (offset 81, 16 bytes) zeroed.
+static void set_mic(std::vector<uint8_t>& e) {
+  memset(e.data()+81, 0, 16);
+  unsigned int l; uint8_t d[20];
+  HMAC(EVP_sha1(), g_ptk, 16 /*KCK*/, e.data(), e.size(), d, &l);
+  memcpy(e.data()+81, d, 16);
+}
+static bool check_mic(const uint8_t* e, int len) {
+  std::vector<uint8_t> t(e, e+len);
+  uint8_t got[16]; memcpy(got, t.data()+81, 16);
+  memset(t.data()+81, 0, 16);
+  unsigned int l; uint8_t d[20];
+  HMAC(EVP_sha1(), g_ptk, 16, t.data(), t.size(), d, &l);
+  return memcmp(got, d, 16) == 0;
+}
+// AES key wrap (RFC 3394) with the KEK (PTK bytes 16..31), for msg3 key data.
+static int aes_wrap(const uint8_t* kek, const uint8_t* in, int inlen, uint8_t* out) {
+  EVP_CIPHER_CTX* c = EVP_CIPHER_CTX_new();
+  EVP_CIPHER_CTX_set_flags(c, EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
+  EVP_EncryptInit_ex(c, EVP_aes_128_wrap(), NULL, kek, NULL);
+  int ol = 0, tmp = 0;
+  EVP_EncryptUpdate(c, out, &ol, in, inlen);
+  EVP_EncryptFinal_ex(c, out+ol, &tmp); ol += tmp;
+  EVP_CIPHER_CTX_free(c);
+  return ol;
+}
+
+// Build an EAPOL-Key data frame (from-DS) to the station.
+static std::vector<uint8_t> eapol_frame(uint16_t keyinfo, const uint8_t* nonce,
+                                        const uint8_t* keydata, int kdlen, bool mic) {
+  std::vector<uint8_t> e(99, 0);
+  e[0]=2; e[1]=3;                                       // EAPOL v2, type Key
+  int blen = 95 + kdlen; e[2]=blen>>8; e[3]=blen&0xff;
+  e[4]=2;                                               // RSN key descriptor
+  e[5]=keyinfo>>8; e[6]=keyinfo&0xff;
+  e[7]=0; e[8]=16;                                      // key length 16
+  memcpy(e.data()+9, g_replay, 8);
+  if (nonce) memcpy(e.data()+17, nonce, 32);
+  e[97]=kdlen>>8; e[98]=kdlen&0xff;
+  if (keydata && kdlen) e.insert(e.end(), keydata, keydata+kdlen);
+  if (mic) set_mic(e);
+  // wrap in 802.11 data (from-DS) + LLC/SNAP ethertype 0x888e
+  std::vector<uint8_t> m = {0x08,0x02,0,0,
+      g_sta[0],g_sta[1],g_sta[2],g_sta[3],g_sta[4],g_sta[5],
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5], 0,0,
+      0xaa,0xaa,0x03,0x00,0x00,0x00, 0x88,0x8e};
+  m.insert(m.end(), e.begin(), e.end());
+  return m;
+}
+static void send_msg1() {
+  RAND_bytes(g_anonce, 32);
+  for (int i=7;i>=0;--i) if (++g_replay[i]) break;      // bump replay counter
+  enqueue(eapol_frame(0x008a, g_anonce, nullptr, 0, false));  // ver2|pair|ack
+  g_state = 1;
+  fprintf(stderr, "  WPA2: sent msg1 (ANonce) to %02x:%02x:%02x:%02x:%02x:%02x\n",
+          g_sta[0],g_sta[1],g_sta[2],g_sta[3],g_sta[4],g_sta[5]);
+}
+static void send_msg3() {
+  RAND_bytes(g_gtk, 16);
+  // key data = RSN IE + GTK KDE, padded to /8, then AES-wrapped with the KEK.
+  std::vector<uint8_t> kd(kRsn, kRsn+sizeof(kRsn));
+  uint8_t gtkkde[24] = {0xdd,0x16,0x00,0x0f,0xac,0x01,0x01,0x00};
+  memcpy(gtkkde+8, g_gtk, 16);
+  kd.insert(kd.end(), gtkkde, gtkkde+24);
+  if (kd.size() % 8) {                                  // 802.11i pad: 0xDD then 0x00s
+    kd.push_back(0xdd);
+    while (kd.size() % 8) kd.push_back(0x00);
+  }
+  std::vector<uint8_t> wrapped(kd.size()+8);
+  int wl = aes_wrap(g_ptk+16, kd.data(), kd.size(), wrapped.data());
+  for (int i=7;i>=0;--i) if (++g_replay[i]) break;
+  enqueue(eapol_frame(0x13ca, g_anonce, wrapped.data(), wl, true));  // install|ack|mic|secure|enc
+  fprintf(stderr, "  WPA2: sent msg3 (GTK, MIC) — 4-way in progress\n");
+}
+
+static void on_rx(const Packet& p) {
+  if (p.Data.size() < 24 || p.RxAtrib.crc_err) return;
+  const uint8_t fc0 = p.Data[0], fc1 = p.Data[1];
+  const uint8_t* a1 = p.Data.data() + 4;
+  const uint8_t* sta = p.Data.data() + 10;
+  bool to_us = std::memcmp(a1, kBssid, 6) == 0;
+  bool bcast = (a1[0] & 0x01) != 0;
+
+  if (fc0 == 0x40) {                                    // probe-req
+    if (!bcast && !to_us) return;
+    auto m = mgmt_hdr(0x50, sta);
+    m.insert(m.end(), {0,0,0,0,0,0,0,0, 0x64,0x00, 0x11,0x00});  // cap: ESS+Privacy
+    append_ies(m, true); enqueue(std::move(m));
+  } else if (fc0 == 0xb0 && to_us) {                    // auth
+    auto m = mgmt_hdr(0xb0, sta);
+    m.insert(m.end(), {0,0, 0x02,0x00, 0,0}); enqueue(std::move(m));
+    fprintf(stderr, "  AUTH from %02x:%02x:%02x:%02x:%02x:%02x\n",
+            sta[0],sta[1],sta[2],sta[3],sta[4],sta[5]);
+  } else if ((fc0 == 0x00 || fc0 == 0x20) && to_us) {   // (re)assoc
+    auto m = mgmt_hdr(0x10, sta);
+    m.insert(m.end(), {0x11,0x00, 0x00,0x00, 0x01,0xc0});
+    append_ies(m, false); enqueue(std::move(m));
+    memcpy(g_sta, sta, 6); memset(g_replay, 0, 8); g_state = 0;
+    fprintf(stderr, "  ASSOC from %02x:%02x:%02x:%02x:%02x:%02x -> start 4-way\n",
+            sta[0],sta[1],sta[2],sta[3],sta[4],sta[5]);
+    send_msg1();
+  } else if ((fc0 == 0x08 || fc0 == 0x88) && (fc1 & 0x01) && to_us) {  // data to-DS
+    int hlen = 24 + (fc0 == 0x88 ? 2 : 0);
+    if ((int)p.Data.size() < hlen + 8) return;
+    const uint8_t* llc = p.Data.data() + hlen;
+    if (!(llc[0]==0xaa && llc[6]==0x88 && llc[7]==0x8e)) return;  // EAPOL
+    const uint8_t* e = llc + 8; int elen = (int)p.Data.size() - (hlen + 8);
+    if (elen < 99 || e[1] != 3) return;                 // EAPOL-Key
+    uint16_t ki = (e[5]<<8) | e[6];
+    if ((ki & 0x0008) && (ki & 0x0100) && !(ki & 0x0040) && !(ki & 0x0200)) {
+      // msg2: pairwise + MIC, no install/secure -> SNonce + MIC
+      memcpy(g_snonce, e+17, 32);
+      compute_ptk();
+      if (!check_mic(e, elen)) { fprintf(stderr, "  WPA2: msg2 MIC FAIL\n"); return; }
+      fprintf(stderr, "  WPA2: msg2 OK (SNonce, MIC verified) — PTK derived\n");
+      send_msg3();
+    } else if ((ki & 0x0100) && (ki & 0x0200)) {        // msg4: MIC + secure
+      if (check_mic(e, elen)) {
+        g_state = 2;
+        fprintf(stderr, "  WPA2: msg4 OK — 4-WAY HANDSHAKE COMPLETE (station keyed)\n");
+      }
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  int sec = argc > 1 ? atoi(argv[1]) : 60;
+  if (const char* c = std::getenv("DEVOURER_CHANNEL")) g_chan = (uint8_t)atoi(c);
+  if (const char* k = std::getenv("DEVOURER_WPA2_PSK")) g_psk = k;
+  auto logger = std::make_shared<Logger>(); apply_logging_env(*logger);
+  libusb_context* ctx = nullptr; libusb_init(&ctx);
+  libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
+  uint16_t vid = 0x0bda, pid = 0xc812;
+  if (const char* v = std::getenv("DEVOURER_VID")) vid = (uint16_t)strtoul(v, 0, 0);
+  if (const char* p = std::getenv("DEVOURER_PID")) pid = (uint16_t)strtoul(p, 0, 0);
+  auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
+  if (!h) { fprintf(stderr, "open %04x:%04x fail\n", vid, pid); return 1; }
+  std::shared_ptr<devourer::UsbDeviceLock> lk;
+  if (devourer::claim_interface_then_reset(h, 0, logger, true, lk) != 0) return 1;
+  WiFiDriver wifi(logger);
+  auto dev = wifi.CreateRtlDevice(h, ctx, lk, devourer_config_from_env());
+  g_dev = dev.get(); if (!g_dev) return 1;
+  g_rt = devourer::build_stream_radiotap(devourer::parse_tx_mode_str("6M"));
+  g_dev->InitWrite(SelectedChannel{g_chan, 0, CHANNEL_WIDTH_20});
+  int tu = 25; if (const char* i = std::getenv("DEVOURER_BCN_TU")) tu = atoi(i);
+  std::vector<uint8_t> bcn = {0,0,0x0a,0,0,0x80,0,0,0x08,0,
+      0x80,0,0,0, 0xff,0xff,0xff,0xff,0xff,0xff,
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],
+      0,0, 0,0,0,0,0,0,0,0, (uint8_t)(tu&0xff),(uint8_t)(tu>>8), 0x11,0x00};
+  append_ies(bcn, true);
+  bool bok = g_dev->StartBeacon(bcn.data(), bcn.size(), tu);
+  std::thread rx([&]{ g_dev->StartRxLoop(on_rx); });
+  fprintf(stderr, "ap_wpa2 up: SSID %s WPA2-PSK '%s' ch%d beacon=%s\n",
+          kSsid, g_psk, g_chan, bok ? "OK" : "FAIL");
+  auto end = std::chrono::steady_clock::now() + std::chrono::seconds(sec);
+  while (std::chrono::steady_clock::now() < end) {
+    std::vector<std::vector<uint8_t>> batch;
+    { std::lock_guard<std::mutex> l(g_q_mu); batch.swap(g_q); }
+    for (auto& f : batch) if (g_dev->send_packet(f.data(), f.size())) g_sent.fetch_add(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  fprintf(stderr, "sent=%llu 4way_state=%d\n", (unsigned long long)g_sent.load(), g_state);
+  _exit(0);
+}

--- a/tests/ap_wpa2.cpp
+++ b/tests/ap_wpa2.cpp
@@ -10,13 +10,12 @@
 // msg2(SNonce,MIC) -> derive PTK, verify MIC -> msg3(GTK,MIC) -> msg4.
 //
 // ENCRYPTED DATA plane too: after the handshake the AP decrypts the station's CCMP
-// data frames (software AES-CCM with the TK = PTK[32:48]) and answers ARP + ICMP
-// echo ENCRYPTED, so a real station pings the AP over WPA2/CCMP at 0% loss
-// (~2.5 ms RTT). The station runs hardware CCMP, the AP software CCMP — they
-// interoperate. So this is a COMPLETE WPA2-PSK AP: associate -> 4-way -> encrypted
-// IP. (A static IP is used; a DHCP-over-CCMP path would be the same handle_plain
-// extension. HW CCMP offload would need porting the J3 security TX/RX descriptor
-// fields.)
+// data frames (software AES-CCM with the TK = PTK[32:48]) and answers ARP + ICMP +
+// DHCP ENCRYPTED, so a real station leases 192.168.99.2 over encrypted DHCP (dhcpcd:
+// "leased") AND pings the AP over WPA2/CCMP at 0% loss (~2.5 ms RTT). The station
+// runs hardware CCMP, the AP software CCMP — they interoperate. So this is a COMPLETE
+// zero-config WPA2-PSK AP: associate -> 4-way -> encrypted DHCP -> encrypted IP.
+// (HW CCMP offload would need porting the J3 security TX/RX descriptor fields.)
 //
 // Details that mattered: (1) msg3 key-data pad is 0xDD then 0x00s (a 2nd 0xDD
 // mis-parses as a KDE and the station rejects msg3); (2) a prior WRONG_KEY failure
@@ -260,9 +259,28 @@ static std::vector<uint8_t> ccmp_tx(const uint8_t* sta, uint16_t eth,
   m.insert(m.end(), mic, mic+8);
   return m;
 }
-// Handle a decrypted L2 payload (LLC/SNAP + eth): answer ARP + ICMP, encrypted.
+// DHCP OFFER/ACK payload (IP+UDP+BOOTP) leasing 192.168.99.2 — encrypted by ccmp_tx.
+static const uint8_t kLeaseIp[4] = {192,168,99,2};
+static std::vector<uint8_t> dhcp_payload(const uint8_t* sta, const uint8_t* xid, uint8_t mt) {
+  std::vector<uint8_t> b(236, 0);
+  b[0]=2; b[1]=1; b[2]=6; memcpy(&b[4],xid,4);
+  memcpy(&b[16],kLeaseIp,4); memcpy(&b[20],kApIp,4); memcpy(&b[28],sta,6);
+  const uint8_t opt[]={0x63,0x82,0x53,0x63, 53,1,mt, 54,4,kApIp[0],kApIp[1],kApIp[2],kApIp[3],
+      51,4,0,1,0x51,0x80, 1,4,255,255,255,0, 3,4,kApIp[0],kApIp[1],kApIp[2],kApIp[3],
+      6,4,kApIp[0],kApIp[1],kApIp[2],kApIp[3], 255};
+  b.insert(b.end(), opt, opt+sizeof(opt));
+  int ul=8+(int)b.size();
+  std::vector<uint8_t> pl(28,0);
+  pl[0]=0x45; int tot=20+ul; pl[2]=tot>>8; pl[3]=tot&0xff; pl[8]=64; pl[9]=17;
+  memcpy(&pl[12],kApIp,4); pl[16]=pl[17]=pl[18]=pl[19]=0xff;
+  uint16_t ic=csum16(pl.data(),20); pl[10]=ic>>8; pl[11]=ic&0xff;
+  pl[20]=0; pl[21]=67; pl[22]=0; pl[23]=68; pl[24]=ul>>8; pl[25]=ul&0xff;
+  pl.insert(pl.end(), b.begin(), b.end());
+  return pl;
+}
+// Handle a decrypted L2 payload (LLC/SNAP + eth): answer ARP + ICMP + DHCP, encrypted.
 static void handle_plain(const uint8_t* sta, const uint8_t* d, int len) {
-  if (len < 8 || d[0]!=0xaa) return;
+  if (len < 8 || d[0]!=0xaa) return;                    // not LLC/SNAP (e.g. IPv6 ND)
   uint16_t eth = (d[6]<<8)|d[7]; const uint8_t* pl = d+8; int pllen = len-8;
   if (eth==0x0806 && pllen>=28) {                        // ARP
     if (((pl[6]<<8)|pl[7])==1 && memcmp(pl+24,kApIp,4)==0) {
@@ -273,13 +291,23 @@ static void handle_plain(const uint8_t* sta, const uint8_t* d, int len) {
     }
   } else if (eth==0x0800 && pllen>=28) {                 // IPv4/ICMP
     const uint8_t* ip=pl; int ihl=(ip[0]&0x0f)*4;
-    if (ip[9]==1 && pllen>=ihl+8 && memcmp(ip+16,kApIp,4)==0 && ip[ihl]==8) {
+    if (ip[9]==1 && pllen>=ihl+8 && memcmp(ip+16,kApIp,4)==0 && ip[ihl]==8) {  // ICMP echo
       std::vector<uint8_t> r(pl, pl+pllen);
       memcpy(r.data()+12,kApIp,4); memcpy(r.data()+16,ip+12,4);
       r[10]=r[11]=0; uint16_t ic=csum16(r.data(),ihl); r[10]=ic>>8; r[11]=ic&0xff;
       r[ihl]=0; r[ihl+2]=r[ihl+3]=0;
       uint16_t cc=csum16(r.data()+ihl,pllen-ihl); r[ihl+2]=cc>>8; r[ihl+3]=cc&0xff;
       enqueue(ccmp_tx(sta,0x0800,r.data(),pllen));
+    } else if (ip[9]==17 && pllen>=ihl+8+240) {          // UDP -> DHCP
+      const uint8_t* udp=ip+ihl;
+      if (((udp[2]<<8)|udp[3])==67) {
+        const uint8_t* dh=udp+8; const uint8_t* end=pl+pllen; uint8_t m=0;
+        for (const uint8_t* o=dh+240; o+1<end && *o!=0xff; ) {
+          if (*o==0){o++;continue;} if (*o==53 && o+2<end) m=o[2]; o+=2+o[1]; }
+        uint8_t reply = (m==1)?2 : (m==3)?5 : 0;
+        if (reply) { auto dp=dhcp_payload(sta, dh+4, reply);
+          enqueue(ccmp_tx(sta,0x0800,dp.data(),(int)dp.size())); }
+      }
     }
   }
 }

--- a/tests/ap_wpa2.cpp
+++ b/tests/ap_wpa2.cpp
@@ -9,11 +9,20 @@
 // IE (WPA2-PSK-CCMP); after assoc the AP runs the authenticator: msg1(ANonce) ->
 // msg2(SNonce,MIC) -> derive PTK, verify MIC -> msg3(GTK,MIC) -> msg4.
 //
-// After the handshake the station disconnects: encrypted CCMP *data* is the
-// follow-on (needs software AES-CCM on the data path), not implemented here. Two
-// details that mattered: (1) msg3 key-data pad is 0xDD then 0x00s (a 2nd 0xDD
+// ENCRYPTED DATA plane too: after the handshake the AP decrypts the station's CCMP
+// data frames (software AES-CCM with the TK = PTK[32:48]) and answers ARP + ICMP
+// echo ENCRYPTED, so a real station pings the AP over WPA2/CCMP at 0% loss
+// (~2.5 ms RTT). The station runs hardware CCMP, the AP software CCMP — they
+// interoperate. So this is a COMPLETE WPA2-PSK AP: associate -> 4-way -> encrypted
+// IP. (A static IP is used; a DHCP-over-CCMP path would be the same handle_plain
+// extension. HW CCMP offload would need porting the J3 security TX/RX descriptor
+// fields.)
+//
+// Details that mattered: (1) msg3 key-data pad is 0xDD then 0x00s (a 2nd 0xDD
 // mis-parses as a KDE and the station rejects msg3); (2) a prior WRONG_KEY failure
-// temp-disables the SSID in wpa_supplicant — cold-cycle the station for a clean run.
+// temp-disables the SSID in wpa_supplicant — cold-cycle the station for a clean run;
+// (3) CCMP AAD masks FC subtype/retry/pm/md + sets protected, and masks the seq
+// number (keep frag); the nonce is 0|A2|PN(6, big-endian).
 //
 // Build: g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/ap_wpa2.cpp \
 //   examples/common/env_config.cpp build/libdevourer.a \
@@ -190,6 +199,91 @@ static void send_msg3() {
   fprintf(stderr, "  WPA2: sent msg3 (GTK, MIC) — 4-way in progress\n");
 }
 
+// --- CCMP data plane (software AES-CCM) so the station pings encrypted --------
+static const uint8_t kApIp[4] = {192, 168, 99, 1};
+static uint64_t g_txpn = 1;                              // AP outbound packet number
+static uint16_t csum16(const uint8_t* d, int len) {
+  uint32_t s = 0; for (int i=0;i+1<len;i+=2) s += (d[i]<<8)|d[i+1];
+  if (len&1) s += d[len-1]<<8; while (s>>16) s=(s&0xffff)+(s>>16); return (uint16_t)~s;
+}
+// CCMP AAD + nonce from the 802.11 header (802.11i 8.3.3.3.2/.3).
+static void ccmp_aad_nonce(const uint8_t* hdr, uint64_t pn, const uint8_t* a2,
+                           uint8_t* aad, int* aadlen, uint8_t* nonce) {
+  uint16_t fc = hdr[0] | (hdr[1] << 8);
+  fc &= ~0x0070; fc &= ~(0x0800|0x1000|0x2000); fc |= 0x4000;  // mask subtype/retry/pm/md, set prot
+  aad[0]=fc&0xff; aad[1]=fc>>8;
+  memcpy(aad+2, hdr+4, 18);                              // addr1,2,3
+  uint16_t seq = (hdr[22]|(hdr[23]<<8)) & 0x000f;        // keep frag, mask seqnum
+  aad[20]=seq&0xff; aad[21]=seq>>8; *aadlen=22;
+  nonce[0]=0; memcpy(nonce+1, a2, 6);
+  for (int i=0;i<6;i++) nonce[7+i] = (pn >> (8*(5-i))) & 0xff;
+}
+static bool ccm(bool enc, const uint8_t* key, const uint8_t* nonce, const uint8_t* aad,
+                int aadlen, const uint8_t* in, int inlen, uint8_t* out, uint8_t* tag) {
+  EVP_CIPHER_CTX* c = EVP_CIPHER_CTX_new(); int l; bool ok=true;
+  if (enc) {
+    EVP_EncryptInit_ex(c, EVP_aes_128_ccm(), 0,0,0);
+    EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_AEAD_SET_IVLEN, 13, 0);
+    EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_AEAD_SET_TAG, 8, 0);
+    EVP_EncryptInit_ex(c, 0,0,key,nonce);
+    EVP_EncryptUpdate(c, 0,&l,0,inlen); EVP_EncryptUpdate(c,0,&l,aad,aadlen);
+    EVP_EncryptUpdate(c, out,&l,in,inlen); EVP_EncryptFinal_ex(c,out+l,&l);
+    EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_AEAD_GET_TAG, 8, tag);
+  } else {
+    EVP_DecryptInit_ex(c, EVP_aes_128_ccm(), 0,0,0);
+    EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_AEAD_SET_IVLEN, 13, 0);
+    EVP_CIPHER_CTX_ctrl(c, EVP_CTRL_AEAD_SET_TAG, 8, tag);
+    EVP_DecryptInit_ex(c, 0,0,key,nonce);
+    EVP_DecryptUpdate(c, 0,&l,0,inlen); EVP_DecryptUpdate(c,0,&l,aad,aadlen);
+    ok = EVP_DecryptUpdate(c, out,&l,in,inlen) > 0;
+  }
+  EVP_CIPHER_CTX_free(c); return ok;
+}
+// Encrypt an AP->STA payload (LLC/SNAP+eth+data) into a CCMP data frame.
+static std::vector<uint8_t> ccmp_tx(const uint8_t* sta, uint16_t eth,
+                                    const uint8_t* pl, int plen) {
+  std::vector<uint8_t> pt = {0xaa,0xaa,0x03,0,0,0,(uint8_t)(eth>>8),(uint8_t)(eth&0xff)};
+  pt.insert(pt.end(), pl, pl+plen);
+  std::vector<uint8_t> hdr = {0x08,0x42,0,0,             // data, from-DS + protected
+      sta[0],sta[1],sta[2],sta[3],sta[4],sta[5],
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5], 0,0};
+  uint64_t pn = g_txpn++;
+  uint8_t aad[32], nonce[13], mic[8]; int aadlen;
+  ccmp_aad_nonce(hdr.data(), pn, kBssid, aad, &aadlen, nonce);
+  std::vector<uint8_t> ct(pt.size());
+  ccm(true, g_ptk+32, nonce, aad, aadlen, pt.data(), pt.size(), ct.data(), mic);
+  uint8_t ch8[8] = {(uint8_t)(pn&0xff),(uint8_t)((pn>>8)&0xff),0,0x20,
+      (uint8_t)((pn>>16)&0xff),(uint8_t)((pn>>24)&0xff),(uint8_t)((pn>>32)&0xff),(uint8_t)((pn>>40)&0xff)};
+  std::vector<uint8_t> m = hdr;
+  m.insert(m.end(), ch8, ch8+8); m.insert(m.end(), ct.begin(), ct.end());
+  m.insert(m.end(), mic, mic+8);
+  return m;
+}
+// Handle a decrypted L2 payload (LLC/SNAP + eth): answer ARP + ICMP, encrypted.
+static void handle_plain(const uint8_t* sta, const uint8_t* d, int len) {
+  if (len < 8 || d[0]!=0xaa) return;
+  uint16_t eth = (d[6]<<8)|d[7]; const uint8_t* pl = d+8; int pllen = len-8;
+  if (eth==0x0806 && pllen>=28) {                        // ARP
+    if (((pl[6]<<8)|pl[7])==1 && memcmp(pl+24,kApIp,4)==0) {
+      uint8_t a[28]={0,1,8,0,6,4,0,2, kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],
+        kApIp[0],kApIp[1],kApIp[2],kApIp[3], pl[8],pl[9],pl[10],pl[11],pl[12],pl[13],
+        pl[14],pl[15],pl[16],pl[17]};
+      enqueue(ccmp_tx(sta,0x0806,a,28));
+    }
+  } else if (eth==0x0800 && pllen>=28) {                 // IPv4/ICMP
+    const uint8_t* ip=pl; int ihl=(ip[0]&0x0f)*4;
+    if (ip[9]==1 && pllen>=ihl+8 && memcmp(ip+16,kApIp,4)==0 && ip[ihl]==8) {
+      std::vector<uint8_t> r(pl, pl+pllen);
+      memcpy(r.data()+12,kApIp,4); memcpy(r.data()+16,ip+12,4);
+      r[10]=r[11]=0; uint16_t ic=csum16(r.data(),ihl); r[10]=ic>>8; r[11]=ic&0xff;
+      r[ihl]=0; r[ihl+2]=r[ihl+3]=0;
+      uint16_t cc=csum16(r.data()+ihl,pllen-ihl); r[ihl+2]=cc>>8; r[ihl+3]=cc&0xff;
+      enqueue(ccmp_tx(sta,0x0800,r.data(),pllen));
+    }
+  }
+}
+
 static void on_rx(const Packet& p) {
   if (p.Data.size() < 24 || p.RxAtrib.crc_err) return;
   const uint8_t fc0 = p.Data[0], fc1 = p.Data[1];
@@ -218,6 +312,23 @@ static void on_rx(const Packet& p) {
     send_msg1();
   } else if ((fc0 == 0x08 || fc0 == 0x88) && (fc1 & 0x01) && to_us) {  // data to-DS
     int hlen = 24 + (fc0 == 0x88 ? 2 : 0);
+    if ((fc1 & 0x40) && g_state == 2) {                 // PROTECTED (CCMP) data
+      int len = (int)p.Data.size();
+      if (len < hlen + 8 + 8) return;                   // hdr + CCMP hdr + MIC
+      const uint8_t* d = p.Data.data();
+      const uint8_t* cc = d + hlen;                     // CCMP header
+      uint64_t pn = cc[0] | (cc[1]<<8) | ((uint64_t)cc[4]<<16) | ((uint64_t)cc[5]<<24)
+                  | ((uint64_t)cc[6]<<32) | ((uint64_t)cc[7]<<40);
+      int ctlen = len - hlen - 8 - 8;
+      const uint8_t* ct = d + hlen + 8; const uint8_t* mic = ct + ctlen;
+      uint8_t aad[32], nonce[13], tag[8]; int aadlen;
+      ccmp_aad_nonce(d, pn, sta, aad, &aadlen, nonce);   // A2 = station
+      memcpy(tag, mic, 8);
+      std::vector<uint8_t> pt(ctlen);
+      if (ccm(false, g_ptk+32, nonce, aad, aadlen, ct, ctlen, pt.data(), tag))
+        handle_plain(sta, pt.data(), ctlen);             // decrypted -> ARP/ICMP
+      return;
+    }
     if ((int)p.Data.size() < hlen + 8) return;
     const uint8_t* llc = p.Data.data() + hlen;
     if (!(llc[0]==0xaa && llc[6]==0x88 && llc[7]==0x8e)) return;  // EAPOL

--- a/tests/ap_wpa2_demo.sh
+++ b/tests/ap_wpa2_demo.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# ap_wpa2_demo.sh — the full encrypted "devourer behaves like a kernel WPA2 AP"
+# demo: bring devourer up as a WPA2-PSK AP (tests/ap_wpa2.cpp), associate a REAL
+# Linux station (rtw88), lease an IP over ENCRYPTED DHCP, and PING over WPA2/CCMP.
+# Proven (in pieces): 4-way "Key negotiation completed [PTK=CCMP GTK=CCMP]",
+# dhcpcd "leased 192.168.99.2", ping 0% loss ~2.5 ms — all CCMP-encrypted.
+#
+# Needs a second Realtek adapter bound to the kernel as a station (rtw88
+# auto-probes a VBUS-cold dongle -> e.g. wlp4s0u2u4). AP adapter = a DIFFERENT
+# full-duplex J2/J3 devourer adapter (8812BU/8822CU). openssl (-lcrypto) required.
+#
+# NOTE: a single clean end-to-end run is flaky when the AP adapter has no VBUS
+# reset (an xhci root-hub port degrades after many cycles) — prefer a
+# VBUS-cyclable AP, and cold-cycle the station between runs.
+#
+#   sudo STA_IF=wlp4s0u2u4 AP_VID=0x2357 AP_PID=0x012d tests/ap_wpa2_demo.sh
+set -uo pipefail
+cd "$(dirname "$0")/.."
+STA_IF=${STA_IF:-wlp4s0u2u4}
+AP_VID=${AP_VID:-0x2357}; AP_PID=${AP_PID:-0x012d}
+CH=${CH:-6}; TU=${TU:-25}; PSK=${PSK:-devourer123}; APIP=192.168.99.1
+
+BIN=$(mktemp); WPA=$(mktemp); LOG=$(mktemp)
+cleanup(){ sudo pkill -9 -x apw_demo wpa_supplicant dhcpcd 2>/dev/null
+  sudo dhcpcd -x "$STA_IF" 2>/dev/null; sudo ip addr flush dev "$STA_IF" 2>/dev/null
+  sudo iw dev "$STA_IF" disconnect 2>/dev/null; rm -f "$BIN" "$WPA" "$LOG"; }
+trap cleanup EXIT
+
+g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/ap_wpa2.cpp \
+    examples/common/env_config.cpp build/libdevourer.a \
+    $(pkg-config --cflags --libs libusb-1.0) -lcrypto -lpthread -o "$BIN" || exit 1
+cp "$BIN" /tmp/apw_demo
+printf 'network={\n\tssid="devourerAP"\n\tpsk="%s"\n\tkey_mgmt=WPA-PSK\n\tproto=RSN\n\tpairwise=CCMP\n\tgroup=CCMP\n\tscan_ssid=1\n}\n' "$PSK" > "$WPA"
+
+sudo pkill -9 -x apw_demo wpa_supplicant dhcpcd 2>/dev/null; sudo iw dev "$STA_IF" disconnect 2>/dev/null; sleep 2
+echo "WPA2 AP: $AP_VID:$AP_PID ch$CH ${TU}TU PSK='$PSK'   station: $STA_IF"
+sudo env DEVOURER_VID=$AP_VID DEVOURER_PID=$AP_PID DEVOURER_CHANNEL=$CH DEVOURER_WPA2_PSK="$PSK" \
+    DEVOURER_BCN_TU=$TU DEVOURER_TX_WITH_RX=thread /tmp/apw_demo 55 2>"$LOG" &
+sleep 6
+sudo wpa_supplicant -i "$STA_IF" -c "$WPA" -B >/dev/null 2>&1
+ok=0; for i in $(seq 1 16); do
+  sudo wpa_cli -i "$STA_IF" status 2>/dev/null | grep -q COMPLETED && { echo "-- WPA2 key negotiation completed (${i}s)"; ok=1; break; }; sleep 1; done
+if [ "$ok" != 1 ]; then echo "FAIL: 4-way did not complete (bench flaky / AP degraded)"; grep -iE "4-WAY|msg" "$LOG" | tail -3; exit 1; fi
+
+sudo ip addr flush dev "$STA_IF" 2>/dev/null
+echo "-- encrypted DHCP:"; sudo timeout 16 dhcpcd -4 -1 -t 14 "$STA_IF" 2>&1 | grep -iE "leased" | sed 's/^/     /'
+echo "-- station IP: $(ip -4 -o addr show "$STA_IF" | grep -oE '192\.168\.99\.[0-9]+' | head -1)"
+sudo ping -c 1 -W 2 -I "$STA_IF" "$APIP" >/dev/null 2>&1
+echo "-- encrypted ping (WPA2/CCMP):"; sudo ping -c 6 -W 1 -I "$STA_IF" "$APIP" | tail -3

--- a/tests/beacon_fullbody.cpp
+++ b/tests/beacon_fullbody.cpp
@@ -61,6 +61,7 @@ static std::vector<uint8_t> full_beacon(int interval_tu, uint8_t chan) {
 int main(int argc, char** argv) {
   int sec = argc > 1 ? atoi(argv[1]) : 20;
   int interval_tu = 100;
+  if (const char* iv = std::getenv("DEVOURER_BCN_TU")) interval_tu = atoi(iv);
   uint8_t ch = 36;
   if (const char* c = std::getenv("DEVOURER_CHANNEL")) ch = (uint8_t)atoi(c);
 

--- a/tests/beacon_fullbody.cpp
+++ b/tests/beacon_fullbody.cpp
@@ -1,0 +1,94 @@
+// beacon_fullbody.cpp — is the "minimal beacon body" constraint real?
+//
+// docs/time-distribution.md claims an extended beacon body breaks the hardware
+// TSF insertion (the MAC writes a per-beacon counter instead of the live TSF).
+// But kernel APs beacon with FULL bodies (SSID + rates + DS + TIM + HT/VHT) and
+// the HW inserts the TSF fine — so the limit is suspect. This brings up a beacon
+// with a realistic, WELL-FORMED full body (canonical SA so the observer matches)
+// and idles; run tests/beacon_ts_check against it (DEVOURER_PID of the observer)
+// and watch the timestamp field (MPDU bytes 24..31): if it steps ~102400 µs per
+// beacon, the HW TSF insertion works with a full body and the constraint is a
+// misdiagnosis (a malformed test frame, not a hardware limit).
+//
+// Build: g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/beacon_fullbody.cpp \
+//   examples/common/env_config.cpp build/libdevourer.a \
+//   $(pkg-config --cflags --libs libusb-1.0) -lpthread -o build/beacon_fullbody
+// Run: sudo DEVOURER_PID=0xc812 DEVOURER_CHANNEL=36 build/beacon_fullbody [sec]
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <libusb.h>
+
+#include "SelectedChannel.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "env_config.h"
+#include "logger.h"
+
+// A full, well-formed 802.11 beacon MPDU (behind a rate-less radiotap). Same
+// canonical SA/BSSID the rx.txhit / beacon_ts_check matchers use, but with a
+// realistic body: 10-char SSID + 8 supported rates + DS param + TIM + ERP.
+static std::vector<uint8_t> full_beacon(int interval_tu, uint8_t chan) {
+  std::vector<uint8_t> f = {
+      0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x00, 0x00, 0x08, 0x00,  // radiotap
+      0x80, 0x00, 0x00, 0x00,                                      // FC beacon + dur
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff,                          // addr1 broadcast
+      0x57, 0x42, 0x75, 0x05, 0xd6, 0x00,                          // addr2 = SA
+      0x57, 0x42, 0x75, 0x05, 0xd6, 0x00,                          // addr3 = BSSID
+      0x00, 0x00,                                                  // seq (HW fills)
+      0, 0, 0, 0, 0, 0, 0, 0,                                      // timestamp (HW fills)
+      static_cast<uint8_t>(interval_tu & 0xff),
+      static_cast<uint8_t>((interval_tu >> 8) & 0xff),             // beacon interval
+      0x01, 0x00,                                                  // capability (ESS)
+      // SSID IE — 10 chars (vs the 3-char minimal)
+      0x00, 0x0a, 'd', 'e', 'v', 'o', 'u', 'r', 'e', 'r', 'A', 'P',
+      // Supported rates IE — 8 rates (vs the 1 minimal)
+      0x01, 0x08, 0x82, 0x84, 0x8b, 0x96, 0x24, 0x30, 0x48, 0x6c,
+      // DS Parameter Set — current channel
+      0x03, 0x01, chan,
+      // TIM IE — DTIM count 0, period 1, bitmap control 0, partial bitmap 0
+      0x05, 0x04, 0x00, 0x01, 0x00, 0x00,
+      // ERP Information
+      0x2a, 0x01, 0x00};
+  return f;
+}
+
+int main(int argc, char** argv) {
+  int sec = argc > 1 ? atoi(argv[1]) : 20;
+  int interval_tu = 100;
+  uint8_t ch = 36;
+  if (const char* c = std::getenv("DEVOURER_CHANNEL")) ch = (uint8_t)atoi(c);
+
+  auto logger = std::make_shared<Logger>();
+  apply_logging_env(*logger);
+  libusb_context* ctx = nullptr;
+  if (libusb_init(&ctx) < 0) return 1;
+  libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
+  uint16_t vid = 0x0bda, pid = 0xc812;
+  if (const char* v = std::getenv("DEVOURER_VID")) vid = (uint16_t)strtoul(v, 0, 0);
+  if (const char* p = std::getenv("DEVOURER_PID")) pid = (uint16_t)strtoul(p, 0, 0);
+  auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
+  if (!h) { fprintf(stderr, "open %04x:%04x failed\n", vid, pid); return 1; }
+  std::shared_ptr<devourer::UsbDeviceLock> lock;
+  if (devourer::claim_interface_then_reset(h, 0, logger, true, lock) != 0) return 1;
+  WiFiDriver wifi(logger);
+  auto dev = wifi.CreateRtlDevice(h, ctx, lock, devourer_config_from_env());
+  if (!dev) { fprintf(stderr, "no driver\n"); return 1; }
+
+  dev->InitWrite(SelectedChannel{ch, 0, CHANNEL_WIDTH_20});
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  auto f = full_beacon(interval_tu, ch);
+  bool ok = dev->StartBeacon(f.data(), f.size(), interval_tu);
+  fprintf(stderr, "FULL-BODY beacon (%zu-byte MPDU: SSID 'devourerAP' + 8 rates + "
+                  "DS + TIM + ERP) StartBeacon -> %s. Idling %d s. Observe the "
+                  "timestamp field with beacon_ts_check.\n",
+          f.size() - 10, ok ? "OK" : "FAILED", sec);
+  if (!ok) return 1;
+  std::this_thread::sleep_for(std::chrono::seconds(sec));
+  return 0;
+}

--- a/tests/beacon_interval_shift.sh
+++ b/tests/beacon_interval_shift.sh
@@ -72,6 +72,7 @@ int main(int argc,char**argv){
   libusb_context*ctx=nullptr; libusb_init(&ctx);
   libusb_set_option(ctx,LIBUSB_OPTION_LOG_LEVEL,LIBUSB_LOG_LEVEL_WARNING);
   uint16_t vid=0x0bda,pid=0xc812;
+  if(const char*v=std::getenv("DEVOURER_VID")) vid=(uint16_t)strtoul(v,0,0);
   if(const char*p=std::getenv("DEVOURER_PID")) pid=(uint16_t)strtoul(p,0,0);
   auto*h=libusb_open_device_with_vid_pid(ctx,vid,pid);
   if(!h){fprintf(stderr,"master open fail\n");return 1;}
@@ -88,8 +89,15 @@ int main(int argc,char**argv){
   fprintf(stderr,"MASTER beacon up @100TU, steady 7s then AdjustBeaconTiming\n");
   std::this_thread::sleep_for(std::chrono::seconds(7));
   int us = (SHORT-100)*1024;   // SHORT<100 => negative => advance (earlier)
-  printf("TWEAK_MS %ld short=%d req_us=%d\n", now_ms(), SHORT, us); fflush(stdout);
-  int applied = dev->AdjustBeaconTiming(us);                // productized primitive
+  int applied;
+  if (const char* f = std::getenv("FINE_US")) {             // µs-fine variant
+    us = atoi(f);
+    printf("TWEAK_MS %ld fine_us=%d\n", now_ms(), us); fflush(stdout);
+    applied = dev->AdjustBeaconTimingFine(us);
+  } else {
+    printf("TWEAK_MS %ld short=%d req_us=%d\n", now_ms(), SHORT, us); fflush(stdout);
+    applied = dev->AdjustBeaconTiming(us);                  // TU-quantized primitive
+  }
   printf("RESTORE_MS %ld applied_us=%d\n", now_ms(), applied); fflush(stdout);
   std::this_thread::sleep_for(std::chrono::seconds(7));
   return 0;
@@ -151,9 +159,9 @@ g++ $CXXFLAGS "$TMP/obs.cpp"    examples/common/env_config.cpp "$LIB" $LDLIBS -o
 cp "$TMP/bshift_master" /tmp/bshift_master; cp "$TMP/bshift_obs" /tmp/bshift_obs
 
 echo "== run: master 8822CU one-shot 100->$SHORT->100 TU, observer 8822EU, ch$CH =="
-sudo DEVOURER_CHANNEL="$CH" /tmp/bshift_obs >"$OLOG" 2>/dev/null &
+sudo DEVOURER_CHANNEL="$CH" DEVOURER_PID="${OBS_PID:-0xa81a}" /tmp/bshift_obs >"$OLOG" 2>/dev/null &
 sleep 3   # let observer's RX settle first
-sudo DEVOURER_CHANNEL="$CH" /tmp/bshift_master "$SHORT" >"$MLOG" 2>/tmp/bshift_m.err &
+sudo DEVOURER_CHANNEL="$CH" ${FINE_US:+FINE_US="$FINE_US"} /tmp/bshift_master "$SHORT" >"$MLOG" 2>/tmp/bshift_m.err &
 wait
 rm -f /tmp/bshift_master /tmp/bshift_obs
 

--- a/tests/beacon_interval_shift.sh
+++ b/tests/beacon_interval_shift.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# beacon_interval_shift.sh — de-risk the uplink timing-advance actuator.
+#
+# WriteTsf (REG_TSFTR 0x0560) was shown NOT to move the beacon TBTT air-time
+# (the beacon engine runs off a separate/per-port timer). This exercises +
+# validates the productized actuator IRtlDevice::AdjustBeaconTiming(us): a
+# ONE-SHOT beacon-interval tweak (REG_BCN_INTERVAL 0x0554) — run one interval at
+# (nominal +/- delta) TU then restore, and a clean interval-phased engine
+# advances/retards the next TBTT by delta TU, resuming cadence phase-shifted.
+#
+# Master  = 8822CU (0xc812): StartBeacon(100 TU) + SetCcaMode(true); after a
+#           steady window, AdjustBeaconTiming((SHORT-100)*1024 us) — a one-shot
+#           phase advance of (100-SHORT) TU via the bare-0x0554 path (no beacon
+#           re-download).
+# Observer= 8822EU (0xa81a): logs each canonical-SA beacon's arrival phase
+#           (its own hardware tsfl % 102400 us). A clean actuator shows a
+#           ~ (100-SHORT)*1024 us step in the arrival phase right after the tweak,
+#           standing well clear of the slow crystal-drift ramp.
+#
+# Both binaries print CLOCK epoch-ms (shared system_clock, same machine) so the
+# observer's phase jump can be lined up against the master's tweak instant.
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+SHORT="${1:-80}"          # short interval in TU (100->80 => +20 TU = 20.48 ms advance)
+CH="${DEVOURER_CHANNEL:-36}"
+LIB="build/libdevourer.a"
+CXXFLAGS="-std=c++20 -O2 -Isrc -Iexamples/common"
+LDLIBS="$(pkg-config --cflags --libs libusb-1.0) -lpthread"
+TMP="$(mktemp -d)"
+MLOG="$(mktemp)"; OLOG="$(mktemp)"
+
+cleanup() {
+  sudo pkill -9 -x bshift_master bshift_obs 2>/dev/null
+  rm -rf "$TMP" "$MLOG" "$OLOG" 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+[ -f "$LIB" ] || { echo "build $LIB first (cmake --build build -j)"; exit 1; }
+
+# ---- master source -------------------------------------------------------
+cat > "$TMP/master.cpp" <<'EOF'
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <thread>
+#include <vector>
+#include <libusb.h>
+#include "SelectedChannel.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "env_config.h"
+#include "logger.h"
+static long now_ms() {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::system_clock::now().time_since_epoch()).count();
+}
+static std::vector<uint8_t> beacon(int itu) {
+  return {0x00,0x00,0x0a,0x00,0x00,0x80,0x00,0x00,0x08,0x00,   // radiotap
+          0x80,0x00,0x00,0x00, 0xff,0xff,0xff,0xff,0xff,0xff,
+          0x57,0x42,0x75,0x05,0xd6,0x00, 0x57,0x42,0x75,0x05,0xd6,0x00,
+          0x00,0x00, 0,0,0,0,0,0,0,0,
+          (uint8_t)(itu&0xff),(uint8_t)((itu>>8)&0xff), 0x00,0x00,
+          0x00,0x03,'T','B','T', 0x01,0x01,0x82};
+}
+int main(int argc,char**argv){
+  int SHORT = argc>1?atoi(argv[1]):80;
+  uint8_t ch = 36; if(const char*c=std::getenv("DEVOURER_CHANNEL")) ch=atoi(c);
+  auto logger=std::make_shared<Logger>(); apply_logging_env(*logger);
+  libusb_context*ctx=nullptr; libusb_init(&ctx);
+  libusb_set_option(ctx,LIBUSB_OPTION_LOG_LEVEL,LIBUSB_LOG_LEVEL_WARNING);
+  uint16_t vid=0x0bda,pid=0xc812;
+  if(const char*p=std::getenv("DEVOURER_PID")) pid=(uint16_t)strtoul(p,0,0);
+  auto*h=libusb_open_device_with_vid_pid(ctx,vid,pid);
+  if(!h){fprintf(stderr,"master open fail\n");return 1;}
+  std::shared_ptr<devourer::UsbDeviceLock> lk;
+  if(devourer::claim_interface_then_reset(h,0,logger,true,lk)!=0)return 1;
+  WiFiDriver wifi(logger);
+  auto dev=wifi.CreateRtlDevice(h,ctx,lk,devourer_config_from_env());
+  if(!dev)return 1;
+  dev->InitWrite(SelectedChannel{ch,0,CHANNEL_WIDTH_20});
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  dev->SetCcaMode(true);
+  auto b100=beacon(100);
+  dev->StartBeacon(b100.data(),b100.size(),100);
+  fprintf(stderr,"MASTER beacon up @100TU, steady 7s then AdjustBeaconTiming\n");
+  std::this_thread::sleep_for(std::chrono::seconds(7));
+  int us = (SHORT-100)*1024;   // SHORT<100 => negative => advance (earlier)
+  printf("TWEAK_MS %ld short=%d req_us=%d\n", now_ms(), SHORT, us); fflush(stdout);
+  int applied = dev->AdjustBeaconTiming(us);                // productized primitive
+  printf("RESTORE_MS %ld applied_us=%d\n", now_ms(), applied); fflush(stdout);
+  std::this_thread::sleep_for(std::chrono::seconds(7));
+  return 0;
+}
+EOF
+
+# ---- observer source -----------------------------------------------------
+cat > "$TMP/obs.cpp" <<'EOF'
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <unistd.h>
+#include <memory>
+#include <thread>
+#include <libusb.h>
+#include "RxPacket.h"
+#include "SelectedChannel.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "env_config.h"
+#include "logger.h"
+static const uint8_t kSa[6]={0x57,0x42,0x75,0x05,0xd6,0x00};
+static long now_ms(){return std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::system_clock::now().time_since_epoch()).count();}
+int main(){
+  auto logger=std::make_shared<Logger>();
+  libusb_context*ctx=nullptr; libusb_init(&ctx);
+  libusb_set_option(ctx,LIBUSB_OPTION_LOG_LEVEL,LIBUSB_LOG_LEVEL_WARNING);
+  uint16_t vid=0x0bda,pid=0xa81a;
+  if(const char*p=std::getenv("DEVOURER_PID")) pid=(uint16_t)strtoul(p,0,0);
+  uint8_t ch=36; if(const char*c=std::getenv("DEVOURER_CHANNEL")) ch=atoi(c);
+  auto*h=libusb_open_device_with_vid_pid(ctx,vid,pid);
+  if(!h){fprintf(stderr,"obs open fail\n");return 1;}
+  std::shared_ptr<devourer::UsbDeviceLock> lk;
+  if(devourer::claim_interface_then_reset(h,0,logger,true,lk)!=0)return 1;
+  WiFiDriver wifi(logger);
+  auto dev=wifi.CreateRtlDevice(h,ctx,lk,devourer_config_from_env());
+  if(!dev)return 1;
+  auto cb=[](const Packet&p){
+    if(p.Data.size()<32||p.RxAtrib.crc_err)return;
+    if(std::memcmp(p.Data.data()+10,kSa,6)!=0)return;
+    uint32_t tsfl=p.RxAtrib.tsfl;
+    printf("BCN_MS %ld tsfl=%u phase=%u\n", now_ms(), tsfl, tsfl%102400);
+    fflush(stdout);
+  };
+  std::thread rx([&]{dev->Init(cb,SelectedChannel{ch,0,CHANNEL_WIDTH_20});});
+  rx.detach();
+  std::this_thread::sleep_for(std::chrono::seconds(17));
+  _exit(0);
+}
+EOF
+
+echo "building master + observer ..."
+g++ $CXXFLAGS "$TMP/master.cpp" examples/common/env_config.cpp "$LIB" $LDLIBS -o "$TMP/bshift_master" || exit 1
+g++ $CXXFLAGS "$TMP/obs.cpp"    examples/common/env_config.cpp "$LIB" $LDLIBS -o "$TMP/bshift_obs"    || exit 1
+cp "$TMP/bshift_master" /tmp/bshift_master; cp "$TMP/bshift_obs" /tmp/bshift_obs
+
+echo "== run: master 8822CU one-shot 100->$SHORT->100 TU, observer 8822EU, ch$CH =="
+sudo DEVOURER_CHANNEL="$CH" /tmp/bshift_obs >"$OLOG" 2>/dev/null &
+sleep 3   # let observer's RX settle first
+sudo DEVOURER_CHANNEL="$CH" /tmp/bshift_master "$SHORT" >"$MLOG" 2>/tmp/bshift_m.err &
+wait
+rm -f /tmp/bshift_master /tmp/bshift_obs
+
+TWEAK=$(awk '/TWEAK_MS/{print $2}' "$MLOG")
+echo "---- master ----"; cat "$MLOG"
+echo "---- observer beacons (phase in us; watch for a step at TWEAK_MS=$TWEAK) ----"
+awk -v tw="$TWEAK" '
+  /BCN_MS/{ ms=$2; sub("tsfl=","",$3); sub("phase=","",$4);
+            tag=(tw!=""&&ms>=tw)?"  <-- after tweak":"";
+            printf "  ms=%s phase=%6s us%s\n", ms, $4, tag }' "$OLOG"
+echo "---- interpretation ----"
+echo "phase ~constant across the tweak  => interval-tweak does NOT move TBTT"
+echo "phase steps ~$(( (100-SHORT)*1024 )) us at the tweak => interval-tweak IS the uplink-TA actuator"

--- a/tests/beacon_kernel_scan.sh
+++ b/tests/beacon_kernel_scan.sh
@@ -12,10 +12,11 @@
 #
 #   sudo SCAN_IF=wlp4s0u2u4 B_VID=0x2357 B_PID=0x012d tests/beacon_kernel_scan.sh
 #
-# Proven result (8812BU beacon, rtw88 8822CU station, ch6):
-#   BSS 57:42:75:05:d6:00  TSF <live>  freq 2437  beacon interval 25 TUs
+# Proven result (8812BU beacon, rtw88 8822CU station) on BOTH bands — ch6
+# (CH=6 FREQ=2437) and ch36 (CH=36 FREQ=5180):
+#   BSS 57:42:75:05:d6:00  TSF <live>  freq <2437|5180>  beacon interval 25 TUs
 #   capability: ESS  SSID: devourerAP  Supported rates 1..54 (basic flags)
-#   DS Parameter set: channel 6  TIM: DTIM Count 0 Period 1  ERP: <no flags>
+#   DS Parameter set: channel <6|36>  TIM: DTIM Count 0 Period 1  ERP: <no flags>
 set -uo pipefail
 cd "$(dirname "$0")/.."
 SCAN_IF=${SCAN_IF:-wlp4s0u2u4}

--- a/tests/beacon_kernel_scan.sh
+++ b/tests/beacon_kernel_scan.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# beacon_kernel_scan.sh — the end-to-end "behaves like a kernel AP" interop test:
+# devourer airs a full-content beacon; a REAL Linux 802.11 station (rtw88/mac80211)
+# scans and must list it as a valid AP with every element parsed. This validates
+# devourer's beacon against the actual kernel BSS/scan parser, not just the wire
+# bytes (tests/beacon_wire_check.cpp).
+#
+# Needs a second Realtek adapter already bound to the kernel as a station — on this
+# rig rtw88 auto-probes any dongle at enumeration, so a VBUS-cold adapter comes up
+# as e.g. wlp4s0u2u4 (managed). Point SCAN_IF at it; use a DIFFERENT adapter
+# (VID/PID) for the devourer beacon.
+#
+#   sudo SCAN_IF=wlp4s0u2u4 B_VID=0x2357 B_PID=0x012d tests/beacon_kernel_scan.sh
+#
+# Proven result (8812BU beacon, rtw88 8822CU station, ch6):
+#   BSS 57:42:75:05:d6:00  TSF <live>  freq 2437  beacon interval 25 TUs
+#   capability: ESS  SSID: devourerAP  Supported rates 1..54 (basic flags)
+#   DS Parameter set: channel 6  TIM: DTIM Count 0 Period 1  ERP: <no flags>
+set -uo pipefail
+cd "$(dirname "$0")/.."
+SCAN_IF=${SCAN_IF:-wlp4s0u2u4}
+B_VID=${B_VID:-0x2357}; B_PID=${B_PID:-0x012d}   # devourer beacon adapter (J2/J3, StartBeacon)
+CH=${CH:-6}; FREQ=${FREQ:-2437}; TU=${TU:-25}; SECS=${SECS:-30}
+BSSID=57:42:75:05:d6:00
+
+BIN=$(mktemp); LOG=$(mktemp)
+cleanup(){ sudo pkill -9 -x bkscan 2>/dev/null; rm -f "$BIN" "$LOG"; }
+trap cleanup EXIT
+
+g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/beacon_fullbody.cpp \
+    examples/common/env_config.cpp build/libdevourer.a \
+    $(pkg-config --cflags --libs libusb-1.0) -lpthread -o "$BIN" || exit 1
+cp "$BIN" /tmp/bkscan
+
+sudo ip link set "$SCAN_IF" up 2>/dev/null; sleep 1
+echo "beacon: $B_VID:$B_PID ch$CH ${TU}TU   scan station: $SCAN_IF"
+sudo pkill -9 -x bkscan 2>/dev/null; sleep 1
+sudo env DEVOURER_VID=$B_VID DEVOURER_PID=$B_PID DEVOURER_CHANNEL=$CH DEVOURER_BCN_TU=$TU \
+    /tmp/bkscan "$SECS" >/dev/null 2>"$LOG" &
+sleep 5
+
+found=0
+for i in 1 2 3 4; do
+  ENTRY=$(sudo iw dev "$SCAN_IF" scan freq "$FREQ" 2>/dev/null | \
+          awk -v b="$BSSID" 'index($0,b){f=1} f{print} f&&/^BSS/&&!index($0,b){exit}')
+  if [ -n "$ENTRY" ]; then
+    echo "=== FOUND — kernel station parsed devourer's beacon (scan $i) ==="
+    echo "$ENTRY" | grep -iE "BSS |TSF:|freq:|beacon interval|capability|SSID:|Supported rates|DS Param|TIM:|ERP:"
+    found=1; break
+  fi
+  echo "scan $i: not yet seen"; sleep 2
+done
+sudo pkill -9 -x bkscan 2>/dev/null
+[ "$found" = 1 ] && echo "PASS: devourer beacon accepted by the kernel 802.11 stack" \
+                 || { echo "FAIL: not listed (check beacon aired: $(grep -c StartBeacon "$LOG"))"; exit 1; }

--- a/tests/beacon_tbtt.cpp
+++ b/tests/beacon_tbtt.cpp
@@ -1,7 +1,7 @@
 // beacon_tbtt.cpp — experiment (idea 6): can the MAC transmit a beacon at each
 // TBTT (hardware-timed off the TSF) in devourer's monitor/injection mode? Brings
 // up TX on a Jaguar1 adapter, loads a beacon into the beacon queue + enables the
-// beacon function (IRtlDevice::BeaconTbttSpike), then IDLES — no send loop. If
+// beacon function (IRtlDevice::StartBeacon), then IDLES — no send loop. If
 // the beacon function works, the chip transmits the beacon on its own at the
 // interval. Observe with a second adapter running rxdemo (count rx.txhit of the
 // canonical SA; ~1 per 102.4 ms at 100 TU => hardware-timed TX confirmed).
@@ -67,8 +67,8 @@ int main(int argc, char** argv) {
       0x00, 0x03, 'T', 'B', 'T',                                   // SSID IE "TBT"
       0x01, 0x01, 0x82};                                          // supported rates (1M)
 
-  bool ok = dev->BeaconTbttSpike(f.data(), f.size(), interval_tu);
-  fprintf(stderr, "BeaconTbttSpike -> %s. Idling %d s (chip should self-TX at "
+  bool ok = dev->StartBeacon(f.data(), f.size(), interval_tu);
+  fprintf(stderr, "StartBeacon -> %s. Idling %d s (chip should self-TX at "
                   "TBTT every %d TU ≈ %.1f ms). Watch a 2nd RX's rx.txhit.\n",
           ok ? "OK" : "FAILED/unsupported", sec, interval_tu, interval_tu * 1.024);
   if (!ok) return 1;

--- a/tests/beacon_tbtt.cpp
+++ b/tests/beacon_tbtt.cpp
@@ -1,0 +1,79 @@
+// beacon_tbtt.cpp — experiment (idea 6): can the MAC transmit a beacon at each
+// TBTT (hardware-timed off the TSF) in devourer's monitor/injection mode? Brings
+// up TX on a Jaguar1 adapter, loads a beacon into the beacon queue + enables the
+// beacon function (IRtlDevice::BeaconTbttSpike), then IDLES — no send loop. If
+// the beacon function works, the chip transmits the beacon on its own at the
+// interval. Observe with a second adapter running rxdemo (count rx.txhit of the
+// canonical SA; ~1 per 102.4 ms at 100 TU => hardware-timed TX confirmed).
+//
+// Build: g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/beacon_tbtt.cpp \
+//   examples/common/env_config.cpp build/libdevourer.a \
+//   $(pkg-config --cflags --libs libusb-1.0) -lpthread -o build/beacon_tbtt
+// Run: sudo DEVOURER_PID=0x8812 DEVOURER_CHANNEL=36 build/beacon_tbtt [interval_tu] [sec]
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <libusb.h>
+
+#include "SelectedChannel.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "env_config.h"
+#include "logger.h"
+
+int main(int argc, char** argv) {
+  int interval_tu = argc > 1 ? atoi(argv[1]) : 100;  // 100 TU ≈ 102.4 ms
+  int sec = argc > 2 ? atoi(argv[2]) : 20;
+  uint8_t ch = 36;
+  if (const char* c = std::getenv("DEVOURER_CHANNEL")) ch = (uint8_t)atoi(c);
+
+  auto logger = std::make_shared<Logger>();
+  apply_logging_env(*logger);
+  libusb_context* ctx = nullptr;
+  if (libusb_init(&ctx) < 0) return 1;
+  libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
+  uint16_t vid = 0x0bda, pid = 0;
+  if (const char* v = std::getenv("DEVOURER_VID")) vid = (uint16_t)strtoul(v, 0, 0);
+  if (const char* p = std::getenv("DEVOURER_PID")) pid = (uint16_t)strtoul(p, 0, 0);
+  auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
+  if (!h) { fprintf(stderr, "open %04x:%04x failed\n", vid, pid); return 1; }
+  std::shared_ptr<devourer::UsbDeviceLock> lock;
+  if (devourer::claim_interface_then_reset(h, 0, logger, true, lock) != 0) return 1;
+  WiFiDriver wifi(logger);
+  auto dev = wifi.CreateRtlDevice(h, ctx, lock, devourer_config_from_env());
+  if (!dev) { fprintf(stderr, "no driver\n"); return 1; }
+
+  dev->InitWrite(SelectedChannel{ch, 0, CHANNEL_WIDTH_20});
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+
+  // Minimal 802.11 beacon behind a rate-less radiotap (SA = the canonical
+  // 57:42:75:05:d6:00 so the RX's rx.txhit matcher recognises it).
+  std::vector<uint8_t> f = {
+      0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x00, 0x00, 0x08, 0x00,  // radiotap
+      0x80, 0x00, 0x00, 0x00,                                      // FC beacon + dur
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff,                          // addr1 broadcast
+      0x57, 0x42, 0x75, 0x05, 0xd6, 0x00,                          // addr2 = SA
+      0x57, 0x42, 0x75, 0x05, 0xd6, 0x00,                          // addr3 = BSSID
+      0x00, 0x00,                                                  // seq
+      0, 0, 0, 0, 0, 0, 0, 0,                                      // timestamp (HW fills)
+      static_cast<uint8_t>(interval_tu & 0xff),
+      static_cast<uint8_t>((interval_tu >> 8) & 0xff),             // beacon interval
+      0x00, 0x00,                                                  // capability
+      0x00, 0x03, 'T', 'B', 'T',                                   // SSID IE "TBT"
+      0x01, 0x01, 0x82};                                          // supported rates (1M)
+
+  bool ok = dev->BeaconTbttSpike(f.data(), f.size(), interval_tu);
+  fprintf(stderr, "BeaconTbttSpike -> %s. Idling %d s (chip should self-TX at "
+                  "TBTT every %d TU ≈ %.1f ms). Watch a 2nd RX's rx.txhit.\n",
+          ok ? "OK" : "FAILED/unsupported", sec, interval_tu, interval_tu * 1.024);
+  if (!ok) return 1;
+
+  // Idle — NO send loop. Any airing frames are the hardware beacon engine.
+  std::this_thread::sleep_for(std::chrono::seconds(sec));
+  return 0;
+}

--- a/tests/beacon_ts_check.cpp
+++ b/tests/beacon_ts_check.cpp
@@ -1,0 +1,57 @@
+// Capture the canonical-SA beacon and print its 802.11 timestamp field (MPDU
+// bytes 24..31, the beacon body's first 8 bytes = the TSF the AP inserts) across
+// beacons. If the hardware inserts a live TSF, consecutive timestamps step by
+// ~102400 us (100 TU) — proving a real time-distributing beacon.
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <unistd.h>
+#include <memory>
+#include <thread>
+#include <libusb.h>
+#include "RxPacket.h"
+#include "SelectedChannel.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "env_config.h"
+#include "logger.h"
+
+static const uint8_t kSa[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
+static std::atomic<int> g_n{0};
+static uint64_t g_prev = 0;
+
+int main() {
+  auto logger = std::make_shared<Logger>();
+  libusb_context* ctx = nullptr; libusb_init(&ctx);
+  uint16_t vid = 0x0bda, pid = 0xa81a;
+  if (const char* p = std::getenv("DEVOURER_PID")) pid = (uint16_t)strtoul(p, 0, 0);
+  uint8_t ch = 6; if (const char* c = std::getenv("DEVOURER_CHANNEL")) ch = atoi(c);
+  auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
+  if (!h) { fprintf(stderr, "open fail\n"); return 1; }
+  std::shared_ptr<devourer::UsbDeviceLock> lk;
+  if (devourer::claim_interface_then_reset(h, 0, logger, true, lk) != 0) return 1;
+  WiFiDriver wifi(logger);
+  auto dev = wifi.CreateRtlDevice(h, ctx, lk, devourer_config_from_env());
+  if (!dev) return 1;
+  auto cb = [](const Packet& p) {
+    if (p.Data.size() < 32 || p.RxAtrib.crc_err) return;
+    if (std::memcmp(p.Data.data() + 10, kSa, 6) != 0) return;   // canonical SA (addr2)
+    uint64_t ts = 0; for (int i = 0; i < 8; ++i) ts |= (uint64_t)p.Data[24 + i] << (8 * i);
+    int n = ++g_n;
+    if (n <= 12) {
+      long d = g_prev ? (long)(ts - g_prev) : 0;
+      printf("beacon %2d: timestamp=%llu us   step=%ld us   (arrival tsfl=%u)\n",
+             n, (unsigned long long)ts, d, p.RxAtrib.tsfl);
+      fflush(stdout);
+    }
+    g_prev = ts;
+  };
+  std::thread rx([&] { dev->Init(cb, SelectedChannel{ch, 0, CHANNEL_WIDTH_20}); });
+  std::this_thread::sleep_for(std::chrono::seconds(8));
+  dev->StopRxLoop(); rx.join();
+  printf("== total canonical-SA beacons: %d ==\n", g_n.load());
+  _exit(0);
+}

--- a/tests/beacon_wire_check.cpp
+++ b/tests/beacon_wire_check.cpp
@@ -1,0 +1,72 @@
+// beacon_wire_check.cpp — verify devourer's hardware beacon looks like a real
+// kernel-AP beacon ON THE WIRE. For the canonical-SA beacon it prints, per
+// frame: the frame control (FC, must be 0x0080 = beacon), the 802.11
+// sequence-control field (MPDU bytes 22-23: seq[15:4] must INCREMENT by 1 per
+// beacon — the hardware sequence numbering a kernel AP does via EN_HWSEQ), and
+// the beacon-body timestamp (bytes 24-31, the live hardware TSF, steps ~102400 µs
+// at 100 TU). Bench-confirmed kernel-equivalent on both HalMAC generations:
+//   J3 8822C : seq 16,17,18,19,20,21...   ts steps ~102400 us
+//   J2 8812BU: seq 730,731,732,733...     ts steps ~102400 us
+// (A beacon whose seq is FROZEN is a degraded engine — e.g. a J2 beacon left in
+// the post-drop state after an AdjustBeaconTiming tweak, which J2 does not
+// survive; a healthy fresh beacon increments.)
+//
+// Build: g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/beacon_wire_check.cpp \
+//   examples/common/env_config.cpp build/libdevourer.a \
+//   $(pkg-config --cflags --libs libusb-1.0) -lpthread -o build/beacon_wire_check
+// Run against any devourer HW beacon airing on the channel:
+//   sudo DEVOURER_PID=<observer> DEVOURER_CHANNEL=36 build/beacon_wire_check
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <unistd.h>
+#include <memory>
+#include <thread>
+#include <libusb.h>
+#include "RxPacket.h"
+#include "SelectedChannel.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "env_config.h"
+#include "logger.h"
+
+static const uint8_t kSa[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
+static std::atomic<int> g_n{0};
+
+int main() {
+  auto logger = std::make_shared<Logger>();
+  libusb_context* ctx = nullptr; libusb_init(&ctx);
+  libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
+  uint16_t vid = 0x0bda, pid = 0xa81a;
+  if (const char* p = std::getenv("DEVOURER_PID")) pid = (uint16_t)strtoul(p, 0, 0);
+  uint8_t ch = 36; if (const char* c = std::getenv("DEVOURER_CHANNEL")) ch = atoi(c);
+  auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
+  if (!h) { fprintf(stderr, "open fail\n"); return 1; }
+  std::shared_ptr<devourer::UsbDeviceLock> lk;
+  if (devourer::claim_interface_then_reset(h, 0, logger, true, lk) != 0) return 1;
+  WiFiDriver wifi(logger);
+  auto dev = wifi.CreateRtlDevice(h, ctx, lk, devourer_config_from_env());
+  if (!dev) return 1;
+  auto cb = [](const Packet& p) {
+    if (p.Data.size() < 32 || p.RxAtrib.crc_err) return;
+    if (std::memcmp(p.Data.data() + 10, kSa, 6) != 0) return;   // canonical SA (addr2)
+    uint16_t fc = p.Data[0] | (p.Data[1] << 8);
+    uint16_t seqctl = p.Data[22] | (p.Data[23] << 8);
+    uint16_t seq = seqctl >> 4, frag = seqctl & 0xf;
+    uint64_t ts = 0; for (int i = 0; i < 8; ++i) ts |= (uint64_t)p.Data[24 + i] << (8 * i);
+    int n = ++g_n;
+    if (n <= 16) {
+      printf("beacon %2d: FC=0x%04x seq=%u frag=%u  ts=%llu us  (len=%zu)\n",
+             n, fc, seq, frag, (unsigned long long)ts, p.Data.size());
+      fflush(stdout);
+    }
+  };
+  std::thread rx([&] { dev->Init(cb, SelectedChannel{ch, 0, CHANNEL_WIDTH_20}); });
+  std::this_thread::sleep_for(std::chrono::seconds(6));
+  printf("== canonical-SA beacons seen: %d (seq should step +1, ts ~102400 us) ==\n",
+         g_n.load());
+  _exit(0);
+}

--- a/tests/golden_dump_beacon.md
+++ b/tests/golden_dump_beacon.md
@@ -1,0 +1,10 @@
+# Golden dump: rtw88_8822c IBSS beacon-enable vs devourer (8822C, ch6 capture)
+# Captured 20738 URBs; 53 beacon re-downloads in ~5s (~94ms = beacon interval).
+## Kernel does (that devourer does NOT):
+1. Re-downloads the beacon EVERY beacon interval (~94ms) — FW/driver-orchestrated, not static HW-TBTT.
+2. Sends H2C RSVD_PAGE (REG_HMEBOX0 0x1d0 = 0x690c0100, cmd 0x00) telling the FW the rsvd-page locations.
+3. BCNQ_BDNY (0x0424) = 0x9207 -> boundary page 0x207 (519); devourer computes rsvd_boundary=1938.
+4. BCN_CTRL (0x0550) cycles 0x10/0x14/0x18/0x1c across the download bracket (devourer used static 0x1e).
+5. Downloads MULTIPLE rsvd pages (beacon+probe-rsp+null) at heads 0x207/0x287/0xa287/0xab87 (0x0204|BIT15).
+## Download bracket (recurring, per beacon interval):
+   0204=0080 ; 0101(CR+1)=01 ; 0550=14 ; 0204=9287(arm head+valid) ; [bulk beacon] ; 0550=14 ; 0101=00 ; 0204=0080

--- a/tests/probe_responder.cpp
+++ b/tests/probe_responder.cpp
@@ -1,0 +1,114 @@
+// probe_responder.cpp — devourer as an AP that answers ACTIVE-SCAN probe
+// requests, like a kernel AP. Full-duplex (InitWrite + StartRxLoop, so needs a
+// clean TX+RX adapter — e.g. 8822CU): the RX callback matches a probe-request and
+// queues the requester; the MAIN thread send_packet's a probe-response (send_packet
+// must NOT be called from the RX event thread — libusb returns BUSY). No beacon is
+// aired, so a scan hit proves the RESPONSE path (userspace RX->TX ~few ms fits the
+// active-scan dwell; management-frame timing is tens of ms, unlike SIFS ACKs).
+//
+// PROVEN: a real Linux station (rtw88, wlp13s0u1u4) `iw scan` lists "devourerAP"
+// via the probe response with NO beacon — devourer answers active scans like an AP.
+// This de-risks the AP-side handshake (probe-resp -> auth -> assoc).
+//
+// Build: g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/probe_responder.cpp \
+//   examples/common/env_config.cpp build/libdevourer.a \
+//   $(pkg-config --cflags --libs libusb-1.0) -lpthread -o build/probe_responder
+// Run: sudo DEVOURER_PID=0xc812 DEVOURER_CHANNEL=6 DEVOURER_TX_WITH_RX=thread \
+//   build/probe_responder [sec]   # then `iw dev <other-kernel-if> scan freq 2437`
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <memory>
+#include <thread>
+#include <vector>
+#include <array>
+#include <unistd.h>
+#include <libusb.h>
+#include "RadiotapBuilder.h"
+#include "RxPacket.h"
+#include "SelectedChannel.h"
+#include "TxMode.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "env_config.h"
+#include "logger.h"
+
+#include <mutex>
+static const uint8_t kBssid[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
+static IRtlDevice* g_dev = nullptr;
+static std::vector<uint8_t> g_rt;   // radiotap prefix (6M)
+static uint8_t g_chan = 6;
+static std::atomic<uint64_t> g_reqs{0}, g_resps{0};
+// Requester MACs queued by the RX callback, drained by the main (TX) thread —
+// send_packet must NOT be called from the RX event thread (libusb BUSY).
+static std::mutex g_q_mu;
+static std::vector<std::array<uint8_t, 6>> g_q;
+
+static void on_rx(const Packet& p) {
+  if (p.Data.size() < 24 || p.RxAtrib.crc_err) return;
+  if (p.Data[0] != 0x40) return;                 // FC: mgmt / probe-request
+  const uint8_t* req = p.Data.data() + 10;        // addr2 = requester
+  g_reqs.fetch_add(1);
+  std::array<uint8_t, 6> a{req[0],req[1],req[2],req[3],req[4],req[5]};
+  std::lock_guard<std::mutex> lk(g_q_mu);
+  if (g_q.size() < 64) g_q.push_back(a);
+}
+
+static void send_resp(const std::array<uint8_t, 6>& req) {
+  std::vector<uint8_t> m = {
+      0x50, 0x00, 0x00, 0x00,                     // FC probe-resp + dur
+      req[0], req[1], req[2], req[3], req[4], req[5],   // addr1 = requester
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],  // addr2 = BSSID
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],  // addr3 = BSSID
+      0x00, 0x00,                                 // seq
+      0,0,0,0,0,0,0,0,                            // timestamp
+      0x64, 0x00,                                 // beacon interval 100 TU
+      0x01, 0x00,                                 // capability ESS
+      0x00, 0x0a, 'd','e','v','o','u','r','e','r','A','P',   // SSID
+      0x01, 0x08, 0x82,0x84,0x8b,0x96,0x24,0x30,0x48,0x6c,   // rates
+      0x03, 0x01, g_chan};                        // DS param
+  std::vector<uint8_t> f;
+  f.reserve(g_rt.size() + m.size());
+  f.insert(f.end(), g_rt.begin(), g_rt.end());
+  f.insert(f.end(), m.begin(), m.end());
+  if (g_dev->send_packet(f.data(), f.size())) g_resps.fetch_add(1);
+}
+
+int main(int argc, char** argv) {
+  int sec = argc > 1 ? atoi(argv[1]) : 40;
+  if (const char* c = std::getenv("DEVOURER_CHANNEL")) g_chan = (uint8_t)atoi(c);
+  auto logger = std::make_shared<Logger>();
+  apply_logging_env(*logger);
+  libusb_context* ctx = nullptr; libusb_init(&ctx);
+  libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
+  uint16_t vid = 0x0bda, pid = 0xc812;
+  if (const char* v = std::getenv("DEVOURER_VID")) vid = (uint16_t)strtoul(v, 0, 0);
+  if (const char* p = std::getenv("DEVOURER_PID")) pid = (uint16_t)strtoul(p, 0, 0);
+  auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
+  if (!h) { fprintf(stderr, "open %04x:%04x fail\n", vid, pid); return 1; }
+  std::shared_ptr<devourer::UsbDeviceLock> lk;
+  if (devourer::claim_interface_then_reset(h, 0, logger, true, lk) != 0) return 1;
+  WiFiDriver wifi(logger);
+  auto dev = wifi.CreateRtlDevice(h, ctx, lk, devourer_config_from_env());
+  g_dev = dev.get();
+  if (!g_dev) return 1;
+  g_rt = devourer::build_stream_radiotap(devourer::parse_tx_mode_str("6M"));
+  g_dev->InitWrite(SelectedChannel{g_chan, 0, CHANNEL_WIDTH_20});
+  std::thread rx([&]{ g_dev->StartRxLoop(on_rx); });
+  fprintf(stderr, "probe-responder up on ch%d (BSSID devourerAP, NO beacon). %ds.\n",
+          g_chan, sec);
+  // Main (TX) thread: drain queued requesters and answer — off the RX event thread.
+  auto end = std::chrono::steady_clock::now() + std::chrono::seconds(sec);
+  while (std::chrono::steady_clock::now() < end) {
+    std::vector<std::array<uint8_t, 6>> batch;
+    { std::lock_guard<std::mutex> lk(g_q_mu); batch.swap(g_q); }
+    for (auto& r : batch) send_resp(r);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  fprintf(stderr, "probe-reqs seen=%llu  probe-resps sent=%llu\n",
+          (unsigned long long)g_reqs.load(), (unsigned long long)g_resps.load());
+  _exit(0);
+}

--- a/tests/timesync_analyze.py
+++ b/tests/timesync_analyze.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Join two timesync SLAVE logs by beacon seq and report the inter-slave sync
+error — how well two UEs agree on the master (eNB) clock, each derived purely
+from the over-the-air beacons with no host clock or GPS.
+
+Each slave emits {"ev":"timesync.lock","seq":N,"pred_master":X,"resid_us":R,...}
+per beacon once its fit is warm. For beacons BOTH slaves predicted, |predA-predB|
+is the inter-slave error (the common master stamp jitter cancels). Each slave's
+own resid_us is its absolute lock error (bounded by that master jitter).
+
+  python3 tests/timesync_analyze.py slaveA.log slaveB.log
+"""
+import json
+import statistics
+import sys
+
+
+def load(path):
+    """seq -> (pred_master, resid_us) for timesync.lock events."""
+    out = {}
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if '"timesync.lock"' not in line:
+                continue
+            try:
+                e = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            out[e["seq"]] = (e["pred_master"], e["resid_us"])
+    return out
+
+
+def rms(xs):
+    return (sum(x * x for x in xs) / len(xs)) ** 0.5 if xs else float("nan")
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit("usage: timesync_analyze.py slaveA.log slaveB.log")
+    A, B = load(sys.argv[1]), load(sys.argv[2])
+    common = sorted(set(A) & set(B))
+    print(f"slave A locked beacons: {len(A)}")
+    print(f"slave B locked beacons: {len(B)}")
+    print(f"common beacons        : {len(common)}")
+    if len(common) < 10:
+        sys.exit("too few common beacons — were both slaves in range of the master?")
+
+    # Per-slave absolute lock error (vs the master's own broadcast).
+    for name, S in (("A", A), ("B", B)):
+        r = [abs(v[1]) for v in S.values()]
+        print(f"  slave {name} lock error : RMS {rms(r):7.2f} us   max {max(r):7.2f} us")
+
+    # Inter-slave agreement: the two UEs' independent estimates of the same
+    # beacon's master TSF. This is the headline — the common master jitter cancels.
+    diffs = [A[s][0] - B[s][0] for s in common]
+    ad = [abs(d) for d in diffs]
+    print(f"\n  inter-slave sync error: RMS {rms(diffs):7.2f} us   "
+          f"max {max(ad):7.2f} us   mean {statistics.mean(diffs):+7.2f} us")
+    print(f"  => two UEs agree on the master (eNB) clock to this, over the air, "
+          f"no GPS.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/timesync_demo.sh
+++ b/tests/timesync_demo.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# timesync bench: LTE-eNB-style over-the-air time distribution. One MASTER
+# broadcasts its hardware TSF; two SLAVES lock to it from the beacons alone (no
+# GPS, no host clock). Then join the slaves' lock streams by beacon seq to get
+# the inter-slave (inter-UE) sync error.
+#
+#   MASTER = 8812AU (0x8812)      SLAVE_A = 8822CU (0xc812)
+#                                 SLAVE_B = 8822BU (2357:012d)
+# Slaves must be Jaguar2/3 (per-frame tsfl); the master can be any TX (ReadTsf).
+#
+#   sudo tests/timesync_demo.sh [secs] [channel] [interval_ms]
+set -uo pipefail
+cd "$(dirname "$0")/.."
+SECS=${1:-30}; CH=${2:-36}; IVL=${3:-100}
+MASTER_PID=${MASTER_PID:-0x8812}
+A_VID=${A_VID:-0x0bda}; A_PID=${A_PID:-0xc812}
+B_VID=${B_VID:-0x2357}; B_PID=${B_PID:-0x012d}
+
+cleanup() { sudo pkill -9 -x timesync 2>/dev/null; }
+trap cleanup EXIT
+cleanup; sleep 2
+
+LOGA=$(mktemp); LOGB=$(mktemp)
+echo "master=$MASTER_PID  slaveA=$A_VID:$A_PID  slaveB=$B_VID:$B_PID  ch$CH  ${IVL}ms beacons  ${SECS}s"
+
+# Master: TX-only sync beacons.
+sudo env DEVOURER_PID=$MASTER_PID DEVOURER_CHANNEL=$CH DEVOURER_TSYNC_ROLE=master \
+    DEVOURER_TSYNC_INTERVAL_MS=$IVL DEVOURER_TSYNC_SECS=$((SECS + 3)) \
+    DEVOURER_LOG_LEVEL=silent DEVOURER_EVENTS=off ./build/timesync >/dev/null 2>&1 &
+sleep 3   # let the master come up before the slaves start locking
+
+# Two slaves: RX-only, each locking to the master.
+sudo env DEVOURER_VID=$A_VID DEVOURER_PID=$A_PID DEVOURER_CHANNEL=$CH \
+    DEVOURER_TSYNC_ROLE=slave DEVOURER_TSYNC_SECS=$SECS DEVOURER_LOG_LEVEL=info \
+    ./build/timesync >"$LOGA" 2>>"$LOGA" &
+sudo env DEVOURER_VID=$B_VID DEVOURER_PID=$B_PID DEVOURER_CHANNEL=$CH \
+    DEVOURER_TSYNC_ROLE=slave DEVOURER_TSYNC_SECS=$SECS DEVOURER_LOG_LEVEL=info \
+    ./build/timesync >"$LOGB" 2>>"$LOGB" &
+
+wait 2>/dev/null
+sleep 1
+
+echo "=== slave A summary ==="; grep -A6 "slave summary" "$LOGA" || echo "(no summary)"
+echo "=== slave B summary ==="; grep -A6 "slave summary" "$LOGB" || echo "(no summary)"
+echo "=== inter-slave (inter-UE) sync ==="
+python3 tests/timesync_analyze.py "$LOGA" "$LOGB"
+rm -f "$LOGA" "$LOGB"

--- a/tests/timesync_selftest.cpp
+++ b/tests/timesync_selftest.cpp
@@ -1,0 +1,111 @@
+// timesync_selftest.cpp — headless unit tests for the timesync pure logic: the
+// LinFit master↔local least-squares fit (does it recover a known crystal offset
+// and predict the master clock tightly through per-frame jitter?) and the 32→64
+// bit TSF Recon wrap handling. No hardware / no libusb — runs in ctest, unlike
+// the timesync master/slave demo which needs real adapters.
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "timesync.h"
+
+static int g_fail = 0;
+#define CHECK(cond, msg)                                                        \
+  do {                                                                          \
+    if (!(cond)) { std::printf("FAIL: %s\n", (msg)); ++g_fail; }                \
+  } while (0)
+
+int main() {
+  // The dominant on-air noise is the MASTER's software stamp→air jitter: it
+  // calls ReadTsf() then send_packet, so a beacon airs a variable δ after the
+  // stamp. δ is COMMON to every slave (same frame, same air-departure). Each
+  // slave's own hardware-TSF latch is precise (sub-µs, modeled as tiny ε).
+  const int NB = 600;
+  uint32_t ds = 3;                                   // shared master δ, ±60 µs
+  std::vector<double> delta(NB);
+  for (int i = 0; i < NB; ++i) {
+    ds = ds * 1664525u + 1013904223u;
+    delta[i] = (double)((int)((ds >> 8) % 120) - 60);
+  }
+
+  // Beacon i airs at master-clock T_i (a clean 100 ms grid) but was STAMPED
+  // δ_i earlier, so its broadcast value is master_stamp = T_i − δ_i. A slave
+  // whose crystal runs `ppm` slower than the master latches its own hardware
+  // clock local = (1 − ppm/1e6)·T at arrival (+ tiny ε latch noise).
+  auto master_stamp = [&](int i) { return (double)i * 100000.0 - delta[i]; };
+
+  // --- 1. LinFit recovers ppm; single-slave lock ~ the master stamp jitter ---
+  // A single slave cannot beat δ (it has no other reference), but the FIT must
+  // still recover the crystal ppm cleanly (δ averages out of the slope) — that's
+  // what lets inter-slave agreement (test 2) cancel δ.
+  {
+    timesync::LinFit fit;
+    const double ppm = 16.5;
+    const double g = 1.0 - ppm / 1e6;    // slave local µs per master µs (slower)
+    const double b = 987654.0;           // constant offset (prop + fixed latency)
+    uint32_t es = 91;
+    auto eps = [&]() { es = es * 1664525u + 1013904223u;
+                       return ((int)((es >> 8) % 20) - 10) * 0.05; };  // ±0.5 µs
+    double max_pred = 0;
+    for (int i = 0; i < NB; ++i) {
+      double local = g * ((double)i * 100000.0) + b + eps();  // slave hw arrival
+      double ms = master_stamp(i);                            // broadcast value
+      if (fit.ready()) {
+        double e = std::fabs(fit.at(local) - ms);
+        if (e > max_pred) max_pred = e;
+      }
+      fit.add(local, ms);
+    }
+    CHECK(fit.ready(), "fit ready after N beacons");
+    CHECK(std::fabs(fit.ppm() - ppm) < 1.0,
+          "master-vs-slave ppm recovered within 1 ppm of the true 16.5");
+    CHECK(max_pred < 120.0,
+          "single-slave lock is bounded by (does not beat) the ~60 us master jitter");
+  }
+
+  // --- 2. two slaves predicting the SAME beacon agree to sub-µs --------------
+  // The inter-UE sync metric: two slaves (different crystals, tiny independent
+  // latch noise) both predict each shared beacon. Because the master stamp
+  // jitter δ is COMMON, it cancels in the difference — so they agree far tighter
+  // than either's absolute lock. This is the real payoff (the dual-RX floor).
+  {
+    auto run_slave = [&](uint32_t seed, double ppm) {
+      timesync::LinFit fit;
+      uint32_t es = seed;
+      auto eps = [&]() { es = es * 1664525u + 1013904223u;
+                         return ((int)((es >> 8) % 20) - 10) * 0.05; };  // ±0.5 µs
+      const double g = 1.0 - ppm / 1e6;
+      std::vector<double> preds;
+      for (int i = 0; i < NB; ++i) {
+        double local = g * ((double)i * 100000.0) + 55555.0 + eps();
+        double ms = master_stamp(i);           // shared broadcast (shared δ)
+        preds.push_back(fit.ready() ? fit.at(local) : ms);
+        fit.add(local, ms);
+      }
+      return preds;
+    };
+    auto A = run_slave(11, 12.0);    // slave A: +12 ppm crystal
+    auto B = run_slave(29, -18.0);   // slave B: -18 ppm crystal
+    double max_disagree = 0;
+    for (size_t i = 50; i < A.size(); ++i) {   // after both fits warm up
+      double d = std::fabs(A[i] - B[i]);
+      if (d > max_disagree) max_disagree = d;
+    }
+    CHECK(max_disagree < 5.0,
+          "two slaves agree to sub-µs — the common master jitter cancels");
+  }
+
+  // --- 3. Recon 32→64-bit TSF wrap ------------------------------------------
+  {
+    timesync::Recon r;
+    CHECK(r(0xFFFFFF00u) == 0xFFFFFF00LL, "first sample = raw low word");
+    CHECK(r(0x00000100u) == 0x100000100LL, "wrap adds 2^32");
+    CHECK(r(0x00000200u) == 0x100000200LL, "no spurious wrap when increasing");
+  }
+
+  std::printf(g_fail ? "timesync_selftest: %d FAILURE(S)\n"
+                     : "timesync_selftest: all passed\n",
+              g_fail);
+  return g_fail ? 1 : 0;
+}

--- a/tests/timesync_selftest.cpp
+++ b/tests/timesync_selftest.cpp
@@ -96,7 +96,35 @@ int main() {
           "two slaves agree to sub-µs — the common master jitter cancels");
   }
 
-  // --- 3. Recon 32→64-bit TSF wrap ------------------------------------------
+  // --- 3. uplink timing-advance loop converges ------------------------------
+  // Model the master integrator exactly as master_ta_cb does: the UE's uplink
+  // arrives with a fixed latency offset L that must be nulled, while the UE↔
+  // master crystal offset drifts the arrival by d µs/slot. ta += gain·phase must
+  // drive the arrival phase from L down to the small drift-tracking residual
+  // (~d/gain), not diverge.
+  {
+    const double L = 520.0;      // initial arrival offset (latency), µs
+    const double d = 0.6;        // crystal drift per slot (≈30 ppm × 20 ms), µs
+    const double gain = 0.3;
+    uint32_t ns = 5;
+    auto noise = [&]() { ns = ns * 1664525u + 1013904223u;
+                         return ((int)((ns >> 8) % 20) - 10) * 0.1; };  // ±1 µs
+    double ta = 0.0, early_max = 0.0, late_ss = 0.0;
+    int late_n = 0;
+    const int STEPS = 400;
+    for (int k = 0; k < STEPS; ++k) {
+      double residual = L - ta + d * k;         // true arrival phase this slot
+      double phase = residual + noise();        // what the master measures
+      if (k < 3 && std::fabs(phase) > early_max) early_max = std::fabs(phase);
+      if (k >= STEPS - 80) { late_ss += phase * phase; ++late_n; }
+      ta += gain * phase;                        // master's TA integrator
+    }
+    CHECK(early_max > 200.0, "loop starts far off the slot boundary (~L)");
+    CHECK(std::sqrt(late_ss / late_n) < 8.0,
+          "TA loop converges: arrival locks to the slot within a few us");
+  }
+
+  // --- 4. Recon 32→64-bit TSF wrap ------------------------------------------
   {
     timesync::Recon r;
     CHECK(r(0xFFFFFF00u) == 0xFFFFFF00LL, "first sample = raw low word");

--- a/tests/timesync_ta_analyze.py
+++ b/tests/timesync_ta_analyze.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Analyze the master's timesync.ta stream: does the uplink timing-advance loop
+CONVERGE — driving each UE uplink's arrival phase onto the master's slot boundary?
+
+The master emits {"ev":"timesync.ta","n":k,"phase_us":P,"ta_us":T} per uplink.
+`phase_us` is the arrival's offset from the nearest slot boundary (what the loop
+nulls); `ta_us` is the accumulated timing advance. Convergence = the early-window
+phase RMS (loop still correcting) ≫ the late-window phase RMS (locked).
+
+  python3 tests/timesync_ta_analyze.py master.log
+"""
+import json
+import sys
+
+
+def rms(xs):
+    return (sum(x * x for x in xs) / len(xs)) ** 0.5 if xs else float("nan")
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit("usage: timesync_ta_analyze.py master.log")
+    phase, ta = [], []
+    with open(sys.argv[1]) as f:
+        for line in f:
+            if '"timesync.ta"' not in line:
+                continue
+            try:
+                e = json.loads(line.strip())
+            except json.JSONDecodeError:
+                continue
+            phase.append(e["phase_us"])
+            ta.append(e["ta_us"])
+    n = len(phase)
+    print(f"uplinks measured: {n}")
+    if n < 40:
+        sys.exit("too few uplinks — did the UE reach the master (8822E TX+RX "
+                 "desense?) and both come up full-duplex?")
+    q = max(10, n // 4)
+    early, late = phase[:q], phase[-q:]
+    mean = lambda xs: sum(xs) / len(xs)
+    # The loop nulls the systematic (DC) arrival offset; the per-uplink scatter
+    # is the UE's full-duplex TX-timing jitter and is irreducible, so track the
+    # MEAN phase (what converges) alongside the RMS (the jitter floor).
+    print(f"  first {q}: mean {mean(early):+8.1f} us   RMS {rms(early):8.1f} us")
+    print(f"  last  {q}: mean {mean(late):+8.1f} us   RMS {rms(late):8.1f} us")
+    print(f"  TA settled at {ta[-1]:+.1f} us (mod-slot)")
+    if abs(mean(late)) < max(50.0, abs(mean(early)) * 0.5):
+        print(f"  => CONVERGED: the loop pulled the mean uplink arrival onto the "
+              f"slot boundary ({mean(early):+.0f} -> {mean(late):+.0f} us).")
+    else:
+        print("  => mean arrival not clearly nulled (see raw phase series).")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/timesync_ta_demo.sh
+++ b/tests/timesync_ta_demo.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# timesync uplink timing-advance bench (LTE TA): a full-duplex MASTER broadcasts
+# beacons + phase-measures each UE uplink against its TSF slot grid, feeding back
+# a timing advance; a full-duplex UE transmits one uplink per beacon, TA-
+# corrected. The loop should drive uplink arrivals onto the slot boundary.
+#
+# BOTH nodes are full-duplex (InitWrite + StartRxLoop), so BOTH must be clean
+# Jaguar2/3 TX+RX adapters. The 8822E desenses its RX in TX+RX mode, so a run
+# with an 8822E node is best-effort (that node may hear little) — use two 8822B/
+# 8822C for a clean result.
+#
+#   MASTER = 8822CU (0xc812, clean full-duplex)   UE = 8822EU (0xa81a, best-effort)
+#
+#   sudo tests/timesync_ta_demo.sh [secs] [channel] [slot_ms]
+set -uo pipefail
+cd "$(dirname "$0")/.."
+SECS=${1:-30}; CH=${2:-36}; SLOT=${3:-20}
+M_VID=${M_VID:-0x0bda}; M_PID=${M_PID:-0xc812}
+U_VID=${U_VID:-0x0bda}; U_PID=${U_PID:-0xa81a}
+
+cleanup() { sudo pkill -9 -x timesync 2>/dev/null; }
+trap cleanup EXIT
+cleanup; sleep 2
+
+LOGM=$(mktemp); LOGU=$(mktemp)
+echo "master=$M_VID:$M_PID  ue=$U_VID:$U_PID  ch$CH  slot=${SLOT}ms  ${SECS}s (full-duplex)"
+
+# Master: full-duplex, TA loop. beacon interval = slot so each beacon is a slot.
+sudo env DEVOURER_VID=$M_VID DEVOURER_PID=$M_PID DEVOURER_CHANNEL=$CH \
+    DEVOURER_TX_WITH_RX=thread DEVOURER_TSYNC_ROLE=master DEVOURER_TSYNC_UPLINK=1 \
+    DEVOURER_TSYNC_INTERVAL_MS=$SLOT DEVOURER_TSYNC_SLOT_MS=$SLOT \
+    DEVOURER_TSYNC_SECS=$((SECS + 3)) DEVOURER_LOG_LEVEL=info DEVOURER_EVENTS=stdout \
+    ./build/timesync >"$LOGM" 2>>"$LOGM" &
+sleep 4   # master up + beaconing before the UE starts locking
+
+# UE: full-duplex, uplink one frame per beacon (TA-corrected).
+sudo env DEVOURER_VID=$U_VID DEVOURER_PID=$U_PID DEVOURER_CHANNEL=$CH \
+    DEVOURER_TX_WITH_RX=thread DEVOURER_TSYNC_ROLE=ue \
+    DEVOURER_TSYNC_INTERVAL_MS=$SLOT DEVOURER_TSYNC_SLOT_MS=$SLOT \
+    DEVOURER_TSYNC_SECS=$SECS DEVOURER_LOG_LEVEL=info \
+    ./build/timesync >"$LOGU" 2>>"$LOGU" &
+
+wait 2>/dev/null
+sleep 1
+
+echo "=== master(TA) summary ==="; grep -A5 "master(TA) summary" "$LOGM" || echo "(none)"
+echo "=== ue summary ==="; grep -A4 "ue summary" "$LOGU" || echo "(none)"
+echo "=== timing-advance convergence ==="
+python3 tests/timesync_ta_analyze.py "$LOGM"
+rm -f "$LOGM" "$LOGU"

--- a/tests/timesync_ta_demo.sh
+++ b/tests/timesync_ta_demo.sh
@@ -15,8 +15,21 @@
 set -uo pipefail
 cd "$(dirname "$0")/.."
 SECS=${1:-30}; CH=${2:-36}; SLOT=${3:-20}
-M_VID=${M_VID:-0x0bda}; M_PID=${M_PID:-0xc812}
-U_VID=${U_VID:-0x0bda}; U_PID=${U_PID:-0xa81a}
+# HWBEACON=1 : the UE airs its uplink from the beacon engine and fine-steers the
+# TBTT (AdjustBeaconTimingFine) — the CONVERGING closed loop. Needs a J3 UE (fine
+# steering) + any full-duplex master (Jaguar1 8812AU works; it needs no steering).
+HWBEACON=${HWBEACON:-0}
+if [ "$HWBEACON" = 1 ]; then
+  M_VID=${M_VID:-0x0bda}; M_PID=${M_PID:-0x8812}   # 8812AU full-duplex master
+  U_VID=${U_VID:-0x0bda}; U_PID=${U_PID:-0xc812}   # 8822CU J3 UE (fine steer)
+  INT=${INT:-100}                                   # slower UE beacon = fewer steers = tighter
+  UE_EXTRA="DEVOURER_TSYNC_HWBEACON=1"
+else
+  M_VID=${M_VID:-0x0bda}; M_PID=${M_PID:-0xc812}
+  U_VID=${U_VID:-0x0bda}; U_PID=${U_PID:-0xa81a}
+  INT=${INT:-$SLOT}                                 # beacon interval = slot
+  UE_EXTRA=""
+fi
 
 cleanup() { sudo pkill -9 -x timesync 2>/dev/null; }
 trap cleanup EXIT
@@ -25,18 +38,18 @@ cleanup; sleep 2
 LOGM=$(mktemp); LOGU=$(mktemp)
 echo "master=$M_VID:$M_PID  ue=$U_VID:$U_PID  ch$CH  slot=${SLOT}ms  ${SECS}s (full-duplex)"
 
-# Master: full-duplex, TA loop. beacon interval = slot so each beacon is a slot.
+# Master: full-duplex, TA loop.
 sudo env DEVOURER_VID=$M_VID DEVOURER_PID=$M_PID DEVOURER_CHANNEL=$CH \
     DEVOURER_TX_WITH_RX=thread DEVOURER_TSYNC_ROLE=master DEVOURER_TSYNC_UPLINK=1 \
-    DEVOURER_TSYNC_INTERVAL_MS=$SLOT DEVOURER_TSYNC_SLOT_MS=$SLOT \
+    DEVOURER_TSYNC_INTERVAL_MS=$INT DEVOURER_TSYNC_SLOT_MS=$SLOT \
     DEVOURER_TSYNC_SECS=$((SECS + 3)) DEVOURER_LOG_LEVEL=info DEVOURER_EVENTS=stdout \
     ./build/timesync >"$LOGM" 2>>"$LOGM" &
 sleep 4   # master up + beaconing before the UE starts locking
 
-# UE: full-duplex, uplink one frame per beacon (TA-corrected).
-sudo env DEVOURER_VID=$U_VID DEVOURER_PID=$U_PID DEVOURER_CHANNEL=$CH \
+# UE: full-duplex. HWBEACON=1 => hardware-beacon uplink fine-steered (converges).
+sudo env DEVOURER_VID=$U_VID DEVOURER_PID=$U_PID DEVOURER_CHANNEL=$CH $UE_EXTRA \
     DEVOURER_TX_WITH_RX=thread DEVOURER_TSYNC_ROLE=ue \
-    DEVOURER_TSYNC_INTERVAL_MS=$SLOT DEVOURER_TSYNC_SLOT_MS=$SLOT \
+    DEVOURER_TSYNC_INTERVAL_MS=$INT DEVOURER_TSYNC_SLOT_MS=$SLOT \
     DEVOURER_TSYNC_SECS=$SECS DEVOURER_LOG_LEVEL=info \
     ./build/timesync >"$LOGU" 2>>"$LOGU" &
 


### PR DESCRIPTION
## Summary

Over-the-air **time distribution** (LTE-eNB style) built on a new **hardware-timed
beacon** primitive, plus an **infrastructure AP mode** that grows on the same
beacon. A Realtek adapter driven by devourer becomes a clock source and/or a real
access point that a stock Linux `rtw88`/`mac80211` station discovers, associates
with, and exchanges traffic with — open or WPA2-PSK encrypted.

All of it rides small, generation-agnostic additions to `IRtlDevice`; the bulk of
the diff is the demo (`examples/timesync/`), docs, and experimental bench harnesses
under `tests/`. The library core is ~400 lines.

## Library API (`src/`)

New `IRtlDevice` virtuals (base no-ops; per-generation where the hardware allows):

- `StartBeacon(mpdu, len, interval_tu)` — load a beacon into the reserved page and
  enable the MAC beacon function, so the chip auto-transmits it at every TBTT,
  hardware-TSF-stamped. Jaguar2/3 (HalMAC reserved-page download); Jaguar1 returns
  `false` (no rsvd-page path).
- `ReadTsf()` / `WriteTsf()` — the 64-bit MAC TSF (adoption / uplink-TA timebase).
- `SetCcaMode(disabled)` — the EDCCA gate, so a TBTT beacon airs on schedule
  instead of after CSMA backoff (the master owns the channel).
- `AdjustBeaconTiming(µs)` / `AdjustBeaconTimingFine(µs)` — steer the beacon TBTT
  (coarse one-shot `REG_BCN_INTERVAL` tweak; µs-fine via the beacon-function toggle
  + TSF shift). **Jaguar3 only** — the Jaguar2 8822B engine drops the beacon on a
  TBTT re-latch, so J2 gates these to `0` rather than silently kill the beacon.

HAL plumbing: HalMAC `send_fw_page` gains a beacon TX-descriptor path (BMC/HWSEQ/
DISQSELSEQ + bcn-valid latch) and the reserved-page boundary is propagated from
MacInit to the FW-download stage (J2 + J3).

## Time distribution (`examples/timesync/`, `docs/time-distribution.md`)

Master → slave/UE clock distribution off the beacon TSF: **sub-µs downlink**, TSF
adoption, and a **closed-loop uplink timing advance** that converges to ~1.3 ms
(USB-actuator-jitter-limited) using the µs-fine steering.

## AP mode (`tests/ap_*`, `docs/ap-mode.md`)

Experimental harnesses that make devourer a real AP: beacon (accepted by a kernel
`iw scan` on both bands) → probe/auth/assoc responses → DHCP/ARP/ICMP, so a Linux
station associates, leases an IP, and pings it. `ap_wpa2` adds the **WPA2-PSK 4-way
handshake** (openssl) and a **software CCMP** data path — a real station connects
encrypted and pings at 0% loss.

## Validation

Bench-tested against a second Realtek adapter running stock kernel `rtw88`:
beacon accepted by `iw scan` (2.4 + 5 GHz), full open + WPA2 association, encrypted
DHCP lease and ping. Headless `ctest` (timesync selftest + existing math guards)
green; multi-platform CI builds clean.

## Scope / caveats

- `StartBeacon` is Jaguar2/3; **beacon-TBTT steering is Jaguar3-only** (gated off on
  J2). Jaguar1 has no reserved-page path.
- The AP-mode WPA2/CCMP crypto is **software** (openssl) in the test harness —
  hardware CCMP offload (J3 security TX/RX descriptor fields) is not ported.
- The `tests/ap_*` / `beacon_*` harnesses are experimental bench tools (manual-build,
  like `beacon_tbtt.cpp`), not library API; only the timesync selftest is a `ctest`.
- No regulatory enforcement — the caller owns compliance (unchanged devourer policy).
- The library reads no environment (audited — the beacon work's experimental
  `getenv` and dead state were removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
