### PR TITLE
CI: auto-collect self-tests into a `selftests` aggregate (stop hand-maintaining the mingw list)

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -140,16 +140,12 @@ jobs:
       - name: Build (library + stream demos + self-tests)
         # rxdemo / txdemo / precoder use POSIX-only APIs
         # (e.g. fork() in examples/tx/main.cpp for the DEVOURER_TX_WITH_RX path) and
-        # are not mingw targets. This job guards the stdin-driven stream demos
-        # and the headless self-tests ctest runs — every registered test's
-        # binary must be listed here, or the Test step fails it as Not Run.
-        run: >
-          cmake --build build --target
-          devourer streamtx duplex StreamStdinSelftest
-          ToneMaskSelftest BfReportDecodeSelftest SweepSpecSelftest
-          TxPowerQuantSelftest LinkHealthSelftest TxCapsSelftest TxPktPwrSelftest
-          RxQualitySelftest AdapterHealthSelftest LogEventSelftest
-          AdapterCapsSelftest TdmaTsfSelftest TimesyncSelftest TsfSyncSelftest
+        # are not mingw targets, so this job can't build the whole tree. It builds
+        # the stdin-driven stream demos plus the `selftests` aggregate — a target
+        # that depends on every *Selftest binary (collected automatically in
+        # CMakeLists.txt), so a newly-added self-test is picked up here without
+        # touching this file, and can never be skipped into a ctest "Not Run".
+        run: cmake --build build --target devourer streamtx duplex selftests
 
       - name: Test
         working-directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -609,3 +609,19 @@ if(Python3_Interpreter_FOUND)
                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/rx_tone_localize.py --self-test
     )
 endif()
+
+# --- selftest aggregate ----------------------------------------------------
+# `cmake --build build --target selftests` builds every headless test binary in
+# one go. The mingw CI job builds this instead of a hand-maintained target list:
+# it can't build the whole tree (some examples aren't mingw targets), yet `ctest`
+# runs every registered test, so a binary missing from the build is a "Not Run"
+# failure. Collected by naming convention — every selftest target ends in
+# "Selftest" — so a newly-added selftest is picked up automatically and can never
+# be silently skipped. Must sit AFTER all *Selftest targets are defined.
+add_custom_target(selftests)
+get_directory_property(_dvr_targets BUILDSYSTEM_TARGETS)
+foreach(_dvr_t IN LISTS _dvr_targets)
+    if(_dvr_t MATCHES "Selftest$")
+        add_dependencies(selftests ${_dvr_t})
+    endif()
+endforeach()


### PR DESCRIPTION
## Problem

The `build-mingw` job can't build the whole tree — `rxdemo` / `txdemo` / `precoder` use POSIX-only APIs (e.g. `fork()`), so it built a **hand-maintained list** of targets. But `ctest` runs *every* registered test, and any self-test binary missing from that list fails as **"Not Run"**.

So adding a self-test meant also remembering to edit the workflow — and forgetting broke CI the same way, repeatedly (most recently `TsfSyncSelftest` in #230).

## Fix

Add a `selftests` aggregate target that depends on **every `*Selftest` executable**, collected automatically by naming convention via `BUILDSYSTEM_TARGETS` in `CMakeLists.txt`:

```cmake
add_custom_target(selftests)
get_directory_property(_dvr_targets BUILDSYSTEM_TARGETS)
foreach(_dvr_t IN LISTS _dvr_targets)
    if(_dvr_t MATCHES "Selftest$")
        add_dependencies(selftests ${_dvr_t})
    endif()
endforeach()
```

The mingw job now builds `devourer streamtx duplex selftests` instead of the explicit list. A newly-added self-test is picked up with **no workflow edit** and can never be silently skipped into a "Not Run".

## Verified

`cmake --build build --target devourer streamtx duplex selftests` builds all 15 `*Selftest` binaries (including the Jaguar2-conditional `TxPktPwrSelftest` and `StreamStdinSelftest`); `ctest` 16/16 green. Naming convention matches every existing self-test target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)