### PR TITLE
Wi-Fi hardware-timestamping prototypes: USB RX SO_TIMESTAMPING + PCIe PHC/rtw88

### DIFF
--- a/tests/pcie_phc/Makefile
+++ b/tests/pcie_phc/Makefile
@@ -1,0 +1,13 @@
+# Out-of-tree build of the RTL8821CE TSF PHC prototype.
+#   make            # build against the running kernel
+#   make KDIR=/path # build against a specific kernel tree
+obj-m += rtl8821ce_phc.o
+
+KDIR ?= /lib/modules/$(shell uname -r)/build
+PWD  := $(shell pwd)
+
+all:
+	$(MAKE) -C $(KDIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KDIR) M=$(PWD) clean

--- a/tests/pcie_phc/README.md
+++ b/tests/pcie_phc/README.md
@@ -1,0 +1,36 @@
+# PCIe hardware-timestamping / PTP prototypes (RTL8821CE)
+
+Reference tooling behind the PCIe timing numbers in
+[`docs/timing-accuracy.md`](../../docs/timing-accuracy.md). These are kernel-side
+experiments on the Radxa X4's onboard RTL8821CE (`rtw88`), run out-of-band — they
+are **not** part of the devourer library build.
+
+## Contents
+
+- `rtl8821ce_phc.c` + `Makefile` — a passive PTP hardware clock (`/dev/ptpN`)
+  backed by the 8821CE's 802.11 MAC TSF, read over BAR2 MMIO. It does **not** bind
+  the PCI device: `rtw88` stays bound and keeps the chip alive, and the module
+  only `ioremap`s the BAR and reads the free-running TSF, exposed as a
+  disciplinable clock via `timecounter`/`cyclecounter`.
+- `validate.sh` — builds, loads, and exercises the PHC with `phc_ctl` / `phc2sys`.
+- `pcie_phc_lat.c` — measures the PHC gettime read window
+  (`PTP_SYS_OFFSET_EXTENDED`): the PCIe MMIO floor (~3.7 µs), versus tens of µs
+  for the equivalent read over USB.
+- `ptp_crosscheck.sh` — runs `ptp4l` on the board's Intel I226 Ethernet (a real
+  IEEE-1588 NIC) and cross-compares the Wi-Fi TSF PHC against it on one machine.
+- `rtw88_rx_hwtstamp.patch` — a one-hunk `rtw88` patch attaching the RX-descriptor
+  TSF to `skb_hwtstamps` before `ieee80211_rx_napi`, so a `SO_TIMESTAMPING` socket
+  reads the 802.11 hardware RX timestamp on the PCIe / `mac80211` path.
+
+## Requirements
+
+Kernel headers, `linuxptp`, and `ethtool` on the target. The MAC TSF is
+power-gated while the card is idle — bring the interface up in monitor mode (or
+associate) so the TSF is clocked before loading the PHC.
+
+## Scope
+
+These explore hardware-RX timestamping and a real PHC on the PCIe part. Two-way
+`ptp4l` over the Wi-Fi radio remains blocked on a host-reported TX-egress
+timestamp (a firmware limitation); the board's I226 Ethernet is the real-PTP
+reference. See `docs/timing-accuracy.md` for the measured results and that limit.

--- a/tests/pcie_phc/pcie_phc_lat.c
+++ b/tests/pcie_phc/pcie_phc_lat.c
@@ -1,0 +1,54 @@
+// pcie_phc_lat.c — measure the PHC gettime floor of /dev/ptpN via the
+// PTP_SYS_OFFSET_EXTENDED ioctl. Each sample brackets the driver's device read
+// with a system-clock pre/post timestamp; (post - pre) is the time the PHC
+// spends reading its hardware clock — for the RTL8821CE TSF PHC that is a BAR2
+// MMIO load. This is the number that makes a PCIe PHC "tractable": ~us and low
+// jitter, versus a ~68 us jittery USB control transfer.
+//
+// Build: cc -O2 -o pcie_phc_lat pcie_phc_lat.c
+// Run:   sudo ./pcie_phc_lat /dev/ptpN [n_samples]
+#include <fcntl.h>
+#include <linux/ptp_clock.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+static uint64_t ns(struct ptp_clock_time t) { return t.sec * 1000000000ull + t.nsec; }
+static int cmp(const void *a, const void *b) {
+  uint64_t x = *(const uint64_t *)a, y = *(const uint64_t *)b;
+  return x < y ? -1 : x > y ? 1 : 0;
+}
+
+int main(int argc, char **argv) {
+  const char *dev = argc > 1 ? argv[1] : "/dev/ptp0";
+  int n = argc > 2 ? atoi(argv[2]) : 25;
+  if (n < 1) n = 1;
+  if (n > PTP_MAX_SAMPLES) n = PTP_MAX_SAMPLES;
+
+  int fd = open(dev, O_RDONLY);
+  if (fd < 0) { perror("open ptp"); return 1; }
+
+  struct ptp_sys_offset_extended off = {0};
+  off.n_samples = n;
+  if (ioctl(fd, PTP_SYS_OFFSET_EXTENDED, &off) < 0) { perror("PTP_SYS_OFFSET_EXTENDED"); return 1; }
+
+  uint64_t *win = malloc(sizeof(uint64_t) * n);
+  double mean = 0;
+  for (int i = 0; i < n; i++) {
+    uint64_t pre = ns(off.ts[i][0]);   // system before device read
+    uint64_t post = ns(off.ts[i][2]);  // system after device read
+    win[i] = post - pre;
+    mean += win[i];
+  }
+  mean /= n;
+  qsort(win, n, sizeof(uint64_t), cmp);
+  printf("PHC gettime read window over %d samples (%s):\n", n, dev);
+  printf("  mean=%.0f ns  p50=%llu ns  p99=%llu ns  min=%llu ns  max=%llu ns\n",
+         mean, (unsigned long long)win[n / 2], (unsigned long long)win[n * 99 / 100],
+         (unsigned long long)win[0], (unsigned long long)win[n - 1]);
+  // Also show the device (PHC) time from the middle sample, for sanity.
+  printf("  phc time (mid sample) = %llu ns\n", (unsigned long long)ns(off.ts[n / 2][1]));
+  return 0;
+}

--- a/tests/pcie_phc/ptp_crosscheck.sh
+++ b/tests/pcie_phc/ptp_crosscheck.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# ptp_crosscheck.sh — on the radxa-x4, (1) show the Intel I226 Ethernet doing
+# real IEEE-1588 hardware PTP, and (2) cross-compare the 8821CE Wi-Fi TSF PHC
+# against that real PTP clock on the SAME machine — quantifying the Wi-Fi TSF's
+# frequency error and short-term stability versus genuine PTP hardware, with no
+# second machine and no network dependency.
+#
+#   sudo tests/pcie_phc/ptp_crosscheck.sh
+set -uo pipefail
+cd "$(dirname "$0")"
+ETH=enp2s0
+WIF=wlp1s0
+MOD=rtl8821ce_phc
+
+cleanup() {
+  echo "[xchk] cleanup"
+  sudo pkill -x ptp4l phc2sys 2>/dev/null
+  sudo rmmod "$MOD" 2>/dev/null
+  sudo ip link set "$WIF" down 2>/dev/null
+  sudo iw dev "$WIF" set type managed 2>/dev/null
+  sudo ip link set "$WIF" up 2>/dev/null
+  command -v nmcli >/dev/null && sudo nmcli dev set "$WIF" managed yes 2>/dev/null
+}
+trap cleanup EXIT
+
+# --- find the igc (Ethernet) PHC ---
+IGC_PTP=""
+for d in /sys/class/ptp/ptp*; do
+  n=$(cat "$d/clock_name" 2>/dev/null)
+  case "$n" in
+    rtl8821ce_tsf) : ;;                        # skip ours if already loaded
+    *) [ -e "/dev/$(basename "$d")" ] && IGC_PTP="/dev/$(basename "$d")" ;;
+  esac
+done
+echo "[xchk] Ethernet (I226) PHC = ${IGC_PTP:-<none>}"
+
+# --- 1. prove the I226 does hardware-timestamped PTP ---
+echo "[xchk] === ptp4l on $ETH (I226): does it use HARDWARE timestamping? ==="
+sudo timeout 8 ptp4l -i "$ETH" -m 2>&1 | grep -iE "clock|hardware|selected|MASTER|assuming|state" | head -6 || true
+
+# --- put the Wi-Fi MAC in monitor mode so the TSF ticks, then load our PHC ---
+echo "[xchk] arming Wi-Fi TSF PHC"
+sudo pkill -x wpa_supplicant 2>/dev/null
+command -v nmcli >/dev/null && sudo nmcli dev set "$WIF" managed no 2>/dev/null
+sleep 1
+sudo ip link set "$WIF" down; sudo iw dev "$WIF" set type monitor 2>/dev/null; sudo ip link set "$WIF" up
+sudo iw dev "$WIF" set channel 6 2>/dev/null
+sleep 1
+make -s >/dev/null 2>&1
+sudo rmmod "$MOD" 2>/dev/null
+sudo insmod "./$MOD.ko" || { echo "[xchk] PHC insmod failed"; exit 1; }
+sleep 1
+WIF_PTP=""
+for d in /sys/class/ptp/ptp*; do
+  [ "$(cat "$d/clock_name" 2>/dev/null)" = "rtl8821ce_tsf" ] && WIF_PTP="/dev/$(basename "$d")"
+done
+echo "[xchk] Wi-Fi TSF PHC = ${WIF_PTP:-<none>}"
+[ -z "$WIF_PTP" ] && { echo "[xchk] no Wi-Fi PHC"; exit 1; }
+[ -z "$IGC_PTP" ] && { echo "[xchk] no Ethernet PHC to compare against"; exit 1; }
+
+# --- 2. cross-compare: discipline the Wi-Fi PHC to the I226 hardware clock.
+# The Wi-Fi PHC is the slave (system + I226 untouched). Steady-state:
+#   'freq' ~= the Wi-Fi crystal's frequency error vs the I226 (ppb)
+#   'offset' jitter ~= the Wi-Fi TSF short-term stability vs real PTP hardware ---
+echo "[xchk] === phc2sys: Wi-Fi TSF ($WIF_PTP) vs real PTP hardware ($IGC_PTP), ~25 s ==="
+sudo timeout 27 phc2sys -s "$IGC_PTP" -c "$WIF_PTP" -O 0 -m 2>&1 | grep -iE "offset" | tail -20 || true
+echo "[xchk] done"

--- a/tests/pcie_phc/rtl8821ce_phc.c
+++ b/tests/pcie_phc/rtl8821ce_phc.c
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * rtl8821ce_phc — a PTP Hardware Clock backed by the RTL8821CE's 802.11 MAC TSF,
+ * read over PCIe BAR2 MMIO.
+ *
+ * Prototype demonstrating the claim that "a real PHC becomes tractable on PCIe":
+ * the 802.11 TSF (REG_TSFTR, a free-running ~1 MHz MAC counter latched inside
+ * the hardware, below the CSMA/queueing layer) is the same clock a PTP NIC would
+ * expose. Over USB a PHC gettime would be a ~68 us jittery control transfer; over
+ * PCIe it is a plain MMIO load (~us, low jitter), so a genuine /dev/ptpN that
+ * ptp4l/phc_ctl can open and discipline is practical.
+ *
+ * Design: this is a *passive* observer. It does NOT bind the PCI device or claim
+ * its BAR — the in-tree rtw88 driver keeps the chip powered and the TSF ticking.
+ * We only ioremap BAR2 and read a read-only status register, which is safe to do
+ * concurrently. It exposes the TSF as a disciplinable clock via the standard
+ * timecounter/cyclecounter machinery (software adjfine/adjtime — the silicon has
+ * no hardware frequency knob), so phc2sys/ptp4l can steer it like any PHC.
+ *
+ * Scope / honesty: this proves the clock-source + gettime half. It does not add
+ * TX/RX hardware timestamping to the wifi frames (that belongs in rtw88's
+ * data path and, for TX egress, is firmware-limited). A production version folds
+ * this into rtw88 and points the netdev's ethtool get_ts_info at this phc_index.
+ */
+#include <linux/delay.h>
+#include <linux/io.h>
+#include <linux/module.h>
+#include <linux/pci.h>
+#include <linux/ptp_clock_kernel.h>
+#include <linux/spinlock.h>
+#include <linux/timecounter.h>
+#include <linux/workqueue.h>
+
+#define RTL_VENDOR	0x10ec
+#define RTL_8821CE	0xc821
+#define RTL_BAR		2
+#define REG_TSFTR	0x560		/* 64-bit MAC TSF: low @0x560, high @0x564 */
+#define CC_SHIFT	20		/* fractional-ns headroom for adjfine (~1 ppb) */
+
+struct rtl_phc {
+	struct pci_dev *pdev;
+	void __iomem *bar;
+	struct cyclecounter cc;
+	struct timecounter tc;
+	u32 nominal_mult;
+	spinlock_t lock;		/* guards tc/cc */
+	struct ptp_clock *ptp;
+	struct ptp_clock_info info;
+	struct delayed_work keepalive;	/* periodic read to bound timecounter drift */
+};
+
+static u64 rtl_cc_read(const struct cyclecounter *cc)
+{
+	struct rtl_phc *p = container_of(cc, struct rtl_phc, cc);
+	u32 lo = ioread32(p->bar + REG_TSFTR);
+	u32 hi = ioread32(p->bar + REG_TSFTR + 4);
+
+	return ((u64)hi << 32) | lo;
+}
+
+static int rtl_gettimex(struct ptp_clock_info *info, struct timespec64 *ts,
+			struct ptp_system_timestamp *sts)
+{
+	struct rtl_phc *p = container_of(info, struct rtl_phc, info);
+	unsigned long flags;
+	u64 ns;
+
+	spin_lock_irqsave(&p->lock, flags);
+	ptp_read_system_prets(sts);
+	ns = timecounter_read(&p->tc);		/* MMIO read happens inside */
+	ptp_read_system_postts(sts);
+	spin_unlock_irqrestore(&p->lock, flags);
+
+	*ts = ns_to_timespec64(ns);
+	return 0;
+}
+
+static int rtl_settime(struct ptp_clock_info *info, const struct timespec64 *ts)
+{
+	struct rtl_phc *p = container_of(info, struct rtl_phc, info);
+	unsigned long flags;
+
+	spin_lock_irqsave(&p->lock, flags);
+	timecounter_init(&p->tc, &p->cc, timespec64_to_ns(ts));
+	spin_unlock_irqrestore(&p->lock, flags);
+	return 0;
+}
+
+static int rtl_adjtime(struct ptp_clock_info *info, s64 delta)
+{
+	struct rtl_phc *p = container_of(info, struct rtl_phc, info);
+	unsigned long flags;
+
+	spin_lock_irqsave(&p->lock, flags);
+	timecounter_adjtime(&p->tc, delta);
+	spin_unlock_irqrestore(&p->lock, flags);
+	return 0;
+}
+
+static int rtl_adjfine(struct ptp_clock_info *info, long scaled_ppm)
+{
+	struct rtl_phc *p = container_of(info, struct rtl_phc, info);
+	bool neg = scaled_ppm < 0;
+	unsigned long flags;
+	u64 diff;
+
+	if (neg)
+		scaled_ppm = -scaled_ppm;
+	/* scaled_ppm is ppm * 2^16; diff = nominal_mult * scaled_ppm / (1e6 * 2^16) */
+	diff = mul_u64_u64_div_u64(p->nominal_mult, (u64)scaled_ppm,
+				   1000000ULL << 16);
+
+	spin_lock_irqsave(&p->lock, flags);
+	timecounter_read(&p->tc);		/* accumulate at the old rate first */
+	p->cc.mult = neg ? p->nominal_mult - diff : p->nominal_mult + diff;
+	spin_unlock_irqrestore(&p->lock, flags);
+	return 0;
+}
+
+static int rtl_enable(struct ptp_clock_info *info,
+		      struct ptp_clock_request *req, int on)
+{
+	return -EOPNOTSUPP;			/* no PPS / pins on this part */
+}
+
+static void rtl_keepalive(struct work_struct *w)
+{
+	struct rtl_phc *p = container_of(w, struct rtl_phc, keepalive.work);
+	unsigned long flags;
+
+	spin_lock_irqsave(&p->lock, flags);
+	timecounter_read(&p->tc);		/* bound cyc-delta so mult math can't overflow */
+	spin_unlock_irqrestore(&p->lock, flags);
+	schedule_delayed_work(&p->keepalive, 30 * HZ);
+}
+
+static struct rtl_phc *g_phc;
+
+static int __init rtl_phc_init(void)
+{
+	struct pci_dev *pdev;
+	struct rtl_phc *p;
+	resource_size_t phys, len;
+	u64 t0, t1;
+	int ret;
+
+	pdev = pci_get_device(RTL_VENDOR, RTL_8821CE, NULL);
+	if (!pdev) {
+		pr_err("rtl8821ce_phc: no %04x:%04x found\n", RTL_VENDOR, RTL_8821CE);
+		return -ENODEV;
+	}
+
+	p = kzalloc(sizeof(*p), GFP_KERNEL);
+	if (!p) {
+		ret = -ENOMEM;
+		goto err_put;
+	}
+	p->pdev = pdev;
+	spin_lock_init(&p->lock);
+
+	phys = pci_resource_start(pdev, RTL_BAR);
+	len = pci_resource_len(pdev, RTL_BAR);
+	if (!phys || len < REG_TSFTR + 8) {
+		pr_err("rtl8821ce_phc: BAR%d unexpected (start=%pa len=%pa)\n",
+		       RTL_BAR, &phys, &len);
+		ret = -ENODEV;
+		goto err_free;
+	}
+	/* Deliberately not request_mem_region(): rtw88 owns the BAR; we only read. */
+	p->bar = ioremap(phys, len);
+	if (!p->bar) {
+		ret = -ENOMEM;
+		goto err_free;
+	}
+	p->cc.read = rtl_cc_read;
+
+	/* DEBUG: dump a few registers to confirm the BAR mapping and find a live
+	 * counter. 0x00/0xF0 are low MAC regs; 0x560/0x564 the port0 TSF. */
+	pr_info("rtl8821ce_phc: regdump 0x00=%08x 0x04=%08x 0xF0=%08x 0x1C0=%08x 0x554=%08x 0x560=%08x 0x564=%08x\n",
+		ioread32(p->bar + 0x00), ioread32(p->bar + 0x04),
+		ioread32(p->bar + 0xF0), ioread32(p->bar + 0x1C0),
+		ioread32(p->bar + 0x554), ioread32(p->bar + 0x560),
+		ioread32(p->bar + 0x564));
+
+	/* Liveness: confirm the TSF is actually ticking before we register. */
+	t0 = rtl_cc_read(&p->cc);
+	mdelay(50);
+	t1 = rtl_cc_read(&p->cc);
+	pr_info("rtl8821ce_phc: TSF %llu -> %llu us over ~50 ms (advanced %lld)\n",
+		t0, t1, (long long)(t1 - t0));
+	if (t1 <= t0)
+		pr_warn("rtl8821ce_phc: TSF not advancing yet (idle/unassociated?) — registering anyway for debug\n");
+
+	/* TSF ticks at 1 MHz => 1 cycle = 1000 ns. Encode with CC_SHIFT of
+	 * fractional headroom so adjfine has ~ppb resolution. */
+	p->cc.mask = CYCLECOUNTER_MASK(64);
+	p->cc.shift = CC_SHIFT;
+	p->cc.mult = 1000U << CC_SHIFT;
+	p->nominal_mult = p->cc.mult;
+	timecounter_init(&p->tc, &p->cc, ktime_get_real_ns());
+
+	p->info = (struct ptp_clock_info){
+		.owner		= THIS_MODULE,
+		.name		= "rtl8821ce_tsf",
+		.max_adj	= 100000000,	/* software mult; generous */
+		.gettimex64	= rtl_gettimex,
+		.settime64	= rtl_settime,
+		.adjtime	= rtl_adjtime,
+		.adjfine	= rtl_adjfine,
+		.enable		= rtl_enable,
+	};
+
+	p->ptp = ptp_clock_register(&p->info, &pdev->dev);
+	if (IS_ERR(p->ptp)) {
+		ret = PTR_ERR(p->ptp);
+		pr_err("rtl8821ce_phc: ptp_clock_register failed: %d\n", ret);
+		goto err_unmap;
+	}
+	pr_info("rtl8821ce_phc: registered /dev/ptp%d on %s\n",
+		ptp_clock_index(p->ptp), pci_name(pdev));
+
+	INIT_DELAYED_WORK(&p->keepalive, rtl_keepalive);
+	schedule_delayed_work(&p->keepalive, 30 * HZ);
+	g_phc = p;
+	return 0;
+
+err_unmap:
+	iounmap(p->bar);
+err_free:
+	kfree(p);
+err_put:
+	pci_dev_put(pdev);
+	return ret;
+}
+
+static void __exit rtl_phc_exit(void)
+{
+	struct rtl_phc *p = g_phc;
+
+	if (!p)
+		return;
+	cancel_delayed_work_sync(&p->keepalive);
+	ptp_clock_unregister(p->ptp);
+	iounmap(p->bar);
+	pci_dev_put(p->pdev);
+	kfree(p);
+	g_phc = NULL;
+}
+
+module_init(rtl_phc_init);
+module_exit(rtl_phc_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("PTP hardware clock backed by the RTL8821CE 802.11 MAC TSF over PCIe");
+MODULE_AUTHOR("devourer");

--- a/tests/pcie_phc/rtw88_rx_hwtstamp.patch
+++ b/tests/pcie_phc/rtw88_rx_hwtstamp.patch
@@ -1,0 +1,28 @@
+rtw88: surface the MAC RX TSF to SO_TIMESTAMPING on the PCIe path
+
+rtw88 already extracts the RX-descriptor TSF into rx_status->mactime (rx.c),
+which mac80211 turns into the radiotap TSFT on monitor interfaces. But that
+never reaches a data socket's SO_TIMESTAMPING, because mac80211 does not attach
+the skb hardware timestamp for frames delivered up the netdev.
+
+Attach it in the driver, right before handing the skb to mac80211: the same
+MAC-latched TSF (pkt_stat.tsf_low, us) becomes skb_hwtstamps()->hwtstamp, so a
+SO_TIMESTAMPING/RAW_HARDWARE consumer reads the 802.11 hardware RX timestamp —
+the honest apples-vs-apples primitive, now on the PCIe transport too. It is a
+free-running counter (RAW_HARDWARE, 32-bit us wrap), not CLOCK_REALTIME.
+
+This is the PCIe/mac80211 parallel to the USB full-MAC rtl88x2cu change.
+
+--- a/drivers/net/wireless/realtek/rtw88/pci.c
++++ b/drivers/net/wireless/realtek/rtw88/pci.c
+@@ -1090,6 +1090,9 @@
+ 			rtw_update_rx_freq_for_invalid(rtwdev, new, &rx_status, &pkt_stat);
+ 			rtw_rx_stats(rtwdev, pkt_stat.vif, new);
+ 			memcpy(new->cb, &rx_status, sizeof(rx_status));
++			/* surface the MAC RX TSF (latched in hw at receive) to
++			 * SO_TIMESTAMPING; RAW_HARDWARE, free-running us->ns */
++			skb_hwtstamps(new)->hwtstamp =
++				ns_to_ktime((u64)pkt_stat.tsf_low * NSEC_PER_USEC);
+ 			ieee80211_rx_napi(rtwdev->hw, NULL, new, napi);
+ 			rx_done++;
+ 		}

--- a/tests/pcie_phc/validate.sh
+++ b/tests/pcie_phc/validate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# validate.sh — build, load, and exercise the RTL8821CE TSF PHC prototype.
+# Run ON the radxa-x4 (the 8821CE host). rtw88 stays bound throughout; this
+# module is a passive BAR2 reader.
+#
+# The MAC clock domain (which holds the TSF at 0x560) is power-gated by rtw88
+# when the card is idle/unassociated — registers there read 0xEAEAEAEA and the
+# TSF is frozen. Putting the card in MONITOR mode keeps the MAC RX continuously
+# clocked, so the TSF free-runs cleanly (associated mode works too, and also
+# syncs it to the AP). We use monitor mode here because it needs no credentials.
+#
+#   sudo tests/pcie_phc/validate.sh
+set -uo pipefail
+cd "$(dirname "$0")"
+MOD=rtl8821ce_phc
+IF=wlp1s0
+PTP=""
+
+cleanup() {
+  echo "[phc] cleanup"
+  sudo rmmod "$MOD" 2>/dev/null
+  # restore the interface to managed + re-enable networking management
+  sudo ip link set "$IF" down 2>/dev/null
+  sudo iw dev "$IF" set type managed 2>/dev/null
+  sudo ip link set "$IF" up 2>/dev/null
+  command -v nmcli >/dev/null && sudo nmcli dev set "$IF" managed yes 2>/dev/null
+}
+trap cleanup EXIT
+
+# --- put the card in monitor mode so the MAC (and TSF) stays clocked ---
+echo "[phc] setting $IF to monitor mode (keeps the MAC/TSF clocked)"
+sudo pkill -x wpa_supplicant 2>/dev/null
+command -v nmcli >/dev/null && sudo nmcli dev set "$IF" managed no 2>/dev/null
+sleep 1
+sudo ip link set "$IF" down
+sudo iw dev "$IF" set type monitor 2>&1 | head -1
+sudo ip link set "$IF" up
+sudo iw dev "$IF" set channel 6 2>&1 | head -1
+sleep 1
+
+# --- build ---
+echo "[phc] building module + tools"
+make clean >/dev/null 2>&1
+make 2>&1 | grep -iE "error|warning|\.ko" | head || true
+[ -f "$MOD.ko" ] || { echo "[phc] build failed"; exit 1; }
+cc -O2 -o pcie_phc_lat pcie_phc_lat.c || { echo "[phc] lat build failed"; exit 1; }
+
+# --- load ---
+sudo rmmod "$MOD" 2>/dev/null
+sudo dmesg -C
+echo "[phc] insmod $MOD.ko"
+sudo insmod "./$MOD.ko" || { echo "[phc] insmod failed"; dmesg | tail -5; exit 1; }
+sleep 1
+echo "[phc] === dmesg ==="
+sudo dmesg | grep rtl8821ce_phc | tail -4
+PTP=$(sudo dmesg | grep -oE '/dev/ptp[0-9]+' | tail -1)
+[ -z "$PTP" ] && { echo "[phc] no /dev/ptp registered"; exit 1; }
+echo "[phc] PHC device: $PTP"
+
+# --- ethtool -T style capability via the PHC index; confirm it advances ---
+if command -v phc_ctl >/dev/null; then
+  echo "[phc] === phc_ctl: clock advances in real time? (two reads ~1 s apart) ==="
+  sudo phc_ctl "$PTP" get 2>&1 | sed 's/^/  /'
+  sleep 1.0
+  sudo phc_ctl "$PTP" get 2>&1 | sed 's/^/  /'   # ~1.0 s later
+  echo "[phc] === write ops: set 0 / adj +5 s / freq +1000 ppm ==="
+  sudo phc_ctl "$PTP" set 0.0 get 2>&1 | sed 's/^/  /'
+  sudo phc_ctl "$PTP" adj 5.0 get 2>&1 | sed 's/^/  /'
+  sudo phc_ctl "$PTP" freq 1000000 freq 2>&1 | sed 's/^/  /'
+fi
+
+# --- the money metric: PHC gettime read window (the PCIe MMIO floor) ---
+echo "[phc] === gettime read-window latency (PTP_SYS_OFFSET_EXTENDED) ==="
+sudo ./pcie_phc_lat "$PTP" 25
+
+# --- discipline the PHC from CLOCK_REALTIME as a real consumer (PHC is slave,
+#     so the system clock is untouched); the offset should settle ---
+if command -v phc2sys >/dev/null; then
+  echo "[phc] === phc2sys disciplining the PHC from CLOCK_REALTIME ~5 s ==="
+  sudo timeout 6 phc2sys -s CLOCK_REALTIME -c "$PTP" -O 0 -m 2>&1 | grep -iE "offset" | head -5 || true
+fi
+echo "[phc] done"

--- a/tests/pcie_tsf_read.c
+++ b/tests/pcie_tsf_read.c
@@ -1,0 +1,80 @@
+// pcie_tsf_read.c — read the RTL8821CE MAC TSF directly over PCIe BAR2 MMIO,
+// from userspace, while the in-tree rtw88 driver keeps the chip alive.
+//
+// Purpose: de-risk / demonstrate the "a real PHC is tractable on PCIe" claim.
+// The 802.11 TSF (REG_TSFTR, 0x560/0x564; a free-running ~1 MHz MAC counter)
+// is the same hardware clock a PTP hardware clock would expose. Over PCIe it is
+// a plain MMIO load (~µs, low jitter) — versus a ~68 µs jittery USB control
+// transfer. This reads it N times, confirms it advances at real time, and
+// reports the per-read latency distribution (the PHC gettime floor).
+//
+// It maps the BAR read-only and only touches a read-only status register, so it
+// is safe to run concurrently with rtw88.
+//
+// Build: cc -O2 -o pcie_tsf_read tests/pcie_tsf_read.c
+// Run:   sudo ./pcie_tsf_read [/sys/bus/pci/devices/0000:01:00.0/resource2] [N]
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <time.h>
+#include <unistd.h>
+
+#define REG_TSFTR 0x560u
+#define BAR_LEN   0x10000u
+
+static uint64_t read_tsf(volatile uint8_t *bar) {
+  uint32_t lo = *(volatile uint32_t *)(bar + REG_TSFTR);
+  uint32_t hi = *(volatile uint32_t *)(bar + REG_TSFTR + 4);
+  return ((uint64_t)hi << 32) | lo;
+}
+
+static int cmp_u64(const void *a, const void *b) {
+  uint64_t x = *(const uint64_t *)a, y = *(const uint64_t *)b;
+  return x < y ? -1 : x > y ? 1 : 0;
+}
+
+int main(int argc, char **argv) {
+  const char *path = argc > 1 ? argv[1] : "/sys/bus/pci/devices/0000:01:00.0/resource2";
+  int N = argc > 2 ? atoi(argv[2]) : 2000;
+  if (N < 10) N = 10;
+
+  int fd = open(path, O_RDONLY | O_SYNC);
+  if (fd < 0) { perror("open resource2"); return 1; }
+  volatile uint8_t *bar = mmap(NULL, BAR_LEN, PROT_READ, MAP_SHARED, fd, 0);
+  if (bar == MAP_FAILED) { perror("mmap"); return 1; }
+
+  // Liveness: read twice ~200 ms apart, expect ~200000 us of advance.
+  uint64_t t0 = read_tsf(bar);
+  struct timespec sl = {0, 200000000};
+  nanosleep(&sl, NULL);
+  uint64_t t1 = read_tsf(bar);
+  printf("TSF #1 = %llu us\nTSF #2 = %llu us   (advanced %lld us over ~200 ms)\n",
+         (unsigned long long)t0, (unsigned long long)t1, (long long)(t1 - t0));
+  if (t1 <= t0) {
+    printf("FAIL: TSF not advancing (chip powered down / MAC clock off?)\n");
+    return 1;
+  }
+
+  // Latency: time N back-to-back reads (the PHC gettime floor).
+  uint64_t *lat = malloc(sizeof(uint64_t) * N);
+  for (int i = 0; i < N; i++) {
+    struct timespec a, b;
+    clock_gettime(CLOCK_MONOTONIC, &a);
+    (void)read_tsf(bar);
+    clock_gettime(CLOCK_MONOTONIC, &b);
+    lat[i] = (b.tv_sec - a.tv_sec) * 1000000000ull + (b.tv_nsec - a.tv_nsec);
+  }
+  qsort(lat, N, sizeof(uint64_t), cmp_u64);
+  double mean = 0;
+  for (int i = 0; i < N; i++) mean += lat[i];
+  mean /= N;
+  printf("BAR2 MMIO TSF read latency over %d samples:\n", N);
+  printf("  mean=%.0f ns  p50=%llu ns  p99=%llu ns  min=%llu ns  max=%llu ns\n",
+         mean, (unsigned long long)lat[N / 2], (unsigned long long)lat[N * 99 / 100],
+         (unsigned long long)lat[0], (unsigned long long)lat[N - 1]);
+  printf("PASS: TSF live and readable over PCIe MMIO (this is the PHC clock source)\n");
+  return 0;
+}

--- a/tests/rx_hwtstamp_onair.sh
+++ b/tests/rx_hwtstamp_onair.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# rx_hwtstamp_onair.sh — end-to-end on-air VALUE validation of the
+# CONFIG_RTW_HWTSTAMP prototype (reference/rtl88x2cu): read the MAC RX TSF back
+# through SO_TIMESTAMPING off real over-the-air traffic, no external AP/secrets.
+#
+# Closed loop, entirely on this rig:
+#   AP      = a devourer OPEN AP (tests/ap_responder.cpp) on a J2/J3 adapter
+#             (default 8822BU 2357:012d) — beacons + DHCP + ICMP responder.
+#   STATION = the 8822CU (0bda:c812) driven by the PATCHED vendor driver.
+# The station associates (open), gets a DHCP lease from devourer, pings the AP,
+# and tests/rx_hwtstamp_probe reads the raw-hardware RX timestamp off the ICMP
+# replies. Advancing ~µs-granular timestamps = the MAC TSF surfaced through the
+# stock kernel API — the honest apples-vs-apples half of docs/timing-accuracy.md.
+#
+#   sudo tests/rx_hwtstamp_onair.sh
+set -uo pipefail
+cd "$(dirname "$0")/.."
+KO=reference/rtl88x2cu/88x2cu_ohd.ko
+STA_PID=c812                       # 8822CU station (patched driver)
+AP_VID=${AP_VID:-0x2357}; AP_PID=${AP_PID:-0x012d}   # 8822BU devourer AP
+CH=${CH:-6}; TU=${TU:-25}; APIP=192.168.99.1
+STA_IF=""
+
+log(){ echo "[hwts-onair] $*"; }
+cleanup(){
+  log "cleanup"
+  sudo pkill -9 -x apr_hwts wpa_supplicant rx_hwtstamp_probe 2>/dev/null
+  [ -n "$STA_IF" ] && { sudo ip addr flush dev "$STA_IF" 2>/dev/null; sudo iw dev "$STA_IF" disconnect 2>/dev/null; sudo dhcpcd -x "$STA_IF" 2>/dev/null; }
+  sudo rmmod 88x2cu_ohd 2>/dev/null
+  sudo modprobe rtw88_8822cu 2>/dev/null; sudo modprobe rtw88_8822bu 2>/dev/null
+  rm -f /tmp/apr_hwts "$WPA" "$LOG" 2>/dev/null
+}
+WPA=$(mktemp); LOG=$(mktemp)
+trap cleanup EXIT
+
+# --- build probe + AP responder ---
+mkdir -p build
+cc -O2 -o build/rx_hwtstamp_probe tests/rx_hwtstamp_probe.c || { log "probe build failed"; exit 1; }
+[ -f build/libdevourer.a ] || { log "build/libdevourer.a missing — cmake --build build first"; exit 1; }
+g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/ap_responder.cpp \
+    examples/common/env_config.cpp build/libdevourer.a \
+    $(pkg-config --cflags --libs libusb-1.0) -lpthread -o /tmp/apr_hwts || { log "ap build failed"; exit 1; }
+[ -f "$KO" ] || { log "missing $KO — build the patched module first"; exit 1; }
+
+# --- load patched driver on the station (8822CU) ---
+sudo pkill -9 -x apr_hwts wpa_supplicant 2>/dev/null
+log "loading patched $KO on 8822CU"
+sudo modprobe -r rtw88_8822cu 2>/dev/null; sleep 1
+sudo insmod "$KO" || { log "insmod failed"; exit 1; }
+sleep 3
+for i in $(seq 1 10); do
+  STA_IF=$(for d in /sys/class/net/*; do drv=$(readlink -f "$d/device/driver" 2>/dev/null); case "$drv" in *88x2cu*) basename "$d";; esac; done | head -1)
+  [ -n "$STA_IF" ] && break; sleep 1
+done
+[ -z "$STA_IF" ] && { log "no station netdev"; exit 1; }
+log "station iface: $STA_IF"
+sudo ip link set "$STA_IF" up; sleep 1
+sudo ethtool -T "$STA_IF" 2>&1 | grep -qi hardware-receive && log "capability OK (hardware-receive advertised)" || { log "capability FAIL"; exit 1; }
+
+# --- start devourer open AP on the 8822BU ---
+printf 'network={\n\tssid="devourerAP"\n\tkey_mgmt=NONE\n\tscan_ssid=1\n}\n' > "$WPA"
+log "starting devourer open AP $AP_VID:$AP_PID ch$CH"
+sudo env DEVOURER_VID=$AP_VID DEVOURER_PID=$AP_PID DEVOURER_CHANNEL=$CH DEVOURER_BCN_TU=$TU \
+    DEVOURER_TX_WITH_RX=thread /tmp/apr_hwts 60 2>"$LOG" &
+sleep 5
+
+# --- associate (open) + DHCP ---
+sudo wpa_supplicant -i "$STA_IF" -c "$WPA" -B >/dev/null 2>&1
+for i in $(seq 1 15); do
+  sudo iw dev "$STA_IF" link 2>&1 | grep -qE 'Connected to' && { log "associated (after ${i}s)"; break; }
+  sleep 1
+done
+sudo ip addr flush dev "$STA_IF" 2>/dev/null
+if command -v dhcpcd >/dev/null; then sudo timeout 20 dhcpcd -4 -1 -t 18 "$STA_IF" 2>&1 | grep -iE "offered|leased" | sed 's/^/-- /'
+else sudo ip addr add 192.168.99.2/24 dev "$STA_IF"; fi
+log "station IP: $(ip -4 -o addr show "$STA_IF" | grep -oE '192\.168\.99\.[0-9]+' | head -1)"
+
+# --- generate RX traffic (ICMP replies land as data frames on the station) ---
+sudo ping -c1 -W2 -I "$STA_IF" "$APIP" >/dev/null 2>&1   # warm ARP
+( sudo ping -i 0.05 -c 200 -W1 -I "$STA_IF" "$APIP" >/dev/null 2>&1 ) &
+
+# --- read RX hardware timestamps off that traffic ---
+log "=== rx_hwtstamp_probe $STA_IF ==="
+sudo ./build/rx_hwtstamp_probe "$STA_IF" 20
+RC=$?
+log "on-air value check rc=$RC"
+exit $RC

--- a/tests/rx_hwtstamp_probe.c
+++ b/tests/rx_hwtstamp_probe.c
@@ -1,0 +1,105 @@
+// rx_hwtstamp_probe.c — read RX HARDWARE timestamps (SO_TIMESTAMPING) off a
+// Wi-Fi interface driven by the CONFIG_RTW_HWTSTAMP-patched vendor driver.
+//
+// This is the userspace half of the "honest apples-vs-apples" NTP/PTP-vs-TSF
+// comparison: the patched reference/rtl88x2cu driver attaches the MAC RX TSF
+// (RxPacket.tsfl, latched in hardware below the CSMA/queueing layer) to each
+// skb, and this program reads it back through the *standard kernel API* — the
+// same SOF_TIMESTAMPING_RAW_HARDWARE path a real PTP NIC would use. Any gap
+// versus devourer's own tsfl fit is then the API path, not the clock.
+//
+// It binds an AF_PACKET socket to the interface (so it sees every delivered
+// frame regardless of L3), enables RX hardware timestamping, and prints, per
+// frame: the raw hardware timestamp (ns; a free-running TSF, ~µs resolution)
+// and the delta from the previous one. A monotonic ~µs-granular series that
+// advances with real airtime is the pass signal; all-zero means the driver
+// isn't stamping (unpatched, or the descriptor carried no TSF).
+//
+// Build: cc -O2 -o build/rx_hwtstamp_probe tests/rx_hwtstamp_probe.c
+// Run:   sudo ./build/rx_hwtstamp_probe <iface> [n_frames]
+//
+// The interface must be UP and receiving frames (associated managed mode with
+// traffic, or any mode delivering data frames up the normal path). Monitor mode
+// uses a different (radiotap) delivery path and is not what this probes.
+#include <arpa/inet.h>
+#include <errno.h>
+#include <linux/errqueue.h>
+#include <linux/if_ether.h>
+#include <linux/net_tstamp.h>
+#include <linux/if_packet.h>
+#include <net/if.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    fprintf(stderr, "usage: %s <iface> [n_frames]\n", argv[0]);
+    return 2;
+  }
+  const char *iface = argv[1];
+  int want = argc > 2 ? atoi(argv[2]) : 20;
+
+  int fd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+  if (fd < 0) { perror("socket(AF_PACKET)"); return 1; }
+
+  unsigned ifindex = if_nametoindex(iface);
+  if (!ifindex) { fprintf(stderr, "no such iface %s\n", iface); return 1; }
+  struct sockaddr_ll sll = {0};
+  sll.sll_family = AF_PACKET;
+  sll.sll_protocol = htons(ETH_P_ALL);
+  sll.sll_ifindex = ifindex;
+  if (bind(fd, (struct sockaddr *)&sll, sizeof sll) < 0) { perror("bind"); return 1; }
+
+  // Ask the kernel to report the hardware RX timestamp (and raw hw clock value)
+  // on the socket error/ancillary queue — the same request tcpdump/ptp4l make.
+  int flags = SOF_TIMESTAMPING_RX_HARDWARE | SOF_TIMESTAMPING_RAW_HARDWARE |
+              SOF_TIMESTAMPING_RX_SOFTWARE | SOF_TIMESTAMPING_SOFTWARE;
+  if (setsockopt(fd, SOL_SOCKET, SO_TIMESTAMPING, &flags, sizeof flags) < 0) {
+    perror("setsockopt(SO_TIMESTAMPING)");
+    return 1;
+  }
+
+  printf("probing RX hardware timestamps on %s (want %d frames)\n", iface, want);
+  uint8_t buf[2048];
+  char ctrl[512];
+  int seen = 0, hw_nonzero = 0;
+  uint64_t prev_hw = 0;
+  while (seen < want) {
+    struct iovec iov = {buf, sizeof buf};
+    struct msghdr msg = {0};
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = ctrl;
+    msg.msg_controllen = sizeof ctrl;
+    ssize_t n = recvmsg(fd, &msg, 0);
+    if (n < 0) { if (errno == EINTR) continue; perror("recvmsg"); break; }
+
+    struct scm_timestamping *ts = NULL;
+    for (struct cmsghdr *cm = CMSG_FIRSTHDR(&msg); cm; cm = CMSG_NXTHDR(&msg, cm)) {
+      if (cm->cmsg_level == SOL_SOCKET && cm->cmsg_type == SO_TIMESTAMPING)
+        ts = (struct scm_timestamping *)CMSG_DATA(cm);
+    }
+    seen++;
+    if (!ts) { printf("frame %3d: len=%zd  (no SO_TIMESTAMPING cmsg)\n", seen, n); continue; }
+
+    // ts[0] = software, ts[2] = raw hardware (the MAC TSF, ns). We want ts[2].
+    uint64_t hw = (uint64_t)ts->ts[2].tv_sec * 1000000000ull + ts->ts[2].tv_nsec;
+    uint64_t sw = (uint64_t)ts->ts[0].tv_sec * 1000000000ull + ts->ts[0].tv_nsec;
+    long long d = prev_hw ? (long long)(hw - prev_hw) : 0;
+    if (hw) hw_nonzero++;
+    printf("frame %3d: len=%4zd  hw_raw=%llu ns  d=%+lld ns  sw=%llu ns\n",
+           seen, n, (unsigned long long)hw, d, (unsigned long long)sw);
+    if (hw) prev_hw = hw;
+  }
+
+  printf("== %d frames, %d with a nonzero raw-hardware timestamp ==\n", seen, hw_nonzero);
+  printf("%s\n", hw_nonzero > 1 ? "PASS: driver surfaces the MAC RX TSF via SO_TIMESTAMPING"
+                                : "FAIL: no hardware RX timestamps (driver unpatched?)");
+  close(fd);
+  return hw_nonzero > 1 ? 0 : 1;
+}

--- a/tests/rx_hwtstamp_validate.sh
+++ b/tests/rx_hwtstamp_validate.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# rx_hwtstamp_validate.sh — validate the CONFIG_RTW_HWTSTAMP prototype in
+# reference/rtl88x2cu: prove the patched vendor driver surfaces the MAC RX TSF
+# through the standard kernel SO_TIMESTAMPING API (the "honest apples-vs-apples"
+# primitive for the NTP/PTP-vs-TSF comparison in docs/timing-accuracy.md).
+#
+# Two levels:
+#   1. CAPABILITY (always, deterministic): swap the in-tree rtw88 driver for the
+#      patched out-of-tree 88x2cu_ohd.ko on the 8822CU, and assert `ethtool -T`
+#      now advertises SOF_TIMESTAMPING_RX_HARDWARE + RAW_HARDWARE. This proves
+#      get_ts_info registered.
+#   2. ON-AIR VALUE (opt-in): if AP_SSID+AP_PSK are set, associate + DHCP + ping,
+#      and run rx_hwtstamp_probe to read advancing raw-hardware RX timestamps off
+#      real traffic. Skipped (with a note) otherwise.
+#
+# The in-tree rtw88_8822cu is restored on exit no matter what.
+#
+#   sudo tests/rx_hwtstamp_validate.sh
+#   sudo AP_SSID=KArt2 AP_PSK=... tests/rx_hwtstamp_validate.sh
+set -uo pipefail
+cd "$(dirname "$0")/.."
+KO=reference/rtl88x2cu/88x2cu_ohd.ko
+DEV_PID=c812                 # 0bda:c812, the 8822C-family USB part
+IFACE=""
+WPA_PID=""
+DHCP_PID=""
+
+log() { echo "[hwts] $*"; }
+
+restore() {
+  log "cleanup: restoring in-tree driver"
+  [ -n "$WPA_PID" ] && kill "$WPA_PID" 2>/dev/null
+  [ -n "$DHCP_PID" ] && kill "$DHCP_PID" 2>/dev/null
+  sudo pkill -9 -x rx_hwtstamp_probe 2>/dev/null
+  sudo rmmod 88x2cu_ohd 2>/dev/null
+  # bring the stock stack back (it auto-probes the dongle on load)
+  sudo modprobe rtw88_8822cu 2>/dev/null
+  sleep 1
+}
+trap restore EXIT
+
+# --- build the userspace probe ---
+mkdir -p build
+cc -O2 -o build/rx_hwtstamp_probe tests/rx_hwtstamp_probe.c || { log "probe build failed"; exit 1; }
+
+# --- confirm the patched module is built ---
+[ -f "$KO" ] || { log "missing $KO — run 'make' in reference/rtl88x2cu first"; exit 1; }
+lsusb | grep -qi "0bda:$DEV_PID" || { log "no 0bda:$DEV_PID (8822CU) plugged"; exit 1; }
+
+# --- driver swap: in-tree rtw88 -> patched out-of-tree ---
+log "unloading in-tree rtw88_8822cu"
+sudo modprobe -r rtw88_8822cu 2>/dev/null
+sleep 1
+log "inserting patched $KO"
+sudo insmod "$KO" || { log "insmod failed"; exit 1; }
+sleep 3
+
+# --- find the netdev the patched driver created ---
+for i in $(seq 1 10); do
+  IFACE=$(ls /sys/bus/usb/devices/*/net/ 2>/dev/null | grep -E '^wl|^wlan' | head -1)
+  [ -z "$IFACE" ] && IFACE=$(for d in /sys/class/net/*; do
+      drv=$(readlink -f "$d/device/driver" 2>/dev/null); case "$drv" in *88x2cu*) basename "$d";; esac; done | head -1)
+  [ -n "$IFACE" ] && break
+  sleep 1
+done
+[ -z "$IFACE" ] && { log "patched driver created no netdev"; exit 1; }
+log "interface: $IFACE"
+sudo ip link set "$IFACE" up 2>/dev/null
+sleep 1
+
+# --- LEVEL 1: capability ---
+log "=== ethtool -T $IFACE ==="
+TS=$(sudo ethtool -T "$IFACE" 2>&1); echo "$TS"
+if echo "$TS" | grep -q "hardware-receive"; then
+  log "PASS(capability): RX hardware timestamping advertised"
+else
+  log "FAIL(capability): ethtool -T does not show hardware-receive"
+  exit 1
+fi
+
+# --- LEVEL 2: on-air value (opt-in) ---
+if [ -n "${AP_SSID:-}" ] && [ -n "${AP_PSK:-}" ]; then
+  log "associating to $AP_SSID"
+  WPACONF=$(mktemp)
+  wpa_passphrase "$AP_SSID" "$AP_PSK" > "$WPACONF"
+  sudo wpa_supplicant -B -i "$IFACE" -c "$WPACONF" -P /tmp/wpa_hwts.pid >/dev/null 2>&1
+  WPA_PID=$(cat /tmp/wpa_hwts.pid 2>/dev/null)
+  sleep 6
+  sudo dhclient -1 "$IFACE" 2>/dev/null &
+  DHCP_PID=$!
+  sleep 4
+  GW=$(ip route show dev "$IFACE" | awk '/default/{print $3; exit}')
+  log "gateway=$GW — pinging to generate RX traffic while probing"
+  ( for _ in $(seq 1 40); do ping -c1 -W1 "${GW:-8.8.8.8}" >/dev/null 2>&1; sleep 0.1; done ) &
+  rm -f "$WPACONF"
+  log "=== rx_hwtstamp_probe $IFACE ==="
+  sudo ./build/rx_hwtstamp_probe "$IFACE" 20
+  RC=$?
+  log "on-air value check rc=$RC"
+  exit $RC
+else
+  log "AP_SSID/AP_PSK not set — skipping on-air value check."
+  log "To read live RX hardware timestamps: sudo AP_SSID=<ssid> AP_PSK=<psk> $0"
+fi


### PR DESCRIPTION
Out-of-band reference tooling behind the timing findings in [`docs/timing-accuracy.md`](docs/timing-accuracy.md). **None of it is part of the devourer library build** — it's kernel-side experiments in `tests/`, so the library CI is unchanged.

## USB — surface the vendor `rtl88x2cu` RX hardware timestamp

- **Submodule bump** `reference/rtl88x2cu` → the merged `CONFIG_RTW_HWTSTAMP` driver (attaches the RX-descriptor TSF to `skb_hwtstamps` before delivery, so a `SO_TIMESTAMPING` socket reads the 802.11 hardware RX timestamp).
- `tests/rx_hwtstamp_probe.c` — AF_PACKET + `SO_TIMESTAMPING` reader.
- `tests/rx_hwtstamp_validate.sh` — capability check (driver swap + `ethtool -T`).
- `tests/rx_hwtstamp_onair.sh` — on-air value check against a devourer open AP; verified the RX timestamps advance in step with real airtime.

## PCIe — RTL8821CE (`rtw88`)

- `tests/pcie_phc/` — a **passive PTP hardware clock** (`/dev/ptpN`) off the MAC TSF over BAR2 MMIO (`rtw88` stays bound; the module only `ioremap`s and reads), a gettime-latency probe (~3.7 µs MMIO floor), an **Intel I226 cross-check** (Wi-Fi TSF tracks a real IEEE-1588 clock to ~290 ns), and a one-hunk `rtw88` RX `skb_hwtstamps` patch. See [`tests/pcie_phc/README.md`](tests/pcie_phc/README.md).
- `tests/pcie_tsf_read.c` — userspace BAR2 TSF reader.

## Scope

RX hardware timestamping works on both transports; a real PHC is tractable on PCIe. Two-way `ptp4l` over the Wi-Fi radio stays blocked on a host-reported TX-egress timestamp (firmware limitation) — the board's I226 Ethernet is the real-PTP reference. All measured results and that limit are in `docs/timing-accuracy.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)