### PR TITLE
tests: PCIe reference TX tool + robust submit-to-air transport-floor extraction

### DIFF
--- a/tests/pcie_txegress_tx.cpp
+++ b/tests/pcie_txegress_tx.cpp
@@ -1,0 +1,63 @@
+// pcie_txegress_tx.cpp — host-pushed DATA-frame TX over the PCIe transport, each
+// frame carrying the transmitter's ReadTsf() submit timestamp in a tdma TD tag.
+// Paired with tests/txegress_witness on a co-located receiver, it measures the
+// submit-to-air jitter over PCIe (vs the ~117 µs measured over USB), isolating
+// how much the faster/more-deterministic transport tightens the open-loop floor.
+//
+// It mirrors the USB timesync software master (ReadTsf *before* send, so the
+// number is comparable), but opens the 8821CE through PcieTransport / vfio.
+//
+// Build (on a DEVOURER_PCIE=ON tree):
+//   g++ -std=c++20 -O2 -Isrc -Iexamples/tdma tests/pcie_txegress_tx.cpp \
+//     build-pcie/libdevourer.a $(pkg-config --cflags --libs libusb-1.0) \
+//     -lpthread -o build-pcie/pcie_txegress_tx
+// Run: sudo DEVOURER_PCIE_BDF=0000:01:00.0 DEVOURER_CHANNEL=36 \
+//        build-pcie/pcie_txegress_tx [secs]
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <thread>
+
+#include "PcieTransport.h"
+#include "RadiotapBuilder.h"
+#include "SelectedChannel.h"
+#include "WiFiDriver.h"
+#include "logger.h"
+#include "tdma.h"
+
+int main(int argc, char **argv) {
+  const char *bdf = std::getenv("DEVOURER_PCIE_BDF");
+  if (!bdf) { fprintf(stderr, "set DEVOURER_PCIE_BDF (e.g. 0000:01:00.0)\n"); return 2; }
+  uint8_t ch = 36;
+  if (const char *c = std::getenv("DEVOURER_CHANNEL")) ch = (uint8_t)atoi(c);
+  int secs = argc > 1 ? atoi(argv[1]) : 45;
+  int gap_us = 8000;
+  if (const char *g = std::getenv("GAP_US")) gap_us = atoi(g);
+
+  auto logger = std::make_shared<Logger>();
+  auto transport = devourer::PcieTransport::Open(bdf, logger);
+  if (!transport) { fprintf(stderr, "pcie open failed for %s (vfio-bound?)\n", bdf); return 1; }
+  WiFiDriver wifi(logger);
+  auto dev = wifi.CreateRtlDevicePcie(std::move(transport));
+  if (!dev) { fprintf(stderr, "CreateRtlDevicePcie failed\n"); return 1; }
+
+  dev->InitWrite(SelectedChannel{ch, 0, CHANNEL_WIDTH_20});
+  dev->SetCcaMode(true);   // disable EDCCA — suppress CSMA backoff so the residual
+                           // reflects the transport + MAC-pipeline floor, not channel load
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+
+  const auto rt = devourer::build_stream_radiotap(
+      devourer::parse_tx_mode_str("6M"));                  // legacy 6M, widely heard
+  uint32_t seq = 0;
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(secs);
+  while (std::chrono::steady_clock::now() < deadline) {
+    uint64_t tsf = dev->ReadTsf();                          // submit-time stamp (TX clock)
+    auto f = tdma::build_frame(rt, tdma::Class::Marker, seq++, 0, tsf);
+    dev->send_packet(f.data(), f.size());
+    std::this_thread::sleep_for(std::chrono::microseconds(gap_us));
+  }
+  fprintf(stderr, "pcie_txegress_tx: %u frames on ch%d\n", seq, ch);
+  return 0;
+}

--- a/tests/txegress_analyze.py
+++ b/tests/txegress_analyze.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # txegress_analyze.py — quantify the "read TSF after send to approximate egress"
-# micro-option from txegress_witness JSONL.
+# submit-to-air jitter from txegress_witness JSONL.
 #
 # Each record has a TX stamp (tx_sw = the transmitter's software ReadTsf, OR
 # tx_hw = the MAC-inserted beacon egress TSF) and rx_tsfl (this receiver's
@@ -8,11 +8,18 @@
 # stamps are in the transmitter's clock; rx_tsfl is in the receiver's clock, so
 # a straight line rx_tsfl = a*tx + b absorbs the constant offset, the two
 # crystals' rate difference, and the fixed propagation delay. What's LEFT — the
-# residual RMS — is the per-frame jitter of that TX stamp versus true air.
+# residual — is the per-frame jitter of that TX stamp versus true air.
 #
-#   software-stamp residual = jitter the read-TSF-after-send micro-option injects
-#   hardware-stamp residual = the MAC egress-timestamp floor (what a real TX HW
-#                             timestamp would look like)
+# Two numbers per stamp:
+#   raw   — RMS over ALL frames. On a busy channel this is dominated by MAC
+#           deferral / queueing outliers (a channel effect, not the transport):
+#           the raw slope goes wild (implausible ppm) when a few frames are
+#           milliseconds late.
+#   floor — robust RMS after iterative 3*MAD outlier rejection: the tight cluster
+#           of frames that aired immediately, i.e. the transport + MAC-pipeline
+#           floor. Deferral only ever ADDS delay, so rejecting the positive tail
+#           recovers the true transport jitter. A sane crystal ppm (~tens of ppm
+#           or less) confirms the robust fit locked onto the real line.
 #
 # Usage: python3 txegress_analyze.py <witness.jsonl>
 import json, sys, math
@@ -25,29 +32,47 @@ def unwrap32(xs):
         out.append(x + hi); prev = x
     return out
 
-def fit_resid(tx, rx):
-    # least-squares rx = a*tx + b; return residual RMS (ns) and slope (ppm dev)
-    n = len(tx)
-    mx = sum(tx) / n; my = sum(rx) / n
-    sxx = sum((t - mx) ** 2 for t in tx)
-    sxy = sum((t - mx) * (r - my) for t, r in zip(tx, rx))
-    a = sxy / sxx; b = my - a * mx
-    res = [r - (a * t + b) for t, r in zip(tx, rx)]   # residual in rx-clock µs
-    rms_us = math.sqrt(sum(r * r for r in res) / n)
-    # rx_tsfl and tx are both µs units; residual is µs -> ns
-    p2p = max(res) - min(res)
-    return rms_us * 1000.0, p2p * 1000.0, a
+def fit(tx, rx, idx):
+    n = len(idx)
+    mx = sum(tx[i] for i in idx) / n
+    my = sum(rx[i] for i in idx) / n
+    sxx = sum((tx[i] - mx) ** 2 for i in idx)
+    sxy = sum((tx[i] - mx) * (rx[i] - my) for i in idx)
+    a = sxy / sxx if sxx else 1.0
+    return a, my - a * mx
+
+def resid(tx, rx, idx, a, b):
+    return [rx[i] - (a * tx[i] + b) for i in idx]
+
+def rms_p2p(res):
+    n = len(res)
+    return math.sqrt(sum(r * r for r in res) / n), (max(res) - min(res))
+
+def robust_fit(tx, rx):
+    """Iterative 3*MAD outlier rejection -> (slope, inlier_idx)."""
+    idx = list(range(len(tx)))
+    for _ in range(6):
+        a, b = fit(tx, rx, idx)
+        res = resid(tx, rx, idx, a, b)
+        s = sorted(res); med = s[len(s) // 2]
+        ab = sorted(abs(r - med) for r in res); mad = ab[len(ab) // 2] * 1.4826 or 1.0
+        keep = [idx[k] for k in range(len(idx)) if abs(res[k] - med) < 3 * mad]
+        if len(keep) == len(idx):
+            break
+        idx = keep
+    return idx
 
 def main():
     recs = []
     for line in open(sys.argv[1]):
         line = line.strip()
-        if not line.startswith("{"): continue
-        try: recs.append(json.loads(line))
-        except Exception: continue
-    recs = [r for r in recs if r.get("ev") == "txeg"]
-    # drop the first few (warm-up) and any with a zero stamp
-    recs = recs[3:]
+        if not line.startswith("{"):
+            continue
+        try:
+            recs.append(json.loads(line))
+        except Exception:
+            continue
+    recs = [r for r in recs if r.get("ev") == "txeg"][3:]   # drop warm-up
     if len(recs) < 20:
         print("too few frames (%d)" % len(recs)); return
 
@@ -56,16 +81,23 @@ def main():
                        ("hardware (MAC beacon egress)", "tx_hw")):
         sub = [(r[key], x) for r, x in zip(recs, rx) if r.get(key, 0) > 0]
         if len(sub) < 20:
-            print("%-32s : n=%d (skipped)" % (label, len(sub))); continue
+            print("%-30s : n=%d (skipped)" % (label, len(sub))); continue
         tx = [s[0] for s in sub]; rxs = [s[1] for s in sub]
-        rms, p2p, slope = fit_resid(tx, rxs)
-        ppm = (slope - 1.0) * 1e6
-        print("%-32s : n=%4d  residual RMS = %8.3f µs  (p2p %8.3f µs)  xtal %+7.1f ppm"
-              % (label, len(sub), rms / 1000.0, p2p / 1000.0, ppm))
+        n = len(tx)
 
-    print("\nThe software residual is the jitter 'read TSF after send' injects vs true")
-    print("air; the hardware residual is the MAC egress-timestamp floor. The gap is")
-    print("why the shortcut is not a substitute for a real TX-egress timestamp.")
+        a0, b0 = fit(tx, rxs, list(range(n)))
+        raw_rms, _ = rms_p2p(resid(tx, rxs, list(range(n)), a0, b0))
+
+        idx = robust_fit(tx, rxs)
+        a, b = fit(tx, rxs, idx)
+        fl_rms, fl_p2p = rms_p2p(resid(tx, rxs, idx, a, b))
+        print("%-30s : n=%4d  raw RMS=%8.1f µs  |  floor=%7.1f µs "
+              "(%d inliers, p2p %.1f µs)  xtal %+6.1f ppm"
+              % (label, n, raw_rms, fl_rms, len(idx), fl_p2p, (a - 1.0) * 1e6))
+
+    print("\nfloor = the transport + MAC-pipeline submit-to-air jitter (deferral")
+    print("outliers rejected); raw includes channel deferral. Compare floors across")
+    print("transports (USB ~93 µs vs PCIe ~12 µs on this bench).")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Reference tooling for the transport-latency comparison — the PCIe half of the submit-to-air measurement, plus the analysis fix that makes it trustworthy on a real (busy) channel. Both live in `tests/` and are **not** in the CMake build, so library CI is unaffected.

## `tests/pcie_txegress_tx.cpp` — PCIe reference TX

A host-pushed **data-frame** TX over the PCIe transport: opens the 8821CE via `PcieTransport`/vfio, disables EDCCA (`SetCcaMode`, so the residual reflects the transport + MAC-pipeline floor, not channel load), and loops `ReadTsf` → `build_frame` (tdma tag) → `send_packet`, embedding the submit stamp in each frame. Paired with the existing `txegress_witness` on a co-located receiver, it measures submit-to-air jitter over PCIe. Mirrors the USB `timesync` software master, so the numbers are directly comparable. Built standalone (`g++` against a `DEVOURER_PCIE=ON` `libdevourer.a`). The reference TX tool for the SDIO-vs-USB benchmark (#235).

## `tests/txegress_analyze.py` — robust transport-floor extraction

Adds an outlier-rejecting fit alongside the raw one. On a busy channel the MAC still defers even with EDCCA off, injecting **ms-scale outliers** that wreck the plain least-squares (the slope goes to an implausible ppm). Iterative 3·MAD rejection recovers the tight cluster of frames that aired immediately — the transport + MAC-pipeline floor. It now reports both `raw` and `floor` per stamp, with the crystal ppm as a sanity check.

## Measured (on-air, this bench)

| Transport | submit-to-air floor (RMS) | p2p | crystal |
|---|---|---|---|
| **USB** (8812AU) | **~93 µs** | 554 µs | −1.2 ppm |
| **PCIe** (8821CE) | **~12 µs** | 63 µs | −1.6 ppm |

PCIe is **~8× tighter** — the USB floor is dominated by the USB submit-path jitter (`reglat` ~68 µs / ±64 µs); PCIe removes it, leaving the MAC TX pipeline (~12 µs). The fundamental TX-egress wall (per-frame *air-departure* control) is unchanged — see #236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)