### PR TITLE
Packet aggregation and hardware ACKs in userspace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -586,6 +586,18 @@ if(DEVOURER_JAGUAR2_8822B OR DEVOURER_JAGUAR2_8821C)
     add_test(NAME txpkt_pwr_quant COMMAND TxPktPwrSelftest)
 endif()
 
+# Headless guard for the USB TX-aggregation URB packing (src/TxAggPlan.h) —
+# block alignment, the never-a-bulk-multiple boundary shim, the OQT
+# descs-per-bulk guard, the frame/byte caps — plus the HalMAC descriptor agg
+# fields (DMA_TXAGG_NUM placement and PKT_OFFSET checksum coverage; those
+# parts self-gate on the DEVOURER_HAVE_JAGUAR2/3 defines the library exports).
+add_executable(TxAggSelftest
+    tests/txagg_selftest.cpp
+)
+target_link_libraries(TxAggSelftest PRIVATE devourer)
+target_include_directories(TxAggSelftest PRIVATE src)
+add_test(NAME txagg_pack COMMAND TxAggSelftest)
+
 # Headless guard for the beamforming-report decoder (src/BfReportDecode.h) — the
 # LSB-first Givens-angle unpacking + per-tone variance behind sense. It
 # decodes a real captured VHT MU report and checks the angles against an offline

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ long-range digital video links.
   clock manages — enough to interleave a robust narrowband link and a wide
   high-throughput one on one shared channel
   ([bandwidth TDMA](docs/narrowband.md)).
+- **Aggregation and hardware ACKs in userspace.** USB TX aggregation, 802.11
+  A-MPDU for +30% on-air goodput, and a hardware ACK/BlockAck responder that
+  turns unicast into a reliable hardware-ARQ link — with per-frame TX-status
+  reports as the transmit-side link sensor ([how](docs/aggregation.md)).
 - **A radio lab in a dongle.** Channel sounding, per-antenna signal quality,
   beamforming report capture (enough to do
   [motion sensing](docs/beamforming-victim-sensing.md)), spectrum sweeps,
@@ -197,6 +201,9 @@ one `IRtlDevice` interface covers all three generations.
 - [AP mode](docs/ap-mode.md) — devourer as an infrastructure access point a real
   Linux station associates with: beacon → probe/auth/assoc → DHCP/ARP/ICMP → ping,
   open or WPA2-PSK (4-way handshake + software CCMP), validated against rtw88.
+- [Aggregation & hardware ACK](docs/aggregation.md) — USB TX aggregation,
+  per-frame CCX TX-status reports, 802.11 A-MPDU (`SetAmpduMode`, +30% on-air
+  goodput), and the hardware ACK/BlockAck responder for reliable-unicast links.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Bandwidth cells are devourer's measured on-air TX throughput (Mbps, HT MCS7,
 `†` = works on-air but the reading varies run-to-run (bracketed = best clean
 reading).
 
+These cells are single-frame injection (the default TX path), measured as
+channel occupancy × PHY rate. A-MPDU (`SetAmpduMode`) does **not** move them on
+a chip already near the PHY ceiling — it raises *goodput* (delivered payload)
+~30% at MCS7/20 by amortizing per-frame overhead, which an occupancy metric
+can't show. See [aggregation & hardware ACK](docs/aggregation.md).
+
 Out of scope: the pre-HalMAC PCIe parts (RTL8812AE/8821AE) and the 11ax
 "Kestrel" generation — same branding, different bus or baseband.
 

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -113,8 +113,31 @@ Bench-established (8822BU TX, monitor-inject USE_RATE frames):
   - `ppdu_cnt` reads 0 on the 8812CU RX used for the bench; `paggr` +
     `tsfl` clustering are the working RX markers.
 
-## Ack stack (deferred)
+## Hardware ACK responder — reliable unicast
 
-Hardware ACK responder mode (the `StartBeacon` MACID+MSR recipe as a
-first-class monitor-mode API) and reliable-unicast measurement via TX reports
-are the next round; see `docs/ap-mode.md` for the proven responder behaviour.
+`IRtlDevice::SetAckResponder(mac)` / `ClearAckResponder()` (env
+`DEVOURER_ACK_RESPONDER=<unicast mac>`, all generations; `src/AckResponder.h`)
+arms the MAC's autonomous ACK engine while monitor RX/injection continue
+unchanged: port identity (MACID/BSSID 0x610/0x618 = `mac`) + net_type (0x102
+[1:0] = AP). No beacon machinery needed — the identity+net_type pair alone is
+the gate (bench-bisected; `StartBeacon`'s extra registers are not required).
+
+With a responder armed, a peer TXing unicast QoS-Data (normal ack-policy) to
+`mac` gets the full hardware ARQ loop — SIFS-timed ACKs from the responder,
+autonomous retransmission on the TX, both ends host-free.
+`tests/ack_responder_check.sh` is the closed-loop A/B, judged by the TX
+side's CCX reports: responder ON = 100% delivered at mean 0.4 retries (67%
+first-try); OFF = 0% delivered, every frame pinned at the 12-retry limit.
+The retry distribution doubles as the per-frame TX-side link-quality sensor.
+
+THE footgun (three strikes now): every MAC in the loop must be UNICAST (I/G
+bit clear) — the responder `mac` (an ACK can't target a group address), and
+the TX frame's TA/addr2 (the ACK's RA is the soliciting frame's addr2; the
+canonical TX SA `57:42:75:05:d6:00` is a GROUP address, so txdemo's QoS shape
+takes `DEVOURER_TX_SA` to override). A group TA silently yields
+retry-limit-pinned reports with the responder perfectly armed.
+
+Opt-in only: arming turns a passive monitor into an active transmitter.
+Remaining ack-stack items: BA-session/ACKed-A-MPDU (aggregates currently need
+retry-limit 0 because a BlockAck responder does not exist yet) and software
+ARQ policy above the reports.

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -134,14 +134,26 @@ side's CCX reports: responder ON = 100% delivered at mean 0.4 retries (67%
 first-try); OFF = 0% delivered, every frame pinned at the 12-retry limit.
 The retry distribution doubles as the per-frame TX-side link-quality sensor.
 
+**The same responder is a hardware BlockAck responder** — no ADDBA session
+state, no separate API. The MAC's immediate-response engine generates a
+SIFS-timed BlockAck for a received A-MPDU addressed to its MACID exactly as it
+generates an ACK for a unicast frame; the gate is the same MACID + net_type
+pair. So reliable-unicast **ACKed A-MPDU** works end to end: the TX runs
+`SetAmpduMode` with `no_ack = false` (normal ack-policy, retry limit kept) and
+the peer runs `SetAckResponder`. `tests/ampdu_ba_check.sh` proves it: with the
+responder armed, aggregates deliver at 100% / mean 0.1 retries and ~27× the
+throughput of the responder-off case (where every aggregate re-airs to the
+retry limit for a BlockAck no one sends). The `no_ack = true` default stays the
+broadcast/FEC flavor (OpenIPC wfb — no responder, no re-air storm); `false` is
+the reliable-unicast flavor against a BA responder.
+
 THE footgun (three strikes now): every MAC in the loop must be UNICAST (I/G
-bit clear) — the responder `mac` (an ACK can't target a group address), and
-the TX frame's TA/addr2 (the ACK's RA is the soliciting frame's addr2; the
-canonical TX SA `57:42:75:05:d6:00` is a GROUP address, so txdemo's QoS shape
-takes `DEVOURER_TX_SA` to override). A group TA silently yields
-retry-limit-pinned reports with the responder perfectly armed.
+bit clear) — the responder `mac` (an ACK/BlockAck can't target a group
+address), and the TX frame's TA/addr2 (the response's RA is the soliciting
+frame's addr2; the canonical TX SA `57:42:75:05:d6:00` is a GROUP address, so
+txdemo's QoS shape takes `DEVOURER_TX_SA` to override). A group TA silently
+yields retry-limit-pinned reports with the responder perfectly armed.
 
 Opt-in only: arming turns a passive monitor into an active transmitter.
-Remaining ack-stack items: BA-session/ACKed-A-MPDU (aggregates currently need
-retry-limit 0 because a BlockAck responder does not exist yet) and software
-ARQ policy above the reports.
+Remaining ack-stack item: a software ARQ policy above the CCX reports (the
+hardware ARQ — ACK, BlockAck, autonomous retransmit — is complete).

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -1,0 +1,103 @@
+# Packet aggregation & TX-status reports
+
+Three layers, separable:
+
+1. **USB TX aggregation** — many `[txdesc][frame]` blocks per bulk-OUT URB
+   (host↔chip transport only, no on-air change). Shipped, on-air-validated.
+2. **Per-frame TX-status reports** — the firmware's CCX report per
+   transmission (delivered / retry count / queue time / final rate). Shipped.
+3. **802.11 A-MPDU formation** — the MAC aggregating co-queued frames into
+   one PPDU (the air-time amortization). EXPERIMENTAL: hardware formation is
+   bench-proven via the spike knobs, but net goodput is still gated on an
+   aggregate-launch pacing quirk (below), so there is no first-class session
+   API yet.
+
+## USB TX aggregation (`send_packets`)
+
+`IRtlDevice::send_packets(TxPacketView*, n)` + `DeviceConfig tx.usb_agg_max`
+(env `DEVOURER_TX_USB_AGG`, default 0 = off → per-frame loop, byte-identical
+descriptors). Packing rules live in `src/TxAggPlan.h` (pure math, ctest'd):
+blocks 8-byte aligned, the FIRST descriptor carries the block count
+(dword7[31:24]: `USB_TXAGG_NUM` Jaguar1 / `DMA_TXAGG_NUM` HalMAC — inside the
+checksummed span, so agg-num is set before the checksum), and the URB total
+never lands on an exact bulk-MPS multiple (the sync bulk path has no ZLP).
+
+Per-family hardware rules (both bench-validated on-air):
+
+- **HalMAC (8822B/8821C/8822C/8822E)**: at most **3 descriptors per bulk
+  transfer** (mainline rtw88 `usb_tx_agg_desc_num` / halmac `BLK_DESC_NUM`) —
+  the library clamps. Layout is rtw88-parity: no first-block reserve; the
+  8-byte PKT_OFFSET shim is inserted only to escape a bulk-boundary total.
+- **Jaguar1 (8812A/8811A/8821A/8814A)**: vendor-parity — first block carries
+  the 8-byte PKT_OFFSET reserve (dropped at a boundary total), and the OQT
+  guard caps descriptor STARTS per bulk window (8812A = 1, 8814A = 3,
+  8821A = 6). When the knob is on, bring-up programs the kernel's TDECTRL
+  block-desc count to match.
+
+Bench (8822BU → 8812CU, ch6, MCS7, 1026-byte MPDUs, per-frame counter
+stamped for uniqueness): batched URBs deliver every frame distinctly
+(receptions == uniques). A multi-frame sync URB is flow-controlled by the
+chip (~ms scale between URB acceptances under sustained flood), so batching
+buys per-frame host/USB overhead, not a higher flood ceiling — at MCS7 the
+air is the bottleneck either way. `tests/txagg_bench.sh` is the A/B harness.
+
+Bench-instrumentation trap (cost this project half a day): when TXing
+"identical" frames to measure aggregation, stamp EVERY frame uniquely
+(txdemo batch mode does, at MPDU bytes 26-29). Stamping one shared buffer per
+batch makes every reception of a batch look like the same frame — which is
+byte-for-byte indistinguishable from "the chip re-aired block 1 N times".
+
+## TX-status reports (`tx.report`)
+
+`DeviceConfig tx.report` (env `DEVOURER_TX_REPORT`) sets `SPE_RPT` in every
+data descriptor; the fw answers each transmission with a CCX report, decoded
+at the C2H RX sites into `tx.report` events (`src/TxReport.h`): `state`
+(0 = delivered/completed, 1 = retry-drop), `retries` (hardware
+retransmissions), `queue_time_raw`, `final_rate`, `bmc`. HalMAC reports echo
+the descriptor SW_DEFINE low byte — the devices stamp a rotating 8-bit `tag`
+for per-frame correlation. Jaguar1 uses the 6-byte 8812 format (queue time
+in 256 µs units; the 8814A fw layout differs and is left to the examples/rx
+best-effort decode). Jaguar3 TX-only sessions get reports via the coex
+thread's C2H drain; TX+RX sessions via the RX loop.
+
+This is the TX-side link sensor: retry counts feed adaptive rate/power the
+way RSSI/EVM feed the RX side.
+
+## A-MPDU (experimental spike surface)
+
+Spike knobs (DeviceConfig debug section, all generations):
+`DEVOURER_TX_QSEL=<0..7|0x12>` (descriptor queue),
+`DEVOURER_TX_AMPDU="max[/density[/rty]]"` (AGG_EN + MAX_AGG_NUM +
+AMPDU_DENSITY + optional per-frame retry-limit override), plus txdemo's
+`DEVOURER_TX_QOS_DATA` / `DEVOURER_TX_QOS_NOACK` / `DEVOURER_TX_RA` QoS-Data
+frame shape. RX side surfaces `paggr` (rx-desc "inside an aggregate") and
+`ppdu_cnt` in `rx_pkt_attrib` and the rxdemo `rx.frame`/`rx.txhit` events.
+`tests/ampdu_spike.sh` runs the matrix.
+
+Bench-established (8822BU TX, monitor-inject USE_RATE frames):
+
+- **The MAC aggregates host-pushed frames** on a data queue: QoS-Data TID0 +
+  `AGG_EN` → true multi-MPDU aggregates (6 subframes at the default max-time,
+  shared RX `tsfl`, `paggr` on every subframe) — broadcast RA included. The
+  aggregation engine renumbers subframe sequence numbers consecutively.
+- **The MGMT queue (0x12, the monitor-inject default) never aggregates**;
+  AGG_EN there wedges the queue.
+- **QoS No-Ack policy does NOT stop aggregate retransmission**: the MAC
+  retries each aggregate to the retry limit waiting for a BlockAck no
+  monitor receiver sends (92% retry-flagged receptions, ~12× re-airings,
+  unique goodput 7× below singles). The `rty` component set to 0 suppresses
+  it completely (receptions == uniques, 0% retry-flagged) — the
+  broadcast/no-ack flavor is `DEVOURER_TX_AMPDU=<max>/<density>/0`.
+- **Open item — aggregate-launch pacing**: the chip flow-controls each
+  aggregate launch at ~3 ms under sustained feed (tracks
+  `REG_AMPDU_MAX_TIME_V1` 0x455 = 0x70, the aggregate-fill timer), so net
+  unique goodput at MCS7/20 MHz is currently BELOW plain singles. Promoting
+  the spike to a session API waits on a 0x455 / burst-mode (0x4BC) / queue
+  page-allocation sweep. `ppdu_cnt` reads 0 on the 8812CU RX used for the
+  bench; `paggr` + `tsfl` clustering are the working markers.
+
+## Ack stack (deferred)
+
+Hardware ACK responder mode (the `StartBeacon` MACID+MSR recipe as a
+first-class monitor-mode API) and reliable-unicast measurement via TX reports
+are the next round; see `docs/ap-mode.md` for the proven responder behaviour.

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -7,10 +7,9 @@ Three layers, separable:
 2. **Per-frame TX-status reports** — the firmware's CCX report per
    transmission (delivered / retry count / queue time / final rate). Shipped.
 3. **802.11 A-MPDU formation** — the MAC aggregating co-queued frames into
-   one PPDU (the air-time amortization). EXPERIMENTAL: hardware formation is
-   bench-proven via the spike knobs, but net goodput is still gated on an
-   aggregate-launch pacing quirk (below), so there is no first-class session
-   API yet.
+   one PPDU (the air-time amortization). Shipped as `SetAmpduMode`
+   (`DEVOURER_TX_AMPDU_MODE`); +30% on-air goodput at MCS7/20, more at higher
+   rates. Needs a deep TX feed to reach the multiplier (below).
 
 ## USB TX aggregation (`send_packets`)
 
@@ -63,55 +62,60 @@ thread's C2H drain; TX+RX sessions via the RX loop.
 This is the TX-side link sensor: retry counts feed adaptive rate/power the
 way RSSI/EVM feed the RX side.
 
-## A-MPDU (experimental spike surface)
+## A-MPDU (`SetAmpduMode`)
 
-Spike knobs (DeviceConfig debug section, all generations):
-`DEVOURER_TX_QSEL=<0..7|0x12>` (descriptor queue),
-`DEVOURER_TX_AMPDU="max[/density[/rty]]"` (AGG_EN + MAX_AGG_NUM +
-AMPDU_DENSITY + optional per-frame retry-limit override), plus txdemo's
-`DEVOURER_TX_QOS_DATA` / `DEVOURER_TX_QOS_NOACK` / `DEVOURER_TX_RA` QoS-Data
-frame shape. RX side surfaces `paggr` (rx-desc "inside an aggregate") and
-`ppdu_cnt` in `rx_pkt_attrib` and the rxdemo `rx.frame`/`rx.txhit` events.
-`tests/ampdu_spike.sh` runs the matrix.
+`IRtlDevice::SetAmpduMode(AmpduMode)` / `ClearAmpduMode()` / `GetAmpduMode()`
+(env `DEVOURER_TX_AMPDU_MODE="tid/maxnum[/density[/noack[/maxtime_hex]]]"`,
+`src/AmpduMode.h`, all generations) bundle the whole proven recipe in one
+call: it marks every data frame aggregatable (data QSEL + AGG_EN +
+MAX_AGG_NUM + AMPDU_DENSITY + retry-limit) AND programs the MAC pacing
+registers live. The struct defaults are the tuned recipe, so the minimal spec
+`0/16` (TID 0, 16 MPDUs) is: density 7, no-ack, max_time 0x20, burst-mode
+cleared. Off keeps every TX byte-identical.
 
-Bench-established (8822BU TX, monitor-inject USE_RATE frames):
+The caller still supplies the frame shape (QoS-Data on the mode's TID — txdemo
+`DEVOURER_TX_QOS_DATA`) and, critically, a **deep TX feed**: send_packets with
+enough frames in flight, or txdemo `DEVOURER_TX_THREADS=N` (N parallel
+senders; ~4 saturates). A shallow feed leaves the MAC SIFS-bursting
+single-MPDU aggregates — the descriptor says "aggregatable" but there's
+nothing co-queued to aggregate with.
 
-- **The MAC aggregates host-pushed frames** on a data queue: QoS-Data TID0 +
-  `AGG_EN` → true multi-MPDU aggregates (6 subframes at the default max-time,
-  shared RX `tsfl`, `paggr` on every subframe) — broadcast RA included. The
-  aggregation engine renumbers subframe sequence numbers consecutively.
-- **The MGMT queue (0x12, the monitor-inject default) never aggregates**;
-  AGG_EN there wedges the queue.
-- **QoS No-Ack policy does NOT stop aggregate retransmission**: the MAC
-  retries each aggregate to the retry limit waiting for a BlockAck no
-  monitor receiver sends (92% retry-flagged receptions, ~12× re-airings,
-  unique goodput 7× below singles). The `rty` component set to 0 suppresses
-  it completely (receptions == uniques, 0% retry-flagged) — the
-  broadcast/no-ack flavor is `DEVOURER_TX_AMPDU=<max>/<density>/0`.
-- **Aggregate-launch pacing — solved by register pokes + feed depth**
-  (tests/ampdu_pacing_sweep.sh, tests/ampdu_onair_ab.sh; SDR duty is the
-  ground truth — RX-capture comparisons vary wildly between sessions):
-  - `REG_AMPDU_MAX_TIME_V1` (0x455): the bring-up value 0x70 paces each
-    aggregate launch at ~3 ms; **0x20 unlocks it** (URB acceptance
-    ~0.8 ms). Values ≤ 0x08 DISABLE aggregation entirely (frames revert to
-    slow singles) — the register is a cliff, not a dial.
-  - `REG_SW_AMPDU_BURST_MODE_CTRL` (0x4BC): **clearing it** (the halmac
-    bring-up sets BIT6) is worth ~+40% on the aggregated path.
-  - Both pokes ride `DEVOURER_REPLAY_WSEQ`, which now also applies at the
-    end of InitWrite (TX bring-ups can be swept like RX ones).
-  - **Feed depth is the other half**: with the sync 3-frame URB feed the
-    queue holds ≤3 frames and the MAC SIFS-bursts single-MPDU aggregates.
-    Parallel senders (txdemo `DEVOURER_TX_THREADS=N`; sync bulk from N
-    threads queues N URBs in flight) restore multi-MPDU amortization —
-    saturating at ~4 threads.
-  - On-air result (8822BU, ch149, MCS7/20, 1026-byte MPDUs, B210 duty):
-    singles 73.3% duty at ~3500 fps (28.7 Mbps MAC goodput) vs deep-fed
-    A-MPDU 79.3% duty at ~4550 fps (**37.4 Mbps, +30%**, +20% frames per
-    duty-point). The multiplier grows with PHY rate (overhead fraction);
-    a session API should bundle: data QSEL + AGG_EN + rty0 + 0x455=0x20 +
-    0x4BC=0 + a ≥4-deep feed.
-  - `ppdu_cnt` reads 0 on the 8812CU RX used for the bench; `paggr` +
-    `tsfl` clustering are the working RX markers.
+The lower-level spike knobs stay as an experimentation layer that composes on
+top: `DEVOURER_TX_QSEL=<0..7|0x12>` (raw QSEL), `DEVOURER_TX_AMPDU=
+"max[/density[/rty]]"` (raw AGG fields), both applied AFTER the product mode
+in the descriptor. RX side surfaces `paggr` (rx-desc "inside an aggregate")
+and `ppdu_cnt` in `rx_pkt_attrib` + the rxdemo `rx.frame`/`rx.txhit` events.
+`tests/ampdu_spike.sh` runs the discovery matrix; `tests/ampdu_pacing_sweep.sh`
+the register sweep; `tests/ampdu_onair_ab.sh` the SDR A/B.
+
+What the sweep + on-air validation established (8822BU TX, monitor-inject
+USE_RATE frames; SDR duty is the ground truth — RX-capture goodput varies
+session to session):
+
+- **The MAC aggregates host-pushed frames** on a data queue (QoS-Data TID0 +
+  AGG_EN), broadcast RA included; the aggregation engine renumbers subframe
+  seqs consecutively. **The MGMT queue (0x12, the monitor-inject default)
+  never aggregates** — AGG_EN there wedges the queue.
+- **QoS No-Ack does NOT stop aggregate retransmission**: without a per-frame
+  retry limit the MAC re-airs each aggregate to the retry limit waiting for a
+  BlockAck no one sends (92% wasted re-airings). `no_ack` = retry-limit 0
+  airs each aggregate once (FEC covers loss, not ARQ) — the broadcast flavor.
+- **Pacing registers** (programmed by `SetAmpduMode`): the aggregate-fill
+  timer `REG_AMPDU_MAX_TIME` (0x0455 HalMAC, **0x0456 Jaguar1**) — bring-up
+  0x70 paces launches at ~3 ms, `0x20` unlocks to ~0.8 ms; a CLIFF, values
+  ≤ 0x08 disable aggregation. The burst-mode gate
+  `REG_SW_AMPDU_BURST_MODE_CTRL` (0x04BC BIT6, halmac/8814A set it) cleared =
+  ~+40%. `AMPDU_DENSITY` counter-intuitively wants 7 (permissive spacing
+  forms better aggregates; density 0 measured ~10% slower).
+- **Feed depth is half the win**: a shallow sync-URB feed SIFS-bursts
+  single-MPDU aggregates; `DEVOURER_TX_THREADS=N` (N URBs in flight)
+  restores multi-MPDU amortization, saturating at ~4.
+- **On-air result** (8822BU, ch149, MCS7/20, 1026-byte MPDUs, B210 duty):
+  singles 73.3% duty vs deep-fed `SetAmpduMode` 79.2% duty — **+30% goodput**
+  (RX-capture cross-check: +33% delivered unique frames). The multiplier
+  grows with PHY rate (overhead is a bigger fraction at high MCS).
+- `ppdu_cnt` reads 0 on the 8812CU RX used for the bench; `paggr` + `tsfl`
+  clustering are the working RX markers.
 
 ## Hardware ACK responder — reliable unicast
 

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -88,13 +88,30 @@ Bench-established (8822BU TX, monitor-inject USE_RATE frames):
   unique goodput 7× below singles). The `rty` component set to 0 suppresses
   it completely (receptions == uniques, 0% retry-flagged) — the
   broadcast/no-ack flavor is `DEVOURER_TX_AMPDU=<max>/<density>/0`.
-- **Open item — aggregate-launch pacing**: the chip flow-controls each
-  aggregate launch at ~3 ms under sustained feed (tracks
-  `REG_AMPDU_MAX_TIME_V1` 0x455 = 0x70, the aggregate-fill timer), so net
-  unique goodput at MCS7/20 MHz is currently BELOW plain singles. Promoting
-  the spike to a session API waits on a 0x455 / burst-mode (0x4BC) / queue
-  page-allocation sweep. `ppdu_cnt` reads 0 on the 8812CU RX used for the
-  bench; `paggr` + `tsfl` clustering are the working markers.
+- **Aggregate-launch pacing — solved by register pokes + feed depth**
+  (tests/ampdu_pacing_sweep.sh, tests/ampdu_onair_ab.sh; SDR duty is the
+  ground truth — RX-capture comparisons vary wildly between sessions):
+  - `REG_AMPDU_MAX_TIME_V1` (0x455): the bring-up value 0x70 paces each
+    aggregate launch at ~3 ms; **0x20 unlocks it** (URB acceptance
+    ~0.8 ms). Values ≤ 0x08 DISABLE aggregation entirely (frames revert to
+    slow singles) — the register is a cliff, not a dial.
+  - `REG_SW_AMPDU_BURST_MODE_CTRL` (0x4BC): **clearing it** (the halmac
+    bring-up sets BIT6) is worth ~+40% on the aggregated path.
+  - Both pokes ride `DEVOURER_REPLAY_WSEQ`, which now also applies at the
+    end of InitWrite (TX bring-ups can be swept like RX ones).
+  - **Feed depth is the other half**: with the sync 3-frame URB feed the
+    queue holds ≤3 frames and the MAC SIFS-bursts single-MPDU aggregates.
+    Parallel senders (txdemo `DEVOURER_TX_THREADS=N`; sync bulk from N
+    threads queues N URBs in flight) restore multi-MPDU amortization —
+    saturating at ~4 threads.
+  - On-air result (8822BU, ch149, MCS7/20, 1026-byte MPDUs, B210 duty):
+    singles 73.3% duty at ~3500 fps (28.7 Mbps MAC goodput) vs deep-fed
+    A-MPDU 79.3% duty at ~4550 fps (**37.4 Mbps, +30%**, +20% frames per
+    duty-point). The multiplier grows with PHY rate (overhead fraction);
+    a session API should bundle: data QSEL + AGG_EN + rty0 + 0x455=0x20 +
+    0x4BC=0 + a ≥4-deep feed.
+  - `ppdu_cnt` reads 0 on the 8812CU RX used for the bench; `paggr` +
+    `tsfl` clustering are the working RX markers.
 
 ## Ack stack (deferred)
 

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -1,15 +1,18 @@
-# Packet aggregation & TX-status reports
+# Packet aggregation, TX reports, and the hardware ACK/BlockAck responder
 
-Three layers, separable:
+devourer's TX path supports three independent, separable capabilities:
 
 1. **USB TX aggregation** — many `[txdesc][frame]` blocks per bulk-OUT URB
-   (host↔chip transport only, no on-air change). Shipped, on-air-validated.
+   (host↔chip transport only, no on-air change).
 2. **Per-frame TX-status reports** — the firmware's CCX report per
-   transmission (delivered / retry count / queue time / final rate). Shipped.
-3. **802.11 A-MPDU formation** — the MAC aggregating co-queued frames into
-   one PPDU (the air-time amortization). Shipped as `SetAmpduMode`
-   (`DEVOURER_TX_AMPDU_MODE`); +30% on-air goodput at MCS7/20, more at higher
-   rates. Needs a deep TX feed to reach the multiplier (below).
+   transmission (delivered / retry count / queue time / final rate).
+3. **802.11 A-MPDU formation** — the MAC aggregating co-queued frames into one
+   PPDU (the air-time amortization), via `SetAmpduMode`: +30% on-air goodput at
+   MCS7/20, more at higher rates, given a deep TX feed.
+
+A fourth capability — the hardware **ACK/BlockAck responder** — makes a monitor
+radio auto-acknowledge frames addressed to it, which turns both single-frame
+and A-MPDU unicast into reliable (hardware-ARQ) links.
 
 ## USB TX aggregation (`send_packets`)
 
@@ -21,139 +24,139 @@ blocks 8-byte aligned, the FIRST descriptor carries the block count
 checksummed span, so agg-num is set before the checksum), and the URB total
 never lands on an exact bulk-MPS multiple (the sync bulk path has no ZLP).
 
-Per-family hardware rules (both bench-validated on-air):
+Per-family hardware rules:
 
 - **HalMAC (8822B/8821C/8822C/8822E)**: at most **3 descriptors per bulk
   transfer** (mainline rtw88 `usb_tx_agg_desc_num` / halmac `BLK_DESC_NUM`) —
   the library clamps. Layout is rtw88-parity: no first-block reserve; the
   8-byte PKT_OFFSET shim is inserted only to escape a bulk-boundary total.
-- **Jaguar1 (8812A/8811A/8821A/8814A)**: vendor-parity — first block carries
-  the 8-byte PKT_OFFSET reserve (dropped at a boundary total), and the OQT
-  guard caps descriptor STARTS per bulk window (8812A = 1, 8814A = 3,
-  8821A = 6). When the knob is on, bring-up programs the kernel's TDECTRL
+- **Jaguar1 (8812A/8811A/8821A/8814A)**: vendor-parity — the first block
+  carries the 8-byte PKT_OFFSET reserve (dropped at a boundary total), and the
+  OQT guard caps descriptor STARTS per bulk window (8812A = 1, 8814A = 3,
+  8821A = 6). With the knob on, bring-up programs the kernel's TDECTRL
   block-desc count to match.
 
-Bench (8822BU → 8812CU, ch6, MCS7, 1026-byte MPDUs, per-frame counter
-stamped for uniqueness): batched URBs deliver every frame distinctly
-(receptions == uniques). A multi-frame sync URB is flow-controlled by the
-chip (~ms scale between URB acceptances under sustained flood), so batching
-buys per-frame host/USB overhead, not a higher flood ceiling — at MCS7 the
-air is the bottleneck either way. `tests/txagg_bench.sh` is the A/B harness.
+A multi-frame sync URB is flow-controlled by the chip (~ms scale between URB
+acceptances under a sustained flood), so batching removes per-frame host/USB
+overhead rather than raising the flood ceiling — at MCS7 the air is the
+bottleneck either way. `tests/txagg_bench.sh` is the single-vs-batch A/B
+(8822BU → 8812CU, MCS7, 1026-byte MPDUs): batched URBs deliver every frame
+distinctly.
 
-Bench-instrumentation trap (cost this project half a day): when TXing
-"identical" frames to measure aggregation, stamp EVERY frame uniquely
-(txdemo batch mode does, at MPDU bytes 26-29). Stamping one shared buffer per
-batch makes every reception of a batch look like the same frame — which is
-byte-for-byte indistinguishable from "the chip re-aired block 1 N times".
+Benchmarking note: to measure aggregation by TXing "identical" frames, stamp
+EVERY frame uniquely (txdemo batch mode writes a per-frame counter at MPDU
+bytes 26-29). A single shared buffer per batch makes every reception look like
+the same frame, which is byte-for-byte indistinguishable from the chip
+re-airing one frame N times.
 
 ## TX-status reports (`tx.report`)
 
 `DeviceConfig tx.report` (env `DEVOURER_TX_REPORT`) sets `SPE_RPT` in every
-data descriptor; the fw answers each transmission with a CCX report, decoded
-at the C2H RX sites into `tx.report` events (`src/TxReport.h`): `state`
+data descriptor; the firmware answers each transmission with a CCX report,
+decoded at the C2H RX sites into `tx.report` events (`src/TxReport.h`): `state`
 (0 = delivered/completed, 1 = retry-drop), `retries` (hardware
 retransmissions), `queue_time_raw`, `final_rate`, `bmc`. HalMAC reports echo
 the descriptor SW_DEFINE low byte — the devices stamp a rotating 8-bit `tag`
-for per-frame correlation. Jaguar1 uses the 6-byte 8812 format (queue time
-in 256 µs units; the 8814A fw layout differs and is left to the examples/rx
-best-effort decode). Jaguar3 TX-only sessions get reports via the coex
-thread's C2H drain; TX+RX sessions via the RX loop.
+for per-frame correlation. Jaguar1 uses the 6-byte 8812 format (queue time in
+256 µs units; the 8814A firmware layout differs and is left to the examples/rx
+best-effort decode). Jaguar3 TX-only sessions get reports via the coex thread's
+C2H drain; TX+RX sessions via the RX loop.
 
-This is the TX-side link sensor: retry counts feed adaptive rate/power the
-way RSSI/EVM feed the RX side.
+This is the TX-side link sensor: retry counts feed adaptive rate/power the way
+RSSI/EVM feed the RX side.
 
 ## A-MPDU (`SetAmpduMode`)
 
 `IRtlDevice::SetAmpduMode(AmpduMode)` / `ClearAmpduMode()` / `GetAmpduMode()`
 (env `DEVOURER_TX_AMPDU_MODE="tid/maxnum[/density[/noack[/maxtime_hex]]]"`,
-`src/AmpduMode.h`, all generations) bundle the whole proven recipe in one
-call: it marks every data frame aggregatable (data QSEL + AGG_EN +
-MAX_AGG_NUM + AMPDU_DENSITY + retry-limit) AND programs the MAC pacing
-registers live. The struct defaults are the tuned recipe, so the minimal spec
-`0/16` (TID 0, 16 MPDUs) is: density 7, no-ack, max_time 0x20, burst-mode
-cleared. Off keeps every TX byte-identical.
+`src/AmpduMode.h`, all generations) configure A-MPDU TX in one call: it marks
+every data frame aggregatable (data QSEL + AGG_EN + MAX_AGG_NUM +
+AMPDU_DENSITY + retry-limit) AND programs the MAC pacing registers live. The
+struct defaults are the tuned values, so the minimal spec `0/16` (TID 0,
+16 MPDUs) means density 7, no-ack, max_time 0x20, burst-mode cleared. Off keeps
+every TX byte-identical.
 
-The caller still supplies the frame shape (QoS-Data on the mode's TID — txdemo
-`DEVOURER_TX_QOS_DATA`) and, critically, a **deep TX feed**: send_packets with
-enough frames in flight, or txdemo `DEVOURER_TX_THREADS=N` (N parallel
+The caller supplies the frame shape (QoS-Data on the mode's TID — txdemo
+`DEVOURER_TX_QOS_DATA`) and, critically, a **deep TX feed**: `send_packets`
+with enough frames in flight, or txdemo `DEVOURER_TX_THREADS=N` (N parallel
 senders; ~4 saturates). A shallow feed leaves the MAC SIFS-bursting
-single-MPDU aggregates — the descriptor says "aggregatable" but there's
+single-MPDU aggregates — the descriptor says "aggregatable" but there is
 nothing co-queued to aggregate with.
 
-The lower-level spike knobs stay as an experimentation layer that composes on
-top: `DEVOURER_TX_QSEL=<0..7|0x12>` (raw QSEL), `DEVOURER_TX_AMPDU=
-"max[/density[/rty]]"` (raw AGG fields), both applied AFTER the product mode
-in the descriptor. RX side surfaces `paggr` (rx-desc "inside an aggregate")
-and `ppdu_cnt` in `rx_pkt_attrib` + the rxdemo `rx.frame`/`rx.txhit` events.
-`tests/ampdu_spike.sh` runs the discovery matrix; `tests/ampdu_pacing_sweep.sh`
-the register sweep; `tests/ampdu_onair_ab.sh` the SDR A/B.
+Two lower-level per-field knobs compose on top for register experimentation,
+applied AFTER the mode in the descriptor: `DEVOURER_TX_QSEL=<0..7|0x12>` (raw
+QSEL) and `DEVOURER_TX_AMPDU="max[/density[/rty]]"` (raw AGG fields). The RX
+side surfaces `paggr` (rx-desc "inside an aggregate") and `ppdu_cnt` in
+`rx_pkt_attrib` + the rxdemo `rx.frame`/`rx.txhit` events.
+`tests/ampdu_spike.sh` sweeps the aggregation-condition matrix,
+`tests/ampdu_pacing_sweep.sh` the pacing registers, `tests/ampdu_onair_ab.sh`
+the SDR A/B.
 
-What the sweep + on-air validation established (8822BU TX, monitor-inject
-USE_RATE frames; SDR duty is the ground truth — RX-capture goodput varies
-session to session):
+Hardware behaviour (8822BU TX, monitor-inject USE_RATE frames; SDR duty is the
+airtime ground truth):
 
-- **The MAC aggregates host-pushed frames** on a data queue (QoS-Data TID0 +
+- The MAC aggregates host-pushed frames on a **data queue** (QoS-Data TID0 +
   AGG_EN), broadcast RA included; the aggregation engine renumbers subframe
-  seqs consecutively. **The MGMT queue (0x12, the monitor-inject default)
+  seqs consecutively. The **MGMT queue (0x12, the monitor-inject default)
   never aggregates** — AGG_EN there wedges the queue.
-- **QoS No-Ack does NOT stop aggregate retransmission**: without a per-frame
-  retry limit the MAC re-airs each aggregate to the retry limit waiting for a
-  BlockAck no one sends (92% wasted re-airings). `no_ack` = retry-limit 0
-  airs each aggregate once (FEC covers loss, not ARQ) — the broadcast flavor.
+- QoS No-Ack ack-policy does **not** stop aggregate retransmission: without a
+  per-frame retry limit the MAC re-airs each aggregate to the retry limit
+  waiting for a BlockAck (92% wasted re-airings when no responder exists).
+  `no_ack` = retry-limit 0 airs each aggregate once (FEC covers loss, not ARQ)
+  — the broadcast flavor.
 - **Pacing registers** (programmed by `SetAmpduMode`): the aggregate-fill
-  timer `REG_AMPDU_MAX_TIME` (0x0455 HalMAC, **0x0456 Jaguar1**) — bring-up
-  0x70 paces launches at ~3 ms, `0x20` unlocks to ~0.8 ms; a CLIFF, values
-  ≤ 0x08 disable aggregation. The burst-mode gate
-  `REG_SW_AMPDU_BURST_MODE_CTRL` (0x04BC BIT6, halmac/8814A set it) cleared =
-  ~+40%. `AMPDU_DENSITY` counter-intuitively wants 7 (permissive spacing
-  forms better aggregates; density 0 measured ~10% slower).
+  timer `REG_AMPDU_MAX_TIME` (0x0455 HalMAC, **0x0456 Jaguar1**) — the
+  bring-up value 0x70 paces launches at ~3 ms, `0x20` paces at ~0.8 ms, and
+  values ≤ 0x08 disable aggregation (a cliff, not a dial). The burst-mode gate
+  `REG_SW_AMPDU_BURST_MODE_CTRL` (0x04BC BIT6, set by halmac/8814A bring-up)
+  cleared is worth ~+40%. `AMPDU_DENSITY` wants 7 (a permissive inter-MPDU
+  spacing forms better aggregates; density 0 measures ~10% slower).
 - **Feed depth is half the win**: a shallow sync-URB feed SIFS-bursts
-  single-MPDU aggregates; `DEVOURER_TX_THREADS=N` (N URBs in flight)
-  restores multi-MPDU amortization, saturating at ~4.
-- **On-air result** (8822BU, ch149, MCS7/20, 1026-byte MPDUs, B210 duty):
-  singles 73.3% duty vs deep-fed `SetAmpduMode` 79.2% duty — **+30% goodput**
-  (RX-capture cross-check: +33% delivered unique frames). The multiplier
-  grows with PHY rate (overhead is a bigger fraction at high MCS).
+  single-MPDU aggregates; `DEVOURER_TX_THREADS=N` (N URBs in flight) restores
+  multi-MPDU amortization, saturating at ~4.
+- On-air (8822BU, ch149, MCS7/20, 1026-byte MPDUs, B210 duty): singles 73.3%
+  duty vs deep-fed `SetAmpduMode` 79.2% duty — **+30% goodput** (RX-capture
+  cross-check: +33% delivered unique frames). The multiplier grows with PHY
+  rate, since preamble overhead is a bigger fraction at high MCS.
 - `ppdu_cnt` reads 0 on the 8812CU RX used for the bench; `paggr` + `tsfl`
   clustering are the working RX markers.
 
-## Hardware ACK responder — reliable unicast
+## Hardware ACK/BlockAck responder — reliable unicast
 
 `IRtlDevice::SetAckResponder(mac)` / `ClearAckResponder()` (env
 `DEVOURER_ACK_RESPONDER=<unicast mac>`, all generations; `src/AckResponder.h`)
 arms the MAC's autonomous ACK engine while monitor RX/injection continue
 unchanged: port identity (MACID/BSSID 0x610/0x618 = `mac`) + net_type (0x102
-[1:0] = AP). No beacon machinery needed — the identity+net_type pair alone is
-the gate (bench-bisected; `StartBeacon`'s extra registers are not required).
+[1:0] = AP). The identity+net_type pair is the whole gate — no beacon
+machinery, no ADDBA session state, no CAM entry.
 
 With a responder armed, a peer TXing unicast QoS-Data (normal ack-policy) to
-`mac` gets the full hardware ARQ loop — SIFS-timed ACKs from the responder,
+`mac` runs a full hardware ARQ loop — SIFS-timed ACKs from the responder,
 autonomous retransmission on the TX, both ends host-free.
-`tests/ack_responder_check.sh` is the closed-loop A/B, judged by the TX
-side's CCX reports: responder ON = 100% delivered at mean 0.4 retries (67%
-first-try); OFF = 0% delivered, every frame pinned at the 12-retry limit.
-The retry distribution doubles as the per-frame TX-side link-quality sensor.
+`tests/ack_responder_check.sh` is the closed-loop A/B judged by the TX side's
+CCX reports: responder ON = 100% delivered at mean 0.4 retries (67%
+first-try); OFF = 0% delivered, every frame pinned at the 12-retry limit. The
+retry distribution is the per-frame TX-side link-quality sensor.
 
-**The same responder is a hardware BlockAck responder** — no ADDBA session
-state, no separate API. The MAC's immediate-response engine generates a
-SIFS-timed BlockAck for a received A-MPDU addressed to its MACID exactly as it
-generates an ACK for a unicast frame; the gate is the same MACID + net_type
-pair. So reliable-unicast **ACKed A-MPDU** works end to end: the TX runs
-`SetAmpduMode` with `no_ack = false` (normal ack-policy, retry limit kept) and
-the peer runs `SetAckResponder`. `tests/ampdu_ba_check.sh` proves it: with the
-responder armed, aggregates deliver at 100% / mean 0.1 retries and ~27× the
-throughput of the responder-off case (where every aggregate re-airs to the
-retry limit for a BlockAck no one sends). The `no_ack = true` default stays the
-broadcast/FEC flavor (OpenIPC wfb — no responder, no re-air storm); `false` is
-the reliable-unicast flavor against a BA responder.
+The same responder is a hardware **BlockAck** responder: the MAC's
+immediate-response engine generates a SIFS-timed BlockAck for a received
+A-MPDU addressed to its MACID, on the same MACID + net_type gate. So
+reliable-unicast **ACKed A-MPDU** works end to end — the TX runs `SetAmpduMode`
+with `no_ack = false` (normal ack-policy, retry limit kept) and the peer runs
+`SetAckResponder`. `tests/ampdu_ba_check.sh`: with the responder armed,
+aggregates deliver at 100% / mean 0.1 retries and ~27× the throughput of the
+responder-off case (where every aggregate re-airs to the retry limit). The
+`no_ack = true` default is the broadcast/FEC flavor (OpenIPC wfb — no
+responder, no re-air storm); `false` is the reliable-unicast flavor against a
+BA responder.
 
-THE footgun (three strikes now): every MAC in the loop must be UNICAST (I/G
-bit clear) — the responder `mac` (an ACK/BlockAck can't target a group
-address), and the TX frame's TA/addr2 (the response's RA is the soliciting
-frame's addr2; the canonical TX SA `57:42:75:05:d6:00` is a GROUP address, so
-txdemo's QoS shape takes `DEVOURER_TX_SA` to override). A group TA silently
-yields retry-limit-pinned reports with the responder perfectly armed.
+Every MAC address in the loop must be **unicast** (I/G bit clear): the
+responder `mac` (an ACK/BlockAck cannot target a group address) and the TX
+frame's TA/addr2 (the response's RA is the soliciting frame's addr2). The
+canonical TX SA `57:42:75:05:d6:00` is a group address, so txdemo's QoS shape
+takes `DEVOURER_TX_SA` to override it — a group TA yields retry-limit-pinned
+reports even with the responder perfectly armed.
 
-Opt-in only: arming turns a passive monitor into an active transmitter.
-Remaining ack-stack item: a software ARQ policy above the CCX reports (the
-hardware ARQ — ACK, BlockAck, autonomous retransmit — is complete).
+Arming a responder turns a passive monitor into an active transmitter, so it
+is opt-in. The hardware ARQ (ACK, BlockAck, autonomous retransmission) is
+complete; devourer layers no software ARQ policy above the reports.

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -7,8 +7,10 @@ devourer's TX path supports three independent, separable capabilities:
 2. **Per-frame TX-status reports** — the firmware's CCX report per
    transmission (delivered / retry count / queue time / final rate).
 3. **802.11 A-MPDU formation** — the MAC aggregating co-queued frames into one
-   PPDU (the air-time amortization), via `SetAmpduMode`: +30% on-air goodput at
-   MCS7/20, more at higher rates, given a deep TX feed.
+   PPDU (the air-time amortization), via `SetAmpduMode`: +30% goodput at
+   MCS7/20 on the HalMAC generations, more at higher rates, given a deep TX
+   feed. (This is a *goodput* gain — delivered payload — not a channel-occupancy
+   one; see the note under the A-MPDU section.)
 
 A fourth capability — the hardware **ACK/BlockAck responder** — makes a monitor
 radio auto-acknowledge frames addressed to it, which turns both single-frame
@@ -113,13 +115,30 @@ airtime ground truth):
   spacing forms better aggregates; density 0 measures ~10% slower).
 - **Feed depth is half the win**: a shallow sync-URB feed SIFS-bursts
   single-MPDU aggregates; `DEVOURER_TX_THREADS=N` (N URBs in flight) restores
-  multi-MPDU amortization, saturating at ~4.
-- On-air (8822BU, ch149, MCS7/20, 1026-byte MPDUs, B210 duty): singles 73.3%
-  duty vs deep-fed `SetAmpduMode` 79.2% duty — **+30% goodput** (RX-capture
-  cross-check: +33% delivered unique frames). The multiplier grows with PHY
-  rate, since preamble overhead is a bigger fraction at high MCS.
+  multi-MPDU amortization, saturating at ~4. This works on the HalMAC
+  generations (J2/J3), whose TX path is synchronous bulk (each sender thread
+  blocks on its own transfer). **Jaguar1 uses the fire-and-forget async TX
+  path, which does not parallelize** — a multi-thread feed collapses its
+  throughput (8812AU 55 → 14 Mbps at threads=4 with no aggregation at all), so
+  the deep feed A-MPDU needs is currently HalMAC-only. Jaguar1's descriptor
+  path still marks frames aggregatable, but the multiplier is not reachable
+  without a feed rework.
+- **The gain is goodput, not channel occupancy.** On-air (8822BU, ch149,
+  MCS7/20, B210 duty), aggregation raised delivered goodput **~+30%** (73.3% →
+  79.2% duty plus a per-airtime payload increase; RX-capture cross-check +33%
+  delivered unique frames). But `tests/bench_onair.py`'s metric — SDR duty ×
+  PHY rate — is channel *occupancy*, and these chips already run at ~80% duty
+  near the 65 Mbps PHY ceiling, so that number moves only ~+2% (8822BU 51 → 52,
+  8812CU 51 → 52). The occupancy metric structurally cannot show A-MPDU's
+  payload gain on a near-saturated chip; measure goodput (delivered payload)
+  to see it. The multiplier grows with PHY rate, since preamble overhead is a
+  bigger fraction at high MCS.
 - `ppdu_cnt` reads 0 on the 8812CU RX used for the bench; `paggr` + `tsfl`
   clustering are the working RX markers.
+
+`tests/bench_onair.py --ampdu` measures the singles / feed-depth / A-MPDU
+comparison per chip per band (SDR duty), and is the harness the occupancy
+numbers above came from.
 
 ## Hardware ACK/BlockAck responder — reliable unicast
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -86,10 +86,10 @@ Emitters: L = library, RX/TX/... = demo. Optional fields in [brackets];
 | ev | emitter | fields |
 |---|---|---|
 | `rx.pkt` | RX | n, len (first 10 + every 100th frame) |
-| `rx.frame` | RX (`DEVOURER_STREAM_OUT`), duplex | rate, len, crc, icv, rssi[2], evm[2], snr[2], seq, tsfl, bw, stbc, ldpc, sgi, body hex; `tx_tsf` (sender's hardware egress TSF) on beacons/probe-responses only |
+| `rx.frame` | RX (`DEVOURER_STREAM_OUT`), duplex | rate, len, crc, icv, rssi[2], evm[2], snr[2], seq, tsfl, bw, stbc, ldpc, sgi, paggr, ppdu, fc1 (FC flags byte; bit3 = 802.11 RETRY), body hex; `tx_tsf` (sender's hardware egress TSF) on beacons/probe-responses only |
 | `rx.body` | RX (`DEVOURER_DUMP_BODY`) | rate, rssi[2], evm[2], snr[2], crc, len, body hex |
 | `rx.corrupt` | RX (`DEVOURER_RX_DUMP_ALL`) | len, crc, icv, rate, bw, stbc, ldpc, sgi, rssi[2], evm[2], snr[2] |
-| `rx.txhit` | RX, TX | hits, total_rx, len — canonical-SA (57:42:75:05:d6:00) matcher |
+| `rx.txhit` | RX, TX | hits, total_rx, len, seq, paggr, ppdu — canonical-SA (57:42:75:05:d6:00) matcher |
 | `rx.count` | TX (its RX thread) | total, len |
 | `rx.path` | RX (`DEVOURER_RX_ALLPATHS`) | seq, rssi[4], snr[4], evm[4] |
 | `rx.path_mask` | L (toggle spec) | t, mask "0xNN" |
@@ -106,6 +106,8 @@ Emitters: L = library, RX/TX/... = demo. Optional fields in [brackets];
 |---|---|---|
 | `tx.frame` | TX | n, rc — precoder demo variant: n, ok |
 | `tx.stats` | TX | submitted, failed, was_timeout, last_rc |
+| `tx.agg` | L (`DEVOURER_TX_USB_AGG`, send_packets) | frames, bytes, shim, ok — one per multi-frame bulk-OUT URB |
+| `tx.report` | L (`DEVOURER_TX_REPORT`, CCX decode) | state (0=delivered, 1=retry-drop), ok, retries, final_rate, queue_time_raw, bmc, macid, fmt ("8812"\|"halmac"); halmac adds tag (SW_DEFINE echo), rts_retries, missed |
 | `tx.status` | RX, duplex (C2H TX_RPT decode) | hoff, queue, retry, airtime_us, rate |
 | `tx.queue` | RX (`DEVOURER_QUEUE_POLL_MS`, 8814) | q1…q5 "0x%08x" |
 | `tx.contx` | TX (continuous mode) | mcs, t_ms |

--- a/examples/common/env_config.cpp
+++ b/examples/common/env_config.cpp
@@ -72,6 +72,8 @@ devourer::DeviceConfig devourer_config_from_env() {
   cfg.tx.cw_tone = env_flag("DEVOURER_CW_TONE");
   if (env_long("DEVOURER_CW_TONE_GAIN", &v))
     cfg.tx.cw_tone_gain = static_cast<uint8_t>(v) & 0x1F;
+  if (env_long("DEVOURER_TX_USB_AGG", &v) && v > 0)
+    cfg.tx.usb_agg_max = static_cast<unsigned>(v);
 
   /* ---- bf ---- */
   if (const char *snd = env_str("DEVOURER_BF_ARM_SOUNDER")) {

--- a/examples/common/env_config.cpp
+++ b/examples/common/env_config.cpp
@@ -77,6 +77,11 @@ devourer::DeviceConfig devourer_config_from_env() {
   if (env_long("DEVOURER_TX_USB_AGG", &v) && v > 0)
     cfg.tx.usb_agg_max = static_cast<unsigned>(v);
   cfg.tx.report = env_flag("DEVOURER_TX_REPORT");
+  if (const char *e = env_str("DEVOURER_TX_AMPDU_MODE")) {
+    devourer::AmpduMode m;
+    if (devourer::parse_ampdu_mode(e, m))
+      cfg.tx.ampdu = m;
+  }
 
   /* ---- bf ---- */
   if (const char *snd = env_str("DEVOURER_BF_ARM_SOUNDER")) {

--- a/examples/common/env_config.cpp
+++ b/examples/common/env_config.cpp
@@ -74,6 +74,7 @@ devourer::DeviceConfig devourer_config_from_env() {
     cfg.tx.cw_tone_gain = static_cast<uint8_t>(v) & 0x1F;
   if (env_long("DEVOURER_TX_USB_AGG", &v) && v > 0)
     cfg.tx.usb_agg_max = static_cast<unsigned>(v);
+  cfg.tx.report = env_flag("DEVOURER_TX_REPORT");
 
   /* ---- bf ---- */
   if (const char *snd = env_str("DEVOURER_BF_ARM_SOUNDER")) {

--- a/examples/common/env_config.cpp
+++ b/examples/common/env_config.cpp
@@ -143,15 +143,19 @@ devourer::DeviceConfig devourer_config_from_env() {
     cfg.debug.replay_wseq = e;
   if (env_long("DEVOURER_TX_QSEL", &v))
     cfg.debug.tx_qsel = static_cast<uint8_t>(v & 0x1f);
-  /* "max[/density]" — A-MPDU spike descriptor overrides. */
+  /* "max[/density[/rty]]" — A-MPDU spike descriptor overrides. */
   if (const char *e = env_str("DEVOURER_TX_AMPDU")) {
     char *end = nullptr;
     long maxn = std::strtol(e, &end, 0);
     if (maxn > 0) {
       cfg.debug.tx_ampdu_max = static_cast<uint8_t>(maxn & 0x1f);
-      if (end && *end == '/')
+      if (end && *end == '/') {
         cfg.debug.tx_ampdu_density =
-            static_cast<uint8_t>(std::strtol(end + 1, nullptr, 0) & 0x7);
+            static_cast<uint8_t>(std::strtol(end + 1, &end, 0) & 0x7);
+        if (end && *end == '/')
+          cfg.debug.tx_ampdu_rty =
+              static_cast<uint8_t>(std::strtol(end + 1, nullptr, 0) & 0x3f);
+      }
     }
   }
   cfg.debug.hop_prof = env_flag("DEVOURER_HOP_PROF");

--- a/examples/common/env_config.cpp
+++ b/examples/common/env_config.cpp
@@ -141,6 +141,19 @@ devourer::DeviceConfig devourer_config_from_env() {
   cfg.debug.log_txpwr = env_flag("DEVOURER_LOG_TXPWR");
   if (const char *e = env_str("DEVOURER_REPLAY_WSEQ"))
     cfg.debug.replay_wseq = e;
+  if (env_long("DEVOURER_TX_QSEL", &v))
+    cfg.debug.tx_qsel = static_cast<uint8_t>(v & 0x1f);
+  /* "max[/density]" — A-MPDU spike descriptor overrides. */
+  if (const char *e = env_str("DEVOURER_TX_AMPDU")) {
+    char *end = nullptr;
+    long maxn = std::strtol(e, &end, 0);
+    if (maxn > 0) {
+      cfg.debug.tx_ampdu_max = static_cast<uint8_t>(maxn & 0x1f);
+      if (end && *end == '/')
+        cfg.debug.tx_ampdu_density =
+            static_cast<uint8_t>(std::strtol(end + 1, nullptr, 0) & 0x7);
+    }
+  }
   cfg.debug.hop_prof = env_flag("DEVOURER_HOP_PROF");
   cfg.debug.gaintab_dbg = env_flag("DEVOURER_GAINTAB_DBG");
 

--- a/examples/common/env_config.cpp
+++ b/examples/common/env_config.cpp
@@ -58,6 +58,8 @@ devourer::DeviceConfig devourer_config_from_env() {
   cfg.rx.phy_status_8821c = !env_flag("DEVOURER_8821C_NO_PHYST");
   if (env_long("DEVOURER_IGI", &v))
     cfg.rx.igi = static_cast<uint8_t>(v & 0x7f);
+  if (const char *e = env_str("DEVOURER_ACK_RESPONDER"))
+    cfg.rx.ack_responder = devourer::parse_mac(e);
 
   /* ---- tx ---- */
   if (env_long("DEVOURER_TX_EP", &v))

--- a/examples/rx/main.cpp
+++ b/examples/rx/main.cpp
@@ -505,7 +505,11 @@ static void packetProcessor(const Packet &packet) {
              * aggregate; ppdu = the halmac 2-bit received-PPDU counter
              * (frames sharing a value shared one PPDU). */
             .f("paggr", packet.RxAtrib.paggr ? 1 : 0)
-            .f("ppdu", packet.RxAtrib.ppdu_cnt);
+            .f("ppdu", packet.RxAtrib.ppdu_cnt)
+            /* FC flags byte (frame byte 1): bit3 = the 802.11 RETRY flag —
+             * distinguishes hardware retransmissions (e.g. an A-MPDU
+             * re-aired for want of a BlockAck) from first airings. */
+            .f("fc1", packet.Data.size() > 1 ? packet.Data[1] : 0);
         /* tx_tsf: the sender's hardware TX-egress TSF (beacons / probe responses
          * only). Pair with tsfl — the local hardware RX timestamp above — for
          * one-way hardware time sync with no host-clock jitter on either end. */

--- a/examples/rx/main.cpp
+++ b/examples/rx/main.cpp
@@ -379,7 +379,10 @@ static void packetProcessor(const Packet &packet) {
         devourer::Ev(*g_ev, "rx.txhit")
             .f("hits", hits)
             .f("total_rx", g_rx_count)
-            .f("len", packet.Data.size());
+            .f("len", packet.Data.size())
+            .f("seq", packet.RxAtrib.seq_num)
+            .f("paggr", packet.RxAtrib.paggr ? 1 : 0)
+            .f("ppdu", packet.RxAtrib.ppdu_cnt);
       }
 #if defined(DEVOURER_HAVE_JAGUAR1)
       /* F2: BB-dbgport sweep on the first kCsiMaxFrames canonical-SA frames.
@@ -497,7 +500,12 @@ static void packetProcessor(const Packet &packet) {
             .f("bw", packet.RxAtrib.bw)
             .f("stbc", packet.RxAtrib.stbc)
             .f("ldpc", packet.RxAtrib.ldpc)
-            .f("sgi", packet.RxAtrib.sgi);
+            .f("sgi", packet.RxAtrib.sgi)
+            /* A-MPDU RX markers (src/RxPacket.h): paggr = inside an
+             * aggregate; ppdu = the halmac 2-bit received-PPDU counter
+             * (frames sharing a value shared one PPDU). */
+            .f("paggr", packet.RxAtrib.paggr ? 1 : 0)
+            .f("ppdu", packet.RxAtrib.ppdu_cnt);
         /* tx_tsf: the sender's hardware TX-egress TSF (beacons / probe responses
          * only). Pair with tsfl — the local hardware RX timestamp above — for
          * one-way hardware time sync with no host-clock jitter on either end. */

--- a/examples/tx/main.cpp
+++ b/examples/tx/main.cpp
@@ -818,6 +818,25 @@ int main(int argc, char **argv) {
    * within the batch. */
   std::vector<std::vector<uint8_t>> tx_batch_bufs;
 
+  /* DEVOURER_TX_THREADS=N (A-MPDU feed-depth bench): N-1 auxiliary sender
+   * threads run send_packets floods in parallel with the main loop, each with
+   * its own stamped buffer copies drawing frame counters from a shared atomic
+   * — so the chip's TX queue holds ~N URBs in flight (sync bulk transfers on
+   * one endpoint are legal from multiple threads and simply queue). Deeper
+   * co-residency is what lets the MAC form multi-MPDU aggregates instead of
+   * SIFS-bursting single-MPDU ones. Aux threads emit no events and skip the
+   * hop/thermal machinery; frame accounting rides tx_counter. Default 1. */
+  long tx_threads = 1;
+  if (const char *e = std::getenv("DEVOURER_TX_THREADS")) {
+    tx_threads = std::strtol(e, nullptr, 0);
+    if (tx_threads < 1)
+      tx_threads = 1;
+    if (tx_threads > 1)
+      logger->info("DEVOURER_TX_THREADS — {} parallel senders", tx_threads);
+  }
+  std::atomic<long> tx_counter{0}; /* shared frame-stamp source (threads>1) */
+  std::vector<std::thread> tx_aux;
+
   /* Channel-hopping mode (frequency-diversity validation). When
    * DEVOURER_HOP_CHANNELS="1,6,11" is set the TX loop dwells DWELL_FRAMES
    * frames on each listed channel, then retunes to the next via
@@ -1128,6 +1147,31 @@ int main(int argc, char **argv) {
       uint32_t v = static_cast<uint32_t>(tx_count);
       std::memcpy(tx_buf.data() + 10 + 26, &v, 4);
     }
+    /* Lazy-start the auxiliary senders on the first main-loop pass (the
+     * chip is up and the first frame primed by then). */
+    if (tx_threads > 1 && tx_aux.empty()) {
+      for (long t = 1; t < tx_threads; ++t) {
+        tx_aux.emplace_back([&, t]() {
+          std::vector<std::vector<uint8_t>> bufs(
+              static_cast<size_t>(tx_batch > 1 ? tx_batch : 1), tx_buf);
+          std::vector<TxPacketView> views;
+          while (!g_devourer_should_stop) {
+            views.clear();
+            const long base =
+                tx_counter.fetch_add(static_cast<long>(bufs.size()));
+            for (size_t k = 0; k < bufs.size(); ++k) {
+              auto &b = bufs[k];
+              if (qos_stamp && b.size() >= 10 + 26 + 4) {
+                uint32_t v = static_cast<uint32_t>(base + (long)k);
+                std::memcpy(b.data() + 10 + 26, &v, 4);
+              }
+              views.push_back(TxPacketView{b.data(), b.size()});
+            }
+            rtlDevice->send_packets(views.data(), views.size());
+          }
+        });
+      }
+    }
     if (tx_batch > 1) {
       /* Batch mode: N frames through send_packets (each keeps its own
        * descriptor; the library packs them into shared URBs when
@@ -1141,7 +1185,8 @@ int main(int argc, char **argv) {
       for (long k = 0; k < tx_batch; ++k) {
         auto &b = tx_batch_bufs[static_cast<size_t>(k)];
         if (qos_stamp && b.size() >= 10 + 26 + 4) {
-          uint32_t v = static_cast<uint32_t>(tx_count + k);
+          uint32_t v = static_cast<uint32_t>(
+              tx_threads > 1 ? tx_counter.fetch_add(1) : tx_count + k);
           std::memcpy(b.data() + 10 + 26, &v, 4);
         }
         tx_batch_views.push_back(TxPacketView{b.data(), b.size()});
@@ -1213,6 +1258,11 @@ int main(int argc, char **argv) {
     } else if (tx_interval_ms > 0)
       std::this_thread::sleep_for(std::chrono::milliseconds(tx_interval_ms));
   }
+
+  g_devourer_should_stop = 1; /* stop the aux senders with the main loop */
+  for (auto &th : tx_aux)
+    if (th.joinable())
+      th.join();
 
   /* Bounded hop mode (DEVOURER_HOP_ROUNDS>0) reaches here when its rounds
    * complete; the signal and back-off paths also fall through. */

--- a/examples/tx/main.cpp
+++ b/examples/tx/main.cpp
@@ -682,7 +682,18 @@ int main(int argc, char **argv) {
   bool qos_stamp = false;
   if (std::getenv("DEVOURER_TX_QOS_DATA") != nullptr) {
     qos_stamp = true;
-    static const uint8_t kQosSa[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
+    /* SA/TA defaults to the canonical TX SA so rx.txhit keeps matching — but
+     * note its I/G bit is SET (a group address). An ACK's RA is the
+     * soliciting frame's addr2, so hardware-ACK experiments need a UNICAST
+     * TA: DEVOURER_TX_SA overrides (the third appearance of the I/G footgun
+     * after docs/ap-mode.md's BSSID and the responder MAC). */
+    uint8_t kQosSa[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
+    if (const char *e = std::getenv("DEVOURER_TX_SA")) {
+      if (auto m = devourer::parse_mac(e))
+        std::memcpy(kQosSa, m->data(), 6);
+      else
+        logger->warn("DEVOURER_TX_SA unparseable — keeping the canonical SA");
+    }
     uint8_t ra[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
     if (const char *e = std::getenv("DEVOURER_TX_RA")) {
       if (auto m = devourer::parse_mac(e))

--- a/examples/tx/main.cpp
+++ b/examples/tx/main.cpp
@@ -679,7 +679,9 @@ int main(int argc, char **argv) {
    * the QoS ack-policy to No-Ack (the wfb-style broadcast flavor). Body =
    * 64 zero bytes; DEVOURER_TX_PAYLOAD_BYTES below pads it further. Overrides
    * the PKT_PWR/NDPA frame shapes. */
+  bool qos_stamp = false;
   if (std::getenv("DEVOURER_TX_QOS_DATA") != nullptr) {
+    qos_stamp = true;
     static const uint8_t kQosSa[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
     uint8_t ra[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
     if (const char *e = std::getenv("DEVOURER_TX_RA")) {
@@ -811,6 +813,10 @@ int main(int argc, char **argv) {
       logger->info("DEVOURER_TX_BATCH — send_packets batches of {}", tx_batch);
   }
   std::vector<TxPacketView> tx_batch_views;
+  /* Batch mode sends N frames per send_packets call — each needs its OWN
+   * buffer so the per-frame counter stamp (QoS spike uniqueness) differs
+   * within the batch. */
+  std::vector<std::vector<uint8_t>> tx_batch_bufs;
 
   /* Channel-hopping mode (frequency-diversity validation). When
    * DEVOURER_HOP_CHANNELS="1,6,11" is set the TX loop dwells DWELL_FRAMES
@@ -1115,12 +1121,31 @@ int main(int argc, char **argv) {
       m.stbc = static_cast<uint8_t>(tx_count & 1);   /* 0,1,0,1,… per frame */
       rtlDevice->SetTxMode(m);
     }
+    /* QoS spike frames carry a per-frame counter at body[0..3] (MPDU bytes
+     * 26..29) so the receiver can count UNIQUE frames vs hardware re-airings
+     * (the A-MPDU engine renumbers seqs per aggregate, so seq can't). */
+    if (qos_stamp && tx_buf.size() >= 10 + 26 + 4) {
+      uint32_t v = static_cast<uint32_t>(tx_count);
+      std::memcpy(tx_buf.data() + 10 + 26, &v, 4);
+    }
     if (tx_batch > 1) {
-      /* Batch mode: N copies of the frame through send_packets (each keeps
-       * its own descriptor; the library packs them into shared URBs when
-       * DEVOURER_TX_USB_AGG is on). rc = the whole batch submitted. */
-      tx_batch_views.assign(static_cast<size_t>(tx_batch),
-                            TxPacketView{tx_buf.data(), tx_buf.size()});
+      /* Batch mode: N frames through send_packets (each keeps its own
+       * descriptor; the library packs them into shared URBs when
+       * DEVOURER_TX_USB_AGG is on). Each batch entry is its own buffer copy
+       * with a DISTINCT counter stamp — stamping one shared buffer would
+       * make every frame in the batch byte-identical and fake a
+       * "first-frame repeated" signature on the receiver. rc = the whole
+       * batch submitted. */
+      tx_batch_bufs.assign(static_cast<size_t>(tx_batch), tx_buf);
+      tx_batch_views.clear();
+      for (long k = 0; k < tx_batch; ++k) {
+        auto &b = tx_batch_bufs[static_cast<size_t>(k)];
+        if (qos_stamp && b.size() >= 10 + 26 + 4) {
+          uint32_t v = static_cast<uint32_t>(tx_count + k);
+          std::memcpy(b.data() + 10 + 26, &v, 4);
+        }
+        tx_batch_views.push_back(TxPacketView{b.data(), b.size()});
+      }
       const size_t okn = rtlDevice->send_packets(tx_batch_views.data(),
                                                  tx_batch_views.size());
       rc = okn == tx_batch_views.size();

--- a/examples/tx/main.cpp
+++ b/examples/tx/main.cpp
@@ -670,6 +670,46 @@ int main(int argc, char **argv) {
     logger->info("DEVOURER_TX_PKT_PWR_DB={} — per-packet power via radiotap", db);
   }
 
+  /* DEVOURER_TX_QOS_DATA=1 — A-MPDU spike frame shape (tests/ampdu_spike.sh):
+   * replace the mgmt probe with a QoS-Data frame (FC 0x88, no-DS), TID 0 —
+   * the only frame type the MAC's A-MPDU engine aggregates. SA/BSSID stay the
+   * canonical TX SA so the rxdemo rx.txhit matcher keeps working; RA defaults
+   * to broadcast (DEVOURER_TX_RA=aa:bb:.. overrides — unicast toward a
+   * hardware-ACKing peer is the ACKed flavor). DEVOURER_TX_QOS_NOACK=1 sets
+   * the QoS ack-policy to No-Ack (the wfb-style broadcast flavor). Body =
+   * 64 zero bytes; DEVOURER_TX_PAYLOAD_BYTES below pads it further. Overrides
+   * the PKT_PWR/NDPA frame shapes. */
+  if (std::getenv("DEVOURER_TX_QOS_DATA") != nullptr) {
+    static const uint8_t kQosSa[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
+    uint8_t ra[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+    if (const char *e = std::getenv("DEVOURER_TX_RA")) {
+      if (auto m = devourer::parse_mac(e))
+        std::memcpy(ra, m->data(), 6);
+      else
+        logger->warn("DEVOURER_TX_RA unparseable — keeping broadcast RA");
+    }
+    const bool noack = std::getenv("DEVOURER_TX_QOS_NOACK") != nullptr;
+    /* Same rate-less TX_FLAGS-only radiotap as the probe frame above. */
+    static const uint8_t kRtap[10] = {0x00, 0x00, 0x0a, 0x00, 0x00,
+                                      0x80, 0x00, 0x00, 0x08, 0x00};
+    std::vector<uint8_t> f(kRtap, kRtap + sizeof(kRtap));
+    const uint8_t qos_hdr[26] = {
+        0x88, 0x00, /* FC: QoS Data, no To/FromDS */
+        0x00, 0x00, /* duration */
+        ra[0], ra[1], ra[2], ra[3], ra[4], ra[5],
+        kQosSa[0], kQosSa[1], kQosSa[2], kQosSa[3], kQosSa[4], kQosSa[5],
+        kQosSa[0], kQosSa[1], kQosSa[2], kQosSa[3], kQosSa[4], kQosSa[5],
+        0x00, 0x00, /* seq (EN_HWSEQ overwrites) */
+        /* QoS ctrl: TID 0; ack-policy bits [6:5] = 01 (No Ack) / 00. */
+        static_cast<uint8_t>(noack ? 0x20 : 0x00), 0x00};
+    f.insert(f.end(), qos_hdr, qos_hdr + sizeof(qos_hdr));
+    f.insert(f.end(), 64, 0x00);
+    tx_buf = std::move(f);
+    logger->info("DEVOURER_TX_QOS_DATA — QoS-Data TID0, RA {}, ack-policy {}",
+                 (ra[0] == 0xff) ? "broadcast" : "unicast",
+                 noack ? "no-ack" : "normal");
+  }
+
   /* Frame-size knob for throughput benchmarking. DEVOURER_TX_PAYLOAD_BYTES=N
    * pads the 802.11 body so the on-air PSDU is exactly N bytes — send_packet
    * writes real_packet_length (= PSDU) into the 16-bit TX-desc PKT_SIZE, so N

--- a/examples/tx/main.cpp
+++ b/examples/tx/main.cpp
@@ -757,6 +757,21 @@ int main(int argc, char **argv) {
     tx_gap_set = true;
   }
 
+  /* DEVOURER_TX_BATCH=N: drive the send_packets batch API in groups of N
+   * frames per call — the USB TX aggregation bench mode. Pair with
+   * DEVOURER_TX_USB_AGG (library knob) to actually pack the group into shared
+   * bulk-OUT URBs; without it send_packets degrades to the per-frame loop.
+   * Default 1 = the classic send_packet loop, byte-identical. */
+  long tx_batch = 1;
+  if (const char *e = std::getenv("DEVOURER_TX_BATCH")) {
+    tx_batch = std::strtol(e, nullptr, 0);
+    if (tx_batch < 1)
+      tx_batch = 1;
+    if (tx_batch > 1)
+      logger->info("DEVOURER_TX_BATCH — send_packets batches of {}", tx_batch);
+  }
+  std::vector<TxPacketView> tx_batch_views;
+
   /* Channel-hopping mode (frequency-diversity validation). When
    * DEVOURER_HOP_CHANNELS="1,6,11" is set the TX loop dwells DWELL_FRAMES
    * frames on each listed channel, then retunes to the next via
@@ -1060,8 +1075,22 @@ int main(int argc, char **argv) {
       m.stbc = static_cast<uint8_t>(tx_count & 1);   /* 0,1,0,1,… per frame */
       rtlDevice->SetTxMode(m);
     }
-    rc = rtlDevice->send_packet(tx_buf.data(), tx_buf.size());
-    ++tx_count;
+    if (tx_batch > 1) {
+      /* Batch mode: N copies of the frame through send_packets (each keeps
+       * its own descriptor; the library packs them into shared URBs when
+       * DEVOURER_TX_USB_AGG is on). rc = the whole batch submitted. */
+      tx_batch_views.assign(static_cast<size_t>(tx_batch),
+                            TxPacketView{tx_buf.data(), tx_buf.size()});
+      const size_t okn = rtlDevice->send_packets(tx_batch_views.data(),
+                                                 tx_batch_views.size());
+      rc = okn == tx_batch_views.size();
+      tx_count += tx_batch;
+      if (!hop_channels.empty())
+        frames_in_dwell += tx_batch - 1; /* the shared ++ below adds one */
+    } else {
+      rc = rtlDevice->send_packet(tx_buf.data(), tx_buf.size());
+      ++tx_count;
+    }
     if (!hop_channels.empty() && ++frames_in_dwell >= hop_dwell)
       frames_in_dwell = 0;
     if (tx_count <= 10 || tx_count % 500 == 0) {

--- a/src/AckResponder.h
+++ b/src/AckResponder.h
@@ -1,0 +1,56 @@
+#pragma once
+
+/* AckResponder — the hardware ACK engine as a first-class monitor-mode knob.
+ *
+ * The Realtek MAC auto-ACKs (SIFS-timed, zero host involvement) any unicast
+ * frame whose RA matches the port-0 MACID, PROVIDED the port has a network
+ * type. devourer's monitor bring-up leaves net_type = 0 (No Link), which is
+ * why a monitor radio never ACKs; the AP-mode work proved the gate — with
+ * MACID + net_type programmed, a real station's auth/assoc arrive at retry=0
+ * (docs/ap-mode.md). This header is that recipe minus the beacon machinery:
+ * program the port identity, flip the net type, and the chip becomes an ACK
+ * responder for one MAC address while everything else about monitor mode
+ * (promiscuous RX, injection) is unchanged.
+ *
+ * The registers are generation-neutral (same map on Jaguar1/2/3):
+ *   0x0610..0x0615  REG_MACID   — the RA the ACK engine matches
+ *   0x0618..0x061d  REG_BSSID   — port identity companion (the proven AP
+ *                                 recipe programs both)
+ *   0x0102[1:0]     MSR/net_type (REG_CR+2) — 0 NoLink / 1 Ad-hoc / 2 Infra /
+ *                                 3 AP; any nonzero arms the responder. We
+ *                                 use AP (3), the bench-proven value.
+ *
+ * Turning a passive monitor into an ACTIVE transmitter is a behavioral
+ * change — hence opt-in only (DeviceConfig rx.ack_responder / the
+ * SetAckResponder runtime call), never a default. The MAC must be UNICAST
+ * (I/G bit clear) — a station cannot ACK-target a group address, and the
+ * same footgun broke AP association (docs/ap-mode.md). */
+
+#include <cstdint>
+
+#include "RtlAdapter.h"
+
+namespace devourer {
+namespace ack {
+
+inline void enable(RtlAdapter &dev, const uint8_t mac[6]) {
+  dev.rtw_write<uint32_t>(0x0610, (uint32_t)mac[0] | ((uint32_t)mac[1] << 8) |
+                                      ((uint32_t)mac[2] << 16) |
+                                      ((uint32_t)mac[3] << 24));
+  dev.rtw_write16(0x0614, (uint16_t)(mac[4] | (mac[5] << 8)));
+  dev.rtw_write<uint32_t>(0x0618, (uint32_t)mac[0] | ((uint32_t)mac[1] << 8) |
+                                      ((uint32_t)mac[2] << 16) |
+                                      ((uint32_t)mac[3] << 24));
+  dev.rtw_write16(0x061c, (uint16_t)(mac[4] | (mac[5] << 8)));
+  const uint8_t nt = dev.rtw_read8(0x0102);
+  dev.rtw_write8(0x0102, static_cast<uint8_t>((nt & ~0x03u) | 0x03u));
+}
+
+/* Disarm: net_type back to No Link — the gate, so the MACID may stay. */
+inline void disable(RtlAdapter &dev) {
+  const uint8_t nt = dev.rtw_read8(0x0102);
+  dev.rtw_write8(0x0102, static_cast<uint8_t>(nt & ~0x03u));
+}
+
+} /* namespace ack */
+} /* namespace devourer */

--- a/src/AckResponder.h
+++ b/src/AckResponder.h
@@ -12,6 +12,13 @@
  * responder for one MAC address while everything else about monitor mode
  * (promiscuous RX, injection) is unchanged.
  *
+ * The SAME gate is a hardware BlockAck responder: the MAC's immediate-response
+ * engine generates a SIFS-timed BlockAck for a received A-MPDU addressed to
+ * its MACID, no ADDBA session state required (bench-proven,
+ * tests/ampdu_ba_check.sh). So this one knob enables both reliable-unicast
+ * ACK (for singles) and reliable-unicast A-MPDU (SetAmpduMode no_ack=false)
+ * on the peer.
+ *
  * The registers are generation-neutral (same map on Jaguar1/2/3):
  *   0x0610..0x0615  REG_MACID   — the RA the ACK engine matches
  *   0x0618..0x061d  REG_BSSID   — port identity companion (the proven AP

--- a/src/AmpduMode.h
+++ b/src/AmpduMode.h
@@ -1,0 +1,91 @@
+#pragma once
+
+/* AmpduMode — the first-class 802.11 A-MPDU TX session knob, bundling the
+ * recipe the spike + pacing sweep proved on-air (docs/aggregation.md). It
+ * replaces the raw per-field spike knobs (DEVOURER_TX_QSEL / DEVOURER_TX_AMPDU,
+ * which stay as a lower-level experimentation layer that composes on top).
+ *
+ * Two halves, both required for net goodput above plain singles:
+ *   1. Per-frame descriptor: a data QSEL (aggregation only forms on a data
+ *      queue, never the monitor-inject MGMT queue 0x12), AGG_EN, MAX_AGG_NUM,
+ *      AMPDU_DENSITY, and — for the broadcast/no-BlockAck-peer case that
+ *      OpenIPC wfb wants — a per-frame retry limit of 0 (otherwise the MAC
+ *      re-airs each aggregate to the retry limit waiting for a BlockAck no
+ *      one sends: 92% wasted re-airings).
+ *   2. MAC pacing registers (SetAmpduMode programs these live): the
+ *      aggregate-fill timer REG_AMPDU_MAX_TIME (0x0455 on the HalMAC chips,
+ *      0x0456 on Jaguar1) and the burst-mode gate REG_SW_AMPDU_BURST_MODE_CTRL
+ *      (0x04BC). The bring-up timer value 0x70 paces each aggregate launch at
+ *      ~3 ms — 0x20 unlocks it to ~0.8 ms (the register is a CLIFF: values
+ *      <= 0x08 disable aggregation entirely). Clearing 0x04BC BIT6 (halmac
+ *      sets it) is worth ~+40% on the aggregated path (8822B-proven).
+ *
+ * The caller still has to keep the TX queue fed deep enough for the MAC to
+ * have frames to aggregate — a shallow feed makes it SIFS-burst single-MPDU
+ * aggregates (txdemo DEVOURER_TX_THREADS is the bench lever; a real feeder
+ * pushes via send_packets with enough in flight). See docs/aggregation.md. */
+
+#include <cstdint>
+#include <cstdlib>
+
+namespace devourer {
+
+struct AmpduMode {
+  bool enabled = false; /* master switch — off keeps every TX byte-identical */
+
+  /* --- descriptor half --- */
+  uint8_t tid = 0;      /* QSEL / TID the aggregatable frames ride (0..7) */
+  uint8_t max_num = 16; /* MAX_AGG_NUM: max MPDUs per A-MPDU (1..0x1f) */
+  /* AMPDU_DENSITY (0..7 = min MPDU start spacing). Counter-intuitively 7 (the
+   * most conservative spacing) is bench-fastest here — a permissive density
+   * makes the MAC form well-shaped aggregates; density 0 measured ~10% slower.
+   * Default 7 so a minimal "tid/max" spec is the full proven recipe. */
+  uint8_t density = 7;
+  /* Broadcast / no-BlockAck-peer flavor: per-frame retry limit 0, so each
+   * aggregate airs exactly once (FEC covers loss, not ARQ). false = normal
+   * retry limit (only sensible against a real BlockAck responder). */
+  bool no_ack = true;
+
+  /* --- MAC pacing half (programmed by SetAmpduMode) --- */
+  /* REG_AMPDU_MAX_TIME value. 0 = leave the bring-up default (0x70, ~3 ms).
+   * 0x20 is the proven unlock; the register is a cliff — <= 0x08 kills
+   * aggregation. */
+  uint8_t max_time = 0x20;
+  /* Clear REG_SW_AMPDU_BURST_MODE_CTRL BIT6 (halmac bring-up sets it).
+   * 8822B-proven +40%; applied where the register exists (J2 / 8814A). */
+  bool clear_burst_mode = true;
+};
+
+/* Parse "tid/maxnum[/density[/noack[/maxtime_hex]]]" into an AmpduMode
+ * (enabled=true). Returns false on a malformed leading field. Used by the
+ * demos' DEVOURER_TX_AMPDU_MODE env front-end; the library itself takes the
+ * struct. Examples: "0/16" (TID0, 16 MPDUs, defaults), "0/16/0/1/20"
+ * (explicit no-ack, max_time 0x20). */
+inline bool parse_ampdu_mode(const char *spec, AmpduMode &out) {
+  if (spec == nullptr || *spec == '\0')
+    return false;
+  char *end = nullptr;
+  long tid = std::strtol(spec, &end, 0);
+  if (tid < 0 || tid > 7 || end == spec)
+    return false;
+  AmpduMode m;
+  m.enabled = true;
+  m.tid = static_cast<uint8_t>(tid);
+  if (end && *end == '/') {
+    long mx = std::strtol(end + 1, &end, 0);
+    if (mx > 0)
+      m.max_num = static_cast<uint8_t>(mx & 0x1f);
+    if (end && *end == '/') {
+      m.density = static_cast<uint8_t>(std::strtol(end + 1, &end, 0) & 0x7);
+      if (end && *end == '/') {
+        m.no_ack = std::strtol(end + 1, &end, 0) != 0;
+        if (end && *end == '/')
+          m.max_time = static_cast<uint8_t>(std::strtol(end + 1, nullptr, 0));
+      }
+    }
+  }
+  out = m;
+  return true;
+}
+
+} /* namespace devourer */

--- a/src/DeviceConfig.h
+++ b/src/DeviceConfig.h
@@ -87,6 +87,12 @@ struct DeviceConfig {
     /* env: DEVOURER_IGI — Jaguar2 fixed initial-gain index override, 7 bits
      * (unset = 0x40, the FA-rate-validated default). */
     std::optional<uint8_t> igi;
+    /* env: DEVOURER_ACK_RESPONDER=<unicast mac> — arm the hardware ACK
+     * responder at the end of bring-up (src/AckResponder.h): the MAC
+     * auto-ACKs unicast frames addressed to this MAC while monitor RX and
+     * injection continue unchanged. Runtime equivalent: SetAckResponder /
+     * ClearAckResponder. OPT-IN: makes a passive monitor transmit. */
+    std::optional<MacAddr> ack_responder;
   } rx;
 
   /* ---- TX ------------------------------------------------------------- */

--- a/src/DeviceConfig.h
+++ b/src/DeviceConfig.h
@@ -253,6 +253,12 @@ struct DeviceConfig {
      * DEVOURER_TX_QOS_DATA) and USB TX agg for co-queueing. */
     std::optional<uint8_t> tx_ampdu_max;
     uint8_t tx_ampdu_density = 0;
+    /* Optional third component of DEVOURER_TX_AMPDU ("max[/density[/rty]]"):
+     * override the per-frame data retry limit (RTY_LMT_EN stays 1). The
+     * A-MPDU spike found the MAC retries an aggregate to the limit waiting
+     * for a BlockAck no monitor-mode receiver sends — rty=0 airs each
+     * aggregate exactly once (the broadcast/no-ack flavor). */
+    std::optional<uint8_t> tx_ampdu_rty;
   } debug;
 
   /* ---- USB / process environment -------------------------------------- */

--- a/src/DeviceConfig.h
+++ b/src/DeviceConfig.h
@@ -239,6 +239,20 @@ struct DeviceConfig {
      * configuration — a debugging lever for hardware-diffing devourer
      * against the vendor driver's end state. */
     std::string replay_wseq;
+    /* env: DEVOURER_TX_QSEL — EXPERIMENTAL (A-MPDU spike, tests/ampdu_spike):
+     * override the data TX-descriptor QSEL (default 0x12 = MGMT queue, the
+     * monitor-inject convention). Data-queue values are the TID (0..7);
+     * hardware A-MPDU formation is expected only on data queues. */
+    std::optional<uint8_t> tx_qsel;
+    /* env: DEVOURER_TX_AMPDU="max[/density]" — EXPERIMENTAL (A-MPDU spike):
+     * set AGG_EN=1 + MAX_AGG_NUM (1..0x1f; hardware units of 2 MPDUs) +
+     * AMPDU_DENSITY (0..7, default 0) on every data TX descriptor, asking the
+     * MAC to aggregate co-queued same-RA/TID frames into A-MPDUs. Whether the
+     * hardware honours it for host-pushed USE_RATE frames is exactly what the
+     * spike measures. Pair with tx_qsel, QoS-Data frames (txdemo
+     * DEVOURER_TX_QOS_DATA) and USB TX agg for co-queueing. */
+    std::optional<uint8_t> tx_ampdu_max;
+    uint8_t tx_ampdu_density = 0;
   } debug;
 
   /* ---- USB / process environment -------------------------------------- */

--- a/src/DeviceConfig.h
+++ b/src/DeviceConfig.h
@@ -119,6 +119,15 @@ struct DeviceConfig {
      * on Jaguar1) and the vendor packing rules (see src/TxAggPlan.h). USB
      * only; the PCIe rings take frames individually. */
     unsigned usb_agg_max = 0;
+    /* env: DEVOURER_TX_REPORT — per-frame TX-status reports (src/TxReport.h):
+     * sets SPE_RPT in every data TX descriptor so the firmware answers each
+     * transmission with a CCX report (delivered/retry-drop + hardware retry
+     * count + queue time + final rate), decoded off the C2H RX path into
+     * `tx.report` events. The TX-side link sensor. On the HalMAC chips the
+     * descriptor SW_DEFINE also carries a rotating 8-bit tag the report
+     * echoes (per-frame correlation). Default off (descriptors
+     * byte-identical). Needs an RX loop to deliver the C2H reports. */
+    bool report = false;
   } tx;
 
   /* ---- Beamforming (bring-up-time arming; see docs/beamforming-*.md) --- */

--- a/src/DeviceConfig.h
+++ b/src/DeviceConfig.h
@@ -112,6 +112,13 @@ struct DeviceConfig {
      * Runtime equivalent: StartCwTone/StopCwTone on the concrete device. */
     bool cw_tone = false;
     uint8_t cw_tone_gain = 0;
+    /* env: DEVOURER_TX_USB_AGG — USB TX aggregation: max frames packed into
+     * one bulk-OUT URB by send_packets (0 = off, the default: send_packets
+     * degrades to a per-frame loop and every TX path is byte-identical to
+     * before the knob existed). Clamped to the 8-bit agg-num field (255; 64
+     * on Jaguar1) and the vendor packing rules (see src/TxAggPlan.h). USB
+     * only; the PCIe rings take frames individually. */
+    unsigned usb_agg_max = 0;
   } tx;
 
   /* ---- Beamforming (bring-up-time arming; see docs/beamforming-*.md) --- */

--- a/src/DeviceConfig.h
+++ b/src/DeviceConfig.h
@@ -17,6 +17,8 @@
 #include <string>
 #include <string_view>
 
+#include "AmpduMode.h"
+
 namespace devourer {
 
 /* 6-byte MAC address carrier (replaces the per-site uint8_t[6] + sscanf). */
@@ -134,6 +136,14 @@ struct DeviceConfig {
      * echoes (per-frame correlation). Default off (descriptors
      * byte-identical). Needs an RX loop to deliver the C2H reports. */
     bool report = false;
+    /* env: DEVOURER_TX_AMPDU_MODE="tid/maxnum[/density[/noack[/maxtime_hex]]]"
+     * — arm the first-class A-MPDU TX mode (src/AmpduMode.h) at the end of
+     * bring-up: mark data frames aggregatable and program the MAC pacing
+     * registers. The product form of the DEVOURER_TX_QSEL / DEVOURER_TX_AMPDU
+     * spike knobs (which still compose on top). Runtime equivalent:
+     * SetAmpduMode. Unset = off (byte-identical). Pair with a deep feed
+     * (send_packets / DEVOURER_TX_THREADS) for the goodput win. */
+    std::optional<AmpduMode> ampdu;
   } tx;
 
   /* ---- Beamforming (bring-up-time arming; see docs/beamforming-*.md) --- */

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -6,6 +6,7 @@
 #include <functional>
 
 #include "AdapterCaps.h"
+#include "AmpduMode.h"
 #include "DeviceConfig.h"
 #include "AdapterHealth.h"
 #include "RxQuality.h"
@@ -210,6 +211,24 @@ public:
     return false;
   }
   virtual void ClearAckResponder() {}
+
+  /* 802.11 A-MPDU TX mode (src/AmpduMode.h): the first-class bundle of the
+   * recipe the spike + pacing sweep proved on-air. When enabled, every data
+   * frame is marked aggregatable (data QSEL + AGG_EN + MAX_AGG_NUM +
+   * AMPDU_DENSITY, and — for the no-BlockAck-peer broadcast case — a per-frame
+   * retry limit of 0), and the call programs the MAC aggregate-fill timer +
+   * burst-mode gate live (the pacing that gates net goodput). Amortizes one
+   * PHY preamble over many MPDUs: +30% on-air goodput at MCS7/20, more at
+   * higher rates. The caller must keep the TX queue fed deep enough for the
+   * MAC to aggregate (send_packets with enough in flight). Off keeps every TX
+   * byte-identical. Returns false where unsupported (USB HalMAC + Jaguar1;
+   * PCIe not wired). The lower-level DEVOURER_TX_QSEL / DEVOURER_TX_AMPDU
+   * spike knobs still compose on top for register-level experimentation. */
+  virtual bool SetAmpduMode(const devourer::AmpduMode & /*mode*/) {
+    return false;
+  }
+  virtual void ClearAmpduMode() {}
+  virtual devourer::AmpduMode GetAmpduMode() { return {}; }
 
   /* Batch TX: submit `count` frames (each buffer = radiotap header + 802.11
    * MPDU, the send_packet contract) in one call. With USB TX aggregation

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -23,6 +23,13 @@ struct Packet;
 
 using Action_ParsedRadioPacket = std::function<void(const Packet &)>;
 
+/* One TX frame handed to send_packets: radiotap header + 802.11 MPDU, the
+ * same buffer contract as send_packet. */
+struct TxPacketView {
+  const uint8_t *data;
+  size_t len;
+};
+
 /* IRtlDevice is the chip-family-agnostic device contract used by the demos and
  * the WiFiDriver factory. Three implementations exist:
  *   - RtlJaguarDevice   — Realtek "Jaguar" wave-1 (8812AU/8811AU/8821AU/8814AU)
@@ -187,6 +194,26 @@ public:
   virtual devourer::ActiveRxPaths GetActiveRxPaths() { return {}; }
 
   virtual bool send_packet(const uint8_t *packet, size_t length) = 0;
+
+  /* Batch TX: submit `count` frames (each buffer = radiotap header + 802.11
+   * MPDU, the send_packet contract) in one call. With USB TX aggregation
+   * enabled (DeviceConfig tx.usb_agg_max > 0) the USB generations pack
+   * consecutive frames into shared bulk-OUT URBs (see src/TxAggPlan.h) — one
+   * transfer per burst instead of one per frame, and the frames land in the
+   * TXDMA back-to-back. The default (and the PCIe / agg-off behaviour) is a
+   * plain send_packet loop, so callers may use this unconditionally.
+   * Semantics notes: a frame whose radiotap CHANNEL differs from the current
+   * channel flushes the pending URB before the retune (per-packet hopping
+   * stays radiotap-driven); a malformed frame is skipped. Returns the number
+   * of frames successfully submitted. */
+  virtual size_t send_packets(const TxPacketView *pkts, size_t count) {
+    size_t ok = 0;
+    for (size_t i = 0; i < count; ++i)
+      if (pkts[i].data != nullptr && send_packet(pkts[i].data, pkts[i].len))
+        ++ok;
+    return ok;
+  }
+
   virtual SelectedChannel GetSelectedChannel() = 0;
 
   /* Read the 64-bit hardware TSF (Timing Synchronization Function) timer — the

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -6,6 +6,7 @@
 #include <functional>
 
 #include "AdapterCaps.h"
+#include "DeviceConfig.h"
 #include "AdapterHealth.h"
 #include "RxQuality.h"
 #include "RxSense.h"
@@ -194,6 +195,21 @@ public:
   virtual devourer::ActiveRxPaths GetActiveRxPaths() { return {}; }
 
   virtual bool send_packet(const uint8_t *packet, size_t length) = 0;
+
+  /* Hardware ACK responder (src/AckResponder.h): program the port identity
+   * (MACID/BSSID = `mac`, net_type = AP) so the MAC auto-ACKs — SIFS-timed,
+   * zero host involvement — any unicast frame addressed to `mac`, while
+   * monitor RX/injection continue unchanged. The reliable-unicast enabler:
+   * a peer TXing to `mac` with normal ack-policy gets hardware
+   * retransmissions until the ACK (its tx.report shows retries~0). `mac`
+   * must be unicast (I/G clear). Turning a passive monitor into an active
+   * transmitter is opt-in only — never a default. Returns false where
+   * unsupported. Clear = net_type back to No Link. */
+  virtual bool SetAckResponder(const devourer::MacAddr &mac) {
+    (void)mac;
+    return false;
+  }
+  virtual void ClearAckResponder() {}
 
   /* Batch TX: submit `count` frames (each buffer = radiotap header + 802.11
    * MPDU, the send_packet contract) in one call. With USB TX aggregation

--- a/src/RadiotapPeek.h
+++ b/src/RadiotapPeek.h
@@ -1,0 +1,57 @@
+#pragma once
+
+/* RadiotapPeek — cheap pre-parse of a send_packet-contract buffer (radiotap
+ * header + 802.11 MPDU) used by the send_packets batch packers: validate the
+ * radiotap framing and peek the per-packet CHANNEL hop target WITHOUT building
+ * a descriptor, so the packer can decide URB grouping (a channel change
+ * flushes the pending URB) before handing the frame to the generation's
+ * builder. Generation-neutral; the full parse stays in each HAL. */
+
+#include <cstddef>
+#include <cstdint>
+
+#include "ChannelFreq.h"
+/* Codebase convention: the radiotap iterator is C (Radiotap.c), so every
+ * include site wraps the header in extern "C" — this header must too, or an
+ * earlier bare include would poison the later wrapped ones with C++ linkage. */
+extern "C" {
+#include "ieee80211_radiotap.h"
+}
+
+namespace devourer {
+
+/* Validate the buffer's radiotap framing (the same checks every generation's
+ * send_packet front-end does) and return the radiotap header length; 0 on a
+ * malformed buffer (too short / zero / no room for an MPDU). */
+inline uint16_t radiotap_hdr_len(const uint8_t *packet, size_t length) {
+  if (packet == nullptr || length < sizeof(struct ieee80211_radiotap_header))
+    return 0;
+  const uint16_t rlen = get_unaligned_le16(packet + 2);
+  if (rlen == 0 || static_cast<size_t>(rlen) >= length)
+    return 0;
+  return rlen;
+}
+
+/* Peek the radiotap CHANNEL field's hop target: the mapped channel number, or
+ * 0 when the field is absent (or the frequency unmappable). Mirrors the
+ * CHANNEL handling in each generation's send_packet (frequency authoritative,
+ * flags ignored). */
+inline int radiotap_peek_channel(const uint8_t *packet, size_t length) {
+  const uint16_t rlen = radiotap_hdr_len(packet, length);
+  if (rlen == 0)
+    return 0;
+  auto *hdr = reinterpret_cast<struct ieee80211_radiotap_header *>(
+      const_cast<uint8_t *>(packet));
+  struct ieee80211_radiotap_iterator it;
+  if (ieee80211_radiotap_iterator_init(&it, hdr, rlen, nullptr) != 0)
+    return 0;
+  while (ieee80211_radiotap_iterator_next(&it) == 0) {
+    if (it.this_arg_index == IEEE80211_RADIOTAP_CHANNEL) {
+      const int chan = freq_to_chan(get_unaligned_le16(it.this_arg));
+      return chan > 0 ? chan : 0;
+    }
+  }
+  return 0;
+}
+
+} /* namespace devourer */

--- a/src/RxPacket.h
+++ b/src/RxPacket.h
@@ -65,6 +65,14 @@ struct rx_pkt_attrib
      * receiver's crystal and the transmitter's — the closed-loop CFO tracker's
      * input (see IRtlDevice::SetXtalCap). 0 when the phy-status carries none. */
     int8_t cfo_tail = 0;
+    /* A-MPDU RX markers. paggr: this MPDU arrived inside an aggregated PPDU
+     * (rx-desc PAGGR — 8812 dword1[15], same position in the halmac layout).
+     * ppdu_cnt (halmac only): the MAC's 2-bit received-PPDU counter —
+     * consecutive frames sharing a value shared one PPDU, THE ground-truth
+     * A-MPDU detection signal on the RX side (with paggr and the fact that
+     * only an aggregate's first subframe carries a PHY status). */
+    bool paggr = false;
+    uint8_t ppdu_cnt = 0;
     RX_PACKET_TYPE pkt_rpt_type;
 };
 

--- a/src/TxAggPlan.h
+++ b/src/TxAggPlan.h
@@ -1,0 +1,110 @@
+#pragma once
+
+/* TxAggPlan — pure layout planning for USB bulk-OUT TX aggregation: packing N
+ * [txdesc][frame] blocks into one URB so the whole burst costs one bulk
+ * transfer (and lands in the TXDMA together, which is what lets the MAC see
+ * back-to-back frames). Mirrors the vendor xmitframe_complete packing rules
+ * (rtl8812au_xmit.c / rtl8822bu_xmit.c):
+ *
+ *  - each block starts 8-byte aligned (_RND8);
+ *  - the FIRST descriptor carries the block count in dword7[31:24]
+ *    (USB_TXAGG_NUM on Jaguar1, DMA_TXAGG_NUM on the HalMAC 88xx chips) —
+ *    the caller sets that after building, then re-checksums (dword7 is inside
+ *    the checksummed region on every generation);
+ *  - the final URB length must never be an exact multiple of the bulk max
+ *    packet size (the chip-side DMA would wait for more data / a ZLP). The
+ *    vendor guarantees this with an 8-byte shim between the first descriptor
+ *    and its frame, advertised via the descriptor PKT_OFFSET field (unit
+ *    8 bytes) and inserted/removed depending on the final total. We plan the
+ *    layout up-front (all lengths are known), so the shim decision is made
+ *    once, deterministically;
+ *  - the OQT guard: at most `descs_per_bulk` descriptors may START inside one
+ *    bulk-size window (the vendor UsbTxAggDescNum / halmac BLK_DESC_NUM
+ *    discipline — 8812A silicon overflows its output-queue tracker beyond 1
+ *    per window, HalMAC chips take 3). Packing stops when the guard trips;
+ *    the remainder goes into the next URB.
+ *
+ * Pure math, no I/O — unit-tested headless in tests/txagg_selftest.cpp. */
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace devourer {
+
+struct TxAggLimits {
+  size_t desc_size = 48;      /* TX descriptor bytes: 40 (Jaguar1) / 48 (J2/J3) */
+  size_t bulk_size = 512;     /* USB bulk max packet: 64 FS / 512 HS / 1024 SS */
+  size_t max_bytes = 20480;   /* URB buffer cap (vendor MAX_XMITBUF_SZ, USB) */
+  unsigned max_frames = 255;  /* agg-num field is 8-bit; Jaguar1 caps at 64 */
+  unsigned descs_per_bulk = 3; /* OQT guard: 1 (8812A), 3 (8814A/HalMAC), 6 (8821A) */
+};
+
+/* One packed block: `offset` is the descriptor start within the URB buffer;
+ * `length` covers desc + (shim pad, first block only) + frame. */
+struct TxAggBlock {
+  size_t offset;
+  size_t length;
+};
+
+struct TxAggPlan {
+  std::vector<TxAggBlock> blocks; /* one per accepted input frame, in order */
+  size_t total = 0;               /* final URB length (shim included) */
+  bool shim = false;              /* first desc gets PKT_OFFSET=1: an 8-byte pad
+                                   * between it and its frame */
+  size_t frames() const { return blocks.size(); }
+};
+
+inline size_t txagg_rnd8(size_t v) { return (v + 7) & ~static_cast<size_t>(7); }
+
+/* Greedily pack frames [0..n) (802.11 payload lengths, radiotap already
+ * stripped) into ONE URB under `lim`. Returns the accepted prefix as a block
+ * layout; frames() < n means the caller submits this URB and re-plans the
+ * rest. An empty plan means frame 0 alone exceeds max_bytes (caller falls
+ * back to the single-frame path, which has no cap). */
+inline TxAggPlan plan_tx_agg(const size_t *frame_lens, size_t n,
+                             const TxAggLimits &lim) {
+  TxAggPlan p;
+  if (n == 0 || lim.bulk_size == 0)
+    return p;
+  /* Keep 8 bytes of headroom for the shim the finalize step may add. */
+  const size_t cap = lim.max_bytes > 8 ? lim.max_bytes - 8 : 0;
+  size_t tail = 0;  /* end of last block (unaligned) */
+  size_t next = 0;  /* aligned start of the next block */
+  unsigned desc_count = 0;
+  size_t bulk_ptr = lim.bulk_size; /* end of the bulk window being filled */
+  for (size_t i = 0; i < n; ++i) {
+    const size_t blk = lim.desc_size + frame_lens[i];
+    if (next + blk > cap)
+      break;
+    p.blocks.push_back({next, blk});
+    tail = next + blk;
+    next = txagg_rnd8(tail);
+    if (p.blocks.size() >= lim.max_frames)
+      break;
+    /* Vendor OQT guard, evaluated on the NEXT descriptor's start position:
+     * another desc starting inside the current bulk window counts against
+     * descs_per_bulk; crossing into a fresh window resets the count. */
+    if (next < bulk_ptr) {
+      if (lim.descs_per_bulk != 0 && ++desc_count >= lim.descs_per_bulk)
+        break;
+    } else {
+      desc_count = 0;
+      bulk_ptr = (next / lim.bulk_size + 1) * lim.bulk_size;
+    }
+  }
+  p.total = tail;
+  /* Never submit an exact bulk-size multiple (chip-side transfer-end
+   * ambiguity): shim the first block — 8 bytes between desc and frame,
+   * PKT_OFFSET=1 — shifting every later block by 8 (alignment preserved). */
+  if (p.total != 0 && p.total % lim.bulk_size == 0) {
+    p.shim = true;
+    p.blocks[0].length += 8;
+    for (size_t i = 1; i < p.blocks.size(); ++i)
+      p.blocks[i].offset += 8;
+    p.total += 8;
+  }
+  return p;
+}
+
+} /* namespace devourer */

--- a/src/TxAggPlan.h
+++ b/src/TxAggPlan.h
@@ -11,13 +11,20 @@
  *    (USB_TXAGG_NUM on Jaguar1, DMA_TXAGG_NUM on the HalMAC 88xx chips) —
  *    the caller sets that after building, then re-checksums (dword7 is inside
  *    the checksummed region on every generation);
- *  - the final URB length must never be an exact multiple of the bulk max
- *    packet size (the chip-side DMA would wait for more data / a ZLP). The
- *    vendor guarantees this with an 8-byte shim between the first descriptor
- *    and its frame, advertised via the descriptor PKT_OFFSET field (unit
- *    8 bytes) and inserted/removed depending on the final total. We plan the
- *    layout up-front (all lengths are known), so the shim decision is made
- *    once, deterministically;
+ *  - the first block MAY carry an 8-byte reserve between its descriptor and
+ *    frame, advertised via the descriptor PKT_OFFSET field (unit 8 bytes).
+ *    Two per-family policies (lim.first_reserve):
+ *      true  — Jaguar1 / vendor rtl8812au parity: the reserve is present on
+ *              every aggregated transfer and removed exactly when the total
+ *              would land on a bulk-MPS multiple (the vendor "usb bulk-out
+ *              block check").
+ *      false — HalMAC (8822B/8821C/J3) / mainline-rtw88 parity: no reserve
+ *              (bench-proven on the 8822BU: the TXDMA block walker does NOT
+ *              account PKT_OFFSET in its next-descriptor stride, so a
+ *              reserved first block makes the chip re-air block 1
+ *              DMA_TXAGG_NUM times). The reserve is ADDED only when the
+ *              total would land on a bulk-MPS multiple (the sync bulk path
+ *              has no ZLP; an exact multiple stalls the chip-side DMA);
  *  - the OQT guard: at most `descs_per_bulk` descriptors may START inside one
  *    bulk-size window (the vendor UsbTxAggDescNum / halmac BLK_DESC_NUM
  *    discipline — 8812A silicon overflows its output-queue tracker beyond 1
@@ -36,8 +43,16 @@ struct TxAggLimits {
   size_t desc_size = 48;      /* TX descriptor bytes: 40 (Jaguar1) / 48 (J2/J3) */
   size_t bulk_size = 512;     /* USB bulk max packet: 64 FS / 512 HS / 1024 SS */
   size_t max_bytes = 20480;   /* URB buffer cap (vendor MAX_XMITBUF_SZ, USB) */
-  unsigned max_frames = 255;  /* agg-num field is 8-bit; Jaguar1 caps at 64 */
-  unsigned descs_per_bulk = 3; /* OQT guard: 1 (8812A), 3 (8814A/HalMAC), 6 (8821A) */
+  unsigned max_frames = 255;  /* agg-num field is 8-bit; Jaguar1 caps at 64.
+                               * HalMAC chips parse at most 3 descriptors per
+                               * bulk transfer (rtw88 usb_tx_agg_desc_num /
+                               * halmac BLK_DESC_NUM) — the caller clamps. */
+  unsigned descs_per_bulk = 0; /* Jaguar1 OQT guard (descriptor STARTS per
+                                * bulk window): 1 (8812A), 3 (8814A),
+                                * 6 (8821A). 0 = off (HalMAC uses the flat
+                                * max_frames cap instead). */
+  bool first_reserve = false; /* first-block 8-byte PKT_OFFSET reserve policy
+                               * (see the header comment). */
 };
 
 /* One packed block: `offset` is the descriptor start within the URB buffer;
@@ -49,9 +64,11 @@ struct TxAggBlock {
 
 struct TxAggPlan {
   std::vector<TxAggBlock> blocks; /* one per accepted input frame, in order */
-  size_t total = 0;               /* final URB length (shim included) */
-  bool shim = false;              /* first desc gets PKT_OFFSET=1: an 8-byte pad
-                                   * between it and its frame */
+  size_t total = 0;               /* final URB length (reserve included) */
+  bool shim = false;              /* first desc gets PKT_OFFSET=1 (an 8-byte
+                                   * pad between it and its frame) — presence
+                                   * follows lim.first_reserve, flipped when
+                                   * the total lands on a bulk multiple. */
   size_t frames() const { return blocks.size(); }
 };
 
@@ -67,14 +84,19 @@ inline TxAggPlan plan_tx_agg(const size_t *frame_lens, size_t n,
   TxAggPlan p;
   if (n == 0 || lim.bulk_size == 0)
     return p;
-  /* Keep 8 bytes of headroom for the shim the finalize step may add. */
-  const size_t cap = lim.max_bytes > 8 ? lim.max_bytes - 8 : 0;
+  p.shim = lim.first_reserve;
+  /* Reserve headroom so the boundary escape can ADD the reserve when the
+   * policy starts without one. */
+  const size_t cap =
+      lim.first_reserve ? lim.max_bytes
+                        : (lim.max_bytes > 8 ? lim.max_bytes - 8 : 0);
   size_t tail = 0;  /* end of last block (unaligned) */
   size_t next = 0;  /* aligned start of the next block */
   unsigned desc_count = 0;
   size_t bulk_ptr = lim.bulk_size; /* end of the bulk window being filled */
   for (size_t i = 0; i < n; ++i) {
-    const size_t blk = lim.desc_size + frame_lens[i];
+    const size_t blk =
+        lim.desc_size + frame_lens[i] + (p.blocks.empty() && p.shim ? 8 : 0);
     if (next + blk > cap)
       break;
     p.blocks.push_back({next, blk});
@@ -82,7 +104,7 @@ inline TxAggPlan plan_tx_agg(const size_t *frame_lens, size_t n,
     next = txagg_rnd8(tail);
     if (p.blocks.size() >= lim.max_frames)
       break;
-    /* Vendor OQT guard, evaluated on the NEXT descriptor's start position:
+    /* Jaguar1 OQT guard, evaluated on the NEXT descriptor's start position:
      * another desc starting inside the current bulk window counts against
      * descs_per_bulk; crossing into a fresh window resets the count. */
     if (next < bulk_ptr) {
@@ -95,14 +117,16 @@ inline TxAggPlan plan_tx_agg(const size_t *frame_lens, size_t n,
   }
   p.total = tail;
   /* Never submit an exact bulk-size multiple (chip-side transfer-end
-   * ambiguity): shim the first block — 8 bytes between desc and frame,
-   * PKT_OFFSET=1 — shifting every later block by 8 (alignment preserved). */
+   * ambiguity): flip the first-block reserve — drop it when present, insert
+   * it when absent. Either way every later block shifts by 8 and alignment
+   * is preserved. */
   if (p.total != 0 && p.total % lim.bulk_size == 0) {
-    p.shim = true;
-    p.blocks[0].length += 8;
+    const int d = p.shim ? -8 : 8;
+    p.shim = !p.shim;
+    p.blocks[0].length += d;
     for (size_t i = 1; i < p.blocks.size(); ++i)
-      p.blocks[i].offset += 8;
-    p.total += 8;
+      p.blocks[i].offset += d;
+    p.total += d;
   }
   return p;
 }

--- a/src/TxReport.h
+++ b/src/TxReport.h
@@ -1,0 +1,120 @@
+#pragma once
+
+/* TxReport — per-frame TX-status feedback (the vendor "CCX report"): when a
+ * frame's TX descriptor carries SPE_RPT=1 (DeviceConfig tx.report), the
+ * firmware answers each transmission with a C2H report saying whether the
+ * frame was delivered (ACKed — or simply completed, for broadcast/no-ack),
+ * how many hardware retransmissions it took, how long it sat in the TX queue,
+ * and the final rate after any fallback. That is the TX-side link sensor: the
+ * retry count is the ground truth an adaptive rate/power controller wants,
+ * and queue time is the TX-pacing signal.
+ *
+ * Two on-wire formats:
+ *  - Jaguar1 (8812/8821): C2H id 0x03 (CCX_TX_RPT), 6-byte payload after the
+ *    2-byte C2H envelope (vendor GET_8812_C2H_TX_RPT_*; queue time in 256 µs
+ *    units). The 8814A firmware uses its own TX_RPT layout — not parsed here
+ *    (examples/rx decodes it behind DEVOURER_TX_STATUS).
+ *  - HalMAC (8822B/8821C/8822C/8822E): a C2H "pkt" — cmd_id 0xFF (C2H_EXTEND),
+ *    sub_cmd_id 0x0F (CCX_RPT) — parsed INCLUDING its 4-byte header (vendor
+ *    halmac_fw_offload_c2h_nic.h CCX_RPT_GET_*). Echoes the descriptor
+ *    SW_DEFINE low byte, so reports correlate to frames per-packet: the
+ *    devices stamp a rotating tag into SW_DEFINE when tx.report is on.
+ *
+ * Decode is header-only and pure; the devices emit the result as a
+ * `tx.report` machine event (docs/logging.md) from their C2H RX sites. */
+
+#include <cstddef>
+#include <cstdint>
+
+#include "Event.h"
+
+namespace devourer {
+
+struct TxReport {
+  bool valid = false;
+  /* Delivery state: 0 = done (ACKed, or completed for BMC/no-ack), 1 =
+   * retry-drop (retry limit exhausted without ACK), 2/3 = firmware-specific
+   * (halmac tx_state passthrough; Jaguar1 maps lifetime-drop to 2). */
+  uint8_t state = 0;
+  bool bmc = false;        /* broadcast/multicast frame (no ACK expected) */
+  uint8_t macid = 0;
+  uint8_t qsel = 0;        /* Jaguar1 only (halmac reports it too) */
+  uint8_t data_retries = 0; /* hardware retransmissions used (0 = first try) */
+  uint8_t rts_retries = 0;  /* halmac only */
+  uint16_t queue_time_raw = 0; /* Jaguar1: 256 µs units; halmac: raw fw units */
+  uint8_t final_rate = 0;  /* DESC_RATE* hw index of the final attempt */
+  uint8_t sw_define = 0;   /* halmac: descriptor SW_DEFINE byte-0 echo */
+  uint8_t missed_rpt = 0;  /* halmac: reports the fw dropped before this one */
+};
+
+/* Jaguar1 (8812/8821) CCX payload: `p` points AFTER the 2-byte C2H envelope
+ * (cmd_id, seq). */
+inline TxReport parse_ccx_8812(const uint8_t *p, size_t len) {
+  TxReport r;
+  if (p == nullptr || len < 6)
+    return r;
+  r.valid = true;
+  r.qsel = p[0] & 0x1f;
+  r.bmc = (p[0] >> 5) & 1;
+  const bool lifetime_over = (p[0] >> 6) & 1;
+  const bool retry_over = (p[0] >> 7) & 1;
+  r.state = retry_over ? 1 : lifetime_over ? 2 : 0;
+  r.macid = p[1];
+  r.data_retries = p[2] & 0x3f;
+  r.queue_time_raw = static_cast<uint16_t>(p[3] | (p[4] << 8));
+  r.final_rate = p[5];
+  return r;
+}
+
+/* HalMAC C2H pkt: `c2h` = the report INCLUDING the 4-byte header
+ * (cmd_id[7:0], seq[15:8], sub_cmd_id[23:16], len[31:24]). */
+inline bool is_ccx_halmac(const uint8_t *c2h, size_t len) {
+  return c2h != nullptr && len >= 16 && c2h[0] == 0xFF && c2h[2] == 0x0F;
+}
+
+inline TxReport parse_ccx_halmac(const uint8_t *c2h, size_t len) {
+  TxReport r;
+  if (!is_ccx_halmac(c2h, len))
+    return r;
+  auto dw = [&](size_t off) -> uint32_t {
+    return static_cast<uint32_t>(c2h[off]) |
+           (static_cast<uint32_t>(c2h[off + 1]) << 8) |
+           (static_cast<uint32_t>(c2h[off + 2]) << 16) |
+           (static_cast<uint32_t>(c2h[off + 3]) << 24);
+  };
+  const uint32_t d1 = dw(4), d2 = dw(8), d3 = dw(12);
+  r.valid = true;
+  r.qsel = (d1 >> 8) & 0x1f;
+  r.missed_rpt = (d1 >> 13) & 0x7;
+  r.macid = (d1 >> 16) & 0x7f;
+  r.queue_time_raw = static_cast<uint16_t>(d2 & 0xffff);
+  r.sw_define = (d2 >> 16) & 0xff;
+  r.rts_retries = (d2 >> 24) & 0xf;
+  r.bmc = (d2 >> 29) & 1;
+  r.state = (d2 >> 30) & 0x3;
+  r.data_retries = d3 & 0x3f;
+  r.final_rate = (d3 >> 8) & 0x7f;
+  return r;
+}
+
+/* Emit the `tx.report` machine event (schema: docs/logging.md). `fmt` names
+ * the on-wire format ("8812" / "halmac"); sw_define/rts fields are
+ * halmac-only and emitted only there. */
+inline void emit_tx_report(EventSink &sink, const TxReport &r,
+                           const char *fmt) {
+  Ev ev(sink, "tx.report");
+  ev.f("state", static_cast<unsigned>(r.state))
+      .f("ok", r.state == 0)
+      .f("retries", static_cast<unsigned>(r.data_retries))
+      .f("final_rate", static_cast<unsigned>(r.final_rate))
+      .f("queue_time_raw", static_cast<unsigned>(r.queue_time_raw))
+      .f("bmc", r.bmc)
+      .f("macid", static_cast<unsigned>(r.macid))
+      .f("fmt", fmt);
+  if (fmt[0] == 'h') /* halmac extras */
+    ev.f("tag", static_cast<unsigned>(r.sw_define))
+        .f("rts_retries", static_cast<unsigned>(r.rts_retries))
+        .f("missed", static_cast<unsigned>(r.missed_rpt));
+}
+
+} /* namespace devourer */

--- a/src/jaguar1/FrameParser.cpp
+++ b/src/jaguar1/FrameParser.cpp
@@ -98,6 +98,9 @@ static rx_pkt_attrib rtl8812_query_rx_desc_status(uint8_t *pdesc) {
   pattrib.seq_num = GET_RX_STATUS_DESC_SEQ_8812(pdesc);
   pattrib.frag_num = GET_RX_STATUS_DESC_FRAG_8812(pdesc);
   /* fragmentation number */
+  /* A-MPDU marker (dword1[15]): this MPDU arrived inside an aggregated PPDU.
+   * The 8812-series rx-desc has no PPDU counter (that is halmac-only). */
+  pattrib.paggr = GET_RX_STATUS_DESC_PAGGR_8812(pdesc) != 0;
 
   if (GET_RX_STATUS_DESC_RPT_SEL_8812(pdesc)) {
     pattrib.pkt_rpt_type = RX_PACKET_TYPE::C2H_PACKET;

--- a/src/jaguar1/HalModule.cpp
+++ b/src/jaguar1/HalModule.cpp
@@ -1778,6 +1778,18 @@ void HalModule::usb_AggSettingTxUpdate_8812A() {
     _device.rtw_write8(REG_TDECTRL + 3, kUsbTxAggDescNum << 1);
     return;
   }
+  /* DEVOURER_TX_USB_AGG: run the kernel's default UsbTxAggMode=1 path (vendor
+   * usb_AggSettingTxUpdate_8812A) so the TXDMA accepts the multi-block
+   * bulk-OUT transfers send_packets builds. Gated on the knob — a no-knob
+   * bring-up stays byte-identical (_usbTxAggMode defaults false). Block-desc
+   * count per chip: 8812A/8811A = 1 (the vendor "OQT overflow" clamp),
+   * 8821A = 6 (kernel default). Must match the descs_per_bulk the URB packer
+   * plans with (RtlJaguarDevice::send_packets). */
+  if (_cfg.tx.usb_agg_max > 0) {
+    _usbTxAggMode = true;
+    _usbTxAggDescNum =
+        _eepromManager->version_id.ICType == CHIP_8821 ? 6 : 1;
+  }
   if (_usbTxAggMode) {
     uint32_t value32 = _device.rtw_read32(REG_TDECTRL);
     value32 = value32 & ~(BLK_DESC_NUM_MASK << BLK_DESC_NUM_SHIFT);

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -354,6 +354,9 @@ size_t RtlJaguarDevice::send_packets(const TxPacketView *pkts, size_t count) {
    * overflow" clamp); the 8821A takes 6, the 8814A runs the kernel's 3. */
   const auto ic = _eepromManager->version_id.ICType;
   lim.descs_per_bulk = ic == CHIP_8814A ? 3 : ic == CHIP_8821 ? 6 : 1;
+  /* Vendor rtl8812au layout: the first aggregated block carries the 8-byte
+   * PKT_OFFSET reserve (xmit_frame pkt_offset = 1). */
+  lim.first_reserve = true;
 
   size_t done = 0, ok = 0;
   while (done < count) {
@@ -771,6 +774,8 @@ size_t RtlJaguarDevice::build_tx_block(const uint8_t *packet, size_t length,
       SET_TX_DESC_AGG_ENABLE_8812(usb_frame, 1);
       SET_TX_DESC_MAX_AGG_NUM_8812(usb_frame, *_cfg.debug.tx_ampdu_max & 0x1f);
       SET_TX_DESC_AMPDU_DENSITY_8812(usb_frame, _cfg.debug.tx_ampdu_density & 0x7);
+      if (_cfg.debug.tx_ampdu_rty)
+        SET_TX_DESC_DATA_RETRY_LIMIT_8812(usb_frame, *_cfg.debug.tx_ampdu_rty);
     }
   }
 

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -90,6 +90,9 @@ void RtlJaguarDevice::InitWrite(SelectedChannel channel) {
    * center frequency. DEVOURER_CW_TONE_GAIN=0..31 sets RF 0x00[4:0]. */
   if (_cfg.tx.cw_tone)
     StartCwTone(_cfg.tx.cw_tone_gain & 0x1F);
+
+  if (_cfg.tx.ampdu)
+    SetAmpduMode(*_cfg.tx.ampdu); /* DEVOURER_TX_AMPDU_MODE */
 }
 
 /* MP single-tone (CW carrier), Jaguar-1 path A. The RF writes are common to the
@@ -349,6 +352,43 @@ void RtlJaguarDevice::ClearAckResponder() {
   devourer::ack::disable(_device);
   _logger->info("Jaguar1: hardware ACK responder disarmed (net_type=NoLink)");
 }
+
+bool RtlJaguarDevice::SetAmpduMode(const devourer::AmpduMode &mode) {
+  /* A-MPDU TX mode (src/AmpduMode.h): record the descriptor state the TX path
+   * reads and program the Jaguar1 MAC pacing registers. NB the aggregate-fill
+   * timer is REG_AMPDU_MAX_TIME_8812 = 0x0456 here (the HalMAC families use
+   * 0x0455) — a family register-map difference. The 0x04BC burst-mode gate is
+   * an 8814A register (rtl8814a_spec.h); on the 8812/8811/8821 it is not
+   * written at bring-up, so clear_burst_mode is applied 8814A-only. Control
+   * calls are the caller's to sequence (Jaguar1 has no register mutex, same
+   * as SetMonitorChannel). */
+  const bool is8814 = _eepromManager->version_id.ICType == CHIP_8814A;
+  if (mode.enabled) {
+    if (mode.max_time != 0)
+      _device.rtw_write8(0x0456, mode.max_time);
+    if (mode.clear_burst_mode && is8814)
+      _device.rtw_write8(0x04BC, _device.rtw_read8(0x04BC) &
+                                     static_cast<uint8_t>(~(1u << 6)));
+  } else {
+    /* Restore the bring-up default (0x5e on 8821, 0x70 otherwise — see
+     * HalModule init_ampdu). */
+    const bool is8821 = _eepromManager->version_id.ICType == CHIP_8821;
+    _device.rtw_write8(0x0456, is8821 ? 0x5e : 0x70);
+    if (is8814)
+      _device.rtw_write8(0x04BC, _device.rtw_read8(0x04BC) | (1u << 6));
+  }
+  _ampdu = mode;
+  if (mode.enabled)
+    _logger->info("Jaguar1: A-MPDU mode ON (tid={} max={} density={} {} "
+                  "max_time=0x{:02x})",
+                  mode.tid, mode.max_num, mode.density,
+                  mode.no_ack ? "no-ack" : "ack", mode.max_time);
+  else
+    _logger->info("Jaguar1: A-MPDU mode OFF (pacing restored)");
+  return true;
+}
+
+void RtlJaguarDevice::ClearAmpduMode() { SetAmpduMode(devourer::AmpduMode{}); }
 
 size_t RtlJaguarDevice::send_packets(const TxPacketView *pkts, size_t count) {
   /* USB TX aggregation (DEVOURER_TX_USB_AGG): pack consecutive frames into
@@ -783,11 +823,19 @@ size_t RtlJaguarDevice::build_tx_block(const uint8_t *packet, size_t length,
     SET_TX_DESC_DISABLE_FB_8812(usb_frame, 1);
   }
 
-  if (_cfg.debug.tx_qsel || _cfg.debug.tx_ampdu_max) {
-    /* EXPERIMENTAL A-MPDU spike overrides (DEVOURER_TX_QSEL /
-     * DEVOURER_TX_AMPDU — DeviceConfig debug section): route the frame to a
-     * data queue and/or mark it aggregatable. Dword2/3 — inside the
-     * checksummed 32 bytes (checksum runs below). */
+  const devourer::AmpduMode am = _ampdu; /* one lock-free load */
+  if (am.enabled || _cfg.debug.tx_qsel || _cfg.debug.tx_ampdu_max) {
+    /* A-MPDU descriptor half. The product SetAmpduMode state applies first,
+     * then the raw DEVOURER_TX_QSEL / DEVOURER_TX_AMPDU spike knobs override
+     * for register-level experimentation. Dword2/3 — inside the checksummed
+     * 32 bytes (checksum runs below). */
+    if (am.enabled) {
+      SET_TX_DESC_QUEUE_SEL_8812(usb_frame, am.tid);
+      SET_TX_DESC_AGG_ENABLE_8812(usb_frame, 1);
+      SET_TX_DESC_MAX_AGG_NUM_8812(usb_frame, am.max_num & 0x1f);
+      SET_TX_DESC_AMPDU_DENSITY_8812(usb_frame, am.density & 0x7);
+      SET_TX_DESC_DATA_RETRY_LIMIT_8812(usb_frame, am.no_ack ? 0 : 12);
+    }
     if (_cfg.debug.tx_qsel)
       SET_TX_DESC_QUEUE_SEL_8812(usb_frame, *_cfg.debug.tx_qsel);
     if (_cfg.debug.tx_ampdu_max) {

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -5,9 +5,12 @@
 #include "Hal8812PhyReg.h"
 #include "NhmReader.h"
 #include "RadioManagementModule.h"
+#include "RadiotapPeek.h" /* send_packets batch pre-parse */
 #include "SignalStop.h"
 #include "ToneMask.h"
+#include "TxAggPlan.h" /* USB TX aggregation URB packing */
 
+#include <algorithm>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -315,9 +318,119 @@ bool RtlJaguarDevice::StartBeacon(const uint8_t *beacon, size_t len,
 }
 
 bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
-  struct tx_desc *ptxdesc;
-  bool resp;
-  uint8_t *usb_frame;
+  /* Build one TXDMA block (40-byte descriptor + frame, build_tx_block) and
+   * submit it as one async bulk-OUT. */
+  const uint16_t rlen = devourer::radiotap_hdr_len(packet, length);
+  if (rlen == 0)
+    return false;
+  std::vector<uint8_t> usb_frame(TXDESC_SIZE + (length - rlen), 0);
+  if (build_tx_block(packet, length, usb_frame.data(), 0) == 0)
+    return false;
+  return _device.send_packet(usb_frame.data(), usb_frame.size());
+}
+
+size_t RtlJaguarDevice::send_packets(const TxPacketView *pkts, size_t count) {
+  /* USB TX aggregation (DEVOURER_TX_USB_AGG): pack consecutive frames into
+   * shared bulk-OUT URBs — each frame keeps its own 40-byte descriptor, blocks
+   * start 8-byte aligned, the FIRST descriptor carries the block count
+   * (USB_TXAGG_NUM; the matching TXDMA TDECTRL block-desc count is programmed
+   * at bring-up by usb_AggSettingTxUpdate_8812A when the knob is on). Packing
+   * rules in src/TxAggPlan.h. Knob off -> the interface-default loop. */
+  const unsigned agg = _cfg.tx.usb_agg_max;
+  if (agg <= 1 || !_device.is_usb() || count == 0)
+    return IRtlDevice::send_packets(pkts, count);
+
+  devourer::TxAggLimits lim;
+  lim.desc_size = TXDESC_SIZE;
+  lim.bulk_size = _device.speed() >= devourer::kUsbSpeedSuper  ? 1024
+                  : _device.speed() >= devourer::kUsbSpeedHigh ? 512
+                                                               : 64;
+  /* MAX_TX_AGG_PACKET_NUMBER_8812: the Jaguar1 TXDMA takes at most 64 blocks
+   * per transfer (vendor hal_com_reg.h). */
+  lim.max_frames = std::min(agg, 64u);
+  /* Vendor UsbTxAggDescNum: how many descriptors may START inside one bulk
+   * window — 8812A silicon overflows its OQT beyond 1 (the vendor "OQT
+   * overflow" clamp); the 8821A takes 6, the 8814A runs the kernel's 3. */
+  const auto ic = _eepromManager->version_id.ICType;
+  lim.descs_per_bulk = ic == CHIP_8814A ? 3 : ic == CHIP_8821 ? 6 : 1;
+
+  size_t done = 0, ok = 0;
+  while (done < count) {
+    /* Collect the contiguous run for ONE URB: well-formed frames staying on
+     * one channel. A frame whose radiotap CHANNEL differs ends the run — the
+     * pending URB airs on the old channel, and the retune happens inside
+     * build_tx_block when that frame leads the next URB. */
+    std::vector<size_t> lens;
+    int run_chan = 0; /* 0 = no per-packet CHANNEL seen yet (current channel) */
+    for (size_t i = done; i < count && lens.size() < lim.max_frames; ++i) {
+      const uint16_t rlen =
+          devourer::radiotap_hdr_len(pkts[i].data, pkts[i].len);
+      if (rlen == 0) {
+        if (lens.empty())
+          ++done; /* skip a malformed leading frame (contract: skipped) */
+        break;
+      }
+      const int want =
+          devourer::radiotap_peek_channel(pkts[i].data, pkts[i].len);
+      if (lens.empty())
+        run_chan = want;
+      else if (want > 0 &&
+               want != (run_chan > 0 ? run_chan : _channel.Channel))
+        break;
+      lens.push_back(pkts[i].len - rlen);
+    }
+    if (lens.empty())
+      continue;
+
+    const devourer::TxAggPlan plan =
+        devourer::plan_tx_agg(lens.data(), lens.size(), lim);
+    if (plan.frames() <= 1) {
+      /* One block (or a frame the URB cap refuses): the classic single-frame
+       * path is byte-identical and uncapped. */
+      if (send_packet(pkts[done].data, pkts[done].len))
+        ++ok;
+      ++done;
+      continue;
+    }
+
+    std::vector<uint8_t> urb(plan.total, 0);
+    size_t built = 0;
+    for (size_t k = 0; k < plan.frames(); ++k) {
+      const uint8_t poff = (k == 0 && plan.shim) ? 1 : 0;
+      if (build_tx_block(pkts[done + k].data, pkts[done + k].len,
+                         urb.data() + plan.blocks[k].offset, poff) == 0)
+        break; /* pre-validated, so only a defensive bail */
+      ++built;
+    }
+    if (built != plan.frames()) {
+      for (size_t k = 0; k < plan.frames(); ++k, ++done)
+        if (send_packet(pkts[done].data, pkts[done].len))
+          ++ok;
+      continue;
+    }
+
+    /* First descriptor advertises the block count. Dword7 sits inside the
+     * checksummed 32 bytes, so re-checksum (idempotent — the checksum field
+     * is re-zeroed first). */
+    uint8_t *first = urb.data() + plan.blocks[0].offset;
+    SET_TX_DESC_USB_TXAGG_NUM_8812(first, plan.frames());
+    rtl8812a_cal_txdesc_chksum(first);
+
+    const bool sent = _device.send_packet(urb.data(), urb.size());
+    devourer::Ev(_logger->events(), "tx.agg")
+        .f("frames", (unsigned long long)plan.frames())
+        .f("bytes", (unsigned long long)urb.size())
+        .f("shim", plan.shim)
+        .f("ok", sent);
+    if (sent)
+      ok += plan.frames();
+    done += plan.frames();
+  }
+  return ok;
+}
+
+size_t RtlJaguarDevice::build_tx_block(const uint8_t *packet, size_t length,
+                                       uint8_t *out, uint8_t pkt_offset) {
   int real_packet_length, usb_frame_length, radiotap_length;
 
   bool vht = false;
@@ -332,18 +445,19 @@ bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
   /* Per-packet hop target from a radiotap CHANNEL field (0 = none present). */
   int radiotap_channel = 0;
   if (length < sizeof(struct ieee80211_radiotap_header)) {
-    return false;
+    return 0;
   }
   radiotap_length = get_unaligned_le16(packet + 2);
   if (radiotap_length == 0 || (size_t)radiotap_length >= length) {
-    return false;
+    return 0;
   }
   real_packet_length = length - radiotap_length;
 
   if (radiotap_length != 0x0d)
     vht = true;
 
-  usb_frame_length = real_packet_length + TXDESC_SIZE;
+  usb_frame_length =
+      real_packet_length + TXDESC_SIZE + (int)pkt_offset * 8;
 
   DVR_DEBUG(_logger, "radiotap length is {}, 80211 length is {}, usb_frame length "
                 "should be {}",
@@ -507,9 +621,7 @@ bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
     fixed_rate = MGN_6M;
   }
 
-  usb_frame = new uint8_t[usb_frame_length]();
-
-  ptxdesc = (struct tx_desc *)usb_frame;
+  uint8_t *usb_frame = out; /* caller-provided zeroed block */
 
   /* Drop an STBC request the chip can't honour: STBC needs >=2 TX chains, so a
    * 1T1R part (8811AU/8821AU) that airs an STBC-marked frame produces a
@@ -642,17 +754,19 @@ bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
     SET_TX_DESC_DISABLE_FB_8812(usb_frame, 1);
   }
 
+  /* USB-agg boundary shim: pkt_offset × 8 bytes of pad between descriptor and
+   * frame (PKT_OFFSET, unit 8 B; dword1 sits inside the checksummed 32 bytes,
+   * so it precedes the checksum). 0 = none (byte-identical). */
+  if (pkt_offset)
+    SET_TX_DESC_PKT_OFFSET_8812(usb_frame, pkt_offset & 0x1f);
   rtl8812a_cal_txdesc_chksum(usb_frame);
-  DVR_TRACE(_logger, "tx desc formed: {}",
-            hex_join(usb_frame, usb_frame_length));
-  uint8_t *addr = usb_frame + TXDESC_SIZE;
+  DVR_TRACE(_logger, "tx desc formed: {}", hex_join(usb_frame, TXDESC_SIZE));
+  uint8_t *addr = usb_frame + TXDESC_SIZE + (size_t)pkt_offset * 8;
   memcpy(addr, packet + radiotap_length, real_packet_length);
   DVR_TRACE(_logger, "packet formed: {}",
             hex_join(usb_frame, usb_frame_length));
-  resp = _device.send_packet(usb_frame, usb_frame_length);
-  delete[] usb_frame;
 
-  return resp;
+  return (size_t)usb_frame_length;
 }
 
 void RtlJaguarDevice::Init(Action_ParsedRadioPacket packetProcessor,

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -5,6 +5,7 @@
 #include "Hal8812PhyReg.h"
 #include "NhmReader.h"
 #include "RadioManagementModule.h"
+#include "AckResponder.h" /* hardware ACK responder recipe */
 #include "RadiotapPeek.h" /* send_packets batch pre-parse */
 #include "SignalStop.h"
 #include "ToneMask.h"
@@ -67,6 +68,9 @@ void RtlJaguarDevice::InitWrite(SelectedChannel channel) {
   StartWithMonitorMode(channel);
   SetMonitorChannel(channel);
   _logger->info("In Monitor Mode");
+
+  if (_cfg.rx.ack_responder)
+    SetAckResponder(*_cfg.rx.ack_responder); /* DEVOURER_ACK_RESPONDER */
 
   /* DEVOURER_XTAL_CAP — crystal-cap trim (issue #217, narrowband CFO lever). */
   if (_cfg.tuning.xtal_cap)
@@ -328,6 +332,22 @@ bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
   if (build_tx_block(packet, length, usb_frame.data(), 0) == 0)
     return false;
   return _device.send_packet(usb_frame.data(), usb_frame.size());
+}
+
+bool RtlJaguarDevice::SetAckResponder(const devourer::MacAddr &mac) {
+  /* Hardware ACK responder (src/AckResponder.h) — same register recipe as
+   * the HalMAC generations (0x610/0x618/0x102 are map-identical here). */
+  devourer::ack::enable(_device, mac.data());
+  _logger->info("Jaguar1: hardware ACK responder armed for "
+                "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                mac.bytes[0], mac.bytes[1], mac.bytes[2], mac.bytes[3],
+                mac.bytes[4], mac.bytes[5]);
+  return true;
+}
+
+void RtlJaguarDevice::ClearAckResponder() {
+  devourer::ack::disable(_device);
+  _logger->info("Jaguar1: hardware ACK responder disarmed (net_type=NoLink)");
 }
 
 size_t RtlJaguarDevice::send_packets(const TxPacketView *pkts, size_t count) {
@@ -798,6 +818,9 @@ void RtlJaguarDevice::Init(Action_ParsedRadioPacket packetProcessor,
                           SelectedChannel channel) {
   StartWithMonitorMode(channel);
   SetMonitorChannel(channel);
+
+  if (_cfg.rx.ack_responder)
+    SetAckResponder(*_cfg.rx.ack_responder); /* DEVOURER_ACK_RESPONDER */
 
   /* DEVOURER_XTAL_CAP — crystal-cap trim (issue #217, narrowband CFO lever). */
   if (_cfg.tuning.xtal_cap)

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -9,6 +9,7 @@
 #include "SignalStop.h"
 #include "ToneMask.h"
 #include "TxAggPlan.h" /* USB TX aggregation URB packing */
+#include "TxReport.h"  /* CCX TX-status report decode + tx.report event */
 
 #include <algorithm>
 #include <chrono>
@@ -717,6 +718,11 @@ size_t RtlJaguarDevice::build_tx_block(const uint8_t *packet, size_t length,
     SET_TX_DESC_GID_8812(usb_frame, static_cast<uint8_t>(0x3F));
   }
   SET_TX_DESC_SW_DEFINE_8812(usb_frame, static_cast<uint16_t>(0x001));
+  /* DEVOURER_TX_REPORT: SPE_RPT asks the fw for a per-frame CCX TX report
+   * (delivered / retry count / queue time — src/TxReport.h). Dword2, inside
+   * the checksummed 32 bytes. */
+  if (_cfg.tx.report)
+    SET_TX_DESC_SPE_RPT_8812(usb_frame, 1);
   SET_TX_DESC_RETRY_LIMIT_ENABLE_8812(usb_frame, 1);
   if (!is_8814a) {
     /* 88XXau leaves DATA_RETRY_LIMIT=0 for monitor injection on 8814A
@@ -927,6 +933,18 @@ void RtlJaguarDevice::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
         _rxpaths.add(p.RxAtrib.rssi, _eepromManager->numTotalRfPath);
         if (_cfg.tuning.cfo_track)
           _cfo.add(p.RxAtrib.cfo_tail); /* closed-loop CFO input (#217) */
+      }
+      /* CCX TX report (DEVOURER_TX_REPORT / SPE_RPT feedback): C2H id 0x03,
+       * 8812/8821 format (byte0=id, byte1=seq, 6-byte payload) — decode +
+       * emit tx.report (src/TxReport.h). The 8814A firmware uses its own
+       * TX_RPT layout (examples/rx best-effort decodes it), so skip there. */
+      if (p.RxAtrib.pkt_rpt_type == RX_PACKET_TYPE::C2H_PACKET &&
+          _eepromManager->version_id.ICType != CHIP_8814A &&
+          p.Data.size() >= 8 && p.Data[0] == 0x03) {
+        const devourer::TxReport r =
+            devourer::parse_ccx_8812(p.Data.data() + 2, p.Data.size() - 2);
+        if (r.valid)
+          devourer::emit_tx_report(_logger->events(), r, "8812");
       }
       _packetProcessor(p);
     }

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -760,6 +760,20 @@ size_t RtlJaguarDevice::build_tx_block(const uint8_t *packet, size_t length,
     SET_TX_DESC_DISABLE_FB_8812(usb_frame, 1);
   }
 
+  if (_cfg.debug.tx_qsel || _cfg.debug.tx_ampdu_max) {
+    /* EXPERIMENTAL A-MPDU spike overrides (DEVOURER_TX_QSEL /
+     * DEVOURER_TX_AMPDU — DeviceConfig debug section): route the frame to a
+     * data queue and/or mark it aggregatable. Dword2/3 — inside the
+     * checksummed 32 bytes (checksum runs below). */
+    if (_cfg.debug.tx_qsel)
+      SET_TX_DESC_QUEUE_SEL_8812(usb_frame, *_cfg.debug.tx_qsel);
+    if (_cfg.debug.tx_ampdu_max) {
+      SET_TX_DESC_AGG_ENABLE_8812(usb_frame, 1);
+      SET_TX_DESC_MAX_AGG_NUM_8812(usb_frame, *_cfg.debug.tx_ampdu_max & 0x1f);
+      SET_TX_DESC_AMPDU_DENSITY_8812(usb_frame, _cfg.debug.tx_ampdu_density & 0x7);
+    }
+  }
+
   /* USB-agg boundary shim: pkt_offset × 8 bytes of pad between descriptor and
    * frame (PKT_OFFSET, unit 8 B; dword1 sits inside the checksummed 32 bytes,
    * so it precedes the checksum). 0 = none (byte-identical). */

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -408,7 +408,7 @@ size_t RtlJaguarDevice::send_packets(const TxPacketView *pkts, size_t count) {
                                                                : 64;
   /* MAX_TX_AGG_PACKET_NUMBER_8812: the Jaguar1 TXDMA takes at most 64 blocks
    * per transfer (vendor hal_com_reg.h). */
-  lim.max_frames = std::min(agg, 64u);
+  lim.max_frames = std::min<unsigned>(agg, 64u);
   /* Vendor UsbTxAggDescNum: how many descriptors may START inside one bulk
    * window — 8812A silicon overflows its OQT beyond 1 (the vendor "OQT
    * overflow" clamp); the 8821A takes 6, the 8814A runs the kernel's 3. */

--- a/src/jaguar1/RtlJaguarDevice.h
+++ b/src/jaguar1/RtlJaguarDevice.h
@@ -53,6 +53,9 @@ class RtlJaguarDevice : public IRtlDevice {
   /* Runtime TX-mode default (SetTxMode/ClearTxMode); applied in send_packet
    * only when the frame's radiotap carries no rate. */
   std::optional<devourer::TxMode> _tx_mode_default;
+  /* A-MPDU TX mode (SetAmpduMode). Read lock-free in the TX descriptor path
+   * (same pattern as _tx_mode_default). */
+  devourer::AmpduMode _ampdu;
 
   /* CW single-tone (StartCwTone/StopCwTone) saved state for a clean restore:
    * the pre-tone RF 0x00 and four BB dwords — RFE-pinmux words on 8812/8821
@@ -209,6 +212,13 @@ public:
   /* Hardware ACK responder (IRtlDevice contract; src/AckResponder.h). */
   bool SetAckResponder(const devourer::MacAddr &mac) override;
   void ClearAckResponder() override;
+  /* A-MPDU TX mode (IRtlDevice contract; src/AmpduMode.h). Programs the
+   * Jaguar1 aggregate-fill timer (0x0456 — NOT the 0x0455 the HalMAC chips
+   * use) + the 8814A burst-mode gate (0x04BC), and records the descriptor
+   * state the TX path reads. */
+  bool SetAmpduMode(const devourer::AmpduMode &mode) override;
+  void ClearAmpduMode() override;
+  devourer::AmpduMode GetAmpduMode() override { return _ampdu; }
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;

--- a/src/jaguar1/RtlJaguarDevice.h
+++ b/src/jaguar1/RtlJaguarDevice.h
@@ -199,6 +199,13 @@ public:
   void ClearTxMode();
 
   bool send_packet(const uint8_t* packet, size_t length) override;
+  /* Batch TX with USB aggregation (IRtlDevice contract): with
+   * cfg.tx.usb_agg_max > 1 consecutive frames are packed into shared bulk-OUT
+   * URBs — one [txdesc][frame] block per frame, first descriptor carrying the
+   * count in USB_TXAGG_NUM (see src/TxAggPlan.h; the MAC-side TDECTRL
+   * block-desc count is programmed at bring-up when the knob is on). Falls
+   * back to the per-frame loop when the knob is off. */
+  size_t send_packets(const TxPacketView *pkts, size_t count) override;
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;
@@ -274,6 +281,15 @@ public:
 private:
   void StartWithMonitorMode(SelectedChannel selectedChannel);
   bool NetDevOpen(SelectedChannel selectedChannel);
+
+  /* Parse one send_packet-contract buffer (radiotap + 802.11) and build its
+   * TXDMA block — 40-byte descriptor, pkt_offset×8 pad, frame — at `out`
+   * (zeroed, sized desc + pad + frame by the caller). Performs the per-packet
+   * radiotap CHANNEL retune, exactly like send_packet. Returns the block
+   * length, 0 on malformed input. Shared by send_packet (pkt_offset=0) and
+   * the send_packets URB packer. */
+  size_t build_tx_block(const uint8_t *packet, size_t length, uint8_t *out,
+                        uint8_t pkt_offset);
 
   std::array<std::atomic<uint32_t>, 5> _qd_snap{};
   std::thread _qd_thread;

--- a/src/jaguar1/RtlJaguarDevice.h
+++ b/src/jaguar1/RtlJaguarDevice.h
@@ -206,6 +206,9 @@ public:
    * block-desc count is programmed at bring-up when the knob is on). Falls
    * back to the per-frame loop when the knob is off. */
   size_t send_packets(const TxPacketView *pkts, size_t count) override;
+  /* Hardware ACK responder (IRtlDevice contract; src/AckResponder.h). */
+  bool SetAckResponder(const devourer::MacAddr &mac) override;
+  void ClearAckResponder() override;
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;

--- a/src/jaguar2/FrameParserJaguar2.h
+++ b/src/jaguar2/FrameParserJaguar2.h
@@ -57,6 +57,11 @@ constexpr size_t RXDESC_SIZE_8822B = 24; /* RX_DESC_SIZE_88XX */
 #define SET_TX_DESC_RTS_DATA_RTY_LMT_8822B(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x10, 18, 6, v)
 #define SET_TX_DESC_SW_DEFINE_8822B(d, v)  SET_BITS_TO_LE_4BYTE((d) + 0x18, 0, 12, v)
 #define SET_TX_DESC_TXDESC_CHECKSUM_8822B(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x1C, 0, 16, v)
+/* USB TX aggregation: number of [txdesc][frame] blocks in this bulk-OUT
+ * transfer, set on the FIRST descriptor only (halmac DMA_TXAGG_NUM,
+ * dword7[31:24]). Inside the 32-byte checksummed region — set BEFORE
+ * cal_txdesc_chksum_8822b. */
+#define SET_TX_DESC_DMA_TXAGG_NUM_8822B(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x1C, 24, 8, v)
 #define SET_TX_DESC_EN_HWSEQ_8822B(d, v)   SET_BITS_TO_LE_4BYTE((d) + 0x20, 15, 1, v)
 #define GET_TX_DESC_PKT_OFFSET_8822B(d)    LE_BITS_TO_4BYTE((d) + 0x04, 24, 5)
 
@@ -126,7 +131,8 @@ inline void fill_data_tx_desc_8822b(uint8_t *d, uint16_t pkt_size,
                                     bool short_gi, bool ldpc, uint8_t stbc,
                                     bool bmc = false, uint8_t wheader_len = 12,
                                     bool ndpa = false, uint8_t data_sc = 0,
-                                    uint8_t pwr_ofset = 0) {
+                                    uint8_t pwr_ofset = 0,
+                                    uint8_t pkt_offset = 0) {
   SET_TX_DESC_TXPKTSIZE_8822B(d, pkt_size);
   SET_TX_DESC_OFFSET_8822B(d, static_cast<uint32_t>(TXDESC_SIZE_8822B));
   SET_TX_DESC_LS_8822B(d, 1);
@@ -152,6 +158,12 @@ inline void fill_data_tx_desc_8822b(uint8_t *d, uint16_t pkt_size,
    * Inside the 32-byte checksummed region (0x14), so set before the checksum. */
   if (pwr_ofset)
     SET_TX_DESC_TXPWR_OFSET_8822B(d, pwr_ofset & 0x7);
+  /* USB-agg boundary shim: pkt_offset × 8 bytes of pad between this descriptor
+   * and its frame (halmac PKT_OFFSET, unit 8 B) — the vendor's lever for
+   * keeping an aggregated transfer off an exact bulk-size multiple. 0 = none
+   * (byte-identical). Inside the checksummed region (0x04). */
+  if (pkt_offset)
+    SET_TX_DESC_PKT_OFFSET_8822B(d, pkt_offset & 0x1f);
   SET_TX_DESC_DATA_SHORT_8822B(d, short_gi ? 1 : 0);
   SET_TX_DESC_DATA_LDPC_8822B(d, ldpc ? 1 : 0);
   SET_TX_DESC_DATA_STBC_8822B(d, stbc & 0x3);

--- a/src/jaguar2/FrameParserJaguar2.h
+++ b/src/jaguar2/FrameParserJaguar2.h
@@ -53,6 +53,9 @@ constexpr size_t RXDESC_SIZE_8822B = 24; /* RX_DESC_SIZE_88XX */
 #define SET_TX_DESC_NDPA_8822B(d, v)       SET_BITS_TO_LE_4BYTE((d) + 0x0C, 22, 2, v)
 #define SET_TX_DESC_DISQSELSEQ_8822B(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x00, 31, 1, v)
 #define SET_TX_DESC_G_ID_8822B(d, v)       SET_BITS_TO_LE_4BYTE((d) + 0x08, 24, 6, v)
+/* Per-frame TX-status report request (halmac SPE_RPT): the fw answers this
+ * frame's transmission with a CCX C2H report (src/TxReport.h). */
+#define SET_TX_DESC_SPE_RPT_8822B(d, v)    SET_BITS_TO_LE_4BYTE((d) + 0x08, 19, 1, v)
 #define SET_TX_DESC_RTY_LMT_EN_8822B(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x10, 17, 1, v)
 #define SET_TX_DESC_RTS_DATA_RTY_LMT_8822B(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x10, 18, 6, v)
 #define SET_TX_DESC_SW_DEFINE_8822B(d, v)  SET_BITS_TO_LE_4BYTE((d) + 0x18, 0, 12, v)

--- a/src/jaguar2/FrameParserJaguar2.h
+++ b/src/jaguar2/FrameParserJaguar2.h
@@ -56,6 +56,12 @@ constexpr size_t RXDESC_SIZE_8822B = 24; /* RX_DESC_SIZE_88XX */
 /* Per-frame TX-status report request (halmac SPE_RPT): the fw answers this
  * frame's transmission with a CCX C2H report (src/TxReport.h). */
 #define SET_TX_DESC_SPE_RPT_8822B(d, v)    SET_BITS_TO_LE_4BYTE((d) + 0x08, 19, 1, v)
+/* A-MPDU formation (halmac AGG_EN / MAX_AGG_NUM / AMPDU_DENSITY): ask the MAC
+ * to aggregate co-queued same-RA/TID frames into an A-MPDU (spike knobs
+ * DEVOURER_TX_AMPDU / DEVOURER_TX_QSEL; see DeviceConfig debug section). */
+#define SET_TX_DESC_AGG_EN_8822B(d, v)        SET_BITS_TO_LE_4BYTE((d) + 0x08, 12, 1, v)
+#define SET_TX_DESC_MAX_AGG_NUM_8822B(d, v)   SET_BITS_TO_LE_4BYTE((d) + 0x0C, 17, 5, v)
+#define SET_TX_DESC_AMPDU_DENSITY_8822B(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x08, 20, 3, v)
 #define SET_TX_DESC_RTY_LMT_EN_8822B(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x10, 17, 1, v)
 #define SET_TX_DESC_RTS_DATA_RTY_LMT_8822B(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x10, 18, 6, v)
 #define SET_TX_DESC_SW_DEFINE_8822B(d, v)  SET_BITS_TO_LE_4BYTE((d) + 0x18, 0, 12, v)
@@ -76,6 +82,10 @@ constexpr size_t RXDESC_SIZE_8822B = 24; /* RX_DESC_SIZE_88XX */
 #define GET_RX_DESC_SHIFT_8822B(r)         LE_BITS_TO_4BYTE((r) + 0x00, 24, 2)
 #define GET_RX_DESC_PHYST_8822B(r)         LE_BITS_TO_4BYTE((r) + 0x00, 26, 1)
 #define GET_RX_DESC_RX_RATE_8822B(r)       LE_BITS_TO_4BYTE((r) + 0x0C, 0, 7)
+/* A-MPDU markers: PAGGR = MPDU arrived inside an aggregate; PPDU_CNT = the
+ * MAC's 2-bit received-PPDU counter (halmac_rx_desc_nic.h). */
+#define GET_RX_DESC_PAGGR_8822B(r)         LE_BITS_TO_4BYTE((r) + 0x04, 15, 1)
+#define GET_RX_DESC_PPDU_CNT_8822B(r)      LE_BITS_TO_4BYTE((r) + 0x08, 29, 2)
 /* DWORD 5 = the 32-bit TSF-low latched at receive (same offset as the 8812's
  * GET_RX_STATUS_DESC_TSFL_8812 at +20). The hardware TSF timing reference. */
 #define GET_RX_DESC_TSFL_8822B(r)          LE_BITS_TO_4BYTE((r) + 0x14, 0, 32)
@@ -204,6 +214,8 @@ struct Rx8822bFrame {
   uint16_t drvinfo_size;
   uint8_t shift;
   uint32_t tsfl;              /* hardware TSF-low at receive */
+  bool paggr;                 /* MPDU arrived inside an A-MPDU */
+  uint8_t ppdu_cnt;           /* 2-bit received-PPDU counter */
   uint32_t next_offset;
 };
 
@@ -222,6 +234,8 @@ inline bool parse_rx_8822b(const uint8_t *buf, size_t buflen,
   out.icv_err = GET_RX_DESC_ICV_ERR_8822B(buf) != 0;
   out.rx_rate = static_cast<uint8_t>(GET_RX_DESC_RX_RATE_8822B(buf));
   out.tsfl = static_cast<uint32_t>(GET_RX_DESC_TSFL_8822B(buf));
+  out.paggr = GET_RX_DESC_PAGGR_8822B(buf) != 0;
+  out.ppdu_cnt = static_cast<uint8_t>(GET_RX_DESC_PPDU_CNT_8822B(buf));
 
   uint32_t frame_off =
       static_cast<uint32_t>(RXDESC_SIZE_8822B) + out.drvinfo_size + out.shift;

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -15,6 +15,7 @@
 
 #include "RadiotapPeek.h"
 #include "TxAggPlan.h"
+#include "TxReport.h"
 
 #include "BeamformingSounder.h"
 #include "ChannelFreq.h" /* radiotap CHANNEL freq -> channel (per-packet hop) */
@@ -457,6 +458,13 @@ void RtlJaguar2Device::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
         const bool is_c2h = (data[off + 11] & 0x10) != 0;
         p.RxAtrib.pkt_rpt_type = is_c2h ? RX_PACKET_TYPE::C2H_PACKET
                                         : RX_PACKET_TYPE::NORMAL_RX;
+        /* CCX TX report (DEVOURER_TX_REPORT / SPE_RPT feedback): the halmac
+         * C2H pkt 0xFF/0x0F carries per-frame delivery + retry count —
+         * decode + emit tx.report (src/TxReport.h). */
+        if (is_c2h && devourer::is_ccx_halmac(f.frame, f.frame_len))
+          devourer::emit_tx_report(
+              _logger->events(),
+              devourer::parse_ccx_halmac(f.frame, f.frame_len), "halmac");
         /* Per-frame RSSI/SNR/EVM from the jgr2 PHY-status (present when
          * APP_PHYSTS is on, i.e. drvinfo carries the 32-byte report). CCK rates
          * (DESC_RATE1M..11M = 0..3) use type0, everything else type1. C2H has no
@@ -1244,6 +1252,15 @@ size_t RtlJaguar2Device::build_tx_block(const uint8_t *packet, size_t length,
       bw_desc, sgi != 0, ldpc != 0, stbc, bmc,
       static_cast<uint8_t>(hdrlen >> 1), ndpa, data_sc, pkt_pwr_step,
       pkt_offset);
+  if (_cfg.tx.report) {
+    /* DEVOURER_TX_REPORT: SPE_RPT asks the fw for a per-frame CCX TX report;
+     * the report echoes SW_DEFINE's low byte, so stamp a rotating tag for
+     * per-frame correlation (src/TxReport.h). Both fields sit inside the
+     * checksummed span — re-checksum (idempotent). */
+    SET_TX_DESC_SPE_RPT_8822B(out, 1);
+    SET_TX_DESC_SW_DEFINE_8822B(out, _tx_rpt_tag.fetch_add(1) & 0xff);
+    jaguar2::cal_txdesc_chksum_8822b(out);
+  }
   const size_t frame_off =
       jaguar2::TXDESC_SIZE_8822B + static_cast<size_t>(pkt_offset) * 8;
   std::memcpy(out + frame_off, dot11, frame_len);

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -449,6 +449,8 @@ void RtlJaguar2Device::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
         p.RxAtrib.icv_err = f.icv_err;
         p.RxAtrib.data_rate = f.rx_rate;
         p.RxAtrib.tsfl = f.tsfl;
+        p.RxAtrib.paggr = f.paggr;
+        p.RxAtrib.ppdu_cnt = f.ppdu_cnt;
         p.RxAtrib.drvinfo_sz = static_cast<uint8_t>(f.drvinfo_size);
         p.RxAtrib.shift_sz = f.shift;
         /* RX desc word2 BIT(28) (GET_RX_DESC_C2H, halmac_rx_desc_nic.h:230) marks
@@ -1259,6 +1261,20 @@ size_t RtlJaguar2Device::build_tx_block(const uint8_t *packet, size_t length,
      * checksummed span — re-checksum (idempotent). */
     SET_TX_DESC_SPE_RPT_8822B(out, 1);
     SET_TX_DESC_SW_DEFINE_8822B(out, _tx_rpt_tag.fetch_add(1) & 0xff);
+    jaguar2::cal_txdesc_chksum_8822b(out);
+  }
+  if (_cfg.debug.tx_qsel || _cfg.debug.tx_ampdu_max) {
+    /* EXPERIMENTAL A-MPDU spike overrides (DEVOURER_TX_QSEL /
+     * DEVOURER_TX_AMPDU — DeviceConfig debug section): route the frame to a
+     * data queue and/or mark it aggregatable. All inside the checksummed
+     * span — re-checksum. */
+    if (_cfg.debug.tx_qsel)
+      SET_TX_DESC_QSEL_8822B(out, *_cfg.debug.tx_qsel);
+    if (_cfg.debug.tx_ampdu_max) {
+      SET_TX_DESC_AGG_EN_8822B(out, 1);
+      SET_TX_DESC_MAX_AGG_NUM_8822B(out, *_cfg.debug.tx_ampdu_max & 0x1f);
+      SET_TX_DESC_AMPDU_DENSITY_8822B(out, _cfg.debug.tx_ampdu_density & 0x7);
+    }
     jaguar2::cal_txdesc_chksum_8822b(out);
   }
   const size_t frame_off =

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include "AckResponder.h"
 #include "RadiotapPeek.h"
 #include "TxAggPlan.h"
 #include "TxReport.h"
@@ -311,6 +312,23 @@ void RtlJaguar2Device::apply_replay_wseq() {
                 _cfg.debug.replay_wseq);
 }
 
+bool RtlJaguar2Device::SetAckResponder(const devourer::MacAddr &mac) {
+  /* Hardware ACK responder (src/AckResponder.h): port identity + net_type so
+   * the MAC auto-ACKs unicast frames to `mac`. Same registers the proven
+   * StartBeacon/AP path programs, minus the beacon machinery. */
+  devourer::ack::enable(_device, mac.data());
+  _logger->info("Jaguar2: hardware ACK responder armed for "
+                "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                mac.bytes[0], mac.bytes[1], mac.bytes[2], mac.bytes[3],
+                mac.bytes[4], mac.bytes[5]);
+  return true;
+}
+
+void RtlJaguar2Device::ClearAckResponder() {
+  devourer::ack::disable(_device);
+  _logger->info("Jaguar2: hardware ACK responder disarmed (net_type=NoLink)");
+}
+
 void RtlJaguar2Device::Init(Action_ParsedRadioPacket packetProcessor,
                             SelectedChannel channel) {
   _channel = channel;
@@ -350,6 +368,8 @@ void RtlJaguar2Device::Init(Action_ParsedRadioPacket packetProcessor,
     }
   }
 
+  if (_cfg.rx.ack_responder)
+    SetAckResponder(*_cfg.rx.ack_responder); /* DEVOURER_ACK_RESPONDER */
   apply_replay_wseq();
 
   if (_cfg.debug.bb_dump) {
@@ -553,6 +573,8 @@ void RtlJaguar2Device::InitWrite(SelectedChannel channel) {
    * center frequency. DEVOURER_CW_TONE_GAIN=0..31 sets RF 0x00[4:0]. */
   if (_cfg.tx.cw_tone)
     StartCwTone(_cfg.tx.cw_tone_gain & 0x1F);
+  if (_cfg.rx.ack_responder)
+    SetAckResponder(*_cfg.rx.ack_responder); /* DEVOURER_ACK_RESPONDER */
   apply_replay_wseq();
   _logger->info("Jaguar2: ready for TX (monitor inject, ch={})",
                 channel.Channel);

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -329,6 +329,44 @@ void RtlJaguar2Device::ClearAckResponder() {
   _logger->info("Jaguar2: hardware ACK responder disarmed (net_type=NoLink)");
 }
 
+bool RtlJaguar2Device::SetAmpduMode(const devourer::AmpduMode &mode) {
+  /* A-MPDU TX mode (src/AmpduMode.h): record the descriptor state the TX path
+   * reads and program the 8822B MAC pacing registers live. The descriptor
+   * half (AGG_EN/QSEL/MAX_AGG_NUM/density/retry) is applied per-frame in
+   * build_tx_block; here we set the pacing that gates net goodput. */
+  {
+    std::lock_guard<std::mutex> lk(_reg_mu);
+    if (mode.enabled) {
+      /* Aggregate-fill timer (0x0455): 0x70 bring-up default paces launches at
+       * ~3 ms; 0x20 is the proven unlock. 0 = leave the default. Cliff: the
+       * mode struct is responsible for staying above the ~0x08 disable floor. */
+      if (mode.max_time != 0)
+        _device.rtw_write8(0x0455, mode.max_time);
+      /* Burst-mode gate (0x04BC BIT6, halmac sets it): clearing = +40%. */
+      if (mode.clear_burst_mode)
+        _device.rtw_write8(0x04BC, _device.rtw_read8(0x04BC) &
+                                       static_cast<uint8_t>(~(1u << 6)));
+    } else {
+      /* Restore the bring-up pacing so a cleared mode leaves no residue. */
+      _device.rtw_write8(0x0455, 0x70);
+      _device.rtw_write8(0x04BC,
+                         _device.rtw_read8(0x04BC) | (1u << 6));
+    }
+  }
+  _ampdu = mode;
+  if (mode.enabled)
+    _logger->info("Jaguar2: A-MPDU mode ON (tid={} max={} density={} "
+                  "{} max_time=0x{:02x} burst_clr={})",
+                  mode.tid, mode.max_num, mode.density,
+                  mode.no_ack ? "no-ack" : "ack", mode.max_time,
+                  mode.clear_burst_mode);
+  else
+    _logger->info("Jaguar2: A-MPDU mode OFF (pacing restored)");
+  return true;
+}
+
+void RtlJaguar2Device::ClearAmpduMode() { SetAmpduMode(devourer::AmpduMode{}); }
+
 void RtlJaguar2Device::Init(Action_ParsedRadioPacket packetProcessor,
                             SelectedChannel channel) {
   _channel = channel;
@@ -575,6 +613,8 @@ void RtlJaguar2Device::InitWrite(SelectedChannel channel) {
     StartCwTone(_cfg.tx.cw_tone_gain & 0x1F);
   if (_cfg.rx.ack_responder)
     SetAckResponder(*_cfg.rx.ack_responder); /* DEVOURER_ACK_RESPONDER */
+  if (_cfg.tx.ampdu)
+    SetAmpduMode(*_cfg.tx.ampdu); /* DEVOURER_TX_AMPDU_MODE */
   apply_replay_wseq();
   _logger->info("Jaguar2: ready for TX (monitor inject, ch={})",
                 channel.Channel);
@@ -1297,11 +1337,20 @@ size_t RtlJaguar2Device::build_tx_block(const uint8_t *packet, size_t length,
     SET_TX_DESC_SW_DEFINE_8822B(out, _tx_rpt_tag.fetch_add(1) & 0xff);
     jaguar2::cal_txdesc_chksum_8822b(out);
   }
-  if (_cfg.debug.tx_qsel || _cfg.debug.tx_ampdu_max) {
-    /* EXPERIMENTAL A-MPDU spike overrides (DEVOURER_TX_QSEL /
-     * DEVOURER_TX_AMPDU — DeviceConfig debug section): route the frame to a
-     * data queue and/or mark it aggregatable. All inside the checksummed
-     * span — re-checksum. */
+  const devourer::AmpduMode am = _ampdu; /* one lock-free load */
+  if (am.enabled || _cfg.debug.tx_qsel || _cfg.debug.tx_ampdu_max) {
+    /* A-MPDU descriptor half. The product SetAmpduMode state applies first
+     * (data QSEL + AGG_EN + MAX_AGG_NUM + density + retry), then the raw
+     * DEVOURER_TX_QSEL / DEVOURER_TX_AMPDU spike knobs override for
+     * register-level experimentation. All inside the checksummed span —
+     * re-checksum once at the end. */
+    if (am.enabled) {
+      SET_TX_DESC_QSEL_8822B(out, am.tid);
+      SET_TX_DESC_AGG_EN_8822B(out, 1);
+      SET_TX_DESC_MAX_AGG_NUM_8822B(out, am.max_num & 0x1f);
+      SET_TX_DESC_AMPDU_DENSITY_8822B(out, am.density & 0x7);
+      SET_TX_DESC_RTS_DATA_RTY_LMT_8822B(out, am.no_ack ? 0 : 12);
+    }
     if (_cfg.debug.tx_qsel)
       SET_TX_DESC_QSEL_8822B(out, *_cfg.debug.tx_qsel);
     if (_cfg.debug.tx_ampdu_max) {

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -1,5 +1,6 @@
 #include "RtlJaguar2Device.h"
 
+#include <algorithm>
 #include <climits>
 #include <cstdint>
 #include <cstdio>
@@ -11,6 +12,9 @@
 #include <stdexcept>
 #include <utility>
 #include <vector>
+
+#include "RadiotapPeek.h"
+#include "TxAggPlan.h"
 
 #include "BeamformingSounder.h"
 #include "ChannelFreq.h" /* radiotap CHANNEL freq -> channel (per-packet hop) */
@@ -944,15 +948,127 @@ devourer::ThermalStatus RtlJaguar2Device::GetThermalStatus() {
 }
 
 bool RtlJaguar2Device::send_packet(const uint8_t *packet, size_t length) {
-  /* Parse the radiotap header for rate/bw/coding, build an 8822B TX descriptor
-   * (48 B) + the 802.11 frame, and synchronously bulk-OUT. The TX antenna paths
-   * are enabled during bring_up, so frames go on-air at the tuned channel.
+  /* Build one TXDMA block (48-byte descriptor + frame, build_tx_block) and
+   * synchronously bulk-OUT. The TX antenna paths are enabled during bring_up,
+   * so frames go on-air at the tuned channel. */
+  const uint16_t rlen = devourer::radiotap_hdr_len(packet, length);
+  if (rlen == 0)
+    return false;
+  std::vector<uint8_t> usb_frame(jaguar2::TXDESC_SIZE_8822B + (length - rlen),
+                                 0);
+  if (build_tx_block(packet, length, usb_frame.data(), 0) == 0)
+    return false;
+  int rc = _device.bulk_send_sync_ep(_device.first_bulk_out_ep(),
+                                     usb_frame.data(), usb_frame.size(),
+                                     /*timeout_ms=*/20);
+  return rc >= 0;
+}
+
+size_t RtlJaguar2Device::send_packets(const TxPacketView *pkts, size_t count) {
+  /* USB TX aggregation (DEVOURER_TX_USB_AGG): pack consecutive frames into
+   * shared bulk-OUT URBs — each frame keeps its own 48-byte descriptor, blocks
+   * start 8-byte aligned, the FIRST descriptor carries the block count
+   * (DMA_TXAGG_NUM). Packing rules in src/TxAggPlan.h. Knob off / PCIe -> the
+   * interface-default per-frame loop. */
+  const unsigned agg = _cfg.tx.usb_agg_max;
+  if (agg <= 1 || !_device.is_usb() || count == 0)
+    return IRtlDevice::send_packets(pkts, count);
+
+  devourer::TxAggLimits lim;
+  lim.desc_size = jaguar2::TXDESC_SIZE_8822B;
+  lim.bulk_size = _device.speed() >= devourer::kUsbSpeedSuper  ? 1024
+                  : _device.speed() >= devourer::kUsbSpeedHigh ? 512
+                                                               : 64;
+  lim.max_frames = std::min(agg, 255u);
+  lim.descs_per_bulk = 3; /* halmac BLK_DESC_NUM (8822B and 8821C) */
+
+  size_t done = 0, ok = 0;
+  while (done < count) {
+    /* Collect the contiguous run for ONE URB: well-formed frames staying on
+     * one channel. A frame whose radiotap CHANNEL differs ends the run — the
+     * pending URB airs on the old channel, and the retune happens inside
+     * build_tx_block when that frame leads the next URB. */
+    std::vector<size_t> lens;
+    int run_chan = 0; /* 0 = no per-packet CHANNEL seen yet (current channel) */
+    for (size_t i = done; i < count && lens.size() < lim.max_frames; ++i) {
+      const uint16_t rlen =
+          devourer::radiotap_hdr_len(pkts[i].data, pkts[i].len);
+      if (rlen == 0) {
+        if (lens.empty())
+          ++done; /* skip a malformed leading frame (contract: skipped) */
+        break;
+      }
+      const int want =
+          devourer::radiotap_peek_channel(pkts[i].data, pkts[i].len);
+      if (lens.empty())
+        run_chan = want;
+      else if (want > 0 &&
+               want != (run_chan > 0 ? run_chan : _channel.Channel))
+        break;
+      lens.push_back(pkts[i].len - rlen);
+    }
+    if (lens.empty())
+      continue;
+
+    const devourer::TxAggPlan plan =
+        devourer::plan_tx_agg(lens.data(), lens.size(), lim);
+    if (plan.frames() <= 1) {
+      /* One block (or a frame the URB cap refuses): the classic single-frame
+       * path is byte-identical and uncapped. */
+      if (send_packet(pkts[done].data, pkts[done].len))
+        ++ok;
+      ++done;
+      continue;
+    }
+
+    std::vector<uint8_t> urb(plan.total, 0);
+    size_t built = 0;
+    for (size_t k = 0; k < plan.frames(); ++k) {
+      const uint8_t poff = (k == 0 && plan.shim) ? 1 : 0;
+      if (build_tx_block(pkts[done + k].data, pkts[done + k].len,
+                         urb.data() + plan.blocks[k].offset, poff) == 0)
+        break; /* pre-validated, so only a defensive bail */
+      ++built;
+    }
+    if (built != plan.frames()) {
+      for (size_t k = 0; k < plan.frames(); ++k, ++done)
+        if (send_packet(pkts[done].data, pkts[done].len))
+          ++ok;
+      continue;
+    }
+
+    /* First descriptor advertises the block count. Dword7 sits inside the
+     * checksummed 32 bytes, so re-checksum (idempotent — the checksum field
+     * is re-zeroed first). */
+    uint8_t *first = urb.data() + plan.blocks[0].offset;
+    SET_TX_DESC_DMA_TXAGG_NUM_8822B(first, plan.frames());
+    jaguar2::cal_txdesc_chksum_8822b(first);
+
+    const int rc = _device.bulk_send_sync_ep(_device.first_bulk_out_ep(),
+                                             urb.data(), urb.size(),
+                                             /*timeout_ms=*/50);
+    devourer::Ev(_logger->events(), "tx.agg")
+        .f("frames", (unsigned long long)plan.frames())
+        .f("bytes", (unsigned long long)urb.size())
+        .f("shim", plan.shim)
+        .f("ok", rc >= 0);
+    if (rc >= 0)
+      ok += plan.frames();
+    done += plan.frames();
+  }
+  return ok;
+}
+
+size_t RtlJaguar2Device::build_tx_block(const uint8_t *packet, size_t length,
+                                        uint8_t *out, uint8_t pkt_offset) {
+  /* Parse the radiotap header for rate/bw/coding and fill the 8822B TX
+   * descriptor + 802.11 frame at `out` (contract in the header decl).
    * Ported from RtlJaguar3Device::send_packet (shared halmac 88xx descriptor). */
   if (length < sizeof(struct ieee80211_radiotap_header))
-    return false;
+    return 0;
   uint16_t radiotap_length = get_unaligned_le16(packet + 2);
   if (radiotap_length == 0 || static_cast<size_t>(radiotap_length) >= length)
-    return false;
+    return 0;
   const size_t frame_len = length - radiotap_length;
 
   uint8_t fixed_rate = MGN_1M;
@@ -1123,17 +1239,15 @@ bool RtlJaguar2Device::send_packet(const uint8_t *packet, size_t length) {
       radiotap_pkt_pwr_db != INT_MIN
           ? jaguar2::txpkt_pwr_step_for_db(radiotap_pkt_pwr_db)
           : _tx_pkt_pwr_step.load();
-  std::vector<uint8_t> usb_frame(jaguar2::TXDESC_SIZE_8822B + frame_len, 0);
   jaguar2::fill_data_tx_desc_8822b(
-      usb_frame.data(), static_cast<uint16_t>(frame_len),
-      MRateToHwRate(fixed_rate), rate_id, bw_desc, sgi != 0, ldpc != 0, stbc,
-      bmc, static_cast<uint8_t>(hdrlen >> 1), ndpa, data_sc, pkt_pwr_step);
-  std::memcpy(usb_frame.data() + jaguar2::TXDESC_SIZE_8822B, dot11, frame_len);
-
-  int rc = _device.bulk_send_sync_ep(_device.first_bulk_out_ep(),
-                                     usb_frame.data(), usb_frame.size(),
-                                     /*timeout_ms=*/20);
-  return rc >= 0;
+      out, static_cast<uint16_t>(frame_len), MRateToHwRate(fixed_rate), rate_id,
+      bw_desc, sgi != 0, ldpc != 0, stbc, bmc,
+      static_cast<uint8_t>(hdrlen >> 1), ndpa, data_sc, pkt_pwr_step,
+      pkt_offset);
+  const size_t frame_off =
+      jaguar2::TXDESC_SIZE_8822B + static_cast<size_t>(pkt_offset) * 8;
+  std::memcpy(out + frame_off, dot11, frame_len);
+  return frame_off + frame_len;
 }
 
 SelectedChannel RtlJaguar2Device::GetSelectedChannel() { return _channel; }

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -1062,7 +1062,7 @@ size_t RtlJaguar2Device::send_packets(const TxPacketView *pkts, size_t count) {
    * usb_tx_agg_desc_num / halmac BLK_DESC_NUM) — beyond that the TXDMA
    * misparses (bench-proven on the 8822BU: block 1 re-aired agg-num times).
    * Layout is rtw88-parity: no first-block PKT_OFFSET reserve. */
-  lim.max_frames = std::min(agg, 3u);
+  lim.max_frames = std::min<unsigned>(agg, 3u);
   lim.descs_per_bulk = 0;
   lim.first_reserve = false;
 

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -989,8 +989,13 @@ size_t RtlJaguar2Device::send_packets(const TxPacketView *pkts, size_t count) {
   lim.bulk_size = _device.speed() >= devourer::kUsbSpeedSuper  ? 1024
                   : _device.speed() >= devourer::kUsbSpeedHigh ? 512
                                                                : 64;
-  lim.max_frames = std::min(agg, 255u);
-  lim.descs_per_bulk = 3; /* halmac BLK_DESC_NUM (8822B and 8821C) */
+  /* HalMAC chips parse at most 3 descriptors per bulk transfer (rtw88
+   * usb_tx_agg_desc_num / halmac BLK_DESC_NUM) — beyond that the TXDMA
+   * misparses (bench-proven on the 8822BU: block 1 re-aired agg-num times).
+   * Layout is rtw88-parity: no first-block PKT_OFFSET reserve. */
+  lim.max_frames = std::min(agg, 3u);
+  lim.descs_per_bulk = 0;
+  lim.first_reserve = false;
 
   size_t done = 0, ok = 0;
   while (done < count) {
@@ -1274,6 +1279,8 @@ size_t RtlJaguar2Device::build_tx_block(const uint8_t *packet, size_t length,
       SET_TX_DESC_AGG_EN_8822B(out, 1);
       SET_TX_DESC_MAX_AGG_NUM_8822B(out, *_cfg.debug.tx_ampdu_max & 0x1f);
       SET_TX_DESC_AMPDU_DENSITY_8822B(out, _cfg.debug.tx_ampdu_density & 0x7);
+      if (_cfg.debug.tx_ampdu_rty)
+        SET_TX_DESC_RTS_DATA_RTY_LMT_8822B(out, *_cfg.debug.tx_ampdu_rty);
     }
     jaguar2::cal_txdesc_chksum_8822b(out);
   }

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -275,6 +275,42 @@ void RtlJaguar2Device::apply_tx_power_current() {
                       static_cast<uint8_t>(_channel.ChannelWidth), _rfe, off);
 }
 
+void RtlJaguar2Device::apply_replay_wseq() {
+  /* Golden-init replay (DEVOURER_REPLAY_WSEQ): apply a captured register
+   * write sequence verbatim (e.g. the kernel driver's post-DLFW init from a
+   * usbmon capture), OVERRIDING everything devourer configured — the debug
+   * lever for hardware-diffing devourer against the vendor's end state, and
+   * for sweeping individual MAC registers post-bring-up (e.g. the A-MPDU
+   * pacing regs, tests/ampdu_pacing_sweep.sh). Runs at the end of BOTH Init
+   * and InitWrite, so RX and TX bring-ups can be poked alike. */
+  if (_cfg.debug.replay_wseq.empty())
+    return;
+  FILE *fp = fopen(_cfg.debug.replay_wseq.c_str(), "r");
+  if (!fp) {
+    _logger->error("replay_wseq: cannot open {}", _cfg.debug.replay_wseq);
+    return;
+  }
+  unsigned addr, width;
+  unsigned long long val;
+  size_t n = 0;
+  while (fscanf(fp, "%x %u %llx", &addr, &width, &val) == 3) {
+    if (width == 1)
+      _device.rtw_write8(static_cast<uint16_t>(addr),
+                         static_cast<uint8_t>(val));
+    else if (width == 2)
+      _device.rtw_write16(static_cast<uint16_t>(addr),
+                          static_cast<uint16_t>(val));
+    else
+      _device.rtw_write32(static_cast<uint16_t>(addr),
+                          static_cast<uint32_t>(val));
+    if (++n % 1000 == 0)
+      _logger->info("replay_wseq: {} writes applied", n);
+  }
+  fclose(fp);
+  _logger->info("replay_wseq: DONE — {} writes from {}", n,
+                _cfg.debug.replay_wseq);
+}
+
 void RtlJaguar2Device::Init(Action_ParsedRadioPacket packetProcessor,
                             SelectedChannel channel) {
   _channel = channel;
@@ -314,37 +350,7 @@ void RtlJaguar2Device::Init(Action_ParsedRadioPacket packetProcessor,
     }
   }
 
-  if (!_cfg.debug.replay_wseq.empty()) {
-    /* Golden-init replay: apply a captured register write sequence verbatim
-     * (e.g. the kernel driver's post-DLFW init from a usbmon capture),
-     * OVERRIDING everything devourer configured above. Debug lever for
-     * hardware-diffing devourer's init against the vendor's — if a behavior
-     * gap survives an identical write stream, it is not host-register state. */
-    FILE *fp = fopen(_cfg.debug.replay_wseq.c_str(), "r");
-    if (!fp) {
-      _logger->error("replay_wseq: cannot open {}", _cfg.debug.replay_wseq);
-    } else {
-      unsigned addr, width;
-      unsigned long long val;
-      size_t n = 0;
-      while (fscanf(fp, "%x %u %llx", &addr, &width, &val) == 3) {
-        if (width == 1)
-          _device.rtw_write8(static_cast<uint16_t>(addr),
-                             static_cast<uint8_t>(val));
-        else if (width == 2)
-          _device.rtw_write16(static_cast<uint16_t>(addr),
-                              static_cast<uint16_t>(val));
-        else
-          _device.rtw_write32(static_cast<uint16_t>(addr),
-                              static_cast<uint32_t>(val));
-        if (++n % 1000 == 0)
-          _logger->info("replay_wseq: {} writes applied", n);
-      }
-      fclose(fp);
-      _logger->info("replay_wseq: DONE — {} writes from {}", n,
-                    _cfg.debug.replay_wseq);
-    }
-  }
+  apply_replay_wseq();
 
   if (_cfg.debug.bb_dump) {
     /* Full BB/RF register dump in the vendor rtw_proc format for canary diff
@@ -547,6 +553,7 @@ void RtlJaguar2Device::InitWrite(SelectedChannel channel) {
    * center frequency. DEVOURER_CW_TONE_GAIN=0..31 sets RF 0x00[4:0]. */
   if (_cfg.tx.cw_tone)
     StartCwTone(_cfg.tx.cw_tone_gain & 0x1F);
+  apply_replay_wseq();
   _logger->info("Jaguar2: ready for TX (monitor inject, ch={})",
                 channel.Channel);
 }

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -199,6 +199,9 @@ private:
   std::atomic<int> _tx_pwr_offset_steps{0};
   /* Default per-packet TXPWR_OFSET LUT step (0 = none) — see SetTxPacketPowerStep. */
   std::atomic<uint8_t> _tx_pkt_pwr_step{0};
+  /* Rotating SW_DEFINE tag stamped when tx.report is on — the CCX report
+   * echoes its low byte, correlating reports to frames (src/TxReport.h). */
+  std::atomic<uint16_t> _tx_rpt_tag{0};
   /* Bring-up completion: gates the live apply in the TX-power setters. */
   bool _brought_up = false;
   /* Re-program TXAGC from the current knob state at the current channel:

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -70,6 +70,9 @@ public:
    * count in DMA_TXAGG_NUM (see src/TxAggPlan.h). Falls back to the
    * per-frame loop when the knob is off. */
   size_t send_packets(const TxPacketView *pkts, size_t count) override;
+  /* Hardware ACK responder (IRtlDevice contract; src/AckResponder.h). */
+  bool SetAckResponder(const devourer::MacAddr &mac) override;
+  void ClearAckResponder() override;
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -64,6 +64,12 @@ public:
   void FastSetBandwidth(ChannelWidth_t bw) override;
   void InitWrite(SelectedChannel channel) override;
   bool send_packet(const uint8_t *packet, size_t length) override;
+  /* Batch TX with USB aggregation (IRtlDevice contract): with
+   * cfg.tx.usb_agg_max > 1 consecutive frames are packed into shared bulk-OUT
+   * URBs — one [txdesc][frame] block per frame, first descriptor carrying the
+   * count in DMA_TXAGG_NUM (see src/TxAggPlan.h). Falls back to the
+   * per-frame loop when the knob is off. */
+  size_t send_packets(const TxPacketView *pkts, size_t count) override;
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;
@@ -163,6 +169,15 @@ public:
   }
 
 private:
+  /* Parse one send_packet-contract buffer (radiotap + 802.11) and build its
+   * TXDMA block — 48-byte descriptor, pkt_offset×8 pad, frame — at `out`
+   * (zeroed, sized desc + pad + frame by the caller). Performs the per-packet
+   * radiotap CHANNEL retune, exactly like send_packet. Returns the block
+   * length, 0 on malformed input. Shared by send_packet (pkt_offset=0) and
+   * the send_packets URB packer. */
+  size_t build_tx_block(const uint8_t *packet, size_t length, uint8_t *out,
+                        uint8_t pkt_offset);
+
   RtlAdapter _device;
   const devourer::DeviceConfig _cfg;
   /* Rolling per-frame RX link-quality aggregate (GetRxQuality). */

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -73,6 +73,12 @@ public:
   /* Hardware ACK responder (IRtlDevice contract; src/AckResponder.h). */
   bool SetAckResponder(const devourer::MacAddr &mac) override;
   void ClearAckResponder() override;
+  /* A-MPDU TX mode (IRtlDevice contract; src/AmpduMode.h). Programs the
+   * 8822B pacing regs (0x455 max-time, 0x4BC burst-mode) under _reg_mu and
+   * records the descriptor state the TX path reads. */
+  bool SetAmpduMode(const devourer::AmpduMode &mode) override;
+  void ClearAmpduMode() override;
+  devourer::AmpduMode GetAmpduMode() override { return _ampdu; }
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;
@@ -209,6 +215,10 @@ private:
   /* Rotating SW_DEFINE tag stamped when tx.report is on — the CCX report
    * echoes its low byte, correlating reports to frames (src/TxReport.h). */
   std::atomic<uint16_t> _tx_rpt_tag{0};
+  /* A-MPDU TX mode (SetAmpduMode). Read lock-free in the TX descriptor path
+   * (same pattern as _tx_mode_default); a control-plane write during TX is
+   * the caller's to sequence and at worst tears one frame's mode benignly. */
+  devourer::AmpduMode _ampdu;
   /* Bring-up completion: gates the live apply in the TX-power setters. */
   bool _brought_up = false;
   /* Re-program TXAGC from the current knob state at the current channel:

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -169,6 +169,10 @@ public:
   }
 
 private:
+  /* Golden-init replay (DEVOURER_REPLAY_WSEQ) — applied at the end of both
+   * Init and InitWrite (see the definition for semantics). */
+  void apply_replay_wseq();
+
   /* Parse one send_packet-contract buffer (radiotap + 802.11) and build its
    * TXDMA block — 48-byte descriptor, pkt_offset×8 pad, frame — at `out`
    * (zeroed, sized desc + pad + frame by the caller). Performs the per-packet

--- a/src/jaguar3/FrameParserJaguar3.h
+++ b/src/jaguar3/FrameParserJaguar3.h
@@ -53,6 +53,11 @@ constexpr size_t RXDESC_SIZE_8822C = 24; /* RX_DESC_SIZE_88XX */
 #define SET_TX_DESC_RTS_DATA_RTY_LMT_8822C(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x10, 18, 6, v)
 #define SET_TX_DESC_SW_DEFINE_8822C(d, v)  SET_BITS_TO_LE_4BYTE((d) + 0x18, 0, 12, v)
 #define SET_TX_DESC_TXDESC_CHECKSUM_8822C(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x1C, 0, 16, v)
+/* USB TX aggregation: number of [txdesc][frame] blocks in this bulk-OUT
+ * transfer, set on the FIRST descriptor only (halmac DMA_TXAGG_NUM,
+ * dword7[31:24]). Inside the checksummed span — set BEFORE
+ * cal_txdesc_chksum_8822c. */
+#define SET_TX_DESC_DMA_TXAGG_NUM_8822C(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x1C, 24, 8, v)
 #define SET_TX_DESC_EN_HWSEQ_8822C(d, v)   SET_BITS_TO_LE_4BYTE((d) + 0x20, 15, 1, v)
 #define GET_TX_DESC_PKT_OFFSET_8822C(d)    LE_BITS_TO_4BYTE((d) + 0x04, 24, 5)
 
@@ -99,7 +104,8 @@ inline void fill_data_tx_desc_8822c(uint8_t *d, uint16_t pkt_size,
                                     uint8_t rate_hw, uint8_t rate_id, uint8_t bw,
                                     bool short_gi, bool ldpc, uint8_t stbc,
                                     bool bmc = false, bool ndpa = false,
-                                    uint8_t data_sc = 0) {
+                                    uint8_t data_sc = 0,
+                                    uint8_t pkt_offset = 0) {
   SET_TX_DESC_TXPKTSIZE_8822C(d, pkt_size);
   SET_TX_DESC_OFFSET_8822C(d, static_cast<uint32_t>(TXDESC_SIZE_8822C));
   SET_TX_DESC_LS_8822C(d, 1);
@@ -133,6 +139,13 @@ inline void fill_data_tx_desc_8822c(uint8_t *d, uint16_t pkt_size,
   SET_TX_DESC_DATA_LDPC_8822C(d, ldpc ? 1 : 0);
   SET_TX_DESC_DATA_STBC_8822C(d, stbc & 0x3);
   SET_TX_DESC_EN_HWSEQ_8822C(d, 1);
+  /* USB-agg boundary shim: pkt_offset × 8 bytes of pad between this descriptor
+   * and its frame (halmac PKT_OFFSET, unit 8 B). 0 = none (byte-identical).
+   * MUST precede the checksum: on the 8822C the checksum span itself extends
+   * by pkt_offset dword-pairs (cal_txdesc_chksum_8822c reads the field), and
+   * the pad bytes it covers are the caller's zeroed buffer. */
+  if (pkt_offset)
+    SET_TX_DESC_PKT_OFFSET_8822C(d, pkt_offset & 0x1f);
   /* Beamforming self-sounding: mark the frame as an NDPA (halmac NDPA field,
    * dword3 [23:22] = 1) so the armed MAC sounding engine follows it with a
    * hardware-generated NDP — the Jaguar-3 mirror of the Jaguar-1

--- a/src/jaguar3/FrameParserJaguar3.h
+++ b/src/jaguar3/FrameParserJaguar3.h
@@ -49,6 +49,9 @@ constexpr size_t RXDESC_SIZE_8822C = 24; /* RX_DESC_SIZE_88XX */
 #define SET_TX_DESC_DATA_STBC_8822C(d, v)  SET_BITS_TO_LE_4BYTE((d) + 0x14, 8, 2, v)
 #define SET_TX_DESC_DISQSELSEQ_8822C(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x00, 31, 1, v)
 #define SET_TX_DESC_G_ID_8822C(d, v)       SET_BITS_TO_LE_4BYTE((d) + 0x08, 24, 6, v)
+/* Per-frame TX-status report request (halmac SPE_RPT): the fw answers this
+ * frame's transmission with a CCX C2H report (src/TxReport.h). */
+#define SET_TX_DESC_SPE_RPT_8822C(d, v)    SET_BITS_TO_LE_4BYTE((d) + 0x08, 19, 1, v)
 #define SET_TX_DESC_RTY_LMT_EN_8822C(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x10, 17, 1, v)
 #define SET_TX_DESC_RTS_DATA_RTY_LMT_8822C(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x10, 18, 6, v)
 #define SET_TX_DESC_SW_DEFINE_8822C(d, v)  SET_BITS_TO_LE_4BYTE((d) + 0x18, 0, 12, v)

--- a/src/jaguar3/FrameParserJaguar3.h
+++ b/src/jaguar3/FrameParserJaguar3.h
@@ -52,6 +52,12 @@ constexpr size_t RXDESC_SIZE_8822C = 24; /* RX_DESC_SIZE_88XX */
 /* Per-frame TX-status report request (halmac SPE_RPT): the fw answers this
  * frame's transmission with a CCX C2H report (src/TxReport.h). */
 #define SET_TX_DESC_SPE_RPT_8822C(d, v)    SET_BITS_TO_LE_4BYTE((d) + 0x08, 19, 1, v)
+/* A-MPDU formation (halmac AGG_EN / MAX_AGG_NUM / AMPDU_DENSITY): ask the MAC
+ * to aggregate co-queued same-RA/TID frames into an A-MPDU (spike knobs
+ * DEVOURER_TX_AMPDU / DEVOURER_TX_QSEL; see DeviceConfig debug section). */
+#define SET_TX_DESC_AGG_EN_8822C(d, v)        SET_BITS_TO_LE_4BYTE((d) + 0x08, 12, 1, v)
+#define SET_TX_DESC_MAX_AGG_NUM_8822C(d, v)   SET_BITS_TO_LE_4BYTE((d) + 0x0C, 17, 5, v)
+#define SET_TX_DESC_AMPDU_DENSITY_8822C(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x08, 20, 3, v)
 #define SET_TX_DESC_RTY_LMT_EN_8822C(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x10, 17, 1, v)
 #define SET_TX_DESC_RTS_DATA_RTY_LMT_8822C(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x10, 18, 6, v)
 #define SET_TX_DESC_SW_DEFINE_8822C(d, v)  SET_BITS_TO_LE_4BYTE((d) + 0x18, 0, 12, v)
@@ -72,6 +78,10 @@ constexpr size_t RXDESC_SIZE_8822C = 24; /* RX_DESC_SIZE_88XX */
 #define GET_RX_DESC_SHIFT_8822C(r)         LE_BITS_TO_4BYTE((r) + 0x00, 24, 2)
 #define GET_RX_DESC_PHYST_8822C(r)         LE_BITS_TO_4BYTE((r) + 0x00, 26, 1)
 #define GET_RX_DESC_RX_RATE_8822C(r)       LE_BITS_TO_4BYTE((r) + 0x0C, 0, 7)
+/* A-MPDU markers: PAGGR = MPDU arrived inside an aggregate; PPDU_CNT = the
+ * MAC's 2-bit received-PPDU counter (halmac_rx_desc_nic.h). */
+#define GET_RX_DESC_PAGGR_8822C(r)         LE_BITS_TO_4BYTE((r) + 0x04, 15, 1)
+#define GET_RX_DESC_PPDU_CNT_8822C(r)      LE_BITS_TO_4BYTE((r) + 0x08, 29, 2)
 /* DWORD 5 = the 32-bit TSF-low latched at receive (same +0x14 offset as the
  * 8812 GET_RX_STATUS_DESC_TSFL_8812). The hardware TSF timing reference. */
 #define GET_RX_DESC_TSFL_8822C(r)          LE_BITS_TO_4BYTE((r) + 0x14, 0, 32)
@@ -176,6 +186,8 @@ struct Rx8822cFrame {
   uint16_t drvinfo_size; /* bytes (DRV_INFO_SIZE * 8) */
   uint8_t shift;         /* SHIFT_SZ */
   uint32_t tsfl;         /* hardware TSF-low at receive */
+  bool paggr;            /* MPDU arrived inside an A-MPDU */
+  uint8_t ppdu_cnt;      /* 2-bit received-PPDU counter */
   uint32_t next_offset;  /* 8-byte-aligned offset of the next frame in an agg */
 };
 
@@ -196,6 +208,8 @@ inline bool parse_rx_8822c(const uint8_t *buf, size_t buflen,
   out.icv_err = GET_RX_DESC_ICV_ERR_8822C(buf) != 0;
   out.rx_rate = static_cast<uint8_t>(GET_RX_DESC_RX_RATE_8822C(buf));
   out.tsfl = static_cast<uint32_t>(GET_RX_DESC_TSFL_8822C(buf));
+  out.paggr = GET_RX_DESC_PAGGR_8822C(buf) != 0;
+  out.ppdu_cnt = static_cast<uint8_t>(GET_RX_DESC_PPDU_CNT_8822C(buf));
 
   uint32_t frame_off =
       static_cast<uint32_t>(RXDESC_SIZE_8822C) + out.drvinfo_size + out.shift;

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -548,6 +548,8 @@ void RtlJaguar3Device::InitWrite(SelectedChannel channel) {
   _coex_thread = std::thread([this] { coex_runtime_loop(); });
   if (_cfg.rx.ack_responder)
     SetAckResponder(*_cfg.rx.ack_responder); /* DEVOURER_ACK_RESPONDER */
+  if (_cfg.tx.ampdu)
+    SetAmpduMode(*_cfg.tx.ampdu); /* DEVOURER_TX_AMPDU_MODE */
   _logger->info("Jaguar3: ready for TX (monitor inject)");
 }
 
@@ -1413,11 +1415,19 @@ size_t RtlJaguar3Device::build_tx_block(const uint8_t *packet, size_t length,
     SET_TX_DESC_SW_DEFINE_8822C(out, _tx_rpt_tag.fetch_add(1) & 0xff);
     jaguar3::cal_txdesc_chksum_8822c(out);
   }
-  if (_cfg.debug.tx_qsel || _cfg.debug.tx_ampdu_max) {
-    /* EXPERIMENTAL A-MPDU spike overrides (DEVOURER_TX_QSEL /
-     * DEVOURER_TX_AMPDU — DeviceConfig debug section): route the frame to a
-     * data queue and/or mark it aggregatable. All inside the checksummed
-     * span — re-checksum. */
+  const devourer::AmpduMode am = _ampdu; /* one lock-free load */
+  if (am.enabled || _cfg.debug.tx_qsel || _cfg.debug.tx_ampdu_max) {
+    /* A-MPDU descriptor half. The product SetAmpduMode state applies first,
+     * then the raw DEVOURER_TX_QSEL / DEVOURER_TX_AMPDU spike knobs override
+     * for register-level experimentation. All inside the checksummed span —
+     * re-checksum once at the end. */
+    if (am.enabled) {
+      SET_TX_DESC_QSEL_8822C(out, am.tid);
+      SET_TX_DESC_AGG_EN_8822C(out, 1);
+      SET_TX_DESC_MAX_AGG_NUM_8822C(out, am.max_num & 0x1f);
+      SET_TX_DESC_AMPDU_DENSITY_8822C(out, am.density & 0x7);
+      SET_TX_DESC_RTS_DATA_RTY_LMT_8822C(out, am.no_ack ? 0 : 12);
+    }
     if (_cfg.debug.tx_qsel)
       SET_TX_DESC_QSEL_8822C(out, *_cfg.debug.tx_qsel);
     if (_cfg.debug.tx_ampdu_max) {
@@ -1478,6 +1488,35 @@ void RtlJaguar3Device::ClearAckResponder() {
   devourer::ack::disable(_device);
   _logger->info("Jaguar3: hardware ACK responder disarmed (net_type=NoLink)");
 }
+
+bool RtlJaguar3Device::SetAmpduMode(const devourer::AmpduMode &mode) {
+  /* A-MPDU TX mode (src/AmpduMode.h): record the descriptor state the TX path
+   * reads and program the 8822C aggregate-fill timer live. The descriptor
+   * half is applied per-frame in build_tx_block. The 8822C has no
+   * bring-up 0x04BC write (unlike the 8822B), so clear_burst_mode is a no-op
+   * here — the 0x0455 timer is the pacing lever on this family (the on-air
+   * unlock was bench-proven on the 8822B; the 8822C shares the register). */
+  {
+    std::lock_guard<std::mutex> lk(_reg_mu);
+    if (mode.enabled) {
+      if (mode.max_time != 0)
+        _device.rtw_write8(0x0455, mode.max_time);
+    } else {
+      _device.rtw_write8(0x0455, 0x70); /* restore the bring-up default */
+    }
+  }
+  _ampdu = mode;
+  if (mode.enabled)
+    _logger->info("Jaguar3: A-MPDU mode ON (tid={} max={} density={} {} "
+                  "max_time=0x{:02x})",
+                  mode.tid, mode.max_num, mode.density,
+                  mode.no_ack ? "no-ack" : "ack", mode.max_time);
+  else
+    _logger->info("Jaguar3: A-MPDU mode OFF (pacing restored)");
+  return true;
+}
+
+void RtlJaguar3Device::ClearAmpduMode() { SetAmpduMode(devourer::AmpduMode{}); }
 
 bool RtlJaguar3Device::StartBeacon(const uint8_t *beacon, size_t len,
                                       int interval_tu) {

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -1164,7 +1164,7 @@ size_t RtlJaguar3Device::send_packets(const TxPacketView *pkts, size_t count) {
    * usb_tx_agg_desc_num / halmac BLK_DESC_NUM) — beyond that the TXDMA
    * misparses (bench-proven on the 8822BU sibling: block 1 re-aired agg-num
    * times). Layout is rtw88-parity: no first-block PKT_OFFSET reserve. */
-  lim.max_frames = std::min(agg, 3u);
+  lim.max_frames = std::min<unsigned>(agg, 3u);
   lim.descs_per_bulk = 0;
   lim.first_reserve = false;
 

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -1,10 +1,14 @@
 #include "RtlJaguar3Device.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <utility>
 #include <vector>
+
+#include "RadiotapPeek.h" /* send_packets batch pre-parse */
+#include "TxAggPlan.h"    /* USB TX aggregation URB packing */
 
 #include "BeamformingSounder.h" /* generation-neutral BF self-sounding recipe */
 
@@ -1078,15 +1082,139 @@ devourer::ThermalStatus RtlJaguar3Device::GetThermalStatus() {
 bool RtlJaguar3Device::send_packet(const uint8_t *packet, size_t length) {
   /* The coex runtime thread (coex_runtime_loop) drives the periodic coex
    * decision + FW heartbeats + C2H draining, so the TX hot path stays lean. */
-  /* Parse the radiotap header (same fields the Jaguar1 path reads) and build an
-   * 8822C TX descriptor + synchronous bulk-OUT. The TX path is enabled during
-   * rtw_hal_init (3-wire RF + DACK + bf_init + enable_tx_path), so frames go
-   * on-air at the tuned channel. */
-  if (length < sizeof(struct ieee80211_radiotap_header))
+  /* Build one TXDMA block (48-byte descriptor + frame, build_tx_block) and
+   * synchronously bulk-OUT. The TX path is enabled during rtw_hal_init
+   * (3-wire RF + DACK + bf_init + enable_tx_path), so frames go on-air at the
+   * tuned channel.
+   *
+   * Synchronous, bounded bulk-OUT. The async submit path (_device.send_packet)
+   * never reaped its completions on the Jaguar3 TX loop (nothing calls
+   * libusb_handle_events there), leaking a libusb_transfer per send. A blocking
+   * transfer with a finite timeout completes-or-fails each send and stays
+   * responsive to the caller's stop flag. No per-send clear_halt: resetting the
+   * data-toggle on the hot path corrupts the chip's USB state machine (see
+   * bulk_send_sync_ep). The caller backs off when these fail repeatedly — until
+   * the TX-path enable registers are programmed the chip NAKs every frame, and
+   * hammering a non-draining endpoint is exactly what wedged its USB core. */
+  const uint16_t rlen = devourer::radiotap_hdr_len(packet, length);
+  if (rlen == 0)
     return false;
+  std::vector<uint8_t> usb_frame(jaguar3::TXDESC_SIZE_8822C + (length - rlen),
+                                 0);
+  if (build_tx_block(packet, length, usb_frame.data(), 0) == 0)
+    return false;
+  int rc = _device.bulk_send_sync_ep(_device.first_bulk_out_ep(),
+                                     usb_frame.data(), usb_frame.size(),
+                                     /*timeout_ms=*/20);
+  return rc >= 0;
+}
+
+size_t RtlJaguar3Device::send_packets(const TxPacketView *pkts, size_t count) {
+  /* USB TX aggregation (DEVOURER_TX_USB_AGG): pack consecutive frames into
+   * shared bulk-OUT URBs — each frame keeps its own 48-byte descriptor, blocks
+   * start 8-byte aligned, the FIRST descriptor carries the block count
+   * (DMA_TXAGG_NUM). Packing rules in src/TxAggPlan.h. Knob off / PCIe -> the
+   * interface-default per-frame loop. */
+  const unsigned agg = _cfg.tx.usb_agg_max;
+  if (agg <= 1 || !_device.is_usb() || count == 0)
+    return IRtlDevice::send_packets(pkts, count);
+
+  devourer::TxAggLimits lim;
+  lim.desc_size = jaguar3::TXDESC_SIZE_8822C;
+  lim.bulk_size = _device.speed() >= devourer::kUsbSpeedSuper  ? 1024
+                  : _device.speed() >= devourer::kUsbSpeedHigh ? 512
+                                                               : 64;
+  lim.max_frames = std::min(agg, 255u);
+  lim.descs_per_bulk = 3; /* halmac BLK_DESC_NUM (8822C) */
+
+  size_t done = 0, ok = 0;
+  while (done < count) {
+    /* Collect the contiguous run for ONE URB: well-formed frames staying on
+     * one channel. A frame whose radiotap CHANNEL differs ends the run — the
+     * pending URB airs on the old channel, and the retune happens inside
+     * build_tx_block when that frame leads the next URB. */
+    std::vector<size_t> lens;
+    int run_chan = 0; /* 0 = no per-packet CHANNEL seen yet (current channel) */
+    for (size_t i = done; i < count && lens.size() < lim.max_frames; ++i) {
+      const uint16_t rlen =
+          devourer::radiotap_hdr_len(pkts[i].data, pkts[i].len);
+      if (rlen == 0) {
+        if (lens.empty())
+          ++done; /* skip a malformed leading frame (contract: skipped) */
+        break;
+      }
+      const int want =
+          devourer::radiotap_peek_channel(pkts[i].data, pkts[i].len);
+      if (lens.empty())
+        run_chan = want;
+      else if (want > 0 &&
+               want != (run_chan > 0 ? run_chan : _channel.Channel))
+        break;
+      lens.push_back(pkts[i].len - rlen);
+    }
+    if (lens.empty())
+      continue;
+
+    const devourer::TxAggPlan plan =
+        devourer::plan_tx_agg(lens.data(), lens.size(), lim);
+    if (plan.frames() <= 1) {
+      /* One block (or a frame the URB cap refuses): the classic single-frame
+       * path is byte-identical and uncapped. */
+      if (send_packet(pkts[done].data, pkts[done].len))
+        ++ok;
+      ++done;
+      continue;
+    }
+
+    std::vector<uint8_t> urb(plan.total, 0);
+    size_t built = 0;
+    for (size_t k = 0; k < plan.frames(); ++k) {
+      const uint8_t poff = (k == 0 && plan.shim) ? 1 : 0;
+      if (build_tx_block(pkts[done + k].data, pkts[done + k].len,
+                         urb.data() + plan.blocks[k].offset, poff) == 0)
+        break; /* pre-validated, so only a defensive bail */
+      ++built;
+    }
+    if (built != plan.frames()) {
+      for (size_t k = 0; k < plan.frames(); ++k, ++done)
+        if (send_packet(pkts[done].data, pkts[done].len))
+          ++ok;
+      continue;
+    }
+
+    /* First descriptor advertises the block count. Dword7 sits inside the
+     * checksummed span, so re-checksum (idempotent — the checksum field is
+     * re-zeroed first, and the 8822C span extension reads the PKT_OFFSET
+     * field that is already in place). */
+    uint8_t *first = urb.data() + plan.blocks[0].offset;
+    SET_TX_DESC_DMA_TXAGG_NUM_8822C(first, plan.frames());
+    jaguar3::cal_txdesc_chksum_8822c(first);
+
+    const int rc = _device.bulk_send_sync_ep(_device.first_bulk_out_ep(),
+                                             urb.data(), urb.size(),
+                                             /*timeout_ms=*/50);
+    devourer::Ev(_logger->events(), "tx.agg")
+        .f("frames", (unsigned long long)plan.frames())
+        .f("bytes", (unsigned long long)urb.size())
+        .f("shim", plan.shim)
+        .f("ok", rc >= 0);
+    if (rc >= 0)
+      ok += plan.frames();
+    done += plan.frames();
+  }
+  return ok;
+}
+
+size_t RtlJaguar3Device::build_tx_block(const uint8_t *packet, size_t length,
+                                        uint8_t *out, uint8_t pkt_offset) {
+  /* Parse the radiotap header (same fields the Jaguar1 path reads) and fill
+   * the 8822C TX descriptor + 802.11 frame at `out` (contract in the header
+   * decl). */
+  if (length < sizeof(struct ieee80211_radiotap_header))
+    return 0;
   uint16_t radiotap_length = get_unaligned_le16(packet + 2);
   if (radiotap_length == 0 || static_cast<size_t>(radiotap_length) >= length)
-    return false;
+    return 0;
   const size_t frame_len = length - radiotap_length;
 
   uint8_t fixed_rate = MGN_1M;
@@ -1234,27 +1362,13 @@ bool RtlJaguar3Device::send_packet(const uint8_t *packet, size_t length) {
    * STBC frame the chip can't do. */
   if (stbc && !GetTxCaps().stbc_ok)
     stbc = 0;
-  std::vector<uint8_t> usb_frame(jaguar3::TXDESC_SIZE_8822C + frame_len, 0);
   jaguar3::fill_data_tx_desc_8822c(
-      usb_frame.data(), static_cast<uint16_t>(frame_len),
-      MRateToHwRate(fixed_rate), rate_id, bw_desc, sgi != 0, ldpc != 0, stbc,
-      bmc, ndpa, data_sc);
-  std::memcpy(usb_frame.data() + jaguar3::TXDESC_SIZE_8822C,
-              packet + radiotap_length, frame_len);
-
-  /* Synchronous, bounded bulk-OUT. The async submit path (_device.send_packet)
-   * never reaped its completions on the Jaguar3 TX loop (nothing calls
-   * libusb_handle_events there), leaking a libusb_transfer per send. A blocking
-   * transfer with a finite timeout completes-or-fails each send and stays
-   * responsive to the caller's stop flag. No per-send clear_halt: resetting the
-   * data-toggle on the hot path corrupts the chip's USB state machine (see
-   * bulk_send_sync_ep). The caller backs off when these fail repeatedly — until
-   * the TX-path enable registers are programmed the chip NAKs every frame, and
-   * hammering a non-draining endpoint is exactly what wedged its USB core. */
-  uint8_t tx_ep = _device.first_bulk_out_ep();
-  int rc = _device.bulk_send_sync_ep(tx_ep, usb_frame.data(),
-                                     usb_frame.size(), /*timeout_ms=*/20);
-  return rc >= 0;
+      out, static_cast<uint16_t>(frame_len), MRateToHwRate(fixed_rate), rate_id,
+      bw_desc, sgi != 0, ldpc != 0, stbc, bmc, ndpa, data_sc, pkt_offset);
+  const size_t frame_off =
+      jaguar3::TXDESC_SIZE_8822C + static_cast<size_t>(pkt_offset) * 8;
+  std::memcpy(out + frame_off, packet + radiotap_length, frame_len);
+  return frame_off + frame_len;
 }
 
 SelectedChannel RtlJaguar3Device::GetSelectedChannel() { return _channel; }

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -1153,8 +1153,13 @@ size_t RtlJaguar3Device::send_packets(const TxPacketView *pkts, size_t count) {
   lim.bulk_size = _device.speed() >= devourer::kUsbSpeedSuper  ? 1024
                   : _device.speed() >= devourer::kUsbSpeedHigh ? 512
                                                                : 64;
-  lim.max_frames = std::min(agg, 255u);
-  lim.descs_per_bulk = 3; /* halmac BLK_DESC_NUM (8822C) */
+  /* HalMAC chips parse at most 3 descriptors per bulk transfer (rtw88
+   * usb_tx_agg_desc_num / halmac BLK_DESC_NUM) — beyond that the TXDMA
+   * misparses (bench-proven on the 8822BU sibling: block 1 re-aired agg-num
+   * times). Layout is rtw88-parity: no first-block PKT_OFFSET reserve. */
+  lim.max_frames = std::min(agg, 3u);
+  lim.descs_per_bulk = 0;
+  lim.first_reserve = false;
 
   size_t done = 0, ok = 0;
   while (done < count) {
@@ -1414,6 +1419,8 @@ size_t RtlJaguar3Device::build_tx_block(const uint8_t *packet, size_t length,
       SET_TX_DESC_AGG_EN_8822C(out, 1);
       SET_TX_DESC_MAX_AGG_NUM_8822C(out, *_cfg.debug.tx_ampdu_max & 0x1f);
       SET_TX_DESC_AMPDU_DENSITY_8822C(out, _cfg.debug.tx_ampdu_density & 0x7);
+      if (_cfg.debug.tx_ampdu_rty)
+        SET_TX_DESC_RTS_DATA_RTY_LMT_8822C(out, *_cfg.debug.tx_ampdu_rty);
     }
     jaguar3::cal_txdesc_chksum_8822c(out);
   }

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -223,6 +223,8 @@ void RtlJaguar3Device::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
         p.RxAtrib.icv_err = f.icv_err;
         p.RxAtrib.data_rate = f.rx_rate;
         p.RxAtrib.tsfl = f.tsfl;
+        p.RxAtrib.paggr = f.paggr;
+        p.RxAtrib.ppdu_cnt = f.ppdu_cnt;
         p.RxAtrib.drvinfo_sz = static_cast<uint8_t>(f.drvinfo_size);
         p.RxAtrib.shift_sz = f.shift;
         /* RX desc word2 BIT(28) = FW C2H report, not an 802.11 frame. During
@@ -1399,6 +1401,20 @@ size_t RtlJaguar3Device::build_tx_block(const uint8_t *packet, size_t length,
      * checksummed span — re-checksum (idempotent). */
     SET_TX_DESC_SPE_RPT_8822C(out, 1);
     SET_TX_DESC_SW_DEFINE_8822C(out, _tx_rpt_tag.fetch_add(1) & 0xff);
+    jaguar3::cal_txdesc_chksum_8822c(out);
+  }
+  if (_cfg.debug.tx_qsel || _cfg.debug.tx_ampdu_max) {
+    /* EXPERIMENTAL A-MPDU spike overrides (DEVOURER_TX_QSEL /
+     * DEVOURER_TX_AMPDU — DeviceConfig debug section): route the frame to a
+     * data queue and/or mark it aggregatable. All inside the checksummed
+     * span — re-checksum. */
+    if (_cfg.debug.tx_qsel)
+      SET_TX_DESC_QSEL_8822C(out, *_cfg.debug.tx_qsel);
+    if (_cfg.debug.tx_ampdu_max) {
+      SET_TX_DESC_AGG_EN_8822C(out, 1);
+      SET_TX_DESC_MAX_AGG_NUM_8822C(out, *_cfg.debug.tx_ampdu_max & 0x1f);
+      SET_TX_DESC_AMPDU_DENSITY_8822C(out, _cfg.debug.tx_ampdu_density & 0x7);
+    }
     jaguar3::cal_txdesc_chksum_8822c(out);
   }
   const size_t frame_off =

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -9,6 +9,7 @@
 
 #include "RadiotapPeek.h" /* send_packets batch pre-parse */
 #include "TxAggPlan.h"    /* USB TX aggregation URB packing */
+#include "TxReport.h"     /* CCX TX-status report decode + tx.report event */
 
 #include "BeamformingSounder.h" /* generation-neutral BF self-sounding recipe */
 
@@ -231,6 +232,13 @@ void RtlJaguar3Device::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
         bool is_c2h = (data[off + 11] & 0x10) != 0;
         p.RxAtrib.pkt_rpt_type = is_c2h ? RX_PACKET_TYPE::C2H_PACKET
                                         : RX_PACKET_TYPE::NORMAL_RX;
+        /* CCX TX report (DEVOURER_TX_REPORT / SPE_RPT feedback): the halmac
+         * C2H pkt 0xFF/0x0F carries per-frame delivery + retry count —
+         * decode + emit tx.report (src/TxReport.h). */
+        if (is_c2h && devourer::is_ccx_halmac(f.frame, f.frame_len))
+          devourer::emit_tx_report(
+              _logger->events(),
+              devourer::parse_ccx_halmac(f.frame, f.frame_len), "halmac");
         /* Decode the jgr3 PHY-status report (per-frame RSSI/SNR/EVM) when it is
          * present (monitor_rx_cfg enables APP_PHYSTS + RX_DRVINFO_SZ=4, so the
          * 32-byte report is counted in drvinfo). Skips C2H reports and any
@@ -320,6 +328,25 @@ void RtlJaguar3Device::coex_runtime_loop() {
         ++rx;
         if (buf[11] & 0x10) /* RX desc word2 BIT(28) = C2H report */
           ++c2h;
+        /* TX-only sessions get their CCX TX reports (DEVOURER_TX_REPORT) on
+         * this drain — walk the buffer and emit tx.report for each
+         * (src/TxReport.h); the RX loop covers TX+RX sessions. */
+        if (_cfg.tx.report) {
+          size_t off = 0;
+          jaguar3::Rx8822cFrame f{};
+          while (off + jaguar3::RXDESC_SIZE_8822C <= static_cast<size_t>(n) &&
+                 jaguar3::parse_rx_8822c(buf.data() + off,
+                                         static_cast<size_t>(n) - off, f)) {
+            if ((buf[off + 11] & 0x10) &&
+                devourer::is_ccx_halmac(f.frame, f.frame_len))
+              devourer::emit_tx_report(
+                  _logger->events(),
+                  devourer::parse_ccx_halmac(f.frame, f.frame_len), "halmac");
+            if (f.next_offset == 0)
+              break;
+            off += f.next_offset;
+          }
+        }
       }
     } else {
       /* StartRxLoop owns bulk-IN — its async URB queue sees the C2H reports
@@ -1365,6 +1392,15 @@ size_t RtlJaguar3Device::build_tx_block(const uint8_t *packet, size_t length,
   jaguar3::fill_data_tx_desc_8822c(
       out, static_cast<uint16_t>(frame_len), MRateToHwRate(fixed_rate), rate_id,
       bw_desc, sgi != 0, ldpc != 0, stbc, bmc, ndpa, data_sc, pkt_offset);
+  if (_cfg.tx.report) {
+    /* DEVOURER_TX_REPORT: SPE_RPT asks the fw for a per-frame CCX TX report;
+     * the report echoes SW_DEFINE's low byte, so stamp a rotating tag for
+     * per-frame correlation (src/TxReport.h). Both fields sit inside the
+     * checksummed span — re-checksum (idempotent). */
+    SET_TX_DESC_SPE_RPT_8822C(out, 1);
+    SET_TX_DESC_SW_DEFINE_8822C(out, _tx_rpt_tag.fetch_add(1) & 0xff);
+    jaguar3::cal_txdesc_chksum_8822c(out);
+  }
   const size_t frame_off =
       jaguar3::TXDESC_SIZE_8822C + static_cast<size_t>(pkt_offset) * 8;
   std::memcpy(out + frame_off, packet + radiotap_length, frame_len);

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "AckResponder.h"
 #include "RadiotapPeek.h" /* send_packets batch pre-parse */
 #include "TxAggPlan.h"    /* USB TX aggregation URB packing */
 #include "TxReport.h"     /* CCX TX-status report decode + tx.report event */
@@ -102,6 +103,8 @@ void RtlJaguar3Device::Init(Action_ParsedRadioPacket packetProcessor,
     }
   }
 
+  if (_cfg.rx.ack_responder)
+    SetAckResponder(*_cfg.rx.ack_responder); /* DEVOURER_ACK_RESPONDER */
   StartRxLoop(std::move(packetProcessor));
 }
 
@@ -543,6 +546,8 @@ void RtlJaguar3Device::InitWrite(SelectedChannel channel) {
   if (_cfg.tuning.xtal_cap)
     SetXtalCap(*_cfg.tuning.xtal_cap);
   _coex_thread = std::thread([this] { coex_runtime_loop(); });
+  if (_cfg.rx.ack_responder)
+    SetAckResponder(*_cfg.rx.ack_responder); /* DEVOURER_ACK_RESPONDER */
   _logger->info("Jaguar3: ready for TX (monitor inject)");
 }
 
@@ -1452,6 +1457,26 @@ void RtlJaguar3Device::WriteTsf(uint64_t tsf) {
   std::lock_guard<std::mutex> lk(_reg_mu);
   _device.rtw_write<uint32_t>(0x0560, static_cast<uint32_t>(tsf));
   _device.rtw_write<uint32_t>(0x0564, static_cast<uint32_t>(tsf >> 32));
+}
+
+bool RtlJaguar3Device::SetAckResponder(const devourer::MacAddr &mac) {
+  /* Hardware ACK responder (src/AckResponder.h): port identity + net_type so
+   * the MAC auto-ACKs unicast frames to `mac`. Same registers the proven
+   * StartBeacon/AP path programs, minus the beacon machinery. Serialized on
+   * _reg_mu like every other register-touching control call. */
+  std::lock_guard<std::mutex> lk(_reg_mu);
+  devourer::ack::enable(_device, mac.data());
+  _logger->info("Jaguar3: hardware ACK responder armed for "
+                "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                mac.bytes[0], mac.bytes[1], mac.bytes[2], mac.bytes[3],
+                mac.bytes[4], mac.bytes[5]);
+  return true;
+}
+
+void RtlJaguar3Device::ClearAckResponder() {
+  std::lock_guard<std::mutex> lk(_reg_mu);
+  devourer::ack::disable(_device);
+  _logger->info("Jaguar3: hardware ACK responder disarmed (net_type=NoLink)");
 }
 
 bool RtlJaguar3Device::StartBeacon(const uint8_t *beacon, size_t len,

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -201,6 +201,9 @@ private:
    * brought up; recorded and folded at InitWrite before. */
   std::atomic<int> _tx_pwr_override{-1};
   std::atomic<int> _tx_pwr_offset_steps{0};
+  /* Rotating SW_DEFINE tag stamped when tx.report is on — the CCX report
+   * echoes its low byte, correlating reports to frames (src/TxReport.h). */
+  std::atomic<uint16_t> _tx_rpt_tag{0};
   /* Rail-hit flags from the last apply (references clamped at 0/0x7f). */
   std::atomic<bool> _txpwr_sat_low{false};
   std::atomic<bool> _txpwr_sat_high{false};

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -63,6 +63,12 @@ public:
   void FastSetBandwidth(ChannelWidth_t bw) override;
   void InitWrite(SelectedChannel channel) override;
   bool send_packet(const uint8_t *packet, size_t length) override;
+  /* Batch TX with USB aggregation (IRtlDevice contract): with
+   * cfg.tx.usb_agg_max > 1 consecutive frames are packed into shared bulk-OUT
+   * URBs — one [txdesc][frame] block per frame, first descriptor carrying the
+   * count in DMA_TXAGG_NUM (see src/TxAggPlan.h). Falls back to the per-frame
+   * loop when the knob is off. */
+  size_t send_packets(const TxPacketView *pkts, size_t count) override;
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;
@@ -171,6 +177,15 @@ public:
   bool should_stop = false;
 
 private:
+  /* Parse one send_packet-contract buffer (radiotap + 802.11) and build its
+   * TXDMA block — 48-byte descriptor, pkt_offset×8 pad, frame — at `out`
+   * (zeroed, sized desc + pad + frame by the caller). Performs the per-packet
+   * radiotap CHANNEL retune and the NDPA-period accounting, exactly like
+   * send_packet. Returns the block length, 0 on malformed input. Shared by
+   * send_packet (pkt_offset=0) and the send_packets URB packer. */
+  size_t build_tx_block(const uint8_t *packet, size_t length, uint8_t *out,
+                        uint8_t pkt_offset);
+
   RtlAdapter _device;
   const devourer::DeviceConfig _cfg;
   Logger_t _logger;

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -72,6 +72,12 @@ public:
   /* Hardware ACK responder (IRtlDevice contract; src/AckResponder.h). */
   bool SetAckResponder(const devourer::MacAddr &mac) override;
   void ClearAckResponder() override;
+  /* A-MPDU TX mode (IRtlDevice contract; src/AmpduMode.h). Programs the 8822C
+   * aggregate-fill timer (0x455) under _reg_mu (serialized against the coex
+   * thread) and records the descriptor state the TX path reads. */
+  bool SetAmpduMode(const devourer::AmpduMode &mode) override;
+  void ClearAmpduMode() override;
+  devourer::AmpduMode GetAmpduMode() override { return _ampdu; }
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;
@@ -207,6 +213,10 @@ private:
   /* Rotating SW_DEFINE tag stamped when tx.report is on — the CCX report
    * echoes its low byte, correlating reports to frames (src/TxReport.h). */
   std::atomic<uint16_t> _tx_rpt_tag{0};
+  /* A-MPDU TX mode (SetAmpduMode). Read lock-free in the TX descriptor path
+   * (same pattern as the TX-mode default); a control write during TX is the
+   * caller's to sequence and at worst tears one frame's mode benignly. */
+  devourer::AmpduMode _ampdu;
   /* Rail-hit flags from the last apply (references clamped at 0/0x7f). */
   std::atomic<bool> _txpwr_sat_low{false};
   std::atomic<bool> _txpwr_sat_high{false};

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -69,6 +69,9 @@ public:
    * count in DMA_TXAGG_NUM (see src/TxAggPlan.h). Falls back to the per-frame
    * loop when the knob is off. */
   size_t send_packets(const TxPacketView *pkts, size_t count) override;
+  /* Hardware ACK responder (IRtlDevice contract; src/AckResponder.h). */
+  bool SetAckResponder(const devourer::MacAddr &mac) override;
+  void ClearAckResponder() override;
   devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;

--- a/tests/ack_responder_check.sh
+++ b/tests/ack_responder_check.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Hardware ACK responder closed-loop check (src/AckResponder.h), judged by the
+# OTHER radio's hardware: the TX side sends unicast QoS-Data with NORMAL
+# ack-policy and per-frame TX reports on (DEVOURER_TX_REPORT — the CCX retry
+# counts are the ground truth), the responder side is a devourer monitor with
+# DEVOURER_ACK_RESPONDER=<mac>.
+#
+#   responder ON  -> the TX's tx.report events show retries ~0, state=0
+#   responder OFF -> retries pinned at the descriptor limit, state=1
+#
+# The delta is pure hardware on both ends: SIFS-timed ACKs from the responder,
+# autonomous retransmission on the TX — no host in either loop.
+#
+#   sudo bash tests/ack_responder_check.sh
+#   TX_PID=0xc812 RESP_PID=0x012d CH=6 sudo bash tests/ack_responder_check.sh
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD="$ROOT/build"
+
+# TX must be a Jaguar3 (TX-only sessions decode CCX reports off the coex
+# drain); the responder can be any generation.
+TX_PID=${TX_PID:-0xc812};  TX_VID=${TX_VID:-0x0bda}
+RESP_PID=${RESP_PID:-0x012d}; RESP_VID=${RESP_VID:-0x2357}
+CH=${CH:-6}; SECS=${SECS:-8}
+MAC=${MAC:-02:12:34:56:78:9a}
+# The TX's TA must be UNICAST — an ACK's RA is the soliciting frame's addr2,
+# and the canonical TX SA (57:42:..) is a group address. Third appearance of
+# the I/G footgun (docs/ap-mode.md BSSID, the responder MAC, now the TA).
+TX_SA=${TX_SA:-02:aa:bb:cc:dd:01}
+OUT=${OUT:-/tmp/ack_responder}
+
+KILL(){ pkill -9 -x rxdemo 2>/dev/null; pkill -9 -x txdemo 2>/dev/null; return 0; }
+trap KILL EXIT
+mkdir -p "$OUT"
+
+run_cell() { # $1 = cell name, $2 = responder env ("" = off)
+  local name="$1" resp_env="$2"
+  echo "=== cell $name (responder ${resp_env:-OFF})"
+  KILL; sleep 1
+  sudo env DEVOURER_VID=$RESP_VID DEVOURER_PID=$RESP_PID DEVOURER_CHANNEL=$CH \
+       $resp_env DEVOURER_LOG_LEVEL=info \
+       "$BUILD/rxdemo" >"$OUT/resp_$name.jsonl" 2>"$OUT/resp_$name.err" &
+  sleep 6 # responder bring-up
+  sudo env DEVOURER_VID=$TX_VID DEVOURER_PID=$TX_PID DEVOURER_CHANNEL=$CH \
+       DEVOURER_TX_RATE=MCS3 DEVOURER_TX_QOS_DATA=1 DEVOURER_TX_RA=$MAC \
+       DEVOURER_TX_SA=$TX_SA \
+       DEVOURER_TX_PAYLOAD_BYTES=200 DEVOURER_TX_GAP_US=5000 \
+       DEVOURER_TX_REPORT=1 DEVOURER_LOG_LEVEL=warn \
+       timeout -s INT $SECS "$BUILD/txdemo" \
+       >"$OUT/tx_$name.jsonl" 2>"$OUT/tx_$name.err" || true
+  sleep 1
+  KILL; sleep 1
+}
+
+run_cell on  "DEVOURER_ACK_RESPONDER=$MAC"
+run_cell off ""
+
+echo
+echo "=== RESULTS (ch$CH, unicast RA=$MAC, normal ack-policy, MCS3) ==="
+python3 - "$OUT" <<'PYEOF'
+import collections, json, os, sys
+
+out = sys.argv[1]
+for cell in ("on", "off"):
+    reports = []
+    for line in open(os.path.join(out, f"tx_{cell}.jsonl"), errors="replace"):
+        if not line.startswith('{"ev":"tx.report"'):
+            continue
+        try:
+            reports.append(json.loads(line))
+        except json.JSONDecodeError:
+            pass
+    if not reports:
+        print(f"{cell:>4}: NO tx.report events — check the TX cell logs")
+        continue
+    n = len(reports)
+    ok = sum(1 for r in reports if r.get("ok"))
+    retries = [r.get("retries", 0) for r in reports]
+    dist = collections.Counter(retries)
+    top = ", ".join(f"{k}x{v}" for k, v in sorted(dist.items())[:5])
+    print(f"{cell:>4}: reports={n} delivered={100*ok//n}% "
+          f"mean_retries={sum(retries)/n:.1f} retry_dist=[{top}]")
+PYEOF
+echo "raw logs: $OUT"

--- a/tests/ampdu_ba_check.sh
+++ b/tests/ampdu_ba_check.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# ACKed A-MPDU / hardware BlockAck responder closed-loop check. Establishes
+# that the SAME gate as the auto-ACK responder (MACID + net_type, no ADDBA
+# session state) makes the MAC auto-generate an immediate SIFS BlockAck for a
+# received A-MPDU — so reliable-unicast A-MPDU works end to end, both ends
+# host-free.
+#
+# The TX sends A-MPDU with NORMAL ack-policy (SetAmpduMode no_ack=false ->
+# retry limit 12, so it retries waiting for a BlockAck), per-frame TX reports
+# on. The responder is a devourer monitor with DEVOURER_ACK_RESPONDER=<mac>.
+#
+#   responder ON  -> tx.report delivered ~100%, retries ~0 (the MAC BlockAck'd
+#                    every aggregate); throughput jumps (no 12x re-air storm)
+#   responder OFF -> 0% delivered, every aggregate pinned at the retry limit
+#
+#   sudo bash tests/ampdu_ba_check.sh
+#   TX_PID=0xc812 RESP_PID=0x012d CH=6 sudo bash tests/ampdu_ba_check.sh
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD="$ROOT/build"
+
+# TX = a Jaguar3 (TX-only sessions decode CCX reports off the coex drain).
+TX_PID=${TX_PID:-0xc812};  TX_VID=${TX_VID:-0x0bda}
+RESP_PID=${RESP_PID:-0x012d}; RESP_VID=${RESP_VID:-0x2357}
+CH=${CH:-6}; SECS=${SECS:-8}
+MAC=${MAC:-02:12:34:56:78:9a}
+# Unicast TA (the BlockAck's RA is the aggregate's addr2; the canonical TX SA
+# is a group address — the I/G footgun, same as tests/ack_responder_check.sh).
+TX_SA=${TX_SA:-02:aa:bb:cc:dd:01}
+OUT=${OUT:-/tmp/ampdu_ba}
+
+KILL(){ pkill -9 -x rxdemo 2>/dev/null; pkill -9 -x txdemo 2>/dev/null; return 0; }
+trap KILL EXIT
+mkdir -p "$OUT"
+
+run_cell() { # $1 = cell name, $2 = responder env ("" = off)
+  local name="$1" resp_env="$2"
+  echo "=== cell $name (responder ${resp_env:-OFF})"
+  KILL; sleep 1
+  sudo env DEVOURER_VID=$RESP_VID DEVOURER_PID=$RESP_PID DEVOURER_CHANNEL=$CH \
+       $resp_env DEVOURER_LOG_LEVEL=info \
+       "$BUILD/rxdemo" >"$OUT/resp_$name.jsonl" 2>"$OUT/resp_$name.err" &
+  sleep 6
+  # A-MPDU, NORMAL ack-policy (no NOACK) => the aggregate solicits a BlockAck;
+  # no_ack=false in the mode keeps the retry limit at 12 so a missing BA shows
+  # as retry-pinned. Deep-fed so real aggregates form.
+  sudo env DEVOURER_VID=$TX_VID DEVOURER_PID=$TX_PID DEVOURER_CHANNEL=$CH \
+       DEVOURER_TX_RATE=MCS3 DEVOURER_TX_QOS_DATA=1 DEVOURER_TX_RA=$MAC \
+       DEVOURER_TX_SA=$TX_SA DEVOURER_TX_AMPDU_MODE=0/16/7/0/20 \
+       DEVOURER_TX_BATCH=3 DEVOURER_TX_USB_AGG=3 DEVOURER_TX_THREADS=2 \
+       DEVOURER_TX_PAYLOAD_BYTES=200 DEVOURER_TX_GAP_US=2000 \
+       DEVOURER_TX_REPORT=1 DEVOURER_LOG_LEVEL=warn \
+       timeout -s INT $SECS "$BUILD/txdemo" \
+       >"$OUT/tx_$name.jsonl" 2>"$OUT/tx_$name.err" || true
+  sleep 1
+  KILL; sleep 1
+}
+
+run_cell on  "DEVOURER_ACK_RESPONDER=$MAC"
+run_cell off ""
+
+echo
+echo "=== RESULTS (ch$CH, A-MPDU normal ack-policy, unicast RA=$MAC) ==="
+python3 - "$OUT" "$SECS" <<'PYEOF'
+import collections, json, os, sys
+
+out, secs = sys.argv[1], float(sys.argv[2])
+for cell in ("on", "off"):
+    reports = []
+    for line in open(os.path.join(out, f"tx_{cell}.jsonl"), errors="replace"):
+        if not line.startswith('{"ev":"tx.report"'):
+            continue
+        try:
+            reports.append(json.loads(line))
+        except json.JSONDecodeError:
+            pass
+    if not reports:
+        print(f"{cell:>4}: NO tx.report events — check the TX cell logs")
+        continue
+    n = len(reports)
+    ok = sum(1 for r in reports if r.get("ok"))
+    retries = [r.get("retries", 0) for r in reports]
+    dist = collections.Counter(retries)
+    top = ", ".join(f"{k}x{v}" for k, v in sorted(dist.items())[:6])
+    print(f"{cell:>4}: reports={n} ({n/secs:.0f}/s) delivered={100*ok//n}% "
+          f"mean_retries={sum(retries)/n:.1f} retry_dist=[{top}]")
+PYEOF
+echo "raw logs: $OUT"

--- a/tests/ampdu_onair_ab.sh
+++ b/tests/ampdu_onair_ab.sh
@@ -64,9 +64,12 @@ run_mode() { # $1 = name, rest = extra TX env
 }
 
 run_mode singles
-run_mode ampdu DEVOURER_TX_QSEL=0 DEVOURER_TX_AMPDU=16/7/0 \
+# The product API in one knob (DEVOURER_TX_AMPDU_MODE = tid/max/density/noack/
+# maxtime): programs the pacing regs AND marks frames aggregatable — no manual
+# REPLAY_WSEQ, no raw spike knobs. Deep-fed via DEVOURER_TX_THREADS.
+run_mode ampdu DEVOURER_TX_AMPDU_MODE=0/16 \
                DEVOURER_TX_BATCH=3 DEVOURER_TX_USB_AGG=3 \
-               DEVOURER_REPLAY_WSEQ="$OUT/pacing.wseq"
+               DEVOURER_TX_THREADS=4
 
 echo
 echo "=== SUMMARY (ch$CH MCS$MCS/$BW payload=$PAYLOAD) ==="

--- a/tests/ampdu_onair_ab.sh
+++ b/tests/ampdu_onair_ab.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# A-MPDU on-air efficiency A/B — SDR ground truth (per bench discipline:
+# judge TX by SDR duty x PHY rate, never receiver frame counts; the RX-capture
+# comparisons in tests/ampdu_pacing_sweep.sh are relative-only).
+#
+# Modes (same adapter, same clean 5 GHz channel, MCS7/20, 1000-byte PSDUs):
+#   singles — the classic per-frame flood (the baseline air behaviour)
+#   ampdu   — data queue + AGG_EN + retry0 + batched feed + the pacing pokes
+#             the sweep found (0x4bc burst-ctrl cleared, 0x455 = 0x20)
+#
+# Per mode: TX floods for $((SECS+10)) s; one sdr_duty read (retried once if
+# the B210 fails to reacquire and reports ~0 — the known back-to-back trap)
+# taken mid-flood; TX-side accepted fps from tx.stats. The verdict metric is
+# accepted-fps per duty point: more frames per unit airtime = real air-time
+# efficiency.
+#
+#   sudo bash tests/ampdu_onair_ab.sh
+#   CH=157 SECS=6 sudo bash tests/ampdu_onair_ab.sh
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD="$ROOT/build"
+
+TX_PID=${TX_PID:-0x012d}; TX_VID=${TX_VID:-0x2357}
+CH=${CH:-149}; SECS=${SECS:-4}; MCS=${MCS:-7}; BW=${BW:-20}
+PAYLOAD=${PAYLOAD:-1000}
+OUT=${OUT:-/tmp/ampdu_onair}
+
+KILL(){ pkill -9 -x txdemo 2>/dev/null; return 0; }
+trap KILL EXIT
+mkdir -p "$OUT"
+FREQ=$(( (5000 + 5 * CH) ))e6
+
+echo "455 1 20" >  "$OUT/pacing.wseq"
+echo "4bc 1 0"  >> "$OUT/pacing.wseq"
+
+duty_read() { # one sdr_duty read; retry once on the ~0 reacquire failure
+  local out
+  out=$(python3 "$ROOT/tests/sdr_duty.py" --freq "$FREQ" --rate 25e6 \
+        --secs "$SECS" --mcs "$MCS" --bw "$BW" 2>&1 | tail -3)
+  echo "$out"
+  if echo "$out" | grep -qE "duty=0\.0%"; then
+    echo "(reacquire retry)"
+    sleep 3
+    python3 "$ROOT/tests/sdr_duty.py" --freq "$FREQ" --rate 25e6 \
+        --secs "$SECS" --mcs "$MCS" --bw "$BW" 2>&1 | tail -3
+  fi
+}
+
+run_mode() { # $1 = name, rest = extra TX env
+  local name="$1"; shift
+  echo "=== mode $name ($*)"
+  KILL; sleep 1
+  sudo env DEVOURER_VID=$TX_VID DEVOURER_PID=$TX_PID DEVOURER_CHANNEL=$CH \
+       DEVOURER_TX_RATE=MCS$MCS/$BW DEVOURER_TX_QOS_DATA=1 \
+       DEVOURER_TX_QOS_NOACK=1 DEVOURER_TX_PAYLOAD_BYTES=$PAYLOAD \
+       DEVOURER_TX_GAP_US=0 DEVOURER_LOG_LEVEL=warn "$@" \
+       timeout -s INT $((SECS + 14)) "$BUILD/txdemo" \
+       >"$OUT/tx_$name.jsonl" 2>"$OUT/tx_$name.err" &
+  sleep 7 # bring-up + steady state
+  duty_read | tee "$OUT/duty_$name.txt"
+  wait || true
+  KILL; sleep 2
+  grep '"ev":"tx.stats"' "$OUT/tx_$name.jsonl" | tail -1
+}
+
+run_mode singles
+run_mode ampdu DEVOURER_TX_QSEL=0 DEVOURER_TX_AMPDU=16/7/0 \
+               DEVOURER_TX_BATCH=3 DEVOURER_TX_USB_AGG=3 \
+               DEVOURER_REPLAY_WSEQ="$OUT/pacing.wseq"
+
+echo
+echo "=== SUMMARY (ch$CH MCS$MCS/$BW payload=$PAYLOAD) ==="
+for m in singles ampdu; do
+  duty=$(grep -oE "duty[ =:]+[0-9.]+" "$OUT/duty_$m.txt" | tail -1 | grep -oE "[0-9.]+$")
+  stats=$(grep '"ev":"tx.stats"' "$OUT/tx_$m.jsonl" | tail -1)
+  sub=$(echo "$stats" | grep -oE '"submitted":[0-9]+' | grep -oE '[0-9]+')
+  fail=$(echo "$stats" | grep -oE '"failed":[0-9]+' | grep -oE '[0-9]+')
+  frames=$(grep '"ev":"tx.frame"' "$OUT/tx_$m.jsonl" | tail -1 | grep -oE '"n":[0-9]+' | grep -oE '[0-9]+')
+  echo "$m: duty=${duty:-?} tx_frames=${frames:-?} urb_submitted=${sub:-?} urb_failed=${fail:-?}"
+done
+echo "raw logs: $OUT"

--- a/tests/ampdu_pacing_sweep.sh
+++ b/tests/ampdu_pacing_sweep.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# A-MPDU aggregate-launch pacing sweep. The spike (tests/ampdu_spike.sh,
+# docs/aggregation.md) established that the MAC hardware-aggregates
+# host-pushed QoS-Data on a data queue, but flow-controls each aggregate
+# launch at ~3 ms under sustained feed — tracking REG_AMPDU_MAX_TIME_V1
+# (0x455 = 0x70, the aggregate-fill timer) — which caps net A-MPDU goodput
+# BELOW plain singles at MCS7/20.
+#
+# This sweep pokes the candidate pacing registers post-bring-up on the TX
+# adapter via the DEVOURER_REPLAY_WSEQ hook (now applied at the end of
+# InitWrite too) and measures unique-frame goodput + burst structure on a
+# second devourer receiver:
+#   - 0x455  AMPDU max time (unit ~32 us): 0x70 baseline, then shrinking
+#   - 0x4bc  SW_AMPDU_BURST_MODE_CTRL variants
+#
+#   sudo bash tests/ampdu_pacing_sweep.sh
+#   TX_PID=0x012d RX_PID=0xc812 SECS=8 sudo bash tests/ampdu_pacing_sweep.sh
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD="$ROOT/build"
+
+TX_PID=${TX_PID:-0x012d}; TX_VID=${TX_VID:-0x2357}
+RX_PID=${RX_PID:-0xc812}; RX_VID=${RX_VID:-0x0bda}
+CH=${CH:-6}; SECS=${SECS:-8}; RATE=${RATE:-MCS7}
+PAYLOAD=${PAYLOAD:-1000}
+OUT=${OUT:-/tmp/ampdu_pacing}
+
+KILL(){ pkill -9 -x rxdemo 2>/dev/null; pkill -9 -x txdemo 2>/dev/null; return 0; }
+trap KILL EXIT
+mkdir -p "$OUT"
+
+run_cell() { # $1 = cell name, $2 = wseq file ("" = none), rest = extra TX env
+  local name="$1" wseq="$2"; shift 2
+  echo "=== cell $name (wseq='$wseq' $*)"
+  KILL; sleep 1
+  sudo env DEVOURER_VID=$RX_VID DEVOURER_PID=$RX_PID DEVOURER_CHANNEL=$CH \
+       DEVOURER_STREAM_OUT=1 DEVOURER_EVENT_FLUSH=0 DEVOURER_LOG_LEVEL=warn \
+       "$BUILD/rxdemo" >"$OUT/rx_$name.jsonl" 2>"$OUT/rx_$name.err" &
+  sleep 6
+  local extra=()
+  [ -n "$wseq" ] && extra=(DEVOURER_REPLAY_WSEQ="$wseq")
+  sudo env DEVOURER_VID=$TX_VID DEVOURER_PID=$TX_PID DEVOURER_CHANNEL=$CH \
+       DEVOURER_TX_RATE=$RATE DEVOURER_TX_QOS_DATA=1 DEVOURER_TX_QOS_NOACK=1 \
+       DEVOURER_TX_PAYLOAD_BYTES=$PAYLOAD DEVOURER_TX_GAP_US=0 \
+       DEVOURER_TX_QSEL=0 DEVOURER_TX_AMPDU=16/7/0 \
+       DEVOURER_TX_BATCH=3 DEVOURER_TX_USB_AGG=3 \
+       DEVOURER_LOG_LEVEL=warn "${extra[@]}" "$@" \
+       timeout -s INT $SECS "$BUILD/txdemo" \
+       >"$OUT/tx_$name.jsonl" 2>"$OUT/tx_$name.err" || true
+  sleep 1
+  KILL; sleep 1
+}
+
+# wseq files: "<addr_hex> <width> <val_hex>" per line.
+mk_wseq() { echo "$2" > "$OUT/$1.wseq"; echo "$OUT/$1.wseq"; }
+
+W_T20=$(mk_wseq t20  "455 1 20")   # max time 0x20 (~1 ms)
+W_T08=$(mk_wseq t08  "455 1 8")    # ~256 us
+W_T02=$(mk_wseq t02  "455 1 2")    # ~64 us
+W_T00=$(mk_wseq t00  "455 1 0")    # timer off (behaviour unknown)
+W_B00=$(mk_wseq b00  "4bc 1 0")    # burst-mode ctrl cleared
+W_BC0=$(mk_wseq bc0  "4bc 1 c0")   # burst-mode bits 7:6
+W_T08B=$(mk_wseq t08b "455 1 8
+4bc 1 c0")                          # combined
+
+run_cell base   ""        # 0x455=0x70 baseline (bring-up value)
+run_cell t20    "$W_T20"
+run_cell t08    "$W_T08"
+run_cell t02    "$W_T02"
+run_cell t00    "$W_T00"
+run_cell b00    "$W_B00"
+run_cell bc0    "$W_BC0"
+run_cell t08bc0 "$W_T08B"
+# singles control for the session (same air conditions)
+KILL; sleep 1
+sudo env DEVOURER_VID=$RX_VID DEVOURER_PID=$RX_PID DEVOURER_CHANNEL=$CH \
+     DEVOURER_STREAM_OUT=1 DEVOURER_EVENT_FLUSH=0 DEVOURER_LOG_LEVEL=warn \
+     "$BUILD/rxdemo" >"$OUT/rx_singles.jsonl" 2>"$OUT/rx_singles.err" &
+sleep 6
+sudo env DEVOURER_VID=$TX_VID DEVOURER_PID=$TX_PID DEVOURER_CHANNEL=$CH \
+     DEVOURER_TX_RATE=$RATE DEVOURER_TX_QOS_DATA=1 DEVOURER_TX_QOS_NOACK=1 \
+     DEVOURER_TX_PAYLOAD_BYTES=$PAYLOAD DEVOURER_TX_GAP_US=0 \
+     DEVOURER_LOG_LEVEL=warn \
+     timeout -s INT $SECS "$BUILD/txdemo" \
+     >"$OUT/tx_singles.jsonl" 2>"$OUT/tx_singles.err" || true
+KILL
+
+echo
+echo "=== RESULTS (payload=$PAYLOAD rate=$RATE secs=$SECS; cells = 0x455/0x4bc pokes) ==="
+python3 - "$OUT" "$PAYLOAD" "$SECS" <<'PYEOF'
+import glob, json, os, sys
+
+out, payload, secs = sys.argv[1], int(sys.argv[2]), float(sys.argv[3])
+want_len = {payload, payload + 4}
+
+def jload(line):
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError:
+        return {}
+
+order = ["singles", "base", "t20", "t08", "t02", "t00", "b00", "bc0", "t08bc0"]
+for cell in order:
+    path = os.path.join(out, f"rx_{cell}.jsonl")
+    if not os.path.exists(path):
+        continue
+    frames, uniq = [], set()
+    for line in open(path, errors="replace"):
+        if not line.startswith('{"ev":"rx.frame"'):
+            continue
+        ev = jload(line)
+        if ev.get("len") in want_len and not ev.get("crc"):
+            frames.append(ev)
+            body = ev.get("body", "")
+            if len(body) >= 12:
+                uniq.add(body[4:12])
+    n = len(frames)
+    if n == 0:
+        print(f"{cell:>8}: NO FRAMES (cell failed — check tx/rx err logs)")
+        continue
+    paggr = sum(1 for f in frames if f.get("paggr"))
+    bursts, cur = [], 1
+    gaps = []
+    for a, b in zip(frames, frames[1:]):
+        dt = (b.get("tsfl", 0) - a.get("tsfl", 0)) & 0xFFFFFFFF
+        if dt == 0:
+            cur += 1
+        else:
+            bursts.append(cur); cur = 1
+            gaps.append(dt)
+    bursts.append(cur)
+    gaps.sort()
+    gap50 = gaps[len(gaps)//2] if gaps else 0
+    print(f"{cell:>8}: uniq_fps={len(uniq)/secs:6.0f}  rx={n} unique={len(uniq)} "
+          f"paggr={100*paggr//n}% mean_burst={sum(bursts)/len(bursts):.1f} "
+          f"max_burst={max(bursts)} inter_gap_p50={gap50}us")
+PYEOF
+echo "raw logs: $OUT"

--- a/tests/ampdu_spike.sh
+++ b/tests/ampdu_spike.sh
@@ -77,6 +77,15 @@ run_cell ampdu_q0     DEVOURER_TX_QOS_NOACK=1 DEVOURER_TX_QSEL=0 \
 run_cell ampdu_q0_urb DEVOURER_TX_QOS_NOACK=1 DEVOURER_TX_QSEL=0 \
                       DEVOURER_TX_AMPDU=$AGG/$DENSITY \
                       DEVOURER_TX_BATCH=$AGG DEVOURER_TX_USB_AGG=$AGG
+# AGG_EN + data queue + RETRY LIMIT 0: the no-ack flavor. Without it the MAC
+# retries every aggregate to the limit waiting for a BlockAck no monitor-mode
+# receiver ever sends (bench-proven: 92% retry-flagged, unique goodput 7x
+# below singles) — rty=0 airs each aggregate exactly once.
+run_cell ampdu_rty0   DEVOURER_TX_QOS_NOACK=1 DEVOURER_TX_QSEL=0 \
+                      DEVOURER_TX_AMPDU=$AGG/$DENSITY/0
+run_cell ampdu_rty0_urb DEVOURER_TX_QOS_NOACK=1 DEVOURER_TX_QSEL=0 \
+                      DEVOURER_TX_AMPDU=$AGG/$DENSITY/0 \
+                      DEVOURER_TX_BATCH=$AGG DEVOURER_TX_USB_AGG=$AGG
 # optional: unicast RA, normal ack policy (nobody ACKs -> hw retry behaviour).
 if [ -n "$FULL" ]; then
   run_cell ampdu_ucast DEVOURER_TX_QSEL=0 DEVOURER_TX_AMPDU=$AGG/$DENSITY \
@@ -86,16 +95,16 @@ fi
 
 echo
 echo "=== RESULTS (payload=$PAYLOAD rate=$RATE agg=$AGG) ==="
-python3 - "$OUT" "$PAYLOAD" <<'PYEOF'
+python3 - "$OUT" "$PAYLOAD" "$SECS" <<'PYEOF'
 import glob, json, os, sys
 
-out, payload = sys.argv[1], int(sys.argv[2])
+out, payload, secs = sys.argv[1], int(sys.argv[2]), float(sys.argv[3])
 # RX pkt_len may include the 4-byte FCS depending on APPFCS handling.
 want_len = {payload, payload + 4}
 
 for path in sorted(glob.glob(os.path.join(out, "rx_*.jsonl"))):
     cell = os.path.basename(path)[3:-6]
-    frames = []
+    frames, uniq, retry = [], set(), 0
     for line in open(path, errors="replace"):
         if not line.startswith('{"ev":"rx.frame"'):
             continue
@@ -105,28 +114,30 @@ for path in sorted(glob.glob(os.path.join(out, "rx_*.jsonl"))):
             continue
         if ev.get("len") in want_len and not ev.get("crc"):
             frames.append(ev)
+            if ev.get("fc1", 0) & 0x08:
+                retry += 1
+            body = ev.get("body", "")
+            if len(body) >= 12:
+                uniq.add(body[4:12])  # txdemo per-frame counter, MPDU bytes 26..29
     n = len(frames)
     if n == 0:
-        print(f"{cell:>14}: NO FRAMES (delivery broken in this cell?)")
+        print(f"{cell:>16}: NO FRAMES (delivery broken in this cell?)")
         continue
     paggr = sum(1 for f in frames if f.get("paggr"))
-    # Burst structure from the 2-bit PPDU counter: consecutive frames sharing
-    # a value shared one PPDU. Also cross-check with tsfl adjacency (<200 us).
+    # Burst structure: subframes of one PPDU latch the SAME rx tsfl.
     bursts, cur = [], 1
     for a, b in zip(frames, frames[1:]):
-        same_ppdu = a.get("ppdu") == b.get("ppdu")
-        dt = (b.get("tsfl", 0) - a.get("tsfl", 0)) & 0xFFFFFFFF
-        if same_ppdu and dt < 200:
+        if ((b.get("tsfl", 0) - a.get("tsfl", 0)) & 0xFFFFFFFF) == 0:
             cur += 1
         else:
             bursts.append(cur); cur = 1
     bursts.append(cur)
     mean_burst = sum(bursts) / len(bursts)
     max_burst = max(bursts)
-    multi = sum(b for b in bursts if b > 1)
-    verdict = "AGGREGATED" if (max_burst >= 4 and multi > n * 0.5) else \
-              "partial" if max_burst >= 2 and paggr else "singles"
-    print(f"{cell:>14}: {verdict:>10}  frames={n} paggr={paggr} "
+    agg = "AGGREGATED" if max_burst >= 4 and paggr > n * 0.5 else \
+          "partial" if max_burst >= 2 and paggr else "singles"
+    print(f"{cell:>16}: {agg:>10}  rx={n} unique={len(uniq)} "
+          f"({len(uniq)/secs:.0f} uniq fps)  retry_flagged={100*retry//max(n,1)}% "
           f"mean_burst={mean_burst:.1f} max_burst={max_burst}")
 PYEOF
 echo "raw logs: $OUT"

--- a/tests/ampdu_spike.sh
+++ b/tests/ampdu_spike.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# A-MPDU feasibility spike: can the MAC hardware aggregate HOST-PUSHED
+# (monitor-inject, USE_RATE=1) frames into A-MPDUs, and under which conditions?
+#
+# Matrix axes (one txdemo run per cell, QoS-Data TID0 frames at $RATE):
+#   - QSEL: the monitor-inject MGMT queue (0x12) vs a data queue (TID 0)
+#   - descriptor AGG_EN/MAX_AGG_NUM/AMPDU_DENSITY on vs off (DEVOURER_TX_AMPDU)
+#   - delivery: gapless single-frame URBs vs one multi-frame URB
+#     (DEVOURER_TX_BATCH + DEVOURER_TX_USB_AGG) — is one-URB co-queueing
+#     required for the MAC to see aggregatable frames?
+#   - QoS ack policy: No-Ack broadcast (the wfb-style flavor) is the default;
+#     FULL=1 adds a unicast/normal-ack cell (expect hardware retry storms —
+#     the monitor-mode receiver never ACKs).
+#
+# Detection = RX-side ground truth on a second devourer adapter in monitor
+# mode (DEVOURER_STREAM_OUT=1 -> per-frame rx.frame events):
+#   - paggr: rx-desc "inside an aggregate" marker
+#   - ppdu: the halmac 2-bit received-PPDU counter — runs of the same value
+#     are subframes of ONE PPDU (burst-length histogram = A-MPDU size)
+#   - tsfl: RX timestamps of subframes within one PPDU cluster within ~its
+#     airtime; singles are spaced by preamble+contention
+# (Airtime/throughput claims come later from the SDR duty bench — this spike
+# only establishes aggregation STRUCTURE.)
+#
+#   sudo bash tests/ampdu_spike.sh                       # default matrix
+#   TX_PID=0xB82C RX_PID=0x8812 sudo bash tests/ampdu_spike.sh
+#   FULL=1 sudo bash tests/ampdu_spike.sh                # + unicast-ack cell
+#
+# Results: per-cell verdict lines + raw logs under $OUT (/tmp/ampdu_spike).
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD="$ROOT/build"
+
+TX_PID=${TX_PID:-0x8812}; TX_VID=${TX_VID:-0x0bda}
+RX_PID=${RX_PID:-0x0120}; RX_VID=${RX_VID:-0x2357}
+CH=${CH:-6}; SECS=${SECS:-8}; RATE=${RATE:-MCS7}
+PAYLOAD=${PAYLOAD:-1000}
+AGG=${AGG:-16}           # frames per batch/URB + MAX_AGG_NUM (desc units of 2)
+DENSITY=${DENSITY:-7}
+FULL=${FULL:-}
+OUT=${OUT:-/tmp/ampdu_spike}
+
+KILL(){ pkill -9 -x rxdemo 2>/dev/null; pkill -9 -x txdemo 2>/dev/null; return 0; }
+trap KILL EXIT
+mkdir -p "$OUT"
+
+run_cell() { # $1 = cell name, rest = extra TX-side K=V env
+  local name="$1"; shift
+  echo "=== cell $name ($*)"
+  KILL; sleep 1
+  sudo env DEVOURER_VID=$RX_VID DEVOURER_PID=$RX_PID DEVOURER_CHANNEL=$CH \
+       DEVOURER_STREAM_OUT=1 DEVOURER_EVENT_FLUSH=0 DEVOURER_LOG_LEVEL=warn \
+       "$BUILD/rxdemo" >"$OUT/rx_$name.jsonl" 2>"$OUT/rx_$name.err" &
+  sleep 6 # rxdemo bring-up
+  sudo env DEVOURER_VID=$TX_VID DEVOURER_PID=$TX_PID DEVOURER_CHANNEL=$CH \
+       DEVOURER_TX_RATE=$RATE DEVOURER_TX_QOS_DATA=1 \
+       DEVOURER_TX_PAYLOAD_BYTES=$PAYLOAD DEVOURER_TX_GAP_US=0 \
+       DEVOURER_LOG_LEVEL=warn "$@" \
+       timeout -s INT $SECS "$BUILD/txdemo" \
+       >"$OUT/tx_$name.jsonl" 2>"$OUT/tx_$name.err" || true
+  sleep 1
+  KILL; sleep 1
+}
+
+# --- the matrix -------------------------------------------------------------
+# control: no agg anywhere — the singles baseline every cell compares against.
+run_cell control      DEVOURER_TX_QOS_NOACK=1
+# data queue alone (no AGG_EN): does QSEL routing itself change anything?
+run_cell qsel0        DEVOURER_TX_QOS_NOACK=1 DEVOURER_TX_QSEL=0
+# AGG_EN on the MGMT queue, one-URB delivery: does 0x12 aggregate at all?
+run_cell ampdu_mgmt   DEVOURER_TX_QOS_NOACK=1 DEVOURER_TX_AMPDU=$AGG/$DENSITY \
+                      DEVOURER_TX_BATCH=$AGG DEVOURER_TX_USB_AGG=$AGG
+# AGG_EN + data queue, gapless SINGLE URBs: is USB-agg co-queueing required?
+run_cell ampdu_q0     DEVOURER_TX_QOS_NOACK=1 DEVOURER_TX_QSEL=0 \
+                      DEVOURER_TX_AMPDU=$AGG/$DENSITY
+# AGG_EN + data queue + one-URB delivery: the full recipe.
+run_cell ampdu_q0_urb DEVOURER_TX_QOS_NOACK=1 DEVOURER_TX_QSEL=0 \
+                      DEVOURER_TX_AMPDU=$AGG/$DENSITY \
+                      DEVOURER_TX_BATCH=$AGG DEVOURER_TX_USB_AGG=$AGG
+# optional: unicast RA, normal ack policy (nobody ACKs -> hw retry behaviour).
+if [ -n "$FULL" ]; then
+  run_cell ampdu_ucast DEVOURER_TX_QSEL=0 DEVOURER_TX_AMPDU=$AGG/$DENSITY \
+                       DEVOURER_TX_BATCH=$AGG DEVOURER_TX_USB_AGG=$AGG \
+                       DEVOURER_TX_RA=02:11:22:33:44:55
+fi
+
+echo
+echo "=== RESULTS (payload=$PAYLOAD rate=$RATE agg=$AGG) ==="
+python3 - "$OUT" "$PAYLOAD" <<'PYEOF'
+import glob, json, os, sys
+
+out, payload = sys.argv[1], int(sys.argv[2])
+# RX pkt_len may include the 4-byte FCS depending on APPFCS handling.
+want_len = {payload, payload + 4}
+
+for path in sorted(glob.glob(os.path.join(out, "rx_*.jsonl"))):
+    cell = os.path.basename(path)[3:-6]
+    frames = []
+    for line in open(path, errors="replace"):
+        if not line.startswith('{"ev":"rx.frame"'):
+            continue
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if ev.get("len") in want_len and not ev.get("crc"):
+            frames.append(ev)
+    n = len(frames)
+    if n == 0:
+        print(f"{cell:>14}: NO FRAMES (delivery broken in this cell?)")
+        continue
+    paggr = sum(1 for f in frames if f.get("paggr"))
+    # Burst structure from the 2-bit PPDU counter: consecutive frames sharing
+    # a value shared one PPDU. Also cross-check with tsfl adjacency (<200 us).
+    bursts, cur = [], 1
+    for a, b in zip(frames, frames[1:]):
+        same_ppdu = a.get("ppdu") == b.get("ppdu")
+        dt = (b.get("tsfl", 0) - a.get("tsfl", 0)) & 0xFFFFFFFF
+        if same_ppdu and dt < 200:
+            cur += 1
+        else:
+            bursts.append(cur); cur = 1
+    bursts.append(cur)
+    mean_burst = sum(bursts) / len(bursts)
+    max_burst = max(bursts)
+    multi = sum(b for b in bursts if b > 1)
+    verdict = "AGGREGATED" if (max_burst >= 4 and multi > n * 0.5) else \
+              "partial" if max_burst >= 2 and paggr else "singles"
+    print(f"{cell:>14}: {verdict:>10}  frames={n} paggr={paggr} "
+          f"mean_burst={mean_burst:.1f} max_burst={max_burst}")
+PYEOF
+echo "raw logs: $OUT"

--- a/tests/beacon_tbtt.cpp
+++ b/tests/beacon_tbtt.cpp
@@ -67,6 +67,17 @@ int main(int argc, char** argv) {
       0x00, 0x03, 'T', 'B', 'T',                                   // SSID IE "TBT"
       0x01, 0x01, 0x82};                                          // supported rates (1M)
 
+  /* DEVOURER_BCN_SA=aa:bb:.. — override the beacon SA/BSSID (the canonical
+   * 57:42:.. has the I/G bit set; a hardware-ACK experiment needs a UNICAST
+   * port identity, same footgun as docs/ap-mode.md). */
+  if (const char *e = std::getenv("DEVOURER_BCN_SA")) {
+    unsigned m[6];
+    if (sscanf(e, "%x:%x:%x:%x:%x:%x", &m[0], &m[1], &m[2], &m[3], &m[4],
+               &m[5]) == 6)
+      for (int i = 0; i < 6; ++i)
+        f[10 + 10 + i] = f[10 + 16 + i] = static_cast<uint8_t>(m[i]);
+  }
+
   bool ok = dev->StartBeacon(f.data(), f.size(), interval_tu);
   fprintf(stderr, "StartBeacon -> %s. Idling %d s (chip should self-TX at "
                   "TBTT every %d TU ≈ %.1f ms). Watch a 2nd RX's rx.txhit.\n",

--- a/tests/bench_onair.py
+++ b/tests/bench_onair.py
@@ -36,6 +36,22 @@ KDRIVERS = ["rtw88_8812au", "rtw88_8814au", "rtw88_8821au", "rtw88_8822cu",
 DUTY_RE = re.compile(r"duty=([\d.]+)%\s+noise=([-\d.]+)dB.*on_air~=([\d.]+)Mbps")
 
 
+def resolve_sysfs(vid: str, pid: str, fallback: str) -> str | None:
+    """Find the current sysfs id for a VID:PID (topology-independent), so the
+    hardcoded CHIPS ports don't have to match this rig. Returns the fallback if
+    the scan finds nothing (and None if even the fallback is absent)."""
+    vlo, plo = vid.lower().replace("0x", ""), pid.lower().replace("0x", "")
+    root = Path("/sys/bus/usb/devices")
+    for d in root.glob("*"):
+        try:
+            if (d / "idVendor").read_text().strip() == vlo and \
+               (d / "idProduct").read_text().strip() == plo:
+                return d.name
+        except OSError:
+            continue
+    return fallback if (root / fallback).exists() else None
+
+
 def free_chip(sysfs: str) -> None:
     for drv in KDRIVERS:
         base = f"/sys/bus/usb/drivers/{drv}"
@@ -64,11 +80,21 @@ def sdr_duty(freq: float, mcs: int, bw: int, noise_db: float | None,
     return (duty, noise, mbps) if return_noise else (duty, mbps)
 
 
-def devourer_flood(vid, pid, ch, mcs, bw, size):
+def devourer_flood(vid, pid, ch, mcs, bw, size, ampdu=False, threads=1):
+    """Flood txdemo. Default = single-frame injection (the baseline table
+    metric). ampdu=True adds the A-MPDU recipe (QoS-Data on a data queue +
+    SetAmpduMode + a deep multi-thread feed) so the MAC actually aggregates;
+    threads>1 alone is the feed-depth control (no aggregation)."""
     env = dict(__import__("os").environ,
                DEVOURER_VID=vid, DEVOURER_PID=pid, DEVOURER_CHANNEL=str(ch),
                DEVOURER_TX_RATE=f"MCS{mcs}/{bw}",
                DEVOURER_TX_PAYLOAD_BYTES=str(size), DEVOURER_TX_GAP_US="0")
+    if threads > 1:
+        env["DEVOURER_TX_THREADS"] = str(threads)
+    if ampdu:
+        env.update(DEVOURER_TX_QOS_DATA="1", DEVOURER_TX_QOS_NOACK="1",
+                   DEVOURER_TX_AMPDU_MODE="0/16",
+                   DEVOURER_TX_BATCH="3", DEVOURER_TX_USB_AGG="3")
     return regress._register_local_proc(subprocess.Popen(
         [str(ROOT / "build" / "txdemo")], env=env,
         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
@@ -86,10 +112,22 @@ def main() -> int:
                     help="skip the CU-control 5 GHz rail-sag pre-flight (rail_check.sh)")
     ap.add_argument("--only", help="comma-separated chip labels to bench "
                     "(default: every plugged-in chip in CHIPS)")
+    ap.add_argument("--ampdu", action="store_true",
+                    help="also measure the deep-fed A-MPDU flood + a feed-depth "
+                    "control, emitting a singles/feed/A-MPDU comparison")
+    ap.add_argument("--threads", type=int, default=4,
+                    help="parallel-sender depth for the A-MPDU + feed modes")
+    ap.add_argument("--bands", help="comma-separated band substrings to bench "
+                    "(default: all; e.g. --bands 149 for the clean 5 GHz band)")
     args = ap.parse_args()
     regress._install_cleanup_handlers()
-    present = {c: v for c, v in CHIPS.items()
-               if Path(f"/sys/bus/usb/devices/{v[0]}").exists()}
+    # Resolve each chip's actual sysfs port from its VID:PID so a stale
+    # hardcoded CHIPS port doesn't drop a plugged-in adapter.
+    present = {}
+    for c, (sysfs, vid, pid) in CHIPS.items():
+        s = resolve_sysfs(vid, pid, sysfs)
+        if s:
+            present[c] = (s, vid, pid)
     if args.only:
         want = {s.strip().upper() for s in args.only.split(",")}
         present = {c: v for c, v in present.items() if c.upper() in want}
@@ -109,8 +147,25 @@ def main() -> int:
             print("!! (2.4 GHz numbers are unaffected. Pass --skip-rail-check to override.)")
             print("!" * 70 + "\n")
 
+    bands = BANDS
+    if args.bands:
+        want = [b.strip() for b in args.bands.split(",")]
+        bands = [b for b in BANDS if any(w in b[0] for w in want)]
+
+    # Modes to measure per chip/band. Default: just the single-frame baseline
+    # (the historical table metric). --ampdu adds the feed-depth control and the
+    # full A-MPDU recipe, so any gain is attributable (feed depth vs aggregation).
+    modes = [("singles", dict())]
+    if args.ampdu:
+        modes = [("singles", dict()),
+                 ("feed", dict(threads=args.threads)),
+                 ("ampdu", dict(ampdu=True, threads=args.threads))]
+
+    def flood(vid, pid, ch, opts):
+        return devourer_flood(vid, pid, ch, args.mcs, args.bw, args.size, **opts)
+
     results: dict = {}
-    for label, ch, freq in BANDS:
+    for label, ch, freq in bands:
         # Calibrate this band's idle noise floor (all chips quiet) so the
         # threshold is right — a fixed floor mis-reads a noisier 2.4 GHz band.
         for sysfs, _, _ in CHIPS.values():
@@ -119,28 +174,46 @@ def main() -> int:
         floor = cal[1] if cal else args.noise_db  # cal = (duty, noise, mbps)
         print(f"  [{label}] idle noise floor {floor:.1f} dB", flush=True)
         for chip, (sysfs, vid, pid) in present.items():
-            print(f"  {chip} {label} …", flush=True)
-            d = None
-            for _ in range(2):  # one retry
-                free_chip(sysfs)
-                proc = devourer_flood(vid, pid, ch, args.mcs, args.bw, args.size)
-                time.sleep(6)
-                d = sdr_duty(freq, args.mcs, args.bw, floor, args.secs)
-                regress._terminate(proc)
-                if d and d[0] > 5:
-                    break
-            results[(chip, label)] = d
-            print(f"     -> {d[1]:.1f} Mbps ({d[0]:.0f}% duty)" if d else "     -> FAIL")
+            for mode, opts in modes:
+                print(f"  {chip} {label} {mode} …", flush=True)
+                d = None
+                for _ in range(2):  # one retry
+                    free_chip(sysfs)
+                    proc = flood(vid, pid, ch, opts)
+                    time.sleep(6)
+                    d = sdr_duty(freq, args.mcs, args.bw, floor, args.secs)
+                    regress._terminate(proc)
+                    if d and d[0] > 5:
+                        break
+                results[(chip, label, mode)] = d
+                print(f"     -> {d[1]:.1f} Mbps ({d[0]:.0f}% duty)" if d
+                      else "     -> FAIL")
 
-    # markdown
-    print("\n| Part | " + " | ".join(l for l, _, _ in BANDS) + " |")
-    print("|------|" + "|".join("------" for _ in BANDS) + "|")
-    for chip in present:
-        cells = []
-        for label, _, _ in BANDS:
-            d = results.get((chip, label))
-            cells.append(f"{d[1]:.0f} Mbps" if d and d[1] > 0.5 else "—")
-        print(f"| {chip} | " + " | ".join(cells) + " |")
+    def cell(chip, label, mode):
+        d = results.get((chip, label, mode))
+        return f"{d[1]:.0f}" if d and d[1] > 0.5 else "—"
+
+    if not args.ampdu:
+        # markdown — the historical single-frame table
+        print("\n| Part | " + " | ".join(l for l, _, _ in bands) + " |")
+        print("|------|" + "|".join("------" for _ in bands) + "|")
+        for chip in present:
+            cells = [cell(chip, l, "singles") + " Mbps" if cell(chip, l, "singles") != "—"
+                     else "—" for l, _, _ in bands]
+            print(f"| {chip} | " + " | ".join(cells) + " |")
+        return 0
+
+    # A-MPDU comparison: per band, singles / feed / A-MPDU on-air Mbps (SDR
+    # duty x PHY rate). NB this metric is channel occupancy x modulation rate;
+    # for a chip already near the PHY ceiling it can't rise even as A-MPDU
+    # raises payload goodput (see docs/aggregation.md).
+    for label, _, _ in bands:
+        print(f"\n### {label}  (on-air Mbps = SDR duty x PHY rate)")
+        print("| Part | singles | +deep feed | +A-MPDU |")
+        print("|------|--------:|-----------:|--------:|")
+        for chip in present:
+            s, f, a = (cell(chip, label, m) for m in ("singles", "feed", "ampdu"))
+            print(f"| {chip} | {s} | {f} | {a} |")
     return 0
 
 

--- a/tests/txagg_bench.sh
+++ b/tests/txagg_bench.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# USB TX aggregation A/B bench: the same frame flood sent per-frame (classic
+# send_packet loop) vs batched through send_packets with USB TX aggregation
+# (DEVOURER_TX_BATCH + DEVOURER_TX_USB_AGG) — one bulk-OUT URB per batch.
+# Measures the host/USB-side frame-rate ceiling and cross-checks delivery on
+# a second devourer adapter in monitor mode (rx.txhit counts — a delivery
+# sanity check, NOT an airtime/throughput claim; that is the SDR bench's job).
+#
+#   sudo bash tests/txagg_bench.sh
+#   TX_PID=0x8812 TX_VID=0x0bda BATCH=32 PAYLOAD=200 sudo bash tests/txagg_bench.sh
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD="$ROOT/build"
+
+TX_PID=${TX_PID:-0x012d}; TX_VID=${TX_VID:-0x2357}
+RX_PID=${RX_PID:-0xc812}; RX_VID=${RX_VID:-0x0bda}
+CH=${CH:-6}; SECS=${SECS:-10}; RATE=${RATE:-MCS7}
+PAYLOAD=${PAYLOAD:-1000}
+BATCH=${BATCH:-16}
+OUT=${OUT:-/tmp/txagg_bench}
+
+KILL(){ pkill -9 -x rxdemo 2>/dev/null; pkill -9 -x txdemo 2>/dev/null; return 0; }
+trap KILL EXIT
+mkdir -p "$OUT"
+
+run_mode() { # $1 = mode name, rest = extra TX env
+  local name="$1"; shift
+  echo "=== mode $name ($*)"
+  KILL; sleep 1
+  sudo env DEVOURER_VID=$RX_VID DEVOURER_PID=$RX_PID DEVOURER_CHANNEL=$CH \
+       DEVOURER_EVENT_FLUSH=0 DEVOURER_LOG_LEVEL=warn \
+       "$BUILD/rxdemo" >"$OUT/rx_$name.jsonl" 2>"$OUT/rx_$name.err" &
+  sleep 6
+  sudo env DEVOURER_VID=$TX_VID DEVOURER_PID=$TX_PID DEVOURER_CHANNEL=$CH \
+       DEVOURER_TX_RATE=$RATE DEVOURER_TX_PAYLOAD_BYTES=$PAYLOAD \
+       DEVOURER_TX_GAP_US=0 DEVOURER_LOG_LEVEL=warn "$@" \
+       timeout -s INT $SECS "$BUILD/txdemo" \
+       >"$OUT/tx_$name.jsonl" 2>"$OUT/tx_$name.err" || true
+  sleep 1
+  KILL; sleep 1
+}
+
+run_mode single
+run_mode batch DEVOURER_TX_BATCH=$BATCH DEVOURER_TX_USB_AGG=$BATCH
+
+echo
+echo "=== RESULTS (payload=$PAYLOAD rate=$RATE batch=$BATCH secs=$SECS) ==="
+python3 - "$OUT" "$SECS" <<'PYEOF'
+import glob, json, os, sys
+
+out, secs = sys.argv[1], float(sys.argv[2])
+def jload(line):
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError:  # unflushed tail line at kill time
+        return {}
+
+for mode in ("single", "batch"):
+    tx_n = 0
+    agg_urbs = agg_frames = 0
+    for line in open(os.path.join(out, f"tx_{mode}.jsonl"), errors="replace"):
+        if line.startswith('{"ev":"tx.frame"'):
+            tx_n = max(tx_n, jload(line).get("n", 0))
+        elif line.startswith('{"ev":"tx.agg"'):
+            ev = jload(line)
+            agg_urbs += 1
+            agg_frames += ev.get("frames", 0)
+    hits = 0
+    for line in open(os.path.join(out, f"rx_{mode}.jsonl"), errors="replace"):
+        if line.startswith('{"ev":"rx.txhit"'):
+            hits = max(hits, jload(line).get("hits", 0))
+    per_urb = (agg_frames / agg_urbs) if agg_urbs else 1.0
+    print(f"{mode:>7}: tx={tx_n} ({tx_n/secs:.0f} fps)  rx_hits={hits}  "
+          f"frames/URB={per_urb:.1f} ({agg_urbs} agg URBs)")
+PYEOF
+echo "raw logs: $OUT"

--- a/tests/txagg_selftest.cpp
+++ b/tests/txagg_selftest.cpp
@@ -1,0 +1,240 @@
+/* Headless guard for the USB TX-aggregation URB packing (src/TxAggPlan.h) and
+ * the descriptor-level agg fields it drives:
+ *   - plan_tx_agg layout math: 8-byte block alignment, the never-a-bulk-
+ *     multiple shim, the max_frames / max_bytes / descs_per_bulk (OQT) stops;
+ *   - the HalMAC descriptor plumbing: DMA_TXAGG_NUM lands at dword7[31:24]
+ *     BEFORE the checksum, PKT_OFFSET moves the frame by 8 bytes, and the
+ *     8822C checksum span extends over the shim pad (it reads PKT_OFFSET).
+ * Prints the failing case and exits nonzero. */
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "TxAggPlan.h"
+#if defined(DEVOURER_HAVE_JAGUAR2)
+#include "jaguar2/FrameParserJaguar2.h"
+#endif
+#if defined(DEVOURER_HAVE_JAGUAR3)
+#include "jaguar3/FrameParserJaguar3.h"
+#endif
+
+static int g_fail = 0;
+
+#define CHECK(cond, ...)                                                       \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      ++g_fail;                                                                \
+      std::printf("FAIL %s:%d: ", __FILE__, __LINE__);                         \
+      std::printf(__VA_ARGS__);                                                \
+      std::printf("\n");                                                       \
+    }                                                                          \
+  } while (0)
+
+static devourer::TxAggLimits lim_halmac_hs() {
+  devourer::TxAggLimits lim;
+  lim.desc_size = 48;
+  lim.bulk_size = 512;
+  lim.max_bytes = 20480;
+  lim.max_frames = 255;
+  lim.descs_per_bulk = 3;
+  return lim;
+}
+
+static void test_plan_basic() {
+  /* Three 1500-byte frames: blocks at 8-aligned offsets, no shim needed. */
+  const size_t lens[] = {1500, 1500, 1500};
+  const auto p = devourer::plan_tx_agg(lens, 3, lim_halmac_hs());
+  CHECK(p.frames() == 3, "basic: frames=%zu want 3", p.frames());
+  size_t expect_off = 0;
+  for (size_t i = 0; i < p.frames(); ++i) {
+    CHECK(p.blocks[i].offset % 8 == 0, "basic: block %zu offset %zu not 8-aligned",
+          i, p.blocks[i].offset);
+    CHECK(p.blocks[i].offset == expect_off, "basic: block %zu offset %zu want %zu",
+          i, p.blocks[i].offset, expect_off);
+    CHECK(p.blocks[i].length == 48 + 1500, "basic: block %zu len %zu", i,
+          p.blocks[i].length);
+    expect_off = devourer::txagg_rnd8(p.blocks[i].offset + p.blocks[i].length);
+  }
+  CHECK(p.total == p.blocks[2].offset + p.blocks[2].length,
+        "basic: total %zu mismatch", p.total);
+  CHECK(!p.shim, "basic: unexpected shim");
+  CHECK(p.total % 512 != 0, "basic: total %zu on bulk boundary", p.total);
+}
+
+static void test_plan_shim() {
+  /* One frame sized so desc+frame == 512 exactly -> the shim must fire and
+   * move the total off the boundary. */
+  const size_t lens1[] = {512 - 48};
+  const auto p1 = devourer::plan_tx_agg(lens1, 1, lim_halmac_hs());
+  CHECK(p1.frames() == 1, "shim1: frames=%zu", p1.frames());
+  CHECK(p1.shim, "shim1: shim not applied at total==512");
+  CHECK(p1.total == 520, "shim1: total=%zu want 520", p1.total);
+  CHECK(p1.blocks[0].length == 48 + 8 + (512 - 48), "shim1: block0 len %zu",
+        p1.blocks[0].length);
+
+  /* Two frames landing exactly on 1024 (two bulk packets): 512-48 = 464 and
+   * second block padded start. Construct: block0 = 512 (aligned end 512),
+   * block1 = 512 -> total 1024. */
+  const size_t lens2[] = {464, 464};
+  const auto p2 = devourer::plan_tx_agg(lens2, 2, lim_halmac_hs());
+  CHECK(p2.frames() == 2, "shim2: frames=%zu", p2.frames());
+  CHECK(p2.shim, "shim2: shim not applied at total==1024");
+  CHECK(p2.total == 1032, "shim2: total=%zu want 1032", p2.total);
+  CHECK(p2.blocks[1].offset == 512 + 8, "shim2: block1 offset %zu want 520",
+        p2.blocks[1].offset);
+  CHECK(p2.blocks[1].offset % 8 == 0, "shim2: block1 not aligned");
+
+  /* Sweep: no plan may ever total an exact bulk multiple. */
+  for (size_t flen = 1; flen < 1600; ++flen) {
+    const size_t lens[] = {flen, flen, flen, flen};
+    const auto p = devourer::plan_tx_agg(lens, 4, lim_halmac_hs());
+    if (p.frames() != 0)
+      CHECK(p.total % 512 != 0, "sweep: flen=%zu total=%zu on boundary", flen,
+            p.total);
+  }
+}
+
+static void test_plan_oqt_guard() {
+  /* 8812A-style descs_per_bulk=1: a second small block would start inside the
+   * first 512-byte window -> packing stops at 1 frame. */
+  auto lim = lim_halmac_hs();
+  lim.desc_size = 40;
+  lim.descs_per_bulk = 1;
+  const size_t small[] = {100, 100, 100, 100};
+  const auto p1 = devourer::plan_tx_agg(small, 4, lim);
+  CHECK(p1.frames() == 1, "oqt1: frames=%zu want 1", p1.frames());
+
+  /* Large frames span whole windows, so the guard never trips: full pack. */
+  const size_t big[] = {1500, 1500, 1500, 1500};
+  const auto p2 = devourer::plan_tx_agg(big, 4, lim);
+  CHECK(p2.frames() == 4, "oqt2: frames=%zu want 4", p2.frames());
+
+  /* HalMAC descs_per_bulk=3 with tiny frames: the guard counts each next
+   * start inside the first window and stops at the cap -> 3 frames (the
+   * vendor loop breaks after appending the frame whose NEXT start is the
+   * 3rd in-window). */
+  auto lim3 = lim_halmac_hs();
+  const size_t tiny[] = {40, 40, 40, 40, 40, 40, 40, 40};
+  const auto p3 = devourer::plan_tx_agg(tiny, 8, lim3);
+  CHECK(p3.frames() == 3, "oqt3: frames=%zu want 3", p3.frames());
+}
+
+static void test_plan_caps() {
+  auto lim = lim_halmac_hs();
+  lim.max_frames = 2;
+  const size_t lens[] = {1000, 1000, 1000};
+  const auto p1 = devourer::plan_tx_agg(lens, 3, lim);
+  CHECK(p1.frames() == 2, "cap-frames: %zu want 2", p1.frames());
+
+  auto lim2 = lim_halmac_hs();
+  lim2.max_bytes = 2200; /* two 1048-byte blocks + shim headroom only */
+  const auto p2 = devourer::plan_tx_agg(lens, 3, lim2);
+  CHECK(p2.frames() == 2, "cap-bytes: %zu want 2", p2.frames());
+
+  /* First frame alone over the cap -> empty plan (caller falls back). */
+  auto lim3 = lim_halmac_hs();
+  lim3.max_bytes = 512;
+  const size_t huge[] = {4000};
+  const auto p3 = devourer::plan_tx_agg(huge, 1, lim3);
+  CHECK(p3.frames() == 0, "cap-first: %zu want 0", p3.frames());
+}
+
+#if defined(DEVOURER_HAVE_JAGUAR2)
+/* XOR checksum over the first 32 bytes, the 8822B hardware rule. */
+static uint16_t xor32(const uint8_t *d) {
+  uint16_t x = 0;
+  for (int i = 0; i < 16; ++i)
+    x = static_cast<uint16_t>(x ^ (d[2 * i] | (d[2 * i + 1] << 8)));
+  return x;
+}
+
+static void test_desc_8822b() {
+  uint8_t d[48];
+
+  /* Baseline descriptor, then the packer's first-descriptor fixup: set
+   * DMA_TXAGG_NUM and re-checksum. The stored checksum must equal the XOR of
+   * the other 15 words (i.e. total XOR == 0), and the agg count must sit in
+   * byte 0x1F. */
+  std::memset(d, 0, sizeof(d));
+  jaguar2::fill_data_tx_desc_8822b(d, 1500, 7, 9, 0, false, false, 0);
+  SET_TX_DESC_DMA_TXAGG_NUM_8822B(d, 5);
+  jaguar2::cal_txdesc_chksum_8822b(d);
+  CHECK(d[0x1F] == 5, "8822b: agg num byte 0x1F=%u want 5", d[0x1F]);
+  CHECK(xor32(d) == 0, "8822b: checksum does not cover the agg field");
+
+  /* pkt_offset=1: PKT_OFFSET field set (dword1[28:24] -> byte 0x07 low bits)
+   * and still checksummed. */
+  std::memset(d, 0, sizeof(d));
+  jaguar2::fill_data_tx_desc_8822b(d, 1500, 7, 9, 0, false, false, 0,
+                                   /*bmc=*/false, /*wheader_len=*/12,
+                                   /*ndpa=*/false, /*data_sc=*/0,
+                                   /*pwr_ofset=*/0, /*pkt_offset=*/1);
+  CHECK((d[0x07] & 0x1f) == 1, "8822b: pkt_offset field=%u want 1",
+        d[0x07] & 0x1f);
+  CHECK(xor32(d) == 0, "8822b: checksum stale after pkt_offset");
+
+  /* Re-checksum idempotence: the packer re-runs it after the agg fixup. */
+  const uint16_t before = static_cast<uint16_t>(d[0x1C] | (d[0x1D] << 8));
+  jaguar2::cal_txdesc_chksum_8822b(d);
+  const uint16_t after = static_cast<uint16_t>(d[0x1C] | (d[0x1D] << 8));
+  CHECK(before == after, "8822b: checksum not idempotent (%04x -> %04x)",
+        before, after);
+}
+#endif /* DEVOURER_HAVE_JAGUAR2 */
+
+#if defined(DEVOURER_HAVE_JAGUAR3)
+static void test_desc_8822c() {
+  /* The 8822C checksum span extends by PKT_OFFSET (the hardware checksums
+   * desc + pad): with pkt_offset=1 a flipped PAD byte must change the
+   * checksum; with pkt_offset=0 a byte at the same position (frame area) must
+   * not. Model the packer's zeroed block: 48-byte desc + 8-byte pad. */
+  uint8_t blk[64];
+
+  std::memset(blk, 0, sizeof(blk));
+  jaguar3::fill_data_tx_desc_8822c(blk, 1500, 7, 9, 0, false, false, 0,
+                                   /*bmc=*/false, /*ndpa=*/false,
+                                   /*data_sc=*/0, /*pkt_offset=*/1);
+  CHECK((blk[0x07] & 0x1f) == 1, "8822c: pkt_offset field=%u want 1",
+        blk[0x07] & 0x1f);
+  const uint16_t ck_pad0 = static_cast<uint16_t>(blk[0x1C] | (blk[0x1D] << 8));
+  blk[48] = 0xA5; /* corrupt the pad the HW would checksum */
+  jaguar3::cal_txdesc_chksum_8822c(blk);
+  const uint16_t ck_pad1 = static_cast<uint16_t>(blk[0x1C] | (blk[0x1D] << 8));
+  CHECK(ck_pad0 != ck_pad1, "8822c: checksum span misses the pkt_offset pad");
+
+  std::memset(blk, 0, sizeof(blk));
+  jaguar3::fill_data_tx_desc_8822c(blk, 1500, 7, 9, 0, false, false, 0);
+  const uint16_t ck0 = static_cast<uint16_t>(blk[0x1C] | (blk[0x1D] << 8));
+  blk[48] = 0xA5; /* first frame byte — outside the 48-byte span */
+  jaguar3::cal_txdesc_chksum_8822c(blk);
+  const uint16_t ck1 = static_cast<uint16_t>(blk[0x1C] | (blk[0x1D] << 8));
+  CHECK(ck0 == ck1, "8822c: pkt_offset=0 checksum leaked past the descriptor");
+
+  /* Agg-num placement mirrors the 8822B. */
+  std::memset(blk, 0, sizeof(blk));
+  jaguar3::fill_data_tx_desc_8822c(blk, 1500, 7, 9, 0, false, false, 0);
+  SET_TX_DESC_DMA_TXAGG_NUM_8822C(blk, 9);
+  jaguar3::cal_txdesc_chksum_8822c(blk);
+  CHECK(blk[0x1F] == 9, "8822c: agg num byte 0x1F=%u want 9", blk[0x1F]);
+}
+#endif /* DEVOURER_HAVE_JAGUAR3 */
+
+int main() {
+  test_plan_basic();
+  test_plan_shim();
+  test_plan_oqt_guard();
+  test_plan_caps();
+#if defined(DEVOURER_HAVE_JAGUAR2)
+  test_desc_8822b();
+#endif
+#if defined(DEVOURER_HAVE_JAGUAR3)
+  test_desc_8822c();
+#endif
+  if (g_fail) {
+    std::printf("txagg selftest: %d failure(s)\n", g_fail);
+    return 1;
+  }
+  std::printf("txagg selftest: OK\n");
+  return 0;
+}

--- a/tests/txagg_selftest.cpp
+++ b/tests/txagg_selftest.cpp
@@ -42,7 +42,8 @@ static devourer::TxAggLimits lim_halmac_hs() {
 }
 
 static void test_plan_basic() {
-  /* Three 1500-byte frames: blocks at 8-aligned offsets, no shim needed. */
+  /* HalMAC policy (rtw88 parity): NO first-block reserve — blocks at
+   * 8-aligned offsets, stride = 48 + rnd8(frame). */
   const size_t lens[] = {1500, 1500, 1500};
   const auto p = devourer::plan_tx_agg(lens, 3, lim_halmac_hs());
   CHECK(p.frames() == 3, "basic: frames=%zu want 3", p.frames());
@@ -58,49 +59,74 @@ static void test_plan_basic() {
   }
   CHECK(p.total == p.blocks[2].offset + p.blocks[2].length,
         "basic: total %zu mismatch", p.total);
-  CHECK(!p.shim, "basic: unexpected shim");
+  CHECK(!p.shim, "basic: unexpected reserve in halmac policy");
   CHECK(p.total % 512 != 0, "basic: total %zu on bulk boundary", p.total);
+
+  /* Jaguar1 policy (vendor parity): reserve present by default. */
+  auto lim1 = lim_halmac_hs();
+  lim1.desc_size = 40;
+  lim1.first_reserve = true;
+  const auto q = devourer::plan_tx_agg(lens, 3, lim1);
+  CHECK(q.frames() == 3, "basic-j1: frames=%zu", q.frames());
+  CHECK(q.shim, "basic-j1: reserve missing");
+  CHECK(q.blocks[0].length == 40 + 8 + 1500, "basic-j1: block0 len %zu",
+        q.blocks[0].length);
+  CHECK(q.blocks[1].length == 40 + 1500, "basic-j1: block1 len %zu",
+        q.blocks[1].length);
+  CHECK(q.total % 512 != 0, "basic-j1: total %zu on boundary", q.total);
 }
 
 static void test_plan_shim() {
-  /* One frame sized so desc+frame == 512 exactly -> the shim must fire and
-   * move the total off the boundary. */
+  /* HalMAC policy: a 464-byte frame alone (48+464 = 512, exact multiple) ->
+   * the escape INSERTS the reserve: shim=true, total 520. */
   const size_t lens1[] = {512 - 48};
   const auto p1 = devourer::plan_tx_agg(lens1, 1, lim_halmac_hs());
   CHECK(p1.frames() == 1, "shim1: frames=%zu", p1.frames());
-  CHECK(p1.shim, "shim1: shim not applied at total==512");
+  CHECK(p1.shim, "shim1: reserve not inserted at total==512");
   CHECK(p1.total == 520, "shim1: total=%zu want 520", p1.total);
   CHECK(p1.blocks[0].length == 48 + 8 + (512 - 48), "shim1: block0 len %zu",
         p1.blocks[0].length);
 
-  /* Two frames landing exactly on 1024 (two bulk packets): 512-48 = 464 and
-   * second block padded start. Construct: block0 = 512 (aligned end 512),
-   * block1 = 512 -> total 1024. */
-  const size_t lens2[] = {464, 464};
-  const auto p2 = devourer::plan_tx_agg(lens2, 2, lim_halmac_hs());
-  CHECK(p2.frames() == 2, "shim2: frames=%zu", p2.frames());
-  CHECK(p2.shim, "shim2: shim not applied at total==1024");
-  CHECK(p2.total == 1032, "shim2: total=%zu want 1032", p2.total);
-  CHECK(p2.blocks[1].offset == 512 + 8, "shim2: block1 offset %zu want 520",
-        p2.blocks[1].offset);
-  CHECK(p2.blocks[1].offset % 8 == 0, "shim2: block1 not aligned");
+  /* Off-boundary frame: no reserve at all. */
+  const size_t lens_off[] = {456};
+  const auto po = devourer::plan_tx_agg(lens_off, 1, lim_halmac_hs());
+  CHECK(!po.shim, "shim-off: unexpected reserve");
+  CHECK(po.total == 504, "shim-off: total=%zu want 504", po.total);
 
-  /* Sweep: no plan may ever total an exact bulk multiple. */
-  for (size_t flen = 1; flen < 1600; ++flen) {
-    const size_t lens[] = {flen, flen, flen, flen};
-    const auto p = devourer::plan_tx_agg(lens, 4, lim_halmac_hs());
-    if (p.frames() != 0)
-      CHECK(p.total % 512 != 0, "sweep: flen=%zu total=%zu on boundary", flen,
-            p.total);
+  /* Jaguar1 policy removal: reserved total 40+8+464 = 512 -> escape DROPS
+   * the reserve, total 504. */
+  auto lim1 = lim_halmac_hs();
+  lim1.desc_size = 40;
+  lim1.first_reserve = true;
+  const size_t lens_rm[] = {464};
+  const auto pr = devourer::plan_tx_agg(lens_rm, 1, lim1);
+  CHECK(pr.frames() == 1, "shim-rm: frames=%zu", pr.frames());
+  CHECK(!pr.shim, "shim-rm: reserve not removed at reserved-total==512");
+  CHECK(pr.total == 504, "shim-rm: total=%zu want 504", pr.total);
+  CHECK(pr.blocks[0].length == 40 + 464, "shim-rm: block0 len %zu",
+        pr.blocks[0].length);
+
+  /* Sweep both policies: no plan may ever total an exact bulk multiple. */
+  for (int reserve = 0; reserve < 2; ++reserve) {
+    auto lim = lim_halmac_hs();
+    lim.first_reserve = reserve != 0;
+    for (size_t flen = 1; flen < 1600; ++flen) {
+      const size_t lens[] = {flen, flen, flen, flen};
+      const auto p = devourer::plan_tx_agg(lens, 4, lim);
+      if (p.frames() != 0)
+        CHECK(p.total % 512 != 0, "sweep(res=%d): flen=%zu total=%zu on boundary",
+              reserve, flen, p.total);
+    }
   }
 }
 
 static void test_plan_oqt_guard() {
-  /* 8812A-style descs_per_bulk=1: a second small block would start inside the
-   * first 512-byte window -> packing stops at 1 frame. */
+  /* 8812A-style descs_per_bulk=1 (Jaguar1 policy): a second small block would
+   * start inside the first 512-byte window -> packing stops at 1 frame. */
   auto lim = lim_halmac_hs();
   lim.desc_size = 40;
   lim.descs_per_bulk = 1;
+  lim.first_reserve = true;
   const size_t small[] = {100, 100, 100, 100};
   const auto p1 = devourer::plan_tx_agg(small, 4, lim);
   CHECK(p1.frames() == 1, "oqt1: frames=%zu want 1", p1.frames());
@@ -110,11 +136,10 @@ static void test_plan_oqt_guard() {
   const auto p2 = devourer::plan_tx_agg(big, 4, lim);
   CHECK(p2.frames() == 4, "oqt2: frames=%zu want 4", p2.frames());
 
-  /* HalMAC descs_per_bulk=3 with tiny frames: the guard counts each next
-   * start inside the first window and stops at the cap -> 3 frames (the
-   * vendor loop breaks after appending the frame whose NEXT start is the
-   * 3rd in-window). */
+  /* HalMAC flat cap: max_frames clamps regardless of frame size (the chip
+   * parses at most 3 descriptors per bulk transfer). */
   auto lim3 = lim_halmac_hs();
+  lim3.max_frames = 3;
   const size_t tiny[] = {40, 40, 40, 40, 40, 40, 40, 40};
   const auto p3 = devourer::plan_tx_agg(tiny, 8, lim3);
   CHECK(p3.frames() == 3, "oqt3: frames=%zu want 3", p3.frames());


### PR DESCRIPTION
## What this adds

Packet aggregation and hardware ACKs in the userspace TX path, across all three
chip generations (Jaguar1 / Jaguar2 / Jaguar3). Every capability is off by
default — with all knobs unset, TX descriptors and bring-up are byte-identical
to before, and the cross-driver regression matrix is unchanged.

Full reference: [`docs/aggregation.md`](docs/aggregation.md).

### USB TX aggregation
`IRtlDevice::send_packets()` packs many `[txdesc][frame]` blocks into one
bulk-OUT URB (`DEVOURER_TX_USB_AGG`). Per-family packing rules —
3-descriptors-per-bulk on HalMAC (rtw88 parity), the PKT_OFFSET reserve + OQT
guard on Jaguar1 — with a headless packer selftest in `ctest`.

### Per-frame TX-status reports
`DEVOURER_TX_REPORT` sets `SPE_RPT`; the firmware's CCX reports are decoded off
the C2H RX path into `tx.report` events (delivered / hardware retry count /
queue time / final rate) — the transmit-side link sensor.

### 802.11 A-MPDU (`SetAmpduMode`)
One call configures the descriptor half (data QSEL + AGG_EN + MAX_AGG_NUM +
density + retry-limit) and programs the MAC pacing registers. The tuned recipe
delivers **+30% on-air goodput at MCS7/20** (measured by SDR duty on a clean
5 GHz channel), more at higher rates. Needs a deep TX feed
(`send_packets` / `DEVOURER_TX_THREADS`) to reach the multiplier.

### Hardware ACK / BlockAck responder (`SetAckResponder`)
Programs the port identity + net_type so the MAC auto-ACKs unicast frames
addressed to it, while monitor RX/injection continue unchanged. The same gate
is a hardware BlockAck responder, so reliable-unicast A-MPDU works end to end.
Closed-loop bench: responder on = 100% delivered at near-zero retries;
responder off = every frame/aggregate pinned at the retry limit.

## Validation

- `ctest`: 17/17 (adds the `txagg_pack` packer selftest).
- Cross-driver regression matrix (`tests/regress.py`): green, devourer↔devourer
  and against the kernel driver, both directions.
- On-air throughput measured by SDR duty × PHY rate (`tests/ampdu_onair_ab.sh`).
- Closed-loop harnesses for each capability under `tests/` (`txagg_bench.sh`,
  `ampdu_spike.sh`, `ampdu_pacing_sweep.sh`, `ack_responder_check.sh`,
  `ampdu_ba_check.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
