### PR TITLE
Jaguar2 fine beacon-TBTT steering via reserved-page re-download — unblock the 8821CE PCIe AP↔PTP loop

### DIFF
--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -158,8 +158,15 @@ and the cadence thereafter — by Δ TU. Bench-proven to the microsecond on an
 (observer arrival phase stepped 88018 → 67565 µs at the tweak). This is the
 802.11 IBSS/TSF-merge mechanism. Granularity is **1 TU = 1.024 ms** (the
 `REG_BCN_INTERVAL` field is integer TU) — a coarse slot/guard-alignment lever.
+The interval register **latches at a TBTT**, so the actuator phase-aligns off
+the TSF (write the tweak early in a beacon period, restore mid-way into the
+first tweaked interval) — a fixed hold instead races with the beacon phase:
+bench-caught on the 8821CE, an advance can silently no-op (write+restore inside
+one period) or double-shift (two shortened TBTTs before the restore latches).
+Consecutive coarse steers move the TBTT grid off `TSF % period == 0`; the
+actuator tracks that offset (a fine steer or `StartBeacon` re-zeroes it).
 
-**Microsecond-fine steering** (`AdjustBeaconTimingFine`, Jaguar3): the reason a
+**Microsecond-fine steering** (`AdjustBeaconTimingFine`): the reason a
 bare `WriteTsf` doesn't move the TBTT is that the counter is latched while the
 beacon function runs — the vendor `reset_tsf` path clears `EN_BCN_FUNCTION`
 first. Toggling the beacon function off, shifting the port-0 TSF by the desired
@@ -173,16 +180,32 @@ resolution is what matters. It also shifts this port's TSF + beacon-body
 timestamp by the same amount, which is the intended UE-advances-its-own-timebase
 behaviour.
 
-Beacon-TBTT steering is **Jaguar3-only**. The Jaguar2 8822B beacon engine drops
-the beacon on *any* TBTT re-latch — bench-proven on the 8812BU, the beacon stops
-airing after both the interval tweak and the beacon-function toggle (the
-bcn-valid latch is lost, and J2 does not retain the beacon bytes to re-download).
-So `AdjustBeaconTiming` / `AdjustBeaconTimingFine` refuse on J2 (return 0) rather
-than silently kill the beacon; the downlink (`StartBeacon` + `SetCcaMode`) is
-unaffected.
+**Jaguar2 steer-then-re-download.** The Jaguar2 beacon engine loses its
+bcn-valid latch on *any* TBTT re-latch — bench-proven on the 8812BU, the beacon
+stops airing after both the interval tweak and the beacon-function toggle — and
+the hardware does not retain the reserved-page bytes to re-arm it. The driver
+does (`StartBeacon` keeps the MPDU), so the J2 actuators steer and then re-run
+the reserved-page beacon download to re-assert the latch — at most one skipped
+beacon per correction. Bench (fine steers, observer arrival phase, hardware seq
+consecutive across every steer):
+
+- **8812BU (USB)**: 0–1 beacon lost per steer, ~9 ms per fine steer; the fine
+  shift undershoots the request by a systematic ~2–3 ms (USB register latency,
+  larger than J3's ~0.5–1.2 ms) that a closed loop absorbs.
+- **8821CE (PCIe MMIO)**: 0–1 beacon lost per steer, ~0–1 ms per fine steer;
+  fine accuracy **−4842…−5047 µs for a −5000 µs request** (systematic offset
+  ~30 µs — the MMIO register path is µs-scale) and coarse −20 TU steers land
+  within ~±150 µs, including back-to-back. This is the actuator that closes
+  the AP-beacon ↔ network-PTP discipline loop on the Radxa X4's 8821CE.
+
+At a realistic discipline cadence (~10 s between corrections against ~40 ppm
+crystal drift and a ~500 µs guard) the cost is ~1 lost beacon per 100. Jaguar3
+needs no re-download — its engine survives the re-latch.
 
 Actuator characterization: `tests/beacon_interval_shift.sh <short_TU>` (TU tweak),
-or `FINE_US=<µs> tests/beacon_interval_shift.sh` (µs-fine, Jaguar3).
+or `FINE_US=<µs> tests/beacon_interval_shift.sh` (µs-fine). Steer *survival* +
+repeated-steer accuracy (incl. a PCIe master via `MASTER_CMD='ssh …'`):
+`tests/beacon_steer_survival.sh [n] [steer_us] [period_s]`.
 
 Harness: `tests/timesync_ta_demo.sh` (+ `tests/timesync_ta_analyze.py`).
 
@@ -195,7 +218,7 @@ Harness: `tests/timesync_ta_demo.sh` (+ `tests/timesync_ta_analyze.py`).
 - `DEVOURER_TSYNC_HWBEACON=1` — hardware-timed beacon downlink (StartBeacon) →
   sub-µs; set on both master and slave. On the **UE** (role=ue) it instead
   selects the hardware-beacon uplink fine-steered by `AdjustBeaconTimingFine` —
-  the converging closed loop (J3 UE required for µs steering)
+  the converging closed loop (Jaguar2/3 UE)
 - `DEVOURER_TSYNC_CSMA=1` — keep CSMA on the HW-beacon master (default: EDCCA
   off so the beacon airs exactly at TBTT — the master owns the channel)
 - `DEVOURER_TSYNC_UPLINK=1` — enable the uplink timing-advance loop (experimental)

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -306,9 +306,10 @@ public:
    * microsecond). Requires an active StartBeacon. BLOCKS the caller ~one beacon
    * interval (the tweaked interval must latch and fire once before restore).
    * Returns the actual applied shift in µs (TU-quantized); 0 if no active beacon
-   * or |microseconds| < 512. Jaguar3 only in practice: the Jaguar2 8822B beacon
-   * engine drops the beacon on any TBTT re-latch (bench-proven), so J2 refuses
-   * (returns 0) rather than silently kill it. Base is a no-op. */
+   * or |microseconds| < 512. Jaguar3 and Jaguar2: the J2 beacon engine loses its
+   * bcn-valid latch on any TBTT re-latch (bench-proven), so the J2 path follows
+   * the steer with a reserved-page re-download of the retained beacon — one
+   * skipped beacon per correction. Base is a no-op. */
   virtual int32_t AdjustBeaconTiming(int32_t microseconds) {
     (void)microseconds;
     return 0;
@@ -324,10 +325,10 @@ public:
    * same amount, which is the intended behaviour for a UE advancing its own
    * timebase. The USB read→write latency adds a sub-ms offset (~0.5–1.2 ms) that
    * a closed timing-advance loop absorbs — the *resolution* is microseconds.
-   * Requires an active StartBeacon; returns the applied shift in µs. Jaguar3 only:
-   * the Jaguar2 beacon engine survives neither the beacon-function toggle nor the
-   * interval tweak (both drop the beacon), so J2 refuses (returns 0). Base is a
-   * no-op. */
+   * Requires an active StartBeacon; returns the applied shift in µs. Jaguar3 and
+   * Jaguar2: the J2 beacon engine drops its bcn-valid latch on the toggle, so the
+   * J2 path re-downloads the retained reserved-page beacon after the re-latch —
+   * one skipped beacon per correction. Base is a no-op. */
   virtual int32_t AdjustBeaconTimingFine(int32_t microseconds) {
     (void)microseconds;
     return 0;

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -1408,34 +1408,135 @@ bool RtlJaguar2Device::StartBeacon(const uint8_t *beacon, size_t len,
   _device.rtw_write8(0x0550 /* REG_BCN_CTRL */, (1u << 3) | (1u << 4));
   uint32_t txq = _device.rtw_read<uint32_t>(0x0420 /* REG_FWHW_TXQ_CTRL */);
   _device.rtw_write<uint32_t>(0x0420, txq | (1u << 22) /* BIT_EN_BCNQ_DL */);
+  /* Retain the MPDU + interval for the TBTT-steer re-download
+   * (AdjustBeaconTiming*): the J2 engine loses the bcn-valid latch on any
+   * re-latch and the hardware does not keep the reserved-page bytes. */
+  _bcn_mpdu.assign(mpdu, mpdu + mpdu_len);
+  _bcn_interval_tu = interval_tu > 0 ? interval_tu : 100;
+  _tbtt_off_us = 0;  // fresh beacon function: TBTT grid at TSF % period == 0
   _logger->info("beacon(J2): beacon@rsvd_boundary, net_type->AP, BCN_CTRL=0x18, "
                 "EN_BCNQ_DL (interval {} TU)", interval_tu);
   return true;
 }
 
-int32_t RtlJaguar2Device::AdjustBeaconTiming(int32_t microseconds) {
-  (void)microseconds;
-  /* Beacon-TBTT STEERING IS NOT SUPPORTED ON JAGUAR2. Both mechanisms that work
-   * on Jaguar3 drop the beacon on the 8822B engine (bench-proven on the 8812BU,
-   * the beacon stops airing after the tweak): the one-shot REG_BCN_INTERVAL
-   * (0x0554) tweak AND the EN_BCN_FUNCTION-toggle + TSF-shift both lose the
-   * bcn-valid latch, and J2 does not retain the beacon bytes to re-download and
-   * re-assert it. So refuse rather than silently kill the beacon. (A fix would
-   * store the beacon bytes in StartBeacon and re-download after the tweak — the
-   * Jaguar3 store-bytes path — but that needs its own hardware validation.) The
-   * downlink (StartBeacon + SetCcaMode) is unaffected; only the uplink-TA
-   * actuator is J3-only. */
-  static bool warned = false;
-  if (!warned) {
-    warned = true;
-    _logger->warn("beacon(J2): TBTT steering not supported (8822B beacon engine "
-                  "drops the beacon on a TBTT re-latch) — uplink-TA is Jaguar3-only");
+/* Re-download the retained reserved-page beacon to re-arm the bcn-valid latch.
+ * The J2 beacon engine loses the latch on ANY TBTT re-latch (bench-proven on
+ * the 8812BU: the beacon stops airing after both the one-shot interval tweak
+ * and the EN_BCN_FUNCTION toggle), and the hardware does not keep the
+ * reserved-page bytes — but the driver does (StartBeacon). So every steer is
+ * "re-latch, then re-download": the TBTT re-derives from the steered timebase
+ * and the fresh download re-asserts the valid latch (its poll is the success
+ * signal). Costs one skipped beacon per correction. Caller holds _reg_mu. */
+bool RtlJaguar2Device::redownload_beacon_locked() {
+  if (_bcn_mpdu.empty())
+    return false;
+  if (!_fw.download_rsvd_page(_fw.rsvd_boundary(), _bcn_mpdu.data(),
+                              static_cast<uint32_t>(_bcn_mpdu.size()))) {
+    _logger->error("beacon(J2): TBTT-steer rsvd-page re-download failed — "
+                   "beacon may have stopped airing");
+    return false;
   }
-  return 0;
+  return true;
+}
+
+int32_t RtlJaguar2Device::AdjustBeaconTiming(int32_t microseconds) {
+  int nominal;
+  {
+    std::lock_guard<std::mutex> lk(_reg_mu);
+    nominal = _bcn_interval_tu;
+  }
+  if (nominal <= 0) return 0;  // no active beacon
+  /* Round to whole TU (REG_BCN_INTERVAL is integer TU); sign follows the request
+   * (>0 = later/retard => longer one-shot interval, <0 = earlier/advance). */
+  int delta_tu = (microseconds >= 0 ? microseconds + 512 : microseconds - 512) / 1024;
+  if (delta_tu == 0) return 0;  // below 1-TU resolution
+  int one = nominal + delta_tu;
+  if (one < 1) {  // can't shorten below one TU
+    one = 1;
+    delta_tu = one - nominal;
+  }
+  /* Latch one interval at the tweaked length; after exactly one TBTT fires
+   * under it the phase has advanced/retarded by delta_tu TU, then restore
+   * nominal (the J3 mechanism). On J2 the tweak drops the bcn-valid latch, so
+   * follow the restore with the reserved-page re-download.
+   *
+   * The interval register latches at a TBTT, so the shift count = the number
+   * of TBTTs between the tweak-latch and the restore-latch — a fixed sleep
+   * races with the beacon phase (bench-caught on the 8821CE: an advance whose
+   * write+restore land inside one period is a silent no-op; one held past two
+   * shortened periods double-shifts). Phase-align off the TSF instead (TBTT
+   * fires at TSF % interval == 0): read the in-period position, write the
+   * tweak, then time the restore to land mid-way into the FIRST tweaked
+   * interval — the restore latches at that interval's closing TBTT, so exactly
+   * one fires under the tweak. Positions are measured against the TBTT grid
+   * (TSF % period == _tbtt_off_us — prior coarse steers move the grid off the
+   * TSF). Serialize register access on _reg_mu but release it across the
+   * waits so the coex/thermal tick isn't starved. */
+  const int64_t period_us = static_cast<int64_t>(nominal) * 1024;
+  auto grid_pos = [&]() {  // in-period position vs the TBTT grid; under _reg_mu
+    uint32_t hi = _device.rtw_read<uint32_t>(0x0564);
+    uint32_t lo = _device.rtw_read<uint32_t>(0x0560);
+    int64_t p = static_cast<int64_t>(((static_cast<uint64_t>(hi) << 32) | lo) %
+                                     static_cast<uint64_t>(period_us));
+    return ((p - _tbtt_off_us) % period_us + period_us) % period_us;
+  };
+  int64_t pos;
+  {
+    std::lock_guard<std::mutex> lk(_reg_mu);
+    pos = grid_pos();
+  }
+  /* Keep the tweak write clear of the next TBTT (so the latching TBTT is
+   * unambiguous even against register/sleep jitter). */
+  if (pos > period_us - 20000)
+    std::this_thread::sleep_for(
+        std::chrono::microseconds(period_us - pos + 5000));
+  {
+    std::lock_guard<std::mutex> lk(_reg_mu);
+    pos = grid_pos();
+    _device.rtw_write16(0x0554 /* REG_BCN_INTERVAL */, static_cast<uint16_t>(one));
+  }
+  /* latch TBTT in (period - pos) µs; restore mid-first-tweaked-interval. */
+  std::this_thread::sleep_for(std::chrono::microseconds(
+      (period_us - pos) + static_cast<int64_t>(one) * 512));
+  {
+    std::lock_guard<std::mutex> lk(_reg_mu);
+    _device.rtw_write16(0x0554, static_cast<uint16_t>(nominal));
+    _tbtt_off_us = ((_tbtt_off_us + static_cast<int64_t>(delta_tu) * 1024) %
+                        period_us + period_us) % period_us;
+    if (!redownload_beacon_locked())
+      return 0;
+  }
+  _logger->info("beacon(J2): TBTT shift {} TU ({} us) via one-shot interval "
+                "{}->{}->{} TU + rsvd-page re-download",
+                delta_tu, delta_tu * 1024, nominal, one, nominal);
+  return delta_tu * 1024;
 }
 
 int32_t RtlJaguar2Device::AdjustBeaconTimingFine(int32_t microseconds) {
-  return AdjustBeaconTiming(microseconds);  // both unsupported on J2 (beacon drops)
+  std::lock_guard<std::mutex> lk(_reg_mu);
+  if (_bcn_interval_tu <= 0) return 0;  // no active beacon
+  /* Same mechanism as J3: a bare TSF write with the beacon function running
+   * leaves the TBTT latched, so toggle the beacon function off, shift the
+   * port-0 TSF, toggle on — the TBTT counter re-derives from the shifted TSF
+   * at microsecond resolution (TBTT fires at TSF % interval, so subtracting
+   * `microseconds` advances (<0) / retards (>0) the next boundary by that many
+   * µs). On J2 the toggle drops the bcn-valid latch, so re-download the
+   * reserved-page beacon afterwards to re-arm it. */
+  uint32_t hi = _device.rtw_read<uint32_t>(0x0564);
+  uint32_t lo = _device.rtw_read<uint32_t>(0x0560);
+  uint64_t tsf = (static_cast<uint64_t>(hi) << 32) | lo;
+  uint64_t nt = tsf - static_cast<uint64_t>(static_cast<int64_t>(microseconds));
+  uint8_t bc = _device.rtw_read8(0x0550 /* REG_BCN_CTRL */);
+  _device.rtw_write8(0x0550, static_cast<uint8_t>(bc & ~(1u << 3)));  // clear EN_BCN_FUNCTION
+  _device.rtw_write<uint32_t>(0x0560, static_cast<uint32_t>(nt));
+  _device.rtw_write<uint32_t>(0x0564, static_cast<uint32_t>(nt >> 32));
+  _device.rtw_write8(0x0550, static_cast<uint8_t>(bc | (1u << 3)));   // set EN_BCN_FUNCTION
+  _tbtt_off_us = 0;  // the re-latch re-derives the TBTT grid from the TSF
+  if (!redownload_beacon_locked())
+    return 0;
+  _logger->info("beacon(J2): fine TBTT shift {} us (TSF toggle + rsvd-page "
+                "re-download)", microseconds);
+  return microseconds;
 }
 
 void RtlJaguar2Device::SetCcaMode(bool disabled) {

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -6,6 +6,7 @@
 #include <mutex>
 #include <optional>
 #include <thread>
+#include <vector>
 
 #include "logger.h"
 #include "IRtlDevice.h"
@@ -87,6 +88,10 @@ public:
   /* Disable/restore the MAC EDCCA gate (BIT_DIS_EDCCA 0x520[15] + EDCCA-mask
    * 0x524[11] — HalMAC-common with J3) so a TBTT beacon airs on schedule. */
   void SetCcaMode(bool disabled) override;
+  /* Beacon-TBTT steering (IRtlDevice contract). The J2 engine loses the
+   * bcn-valid latch on ANY TBTT re-latch (bench-proven on the 8812BU), so both
+   * actuators steer then re-download the retained reserved-page beacon to
+   * re-arm the latch — one skipped beacon per correction. */
   int32_t AdjustBeaconTiming(int32_t microseconds) override;
   int32_t AdjustBeaconTimingFine(int32_t microseconds) override;
   void Stop() override;
@@ -269,6 +274,23 @@ private:
   std::atomic<bool> _pwrtrack_stop{false};
   void start_pwrtrack();
   void stop_pwrtrack();
+
+  /* Beacon retained for the TBTT-steer re-download (AdjustBeaconTiming*): the
+   * J2 engine loses the bcn-valid latch on any TBTT re-latch and does not keep
+   * the reserved-page bytes, so the steer path re-downloads this copy to
+   * re-arm it. Guarded by _reg_mu (written in StartBeacon, read in the
+   * steer actuators). _bcn_interval_tu = 0 means no active beacon. */
+  std::vector<uint8_t> _bcn_mpdu;
+  int _bcn_interval_tu = 0;
+  /* TBTT-grid offset vs the TSF, in µs: TBTT fires at TSF % period == this.
+   * 0 after StartBeacon and after every fine steer (the EN_BCN_FUNCTION
+   * re-latch re-derives the grid from the TSF); each coarse interval-tweak
+   * steer moves the grid by its applied shift without moving the TSF, so the
+   * coarse path's TBTT phase-alignment must subtract it. Guarded by _reg_mu. */
+  int64_t _tbtt_off_us = 0;
+  /* Re-download _bcn_mpdu to the reserved page (re-arms the bcn-valid latch
+   * after a TBTT re-latch). Caller holds _reg_mu. */
+  bool redownload_beacon_locked();
 
   /* StartRxLoop stop request (StopRxLoop). volatile (not atomic) to match the
    * signal-flag pattern used across the library (g_devourer_should_stop). */

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -1579,6 +1579,7 @@ bool RtlJaguar3Device::StartBeacon(const uint8_t *beacon, size_t len,
    * content-update path (not this static beacon) and belongs behind a
    * DeviceConfig knob, not env — the library reads no environment. */
   _bcn_interval_tu = interval_tu > 0 ? interval_tu : 100;
+  _tbtt_off_us = 0;  // fresh beacon function: TBTT grid at TSF % period == 0
   return true;
 }
 
@@ -1599,18 +1600,53 @@ int32_t RtlJaguar3Device::AdjustBeaconTiming(int32_t microseconds) {
     delta_tu = one - nominal;
   }
   /* Latch one interval at the tweaked length; after exactly one TBTT fires under
-   * it the phase has advanced/retarded by delta_tu TU, so restore nominal. The
+   * it the phase has advanced/retarded by delta_tu TU, then restore nominal. The
    * TSF free-runs — this steers the beacon-engine TBTT counter, not the TSF
-   * (WriteTsf can't; bench-proven). Serialize the two writes on _reg_mu, but
-   * release it across the wait so the coex tick / other setters aren't starved. */
+   * (WriteTsf can't; bench-proven).
+   *
+   * The interval register latches at a TBTT, so the shift count = the number of
+   * TBTTs between the tweak-latch and the restore-latch — a fixed sleep races
+   * with the beacon phase (bench-caught on the J2 8821CE, same latch semantics:
+   * an advance whose write+restore land inside one period is a silent no-op;
+   * one held past two shortened periods double-shifts). Phase-align off the TSF
+   * instead (TBTT fires at TSF % interval == 0): read the in-period position,
+   * write the tweak, then time the restore to land mid-way into the FIRST
+   * tweaked interval — the restore latches at that interval's closing TBTT, so
+   * exactly one fires under the tweak. Positions are measured against the TBTT
+   * grid (TSF % period == _tbtt_off_us — prior coarse steers move the grid off
+   * the TSF). Serialize register access on _reg_mu but release it across the
+   * waits so the coex tick isn't starved. */
+  const int64_t period_us = static_cast<int64_t>(nominal) * 1024;
+  auto grid_pos = [&]() {  // in-period position vs the TBTT grid; under _reg_mu
+    uint32_t hi = _device.rtw_read<uint32_t>(0x0564);
+    uint32_t lo = _device.rtw_read<uint32_t>(0x0560);
+    int64_t p = static_cast<int64_t>(((static_cast<uint64_t>(hi) << 32) | lo) %
+                                     static_cast<uint64_t>(period_us));
+    return ((p - _tbtt_off_us) % period_us + period_us) % period_us;
+  };
+  int64_t pos;
   {
     std::lock_guard<std::mutex> lk(_reg_mu);
+    pos = grid_pos();
+  }
+  /* Keep the tweak write clear of the next TBTT (so the latching TBTT is
+   * unambiguous even against register/sleep jitter). */
+  if (pos > period_us - 20000)
+    std::this_thread::sleep_for(
+        std::chrono::microseconds(period_us - pos + 5000));
+  {
+    std::lock_guard<std::mutex> lk(_reg_mu);
+    pos = grid_pos();
     _device.rtw_write16(0x0554 /* REG_BCN_INTERVAL */, static_cast<uint16_t>(one));
   }
-  std::this_thread::sleep_for(std::chrono::microseconds(one * 1024 + 2000));
+  /* latch TBTT in (period - pos) µs; restore mid-first-tweaked-interval. */
+  std::this_thread::sleep_for(std::chrono::microseconds(
+      (period_us - pos) + static_cast<int64_t>(one) * 512));
   {
     std::lock_guard<std::mutex> lk(_reg_mu);
     _device.rtw_write16(0x0554, static_cast<uint16_t>(nominal));
+    _tbtt_off_us = ((_tbtt_off_us + static_cast<int64_t>(delta_tu) * 1024) %
+                        period_us + period_us) % period_us;
   }
   _logger->info("beacon(J3): TBTT shift {} TU ({} us) via one-shot interval "
                 "{}->{}->{} TU",
@@ -1637,6 +1673,7 @@ int32_t RtlJaguar3Device::AdjustBeaconTimingFine(int32_t microseconds) {
   _device.rtw_write<uint32_t>(0x0560, static_cast<uint32_t>(nt));
   _device.rtw_write<uint32_t>(0x0564, static_cast<uint32_t>(nt >> 32));
   _device.rtw_write8(0x0550, static_cast<uint8_t>(bc | (1u << 3)));   // set EN_BCN_FUNCTION
+  _tbtt_off_us = 0;  // the re-latch re-derives the TBTT grid from the TSF
   _logger->info("beacon(J3): fine TBTT shift {} us (TSF toggle: EN_BCN off/shift/on)",
                 microseconds);
   return microseconds;

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -291,6 +291,12 @@ private:
   /* Nominal beacon interval in TU while a beacon is active (0 = none); the
    * AdjustBeaconTiming one-shot tweak restores to this. */
   int _bcn_interval_tu = 0;
+  /* TBTT-grid offset vs the TSF, in µs: TBTT fires at TSF % period == this.
+   * 0 after StartBeacon and after every fine steer (the EN_BCN_FUNCTION
+   * re-latch re-derives the grid from the TSF); each coarse interval-tweak
+   * steer moves the grid by its applied shift without moving the TSF, so the
+   * coarse path's TBTT phase-alignment must subtract it. Guarded by _reg_mu. */
+  int64_t _tbtt_off_us = 0;
   /* StartRxLoop stop request (StopRxLoop). */
   volatile bool _rx_stop = false;
   /* True while StartRxLoop owns bulk-IN (gates the coex thread's drain). */

--- a/tests/beacon_steer_check.cpp
+++ b/tests/beacon_steer_check.cpp
@@ -1,0 +1,132 @@
+// beacon_steer_check.cpp — beacon-TBTT steer SURVIVAL + accuracy master (issue
+// #241: the Jaguar2 steer-then-re-download actuator). Brings up TX, starts the
+// hardware beacon, then applies N repeated AdjustBeaconTimingFine (or coarse
+// AdjustBeaconTiming) steers at a fixed cadence. The beacon must keep airing
+// across every steer — watch with an observer (tests/beacon_steer_survival.sh
+// pairs this with a phase-logging RX): a frozen 802.11 seq / vanished beacon =
+// the J2 post-re-latch drop; a phase step per steer = the actuator works.
+//
+// Opens USB (DEVOURER_VID/DEVOURER_PID) or PCIe (DEVOURER_PCIE_BDF, needs a
+// DEVOURER_PCIE=ON build + -DDEVOURER_HAVE_PCIE on this TU).
+//
+// Build (USB): g++ -std=c++20 -O2 -Isrc -Iexamples/common \
+//   tests/beacon_steer_check.cpp examples/common/env_config.cpp \
+//   build/libdevourer.a $(pkg-config --cflags --libs libusb-1.0) -lpthread \
+//   -o build/beacon_steer_check
+// Run: sudo DEVOURER_PID=0x012d DEVOURER_VID=0x2357 DEVOURER_CHANNEL=36 \
+//   build/beacon_steer_check [n_steers] [steer_us] [period_s]
+//   STEER_MODE=coarse selects AdjustBeaconTiming (TU-quantized) instead.
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <libusb.h>
+
+#include "SelectedChannel.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "env_config.h"
+#include "logger.h"
+#if defined(DEVOURER_HAVE_PCIE)
+#include "PcieTransport.h"
+#endif
+
+static long now_ms() {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+             std::chrono::system_clock::now().time_since_epoch())
+      .count();
+}
+
+int main(int argc, char **argv) {
+  int n_steers = argc > 1 ? atoi(argv[1]) : 5;
+  int steer_us = argc > 2 ? atoi(argv[2]) : -5000;
+  int period_s = argc > 3 ? atoi(argv[3]) : 5;
+  const bool coarse = [] {
+    const char *m = std::getenv("STEER_MODE");
+    return m && std::strcmp(m, "coarse") == 0;
+  }();
+  uint8_t ch = 36;
+  if (const char *c = std::getenv("DEVOURER_CHANNEL")) ch = (uint8_t)atoi(c);
+  int interval_tu = 100;
+
+  auto logger = std::make_shared<Logger>();
+  apply_logging_env(*logger);
+  libusb_context *ctx = nullptr;
+  if (libusb_init(&ctx) < 0) return 1;
+  libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
+
+  WiFiDriver wifi(logger);
+  std::unique_ptr<IRtlDevice> dev;
+  const char *bdf = std::getenv("DEVOURER_PCIE_BDF");
+#if defined(DEVOURER_HAVE_PCIE)
+  if (bdf) {
+    auto transport = devourer::PcieTransport::Open(bdf, logger);
+    if (!transport) { fprintf(stderr, "PCIe open %s failed\n", bdf); return 1; }
+    dev = wifi.CreateRtlDevicePcie(std::move(transport),
+                                   devourer_config_from_env());
+  } else
+#endif
+  {
+    if (bdf) { fprintf(stderr, "DEVOURER_PCIE_BDF set but built without DEVOURER_HAVE_PCIE\n"); return 1; }
+    uint16_t vid = 0x0bda, pid = 0;
+    if (const char *v = std::getenv("DEVOURER_VID")) vid = (uint16_t)strtoul(v, 0, 0);
+    if (const char *p = std::getenv("DEVOURER_PID")) pid = (uint16_t)strtoul(p, 0, 0);
+    auto *h = libusb_open_device_with_vid_pid(ctx, vid, pid);
+    if (!h) { fprintf(stderr, "open %04x:%04x failed\n", vid, pid); return 1; }
+    std::shared_ptr<devourer::UsbDeviceLock> lock;
+    if (devourer::claim_interface_then_reset(h, 0, logger, true, lock) != 0)
+      return 1;
+    dev = wifi.CreateRtlDevice(h, ctx, lock, devourer_config_from_env());
+  }
+  if (!dev) { fprintf(stderr, "no driver\n"); return 1; }
+
+  dev->InitWrite(SelectedChannel{ch, 0, CHANNEL_WIDTH_20});
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  dev->SetCcaMode(true);  // beacon airs exactly at TBTT (master owns channel)
+
+  // Minimal beacon, canonical SA 57:42:75:05:d6:00 (rx.txhit matcher).
+  std::vector<uint8_t> f = {
+      0x00, 0x00, 0x0a, 0x00, 0x00, 0x80, 0x00, 0x00, 0x08, 0x00,  // radiotap
+      0x80, 0x00, 0x00, 0x00,                                      // FC + dur
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff,                          // addr1
+      0x57, 0x42, 0x75, 0x05, 0xd6, 0x00,                          // addr2 = SA
+      0x57, 0x42, 0x75, 0x05, 0xd6, 0x00,                          // addr3
+      0x00, 0x00,                                                  // seq
+      0, 0, 0, 0, 0, 0, 0, 0,                                      // timestamp
+      static_cast<uint8_t>(interval_tu & 0xff),
+      static_cast<uint8_t>((interval_tu >> 8) & 0xff),
+      0x00, 0x00,                                                  // capability
+      0x00, 0x03, 'T', 'B', 'T',                                   // SSID
+      0x01, 0x01, 0x82};                                           // rates
+  if (!dev->StartBeacon(f.data(), f.size(), interval_tu)) {
+    fprintf(stderr, "StartBeacon FAILED\n");
+    return 1;
+  }
+  printf("BEACON_MS %ld ch=%d interval_tu=%d mode=%s n=%d steer_us=%d period_s=%d\n",
+         now_ms(), ch, interval_tu, coarse ? "coarse" : "fine", n_steers,
+         steer_us, period_s);
+  fflush(stdout);
+  std::this_thread::sleep_for(std::chrono::seconds(period_s));
+
+  for (int i = 0; i < n_steers; ++i) {
+    long t0 = now_ms();
+    int applied = coarse ? dev->AdjustBeaconTiming(steer_us)
+                         : dev->AdjustBeaconTimingFine(steer_us);
+    printf("STEER_MS %ld n=%d req_us=%d applied_us=%d dur_ms=%ld\n", t0, i + 1,
+           steer_us, applied, now_ms() - t0);
+    fflush(stdout);
+    if (applied == 0) {
+      fprintf(stderr, "steer %d refused/failed (applied=0)\n", i + 1);
+      return 1;
+    }
+    std::this_thread::sleep_for(std::chrono::seconds(period_s));
+  }
+  printf("DONE_MS %ld\n", now_ms());
+  fflush(stdout);
+  return 0;
+}

--- a/tests/beacon_steer_survival.sh
+++ b/tests/beacon_steer_survival.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# beacon_steer_survival.sh — validate the Jaguar2 steer-then-re-download TBTT
+# actuator (issue #241): the beacon must KEEP AIRING across N repeated
+# AdjustBeaconTimingFine / AdjustBeaconTiming steers, with the observed 802.11
+# seq still incrementing (frozen seq = the J2 post-re-latch drop) and an
+# arrival-phase step per steer.
+#
+# Master  = tests/beacon_steer_check.cpp — StartBeacon(100 TU) + SetCcaMode,
+#           then N steers at a cadence. USB (MASTER_VID/MASTER_PID) or PCIe
+#           (MASTER_PCIE_BDF=0000:01:00.0; can run on a remote rig — then run
+#           the master there by hand and this script observer-only: OBS_ONLY=1).
+# Observer= logs each canonical-SA beacon's seq + arrival phase
+#           (its own hardware tsfl % interval).
+#
+# Usage: sudo -v; tests/beacon_steer_survival.sh [n_steers] [steer_us] [period_s]
+#   MASTER_VID/MASTER_PID  master USB ids   (default 0x2357/0x012d — 8812BU)
+#   OBS_PID                observer USB pid (default 0xc811 — 8811CU)
+#   STEER_MODE=coarse      use AdjustBeaconTiming instead of the fine variant
+#   OBS_ONLY=1             observer only (master runs elsewhere, e.g. PCIe rig)
+#   MASTER_CMD='ssh rig …' run this command as the master instead of the local
+#                          USB binary (e.g. the PCIe master on the radxa-x4);
+#                          its stdout is analyzed as the master log. The two
+#                          hosts' clocks must be NTP-close (~tens of ms) for
+#                          the epoch-ms line-up.
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+N="${1:-5}"; STEER_US="${2:--5000}"; PERIOD="${3:-5}"
+CH="${DEVOURER_CHANNEL:-36}"
+LIB="build/libdevourer.a"
+CXXFLAGS="-std=c++20 -O2 -Isrc -Iexamples/common"
+LDLIBS="$(pkg-config --cflags --libs libusb-1.0) -lpthread"
+TMP="$(mktemp -d)"
+MLOG="$TMP/master.log"; OLOG="$TMP/obs.log"
+OBS_SECS=$(( 4 + PERIOD * (N + 2) + 6 ))
+
+cleanup() {
+  sudo pkill -9 -x bsteer_master 2>/dev/null
+  sudo pkill -9 -x bsteer_obs 2>/dev/null
+  rm -f /tmp/bsteer_master /tmp/bsteer_obs
+}
+trap cleanup EXIT INT TERM
+
+[ -f "$LIB" ] || { echo "build $LIB first (cmake --build build -j)"; exit 1; }
+
+# ---- observer source (seq + phase per canonical-SA beacon) -----------------
+cat > "$TMP/obs.cpp" <<'EOF'
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <unistd.h>
+#include <memory>
+#include <thread>
+#include <libusb.h>
+#include "RxPacket.h"
+#include "SelectedChannel.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "env_config.h"
+#include "logger.h"
+static const uint8_t kSa[6]={0x57,0x42,0x75,0x05,0xd6,0x00};
+static long now_ms(){return std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::system_clock::now().time_since_epoch()).count();}
+int main(int argc,char**argv){
+  int secs = argc>1?atoi(argv[1]):40;
+  auto logger=std::make_shared<Logger>();
+  libusb_context*ctx=nullptr; libusb_init(&ctx);
+  libusb_set_option(ctx,LIBUSB_OPTION_LOG_LEVEL,LIBUSB_LOG_LEVEL_WARNING);
+  uint16_t vid=0x0bda,pid=0xc811;
+  if(const char*p=std::getenv("OBS_PID")) pid=(uint16_t)strtoul(p,0,0);
+  uint8_t ch=36; if(const char*c=std::getenv("DEVOURER_CHANNEL")) ch=atoi(c);
+  auto*h=libusb_open_device_with_vid_pid(ctx,vid,pid);
+  if(!h){fprintf(stderr,"obs open %04x:%04x fail\n",vid,pid);return 1;}
+  std::shared_ptr<devourer::UsbDeviceLock> lk;
+  if(devourer::claim_interface_then_reset(h,0,logger,true,lk)!=0)return 1;
+  WiFiDriver wifi(logger);
+  auto dev=wifi.CreateRtlDevice(h,ctx,lk,devourer_config_from_env());
+  if(!dev)return 1;
+  auto cb=[](const Packet&p){
+    if(p.Data.size()<32||p.RxAtrib.crc_err)return;
+    if(p.Data[0]!=0x80)return;                      // beacons only
+    if(std::memcmp(p.Data.data()+10,kSa,6)!=0)return;
+    uint16_t sc=(uint16_t)(p.Data[22]|(p.Data[23]<<8));
+    uint32_t tsfl=p.RxAtrib.tsfl;
+    printf("BCN_MS %ld seq=%u tsfl=%u phase=%u\n", now_ms(), sc>>4, tsfl,
+           tsfl%102400u);
+    fflush(stdout);
+  };
+  std::thread rx([&]{dev->Init(cb,SelectedChannel{ch,0,CHANNEL_WIDTH_20});});
+  rx.detach();
+  std::this_thread::sleep_for(std::chrono::seconds(secs));
+  _exit(0);
+}
+EOF
+
+echo "building observer + master ..."
+g++ $CXXFLAGS "$TMP/obs.cpp" examples/common/env_config.cpp "$LIB" $LDLIBS \
+    -o /tmp/bsteer_obs || exit 1
+if [ -z "${OBS_ONLY:-}" ] && [ -z "${MASTER_CMD:-}" ]; then
+  g++ $CXXFLAGS tests/beacon_steer_check.cpp examples/common/env_config.cpp \
+      "$LIB" $LDLIBS -o /tmp/bsteer_master || exit 1
+fi
+
+echo "== observer pid=${OBS_PID:-0xc811} ch$CH for ${OBS_SECS}s =="
+sudo DEVOURER_CHANNEL="$CH" OBS_PID="${OBS_PID:-0xc811}" \
+    /tmp/bsteer_obs "$OBS_SECS" >"$OLOG" 2>/dev/null &
+OBS=$!
+sleep 3   # let observer RX settle
+
+if [ -n "${MASTER_CMD:-}" ]; then
+  echo "== master (MASTER_CMD): $N x ${STEER_US}us every ${PERIOD}s (${STEER_MODE:-fine}) =="
+  bash -c "$MASTER_CMD" >"$MLOG" 2>"$TMP/master.err" ||
+      { echo "MASTER FAILED"; tail -3 "$TMP/master.err"; }
+  cat "$MLOG"
+elif [ -z "${OBS_ONLY:-}" ]; then
+  echo "== master ${MASTER_VID:-0x2357}:${MASTER_PID:-0x012d} — $N x ${STEER_US}us every ${PERIOD}s (${STEER_MODE:-fine}) =="
+  sudo DEVOURER_CHANNEL="$CH" DEVOURER_VID="${MASTER_VID:-0x2357}" \
+      DEVOURER_PID="${MASTER_PID:-0x012d}" ${STEER_MODE:+STEER_MODE="$STEER_MODE"} \
+      /tmp/bsteer_master "$N" "$STEER_US" "$PERIOD" >"$MLOG" 2>"$TMP/master.err" ||
+      { echo "MASTER FAILED"; sed -n '$p' "$TMP/master.err"; }
+  cat "$MLOG"
+else
+  echo "== OBS_ONLY: start the master on the remote rig now =="
+fi
+wait $OBS 2>/dev/null
+
+echo "---- analysis ----"
+python3 - "$MLOG" "$OLOG" <<'PYEOF'
+import sys
+mlog, olog = sys.argv[1], sys.argv[2]
+steers = []
+try:
+    for ln in open(mlog):
+        if ln.startswith("STEER_MS"):
+            f = dict(kv.split("=") for kv in ln.split()[2:])
+            steers.append((int(ln.split()[1]), int(f["req_us"]), int(f["applied_us"])))
+except FileNotFoundError:
+    pass
+bcns = []
+for ln in open(olog):
+    if ln.startswith("BCN_MS"):
+        p = ln.split()
+        f = dict(kv.split("=") for kv in p[2:])
+        bcns.append((int(p[1]), int(f["seq"]), int(f["phase"])))
+if not bcns:
+    print("FAIL: observer saw no beacons at all"); sys.exit(1)
+print(f"{len(bcns)} beacons observed")
+ok = True
+for i, (t, req, app) in enumerate(steers):
+    pre  = [b for b in bcns if t - 3000 <= b[0] < t]
+    post = [b for b in bcns if t + 500 <= b[0] < t + 4000]
+    if not post:
+        print(f"steer {i+1} @ {t}: FAIL — no beacons within 4 s after"); ok = False; continue
+    # seq must advance across the steer
+    if pre and post[-1][1] == pre[-1][1]:
+        print(f"steer {i+1} @ {t}: FAIL — seq frozen at {pre[-1][1]}"); ok = False; continue
+    dphase = ""
+    if pre:
+        d = (post[0][2] - pre[-1][2]) % 102400
+        if d > 51200: d -= 102400
+        dphase = f" phase_step={d}us (req {req}, applied {app})"
+    # real beacon downtime: max consecutive inter-beacon gap around the steer
+    win = [b[0] for b in bcns if t - 1000 <= b[0] < t + 4000]
+    gap = max((b - a for a, b in zip(win, win[1:])), default=0)
+    print(f"steer {i+1} @ {t}: OK — {len(post)} beacons after, "
+          f"max_gap={gap}ms (~{max(0, round(gap/102.4) - 1)} lost){dphase}")
+if steers:
+    print("SURVIVAL:", "PASS" if ok else "FAIL")
+    sys.exit(0 if ok else 1)
+print("(no STEER_MS lines — observer-only run; inspect phases by hand)")
+PYEOF
+rc=$?
+echo "logs: $TMP"
+trap - EXIT; cleanup
+exit $rc


### PR DESCRIPTION
Closes #241.

## What

`AdjustBeaconTiming` / `AdjustBeaconTimingFine` now work on **Jaguar2**. The J2 beacon engine loses its bcn-valid latch on *any* TBTT re-latch and the hardware does not retain the reserved-page bytes — but the driver does: `StartBeacon` retains the beacon MPDU + interval, and both actuators steer then **re-run the reserved-page beacon download** to re-arm the latch. The re-download is bus-neutral (`QSEL_BEACON` routes to the PCIe BCN ring), so the same path serves the 8821CE over vfio-pci MMIO.

Cost: at most **one skipped beacon per correction** — at a realistic ~10 s discipline cadence, ~1 lost beacon per 100.

## Bonus fix: coarse-steer latch race (J2 **and** J3)

`REG_BCN_INTERVAL` latches **at a TBTT**, so the previous fixed-hold one-shot tweak raced the beacon phase — bench-caught on the 8821CE:

- write + restore inside one beacon period → **silent no-op** (returns applied≠0, phase unmoved; 1 of 3 advances)
- holding past two shortened periods → **double shift** (1 of 6)

The coarse path now phase-aligns off the TSF: land the tweak write clear of the next TBTT, restore mid-way into the first tweaked interval so its closing TBTT latches the restore → **exactly one** tweaked TBTT, deterministically. Consecutive coarse steers move the TBTT grid off `TSF % period == 0`; the actuator tracks that offset (`_tbtt_off_us`; a fine steer / `StartBeacon` re-zeroes it — the `EN_BCN_FUNCTION` re-latch re-derives the grid from the TSF).

## Hardware validation

Two-adapter observer benches (`tests/beacon_steer_survival.sh`): hardware seq stayed **consecutive across every steer** — the beacon never stopped airing.

| Rig | Fine | Coarse | Loss/steer | Accuracy |
|---|---|---|---|---|
| **8812BU USB** — the chip the fatal re-latch was proven on | 9/9 PASS | 7/7 PASS | 0–1 beacon | fine ~2–3 ms systematic undershoot (USB reg latency; closed loop absorbs), coarse ±150 µs |
| **8821CE PCIe** (radxa-x4, vfio) | 9/9 PASS incl. 10 s cadence | 9/9 PASS incl. back-to-back | 0–1 beacon | fine **−4842…−5047 µs for −5000 µs** (~30 µs offset — MMIO is µs-scale), coarse ±150 µs |

Steer duration: ~9 ms over USB, **0–1 ms over PCIe**. `ctest`: 17/17.

With the read/hold half already at ~240 ns RMS vs the I226 PTP reference, this actuator closes the AP-beacon ↔ network-PTP discipline loop on hardware that exists today.

## New tests

- `tests/beacon_steer_check.cpp` — steer master: `InitWrite` + `StartBeacon`, then N repeated steers at a cadence; opens USB or PCIe (`DEVOURER_PCIE_BDF`)
- `tests/beacon_steer_survival.sh` — pairs it with a phase/seq-logging observer + survival/accuracy analysis; `MASTER_CMD='ssh …'` runs the master on a remote PCIe rig

🤖 Generated with [Claude Code](https://claude.com/claude-code)