### PR TITLE
Jaguar1 hardware beacon + TBTT steering — StartBeacon on every generation

### DIFF
--- a/docs/ap-mode.md
+++ b/docs/ap-mode.md
@@ -10,8 +10,9 @@ responses, DHCP/ARP/ICMP, the WPA2 4-way handshake, software CCMP) lives in the
 harness. All bench-validated against the real Linux `rtw88`/`mac80211` stack.
 
 A dense beacon interval (`DEVOURER_BCN_TU=25`) is needed throughout, so a
-supplicant's fast channel-hopping scan catches the AP. The AP adapter must be a
-full-duplex J2/J3 (`StartBeacon` + `StartRxLoop`); the station is a second
+supplicant's fast channel-hopping scan catches the AP. The AP adapter must
+run `StartBeacon` (all generations) plus full-duplex `StartRxLoop` — the AP
+harnesses are bench-validated on J2/J3 adapters; the station is a second
 Realtek adapter bound to the kernel (rtw88 auto-probes a VBUS-cold dongle to a
 `wlp*` interface). `send_packet` must run **off** the RX event thread (queue the
 requester, TX from another thread — libusb returns BUSY from the RX callback).
@@ -21,7 +22,9 @@ requester, TX from another thread — libusb returns BUSY from the RX callback).
 `tests/beacon_wire_check.cpp` checks the on-wire beacon: right frame control
 (0x0080), an 802.11 sequence number that **increments by 1 per beacon** (the
 hardware sequence numbering a kernel AP does via `EN_HWSEQ`), and the live TSF —
-on both HalMAC generations. `tests/beacon_kernel_scan.sh` goes further: a real
+on all three generations (exception: the 8814A airs its stored beacon with the
+sequence pinned at 0, matching the kernel rtw88 driver on the same chip).
+`tests/beacon_kernel_scan.sh` goes further: a real
 station bound to `rtw88` runs `iw scan` and lists devourer, parsing every element:
 
     BSS 57:42:75:05:d6:00   TSF <live>   freq 2437   beacon interval 25 TUs

--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -67,8 +67,23 @@ the MAC's beacon reserved-page and lets the chip **auto-transmit it at each
 TBTT** — hardware-timed, and the MAC inserts the live 64-bit TSF into the
 beacon's timestamp field at the transmit instant. No `ReadTsf()`, no
 `send_packet`, no software in the timing path. One call suffices; the chip
-beacons indefinitely. Implemented on both HalMAC generations (Jaguar2 8822B/
-8812BU/8821C and Jaguar3 8822C/8822E); Jaguar1 has no reserved-page path.
+beacons indefinitely. Implemented on all three generations: Jaguar2 (8822B/
+8812BU/8821C) and Jaguar3 (8822C/8822E) via the HalMAC reserved-page download,
+and Jaguar1 (8812A/8811A/8821A — bench-proven on the 8821AU) via the
+pre-HalMAC BCNQ-boundary store bracket, byte-matched to a golden usbmon dump
+of the in-tree `rtw88_8821au` beacon download: BCN_VALID (0x20A[0]) W1C →
+CR+1 SW-beacon-DMA on → beacon function off → bulk a **minimal** descriptor
+(LAST_SEG + OFFSET + PKT_SIZE + QSEL_BEACON + rate-FB-limit; OWN/FIRST_SEG/
+BMC/HWSEQ mark a live TX and the store path rejects them) → function on →
+SW-beacon-DMA off, then the port-0 AP enable (MSR=AP, DUAL_TSF_RST BIT0,
+BCN_CTRL 0x18, the 8821A "BCN on port 0" 0x454[5] clear, ResumeTxBeacon).
+The 8814A (bench-proven, own golden dump) differs in three ways: its valid
+latch is 0x204[15] with the head held at the BCNQ boundary during the store
+(pointing the head at page 0 — the firmware-download bracket's shape — stores
+the beacon where the TBTT engine never reads), it needs 0x420[12] + a
+0x454[2:0]=0x05 enable, and its stored beacon airs with the 802.11 sequence
+pinned at 0 (kernel rtw88 parity — seq-based beacon-health checks don't apply
+there).
 
 The slave then reads the *standard 802.11 beacon timestamp* (the master's live
 TSF) instead of a software tag, and fits it against its own arrival `tsfl`.
@@ -180,18 +195,32 @@ resolution is what matters. It also shifts this port's TSF + beacon-body
 timestamp by the same amount, which is the intended UE-advances-its-own-timebase
 behaviour.
 
-**Jaguar2 steer-then-re-download.** The Jaguar2 beacon engine loses its
+**Jaguar1/2 steer-then-re-download.** The Jaguar1 and Jaguar2 beacon engines lose their
 bcn-valid latch on *any* TBTT re-latch — bench-proven on the 8812BU, the beacon
 stops airing after both the interval tweak and the beacon-function toggle — and
 the hardware does not retain the reserved-page bytes to re-arm it. The driver
-does (`StartBeacon` keeps the MPDU), so the J2 actuators steer and then re-run
+does (`StartBeacon` keeps the MPDU), so the J1/J2 actuators steer and then re-run
 the reserved-page beacon download to re-assert the latch — at most one skipped
-beacon per correction. Bench (fine steers, observer arrival phase, hardware seq
-consecutive across every steer):
+beacon per correction. On Jaguar1 the interval tweak is additionally **inert**
+(8821AU: the beacon survives but the phase never moves), so its coarse
+`AdjustBeaconTiming` rides the fine TSF-toggle mechanism, TU-quantized (note it
+then also shifts the reported TSF). Bench (fine steers, observer arrival phase,
+hardware seq consecutive across every steer):
 
 - **8812BU (USB)**: 0–1 beacon lost per steer, ~9 ms per fine steer; the fine
   shift undershoots the request by a systematic ~2–3 ms (USB register latency,
   larger than J3's ~0.5–1.2 ms) that a closed loop absorbs.
+- **8821AU (USB, Jaguar1)**: 0–1 beacon lost per steer, ~8 ms per fine steer,
+  systematic undershoot ~1.6 ms with ±40 µs consistency (−3392…−3472 µs for a
+  −5000 µs request).
+- **8814AU (USB, Jaguar1)**: 0–3 beacons lost per steer (RF-weak bench unit).
+  Its TBTT counter free-runs across the EN_BCN toggle (it only pauses while
+  off — a bare TSF shift moves the phase by just the bracket's ~0.8 ms), so
+  the fine steer additionally pulses port-0 `DUAL_TSF_RST`: the grid re-derives
+  **absolutely** from the shifted TSF (`TSF % period`), so each step also
+  cancels accumulated free-run drift — the TBTT is effectively TSF-locked,
+  which is what a disciplined master wants; open-loop single-steer accuracy is
+  ±few ms.
 - **8821CE (PCIe MMIO)**: 0–1 beacon lost per steer, ~0–1 ms per fine steer;
   fine accuracy **−4842…−5047 µs for a −5000 µs request** (systematic offset
   ~30 µs — the MMIO register path is µs-scale) and coarse −20 TU steers land

--- a/src/AdapterCaps.h
+++ b/src/AdapterCaps.h
@@ -124,8 +124,8 @@ struct AdapterCaps {
    * generations. hw_beacon_txtsf: this adapter, as a transmitter, inserts its
    * live hardware TSF into the beacons it airs at the instant of transmission
    * (a genuine sub-µs TX-egress timestamp a receiver reads via
-   * Packet::TxEgressTsf) — requires the hardware beacon function (StartBeacon),
-   * so Jaguar2/Jaguar3 only. Together they are the primitives for one-way
+   * Packet::TxEgressTsf) — rides the hardware beacon function (StartBeacon);
+   * true on all generations. Together they are the primitives for one-way
    * hardware time distribution (see TsfSync). */
   bool hw_rx_timestamp = false;
   bool hw_beacon_txtsf = false;

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -279,8 +279,10 @@ public:
    * MPDU (a leading radiotap header, if present, is stripped); addr2/addr3 set
    * the port MAC/BSSID. `interval_tu` is the beacon interval in TU (1 TU =
    * 1024 µs). One call suffices — the hardware beacons indefinitely. Implemented
-   * on Jaguar2/3 (HalMAC reserved-page download); returns false where unsupported
-   * (Jaguar1 has no reserved-page path). See docs/time-distribution.md. */
+   * on all three generations (Jaguar2/3: HalMAC reserved-page download;
+   * Jaguar1 incl. the 8814A: the pre-HalMAC BCNQ-boundary store bracket —
+   * note the 8814A's stored beacon airs with the 802.11 sequence pinned at 0,
+   * kernel rtw88 parity). See docs/time-distribution.md. */
   virtual bool StartBeacon(const uint8_t *beacon, size_t len,
                            int interval_tu) {
     (void)beacon; (void)len; (void)interval_tu;
@@ -309,7 +311,10 @@ public:
    * or |microseconds| < 512. Jaguar3 and Jaguar2: the J2 beacon engine loses its
    * bcn-valid latch on any TBTT re-latch (bench-proven), so the J2 path follows
    * the steer with a reserved-page re-download of the retained beacon — one
-   * skipped beacon per correction. Base is a no-op. */
+   * skipped beacon per correction. On Jaguar1 the interval tweak is inert
+   * (bench-proven on the 8821AU), so the TU-quantized shift rides the fine
+   * TSF-toggle mechanism instead — which also moves the reported TSF, unlike
+   * J2/J3. Base is a no-op. */
   virtual int32_t AdjustBeaconTiming(int32_t microseconds) {
     (void)microseconds;
     return 0;
@@ -325,10 +330,14 @@ public:
    * same amount, which is the intended behaviour for a UE advancing its own
    * timebase. The USB read→write latency adds a sub-ms offset (~0.5–1.2 ms) that
    * a closed timing-advance loop absorbs — the *resolution* is microseconds.
-   * Requires an active StartBeacon; returns the applied shift in µs. Jaguar3 and
-   * Jaguar2: the J2 beacon engine drops its bcn-valid latch on the toggle, so the
-   * J2 path re-downloads the retained reserved-page beacon after the re-latch —
-   * one skipped beacon per correction. Base is a no-op. */
+   * Requires an active StartBeacon; returns the applied shift in µs. All three
+   * generations: the J2 and J1 beacon engines drop their bcn-valid latch on the
+   * toggle, so those paths re-download the retained reserved-page beacon after
+   * the re-latch — one skipped beacon per correction. The 8814A additionally
+   * pulses DUAL_TSF_RST (its TBTT counter free-runs across the toggle), which
+   * re-derives the grid ABSOLUTELY from the shifted TSF — each steer also
+   * cancels accumulated drift, so the TBTT ends up TSF-locked. Base is a
+   * no-op. */
   virtual int32_t AdjustBeaconTimingFine(int32_t microseconds) {
     (void)microseconds;
     return 0;

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -313,16 +313,207 @@ uint64_t RtlJaguarDevice::ReadTsf() {
   return (static_cast<uint64_t>(hi) << 32) | lo;
 }
 
+bool RtlJaguarDevice::download_rsvd_beacon(const uint8_t *mpdu,
+                                           size_t mpdu_len) {
+  /* The vendor rtl8812_download_rsvd_page bracket (rtl8812a_cmd.c): a plain
+   * QSEL-beacon bulk-OUT is aired once and NOT retained; with the bracket open
+   * the same bulk-OUT is STORED at the BCNQ boundary page (REG_BCNQ_BDNY /
+   * REG_TDECTRL+1, programmed at init) — the buffer the TBTT engine
+   * re-transmits from. */
+  /* Byte-matched to golden usbmon dumps of the in-tree rtw88 IBSS beacon
+   * download on the same adapters (rtw88_8821au / rtw88_8814au; the vendor
+   * rtl8812au bracket differs in three ways that were bench-fatal: it toggles
+   * 0x422[6], leaves CR+1 BIT0 set, and posts a full mgmt-style descriptor):
+   *   clear BCN_VALID (W1C) -> CR+1 |= BIT0 -> beacon function off
+   *   -> bulk [minimal desc][MPDU] -> poll BCN_VALID -> function on
+   *   -> CR+1 &= ~BIT0
+   * 0x422[6] stays set throughout. The valid latch differs per die:
+   * 8812/8821 = REG_TDECTRL BIT16 (0x20A[0]); 8814 = REG_FIFOPAGE_CTRL_2
+   * BIT15 (0x205[7], the same latch the 8814 firmware download polls), with
+   * the beacon-head page selected in 0x204[11:0] around the store. */
+  const bool is_8814 = _eepromManager->version_id.ICType == CHIP_8814A;
+  uint16_t head_8814 = 0;
+  if (is_8814) {
+    /* rtw88 pre-download ritual: TCR bit5 set + 0x5a8=0, then clear the
+     * BCN_VALID latch with the head HELD AT THE BOUNDARY (0x204 =
+     * boundary|BIT15) — the store lands at the head page, so pointing it at
+     * page 0 during the download (the FW-download bracket's shape) stores
+     * the beacon where the TBTT engine never reads. */
+    uint32_t tcr = _device.rtw_read<uint32_t>(0x0604);
+    _device.rtw_write<uint32_t>(0x0604, tcr | (1u << 5));
+    _device.rtw_write8(0x05a8, 0x00);
+    head_8814 = static_cast<uint16_t>(
+        _device.rtw_read16(0x0204 /* REG_FIFOPAGE_CTRL_2 */) & 0x0fffu);
+    _device.rtw_write16(0x0204, static_cast<uint16_t>(head_8814 | 0x8000u));
+  } else {
+    _device.rtw_write8(0x020A, static_cast<uint8_t>(
+                                   _device.rtw_read8(0x020A) | 0x01)); // W1C
+  }
+  uint8_t cr1 = _device.rtw_read8(0x0101 /* REG_CR+1 */);
+  _device.rtw_write8(0x0101, static_cast<uint8_t>(cr1 | 0x01)); // SW beacon DMA
+  uint8_t bcn_ctrl = _device.rtw_read8(0x0550 /* REG_BCN_CTRL */);
+  _device.rtw_write8(0x0550, static_cast<uint8_t>(bcn_ctrl & ~0x08u)); // EN_BCN off
+
+  /* [minimal desc][MPDU] on every die (golden-dumped on both the 8821AU and
+   * the 8814AU): LAST_SEG + OFFSET + PKT_SIZE + QSEL_BEACON (+ the 0x1f
+   * rate-fallback-limit default on 8812/8821; the 8814 dump leaves dword4
+   * zero). The stored descriptor doubles as the TBTT TX descriptor; OWN /
+   * FIRST_SEG / BMC / HWSEQ / USE_RATE mark a live TX and the store path
+   * rejects them. */
+  std::vector<uint8_t> frame(TXDESC_SIZE + mpdu_len, 0);
+  uint8_t *d = frame.data();
+  SET_TX_DESC_LAST_SEG_8812(d, 1);
+  SET_TX_DESC_OFFSET_8812(d, TXDESC_SIZE);
+  SET_TX_DESC_PKT_SIZE_8812(d, static_cast<uint32_t>(mpdu_len));
+  SET_TX_DESC_QUEUE_SEL_8812(d, 0x10 /* QSLT_BEACON */);
+  if (!is_8814)
+    SET_TX_DESC_DATA_RATE_FB_LIMIT_8812(d, 0x1f);
+  rtl8812a_cal_txdesc_chksum(d);
+  std::memcpy(d + TXDESC_SIZE, mpdu, mpdu_len);
+  int got = _device.bulk_send_sync_ep(_device.first_bulk_out_ep(), frame.data(),
+                                      static_cast<int>(frame.size()), 1000);
+  bool status = (got == static_cast<int>(frame.size()));
+  if (status) {
+    int cnt = 1000;
+    auto bcn_valid = [&]() -> bool {
+      return is_8814 ? (_device.rtw_read8(0x0205) & 0x80) != 0
+                     : (_device.rtw_read8(0x020A) & 0x01) != 0;
+    };
+    while (!bcn_valid()) {
+      if (--cnt == 0) {
+        _logger->error("beacon(J1): rsvd-page BCN_VALID poll failed");
+        status = false;
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::microseconds(10));
+    }
+  } else {
+    _logger->error("beacon(J1): rsvd-page bulk-OUT failed");
+  }
+  if (is_8814)
+    _device.rtw_write16(0x0204, static_cast<uint16_t>(head_8814 | 0x8000u));
+  _device.rtw_write8(0x0550, static_cast<uint8_t>(bcn_ctrl | 0x08u)); // EN_BCN on
+  _device.rtw_write8(0x0101, static_cast<uint8_t>(cr1 & ~0x01u));
+  return status;
+}
+
 bool RtlJaguarDevice::StartBeacon(const uint8_t *beacon, size_t len,
                                   int interval_tu) {
-  (void)beacon; (void)len; (void)interval_tu;
-  /* Unsupported on Jaguar1: the 8812/8821 have no HalMAC reserved-page download
-   * (a QSEL-beacon bulk-OUT transmits once, it does not load a persistent
-   * TBTT-retransmitted beacon buffer — bench-confirmed negative). The 8814's
-   * IDDMA rsvd-page path differs and is not ported. Hardware-timed beaconing is
-   * a Jaguar2/3 feature (see RtlJaguar3Device::StartBeacon). */
-  _logger->warn("StartBeacon: unsupported on Jaguar1 (no reserved-page download)");
-  return false;
+  /* Mirrors RtlJaguar2Device::StartBeacon on the pre-HalMAC registers. */
+  const bool is_8814 = _eepromManager->version_id.ICType == CHIP_8814A;
+  size_t rt = (len >= 4) ? (size_t)(beacon[2] | (beacon[3] << 8)) : 0;
+  if (rt > len) rt = 0;
+  const uint8_t *mpdu = beacon + rt;
+  size_t mpdu_len = len - rt;
+  if (!download_rsvd_beacon(mpdu, mpdu_len)) {
+    _logger->error("beacon(J1): rsvd-page beacon download failed");
+    return false;
+  }
+  /* Port identity: MAC (REG_MACID 0x0610) + BSSID (REG_BSSID 0x0618) from the
+   * MPDU's addr2/addr3. */
+  if (mpdu_len >= 24) {
+    const uint8_t *sa = mpdu + 10, *bs = mpdu + 16;
+    _device.rtw_write<uint32_t>(0x0610, (uint32_t)sa[0] | (sa[1] << 8) |
+                                            (sa[2] << 16) | ((uint32_t)sa[3] << 24));
+    _device.rtw_write16(0x0614, (uint16_t)(sa[4] | (sa[5] << 8)));
+    _device.rtw_write<uint32_t>(0x0618, (uint32_t)bs[0] | (bs[1] << 8) |
+                                            (bs[2] << 16) | ((uint32_t)bs[3] << 24));
+    _device.rtw_write16(0x061c, (uint16_t)(bs[4] | (bs[5] << 8)));
+  }
+  /* The vendor port-0 AP recipe (hw_var_set_opmode _HW_STATE_AP_ +
+   * SetBeaconRelatedRegisters8812A), in order: MSR=AP, beacon-DMA/ATIM
+   * windows, TSF-sync offset, a REG_DUAL_TSF_RST BIT0 pulse (arms the port-0
+   * TBTT counter — the TCR TSFRST toggle is the IBSS path and does NOT arm
+   * it), BCN_CTRL = DIS_TSF_UDT | EN_BCN_FUNCTION | EN_TXBCN_RPT |
+   * DIS_BCNQ_SUB (0x1e), the 8821A-only "select BCN on port 0"
+   * (REG_CCK_CHECK 0x454 bit5 clear), RD_CTRL, and ResumeTxBeacon
+   * (0x422[6]=1 + the 4 ms TBTT hold — init leaves the chip in the
+   * StopTxBeacon state with the 3.2 ms stop-hold). */
+  uint8_t nt = _device.rtw_read8(0x0102);
+  _device.rtw_write8(0x0102, static_cast<uint8_t>((nt & ~0x03u) | 0x03u));
+  _device.rtw_write16(0x0554 /* REG_BCN_INTERVAL */,
+                      static_cast<uint16_t>(interval_tu));
+  _device.rtw_write8(0x0559 /* REG_BCNDMATIM */, 0x02);
+  _device.rtw_write8(0x055a /* REG_ATIMWND */, 0x0c);
+  if (!is_8814)
+    _device.rtw_write16(0x0518 /* REG_TSFTR_SYN_OFFSET */, 0x7fff);
+  _device.rtw_write8(0x0553 /* REG_DUAL_TSF_RST */, 0x01); // reset port-0 TSF
+  _device.rtw_write8(0x0550 /* REG_BCN_CTRL */,
+                     0x18 /* DIS_TSF_UDT|EN_BCN_FUNCTION — the rtw88 enabled state */);
+  if (_eepromManager->version_id.ICType == CHIP_8821) {
+    uint8_t cck = _device.rtw_read8(0x0454 /* REG_CCK_CHECK */);
+    _device.rtw_write8(0x0454, static_cast<uint8_t>(cck & ~0x20u)); // BCN on port 0
+  }
+  if (is_8814) {
+    /* Two 8814 deltas from the rtw88 beacons-airing register state
+     * (register-diffed on the same adapter; devourer's init leaves both
+     * clear and the TBTT engine stays silent):
+     * 0x420[12] — the gen1 beacon-queue download/fetch enable (the analog
+     * of the HalMAC BIT_EN_BCNQ_DL), and 0x454[2:0] = 0x05. */
+    _device.rtw_write8(0x0421, static_cast<uint8_t>(
+                                   _device.rtw_read8(0x0421) | 0x10u));
+    _device.rtw_write8(0x0454, static_cast<uint8_t>(
+                                   (_device.rtw_read8(0x0454) & ~0x07u) | 0x05u));
+  }
+  _device.rtw_write8(0x0525 /* REG_RD_CTRL+1 */, 0x6F);
+  /* ResumeTxBeacon */
+  _device.rtw_write8(0x0422, static_cast<uint8_t>(
+                                 _device.rtw_read8(0x0422) | 0x40u));
+  _device.rtw_write8(0x0541 /* REG_TBTT_PROHIBIT+1 */, 0x80);
+  uint8_t tb2 = _device.rtw_read8(0x0542);
+  _device.rtw_write8(0x0542, static_cast<uint8_t>(tb2 & 0xF0));
+  _bcn_mpdu.assign(mpdu, mpdu + mpdu_len);
+  _bcn_interval_tu = interval_tu > 0 ? interval_tu : 100;
+  _logger->info("beacon(J1): beacon@BCNQ boundary, net_type->AP, BCN_CTRL=0x1a "
+                "(interval {} TU)", interval_tu);
+  return true;
+}
+
+int32_t RtlJaguarDevice::AdjustBeaconTiming(int32_t microseconds) {
+  int nominal = _bcn_interval_tu;
+  if (nominal <= 0) return 0;  // no active beacon
+  int delta_tu = (microseconds >= 0 ? microseconds + 512 : microseconds - 512) / 1024;
+  if (delta_tu == 0) return 0;  // below 1-TU resolution
+  /* The one-shot REG_BCN_INTERVAL tweak that steers the J2/J3 TBTT is INERT
+   * on this engine — bench-proven on the 8821AU (the beacon survives, the
+   * phase never moves; the tweaked interval doesn't latch a shift). So the
+   * TU-quantized coarse contract rides the fine mechanism instead. NOTE this
+   * also shifts the reported TSF by the same amount (unlike the J2/J3 coarse
+   * actuator, which moves only the TBTT). */
+  int32_t applied = AdjustBeaconTimingFine(delta_tu * 1024);
+  return applied == 0 ? 0 : delta_tu * 1024;
+}
+
+int32_t RtlJaguarDevice::AdjustBeaconTimingFine(int32_t microseconds) {
+  if (_bcn_interval_tu <= 0) return 0;  // no active beacon
+  /* The J2 fine steer on the same registers: beacon function off, shift the
+   * port-0 TSF, back on (TBTT re-derives from the shifted TSF), then
+   * re-download the retained beacon to re-arm the valid latch. */
+  uint32_t hi = _device.rtw_read<uint32_t>(0x0564);
+  uint32_t lo = _device.rtw_read<uint32_t>(0x0560);
+  uint64_t tsf = (static_cast<uint64_t>(hi) << 32) | lo;
+  uint64_t nt = tsf - static_cast<uint64_t>(static_cast<int64_t>(microseconds));
+  uint8_t bc = _device.rtw_read8(0x0550 /* REG_BCN_CTRL */);
+  _device.rtw_write8(0x0550, static_cast<uint8_t>(bc & ~(1u << 3)));
+  _device.rtw_write<uint32_t>(0x0560, static_cast<uint32_t>(nt));
+  _device.rtw_write<uint32_t>(0x0564, static_cast<uint32_t>(nt >> 32));
+  _device.rtw_write8(0x0550, static_cast<uint8_t>(bc | (1u << 3)));
+  if (_eepromManager->version_id.ICType == CHIP_8814A) {
+    /* The 8814 TBTT counter free-runs across the EN_BCN toggle (it only
+     * pauses while off — bench: a −5000 µs TSF shift moved the phase by just
+     * the bracket's ~0.8 ms off-time). Pulse the port-0 DUAL_TSF_RST so the
+     * TBTT re-derives from the (shifted) TSF, the vendor AP-recipe arm. */
+    _device.rtw_write8(0x0553 /* REG_DUAL_TSF_RST */, 0x01);
+  }
+  if (!_bcn_mpdu.empty() &&
+      !download_rsvd_beacon(_bcn_mpdu.data(), _bcn_mpdu.size())) {
+    _logger->error("beacon(J1): TBTT-steer re-download failed — beacon may "
+                   "have stopped airing");
+    return 0;
+  }
+  _logger->info("beacon(J1): fine TBTT shift {} us (TSF toggle + rsvd-page "
+                "re-download)", microseconds);
+  return microseconds;
 }
 
 bool RtlJaguarDevice::send_packet(const uint8_t *packet, size_t length) {
@@ -1223,7 +1414,9 @@ devourer::AdapterCaps RtlJaguarDevice::GetAdapterCaps() {
   }
   c.fastretune_ok = true; /* phy_SwChnl8812_fast (8812/8821) + full-path fallback */
   c.hw_rx_timestamp = true;   /* FrameParser fills RxAtrib.tsfl on every frame */
-  c.hw_beacon_txtsf = false;  /* no reserved-page beacon download on Jaguar1 */
+  c.hw_beacon_txtsf = true;  /* StartBeacon: MAC inserts the egress TSF into
+                              * beacons (bench: 8821AU + 8814AU body-TS steps
+                              * live at the beacon interval) */
   c.xtal_cap_max = 0x3f; /* 6-bit AFE crystal-cap trim (0x2C) */
   c.xtal_cap_default = _eepromManager->crystal_cap & 0x3f;
   devourer::set_standard_freq_ranges(c);

--- a/src/jaguar1/RtlJaguarDevice.h
+++ b/src/jaguar1/RtlJaguarDevice.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <thread>
+#include <vector>
 
 #include "logger.h"
 #include "BbDbgportReader.h"
@@ -223,11 +224,20 @@ public:
   SelectedChannel GetSelectedChannel() override;
   uint64_t ReadTsf() override;
 
-  /* EXPERIMENTAL (idea 6 spike): load a beacon into the beacon queue and enable
-   * the MAC beacon function so the chip auto-transmits it at each TBTT — a
-   * hardware-timed, host-jitter-free TX. Returns false if unsupported.
-   * `interval_tu` is the beacon interval in TU (1024 µs). */
-  bool StartBeacon(const uint8_t* beacon, size_t len, int interval_tu);
+  /* Hardware-timed beacon (IRtlDevice contract): download the beacon MPDU to
+   * the reserved page at the BCNQ boundary (the vendor rtl8812_download_rsvd_page
+   * bracket: CR+1 SW-beacon-DMA, beacon function off, 0x422[6] cleared so the
+   * QSEL-beacon bulk-OUT is stored instead of aired, BCN_VALID 0x20A[0] W1C +
+   * poll) and enable the TBTT engine. All four chips: the 8814A uses its own
+   * valid latch (0x0204[15] with the head held at the BCNQ boundary) and its
+   * stored beacon airs with the hardware sequence pinned at 0 (kernel rtw88
+   * parity). `interval_tu` is the beacon interval in TU (1024 µs). */
+  bool StartBeacon(const uint8_t* beacon, size_t len, int interval_tu) override;
+  /* Beacon-TBTT steering (IRtlDevice contract) — the Jaguar2 steer-then-
+   * re-download pattern: re-download the retained MPDU after the re-latch to
+   * re-arm the bcn-valid latch. */
+  int32_t AdjustBeaconTiming(int32_t microseconds) override;
+  int32_t AdjustBeaconTimingFine(int32_t microseconds) override;
 
   /* Runtime RX-chain selection — the adaptive-link spatial-diversity lever
    * (the read/write superset of the DEVOURER_RX_PATHS env knob). Writes the
@@ -303,6 +313,18 @@ private:
    * the send_packets URB packer. */
   size_t build_tx_block(const uint8_t *packet, size_t length, uint8_t *out,
                         uint8_t pkt_offset);
+
+  /* Beacon retained for the TBTT-steer re-download (AdjustBeaconTiming*),
+   * mirroring RtlJaguar2Device: re-latching the TBTT drops the bcn-valid
+   * latch, so the steer path re-downloads this copy. _bcn_interval_tu = 0
+   * means no active beacon. (No TBTT-grid offset member here: the J1 coarse
+   * steer rides the fine mechanism, which keeps the grid TSF-derived.) */
+  std::vector<uint8_t> _bcn_mpdu;
+  int _bcn_interval_tu = 0;
+  /* Download `mpdu` to the reserved page at the BCNQ boundary via the vendor
+   * rtl8812_download_rsvd_page bracket; polls BCN_VALID (0x20A[0]). Leaves
+   * BCN_CTRL as it found it. */
+  bool download_rsvd_beacon(const uint8_t *mpdu, size_t mpdu_len);
 
   std::array<std::atomic<uint32_t>, 5> _qd_snap{};
   std::thread _qd_thread;

--- a/tests/ap_ping_demo.sh
+++ b/tests/ap_ping_demo.sh
@@ -5,7 +5,8 @@
 #
 # Needs a second Realtek adapter bound to the kernel as a station (rtw88
 # auto-probes a VBUS-cold dongle -> e.g. wlp4s0u2u4). AP adapter = a DIFFERENT
-# J2/J3 devourer adapter (StartBeacon + full-duplex; 8812BU/8822CU work).
+# devourer adapter running StartBeacon + full-duplex RX (any generation has
+# the beacon; the AP harness is bench-validated on 8812BU/8822CU).
 #
 #   sudo STA_IF=wlp4s0u2u4 AP_VID=0x2357 AP_PID=0x012d tests/ap_ping_demo.sh
 set -uo pipefail

--- a/tests/beacon_kernel_scan.sh
+++ b/tests/beacon_kernel_scan.sh
@@ -20,7 +20,7 @@
 set -uo pipefail
 cd "$(dirname "$0")/.."
 SCAN_IF=${SCAN_IF:-wlp4s0u2u4}
-B_VID=${B_VID:-0x2357}; B_PID=${B_PID:-0x012d}   # devourer beacon adapter (J2/J3, StartBeacon)
+B_VID=${B_VID:-0x2357}; B_PID=${B_PID:-0x012d}   # devourer beacon adapter (StartBeacon, any generation)
 CH=${CH:-6}; FREQ=${FREQ:-2437}; TU=${TU:-25}; SECS=${SECS:-30}
 BSSID=57:42:75:05:d6:00
 

--- a/tests/beacon_steer_survival.sh
+++ b/tests/beacon_steer_survival.sh
@@ -153,8 +153,10 @@ for i, (t, req, app) in enumerate(steers):
     post = [b for b in bcns if t + 500 <= b[0] < t + 4000]
     if not post:
         print(f"steer {i+1} @ {t}: FAIL — no beacons within 4 s after"); ok = False; continue
-    # seq must advance across the steer
-    if pre and post[-1][1] == pre[-1][1]:
+    # seq must advance across the steer — except on the 8814A, whose stored
+    # beacon airs with hardware seq pinned at 0 (kernel rtw88 parity; beacon
+    # presence/cadence is the survival signal there)
+    if pre and post[-1][1] == pre[-1][1] and post[-1][1] != 0:
         print(f"steer {i+1} @ {t}: FAIL — seq frozen at {pre[-1][1]}"); ok = False; continue
     dphase = ""
     if pre:

--- a/tests/beacon_wire_check.cpp
+++ b/tests/beacon_wire_check.cpp
@@ -4,12 +4,13 @@
 // sequence-control field (MPDU bytes 22-23: seq[15:4] must INCREMENT by 1 per
 // beacon — the hardware sequence numbering a kernel AP does via EN_HWSEQ), and
 // the beacon-body timestamp (bytes 24-31, the live hardware TSF, steps ~102400 µs
-// at 100 TU). Bench-confirmed kernel-equivalent on both HalMAC generations:
+// at 100 TU). Bench-confirmed kernel-equivalent on all three generations:
 //   J3 8822C : seq 16,17,18,19,20,21...   ts steps ~102400 us
 //   J2 8812BU: seq 730,731,732,733...     ts steps ~102400 us
-// (A beacon whose seq is FROZEN is a degraded engine — e.g. a J2 beacon left in
-// the post-drop state after an AdjustBeaconTiming tweak, which J2 does not
-// survive; a healthy fresh beacon increments.)
+//   J1 8821AU: seq increments, ts steps; the 8814A pins seq at 0 (kernel rtw88
+//   parity on that chip — judge it by presence/cadence/ts, not seq)
+// (Elsewhere a beacon whose seq is FROZEN is a degraded engine — e.g. a beacon
+// left in the post-re-latch drop state; a healthy fresh beacon increments.)
 //
 // Build: g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/beacon_wire_check.cpp \
 //   examples/common/env_config.cpp build/libdevourer.a \

--- a/tests/timesync_ta_demo.sh
+++ b/tests/timesync_ta_demo.sh
@@ -16,8 +16,9 @@ set -uo pipefail
 cd "$(dirname "$0")/.."
 SECS=${1:-30}; CH=${2:-36}; SLOT=${3:-20}
 # HWBEACON=1 : the UE airs its uplink from the beacon engine and fine-steers the
-# TBTT (AdjustBeaconTimingFine) — the CONVERGING closed loop. Needs a J3 UE (fine
-# steering) + any full-duplex master (Jaguar1 8812AU works; it needs no steering).
+# TBTT (AdjustBeaconTimingFine — all generations steer now; this harness is
+# bench-validated with a J3 UE) + any full-duplex master (Jaguar1 8812AU works;
+# it needs no steering).
 HWBEACON=${HWBEACON:-0}
 if [ "$HWBEACON" = 1 ]; then
   M_VID=${M_VID:-0x0bda}; M_PID=${M_PID:-0x8812}   # 8812AU full-duplex master


### PR DESCRIPTION
Extends #242's beacon-TBTT steering to **Jaguar1** — `StartBeacon` / `AdjustBeaconTiming` / `AdjustBeaconTimingFine` now work on all three generations (8812AU / 8811AU / 8821AU / 8814AU included), so the hardware-beacon downlink and the uplink-TA / PTP-discipline actuator are no longer generation-gated. `AdapterCaps.hw_beacon_txtsf` is now true on J1 (body-timestamp verified live on air).

## How the old "impossible" became possible

The previous refusal ("no reserved-page path on Jaguar1, bench-confirmed negative") only ruled out a plain QSEL-beacon send. Golden usbmon dumps of the in-tree `rtw88_8821au` / `rtw88_8814au` — captured on the same adapters — recovered the real store bracket:

```
clear BCN_VALID (W1C) → CR+1 |= BIT0 (SW beacon DMA) → beacon function off
→ bulk [MINIMAL descriptor][MPDU] → poll BCN_VALID → function on → CR+1 &= ~BIT0
```

**The descriptor is the crack**: `LAST_SEG + OFFSET + PKT_SIZE + QSEL_BEACON` only. `OWN`/`FIRST_SEG`/`BMC`/`HWSEQ`/`USE_RATE` mark a live TX and make the store silently no-op — while BCN_VALID *still latches*, deceptively. Enable = the vendor port-0 AP recipe (MSR=AP, `DUAL_TSF_RST` BIT0, BCN_CTRL 0x18, ResumeTxBeacon) + the 8821A-only "BCN on port 0" `0x454[5]` clear.

## 8814A specifics (own golden dump + live register diff)

- Valid latch at `0x204[15]`, with the head **held at the BCNQ boundary** during the store — pointing it at page 0 (the fw-download bracket's shape) stores the beacon where the TBTT engine never reads
- Enable bits `0x420[12]` (gen1 `EN_BCNQ_DL` analog) + `0x454[2:0]=0x05`
- Its stored beacon airs with the 802.11 **seq pinned at 0 — kernel rtw88 parity** (verified against the kernel driver's own beacons on the same chip)
- Its TBTT counter **free-runs across the EN_BCN toggle** (a bare TSF shift moves the phase by only the bracket's ~0.8 ms), so the fine steer pulses `DUAL_TSF_RST`: the grid re-derives absolutely from the shifted TSF — the TBTT ends up TSF-locked and each steer cancels accumulated drift

## Steering

Rides #242's steer-then-re-download pattern (the J1 engines also lose the bcn-valid latch on a re-latch). The coarse one-shot interval tweak is **inert** on the J1 engine (bench: beacon survives, phase never moves), so `AdjustBeaconTiming` delegates TU-quantized to the fine mechanism (documented: it then also shifts the reported TSF).

## Bench (observer = 8811CU, `tests/beacon_steer_survival.sh`)

| Chip | Fine | Coarse | Loss/steer | Accuracy |
|---|---|---|---|---|
| **8821AU** | 11/11 PASS | 3/3 PASS | 0–1 beacon | −3392…−3472 µs for −5000 µs (±40 µs consistency; ~1.6 ms USB systematic a closed loop absorbs) |
| **8814AU** | 5/5 PASS | 3/3 PASS | 0–3 beacons (RF-weak unit) | −3139…−3424 µs for −5000 µs; absolute TSF-locked re-derive |

Beacon body timestamps verified live on both. `ctest` 17/17.

## Docs/comments sweep

All stale "Jaguar2/3-only" / "both HalMAC generations" / "no reserved-page path on Jaguar1" claims for this feature removed across `IRtlDevice.h`, `AdapterCaps.h`, `docs/time-distribution.md`, `docs/ap-mode.md`, and the beacon test headers. `tests/beacon_steer_survival.sh` gates its frozen-seq check on `seq != 0` (8814A kernel parity) and gains a `MASTER_CMD='ssh …'` hook for remote masters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)