### PR TITLE
PinBeaconTbtt: TSF-preserving absolute TBTT pin — steering that doesn't corrupt the discipline loop's clock

### DIFF
--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -241,6 +241,30 @@ At a realistic discipline cadence (~10 s between corrections against ~40 ppm
 crystal drift and a ~500 µs guard) the cost is ~1 lost beacon per 100. Jaguar3
 needs no re-download — its engine survives the re-latch.
 
+**Steering corrupts the controller's own clock — use `PinBeaconTbtt`.**
+`AdjustBeaconTimingFine` necessarily jumps the reported TSF (the TBTT re-derives
+from a shifted TSF), so a discipline loop whose phase estimate is a fit against
+that TSF (`ref = a·tsf + b`) breaks its own sensor at every steer. Bench-observed
+on the 8821CE AP↔PTP loop: high-authority controllers (PI, large clamped steps)
+chase the corrupted estimate into a limit cycle, and the working ~60 µs
+proportional loop is a **sweet spot, not a floor** — its steers are only small
+enough (≈0.5·e) not to wreck the fit, so more authority makes it worse, and
+`SetXtalCap` can't buy a lower steer cadence (the AFE trim moves only ~10 of the
+~42 ppm crystal offset). The escape is `PinBeaconTbtt(offset_us)`: the same
+shift + re-latch, immediately followed by a TSF write back onto the original
+timeline — a bare TSF write does not move the TBTT, so the steered phase
+survives while the clock the loop reads stays continuous. Bench (8821CE PCIe):
+TSF discontinuity **~10 µs** per correction (vs the full steer magnitude for
+the fine variant — ~500× less fit disturbance), on-air phase pinned within
+~±150 µs of the commanded offset, zero beacons lost. Semantics are **absolute**
+(TBTT fires at `TSF % interval == offset`), so the controller commands the
+target offset directly instead of integrating steps — and a PTP-disciplined
+TSF drags the pinned TBTT with it between corrections. Where `PinBeaconTbtt`
+is unavailable (USB: the restore write costs ~0.5–1 ms, worse than a small
+steer), the controller-side fix is a steering ledger: add the cumulative
+commanded shifts back onto the raw TSF before fitting, so the fit sees a
+continuous virtual clock and full authority is safe again.
+
 Actuator characterization: `tests/beacon_interval_shift.sh <short_TU>` (TU tweak),
 or `FINE_US=<µs> tests/beacon_interval_shift.sh` (µs-fine). Steer *survival* +
 repeated-steer accuracy (incl. a PCIe master via `MASTER_CMD='ssh …'`):

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -343,6 +343,32 @@ public:
     return 0;
   }
 
+  /* TSF-PRESERVING µs-fine TBTT actuator: pin the beacon TBTT so it fires at
+   * TSF % interval == offset_us, WITHOUT disturbing the reported TSF.
+   * AdjustBeaconTimingFine necessarily jumps the TSF (the TBTT re-derives from
+   * a shifted TSF), which corrupts any controller whose phase estimate is a
+   * fit against this port's TSF (ref = a·tsf + b — every steer breaks the
+   * slope, and a high-authority loop chases the corrupted estimate into a
+   * limit cycle; bench-observed on the 8821CE AP↔PTP loop). This variant does
+   * the same shift + re-latch, then immediately writes the TSF back onto its
+   * original timeline — a bare TSF write does not move the TBTT (bench-proven),
+   * so the steered TBTT phase survives while the clock the loop reads stays
+   * continuous. The residual TSF discontinuity is one register-write latency:
+   * ~µs over PCIe MMIO, ~0.5–1 ms over USB (so on USB this only pays off for
+   * steers larger than that).
+   *
+   * ABSOLUTE semantics (unlike the incremental AdjustBeaconTimingFine): each
+   * call re-pins the TBTT to the TSF grid, so consecutive calls don't
+   * accumulate, and a PTP-disciplined TSF drags the pinned TBTT with it
+   * between corrections — the fit-free discipline pattern. Requires an active
+   * StartBeacon; returns the applied offset (normalized into the beacon
+   * period), 0 if no active beacon. Jaguar2 (bench: 8821CE PCIe); base is a
+   * no-op. */
+  virtual int32_t PinBeaconTbtt(int32_t offset_us) {
+    (void)offset_us;
+    return 0;
+  }
+
   /* Clean shutdown: halt TRX DMA and power the chip down to a re-enumerable
    * state (mirrors the kernel driver's card-disable on unbind). Call after the
    * RX/TX loop exits and BEFORE releasing/closing the USB interface, so the

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -1539,6 +1539,48 @@ int32_t RtlJaguar2Device::AdjustBeaconTimingFine(int32_t microseconds) {
   return microseconds;
 }
 
+int32_t RtlJaguar2Device::PinBeaconTbtt(int32_t offset_us) {
+  std::lock_guard<std::mutex> lk(_reg_mu);
+  if (_bcn_interval_tu <= 0) return 0;  // no active beacon
+  const int64_t period_us = static_cast<int64_t>(_bcn_interval_tu) * 1024;
+  const int64_t off =
+      ((static_cast<int64_t>(offset_us) % period_us) + period_us) % period_us;
+  /* Same shift + re-latch as AdjustBeaconTimingFine — the TBTT re-derives
+   * from (TSF - off), i.e. it will fire when TSF % period == off — followed
+   * IMMEDIATELY by a TSF restore write: a bare TSF write does not move the
+   * TBTT (bench-proven), so the pinned phase survives while the reported TSF
+   * returns to its original timeline. The residual discontinuity is one
+   * register-write latency (~µs over PCIe MMIO). Keep the off-timeline window
+   * minimal: restore before the reserved-page re-download. */
+  auto read_tsf = [&]() {
+    uint32_t hi = _device.rtw_read<uint32_t>(0x0564);
+    uint32_t lo = _device.rtw_read<uint32_t>(0x0560);
+    if (_device.rtw_read<uint32_t>(0x0564) != hi) {
+      hi = _device.rtw_read<uint32_t>(0x0564);
+      lo = _device.rtw_read<uint32_t>(0x0560);
+    }
+    return (static_cast<uint64_t>(hi) << 32) | lo;
+  };
+  uint64_t nt = read_tsf() - static_cast<uint64_t>(off);
+  uint8_t bc = _device.rtw_read8(0x0550 /* REG_BCN_CTRL */);
+  _device.rtw_write8(0x0550, static_cast<uint8_t>(bc & ~(1u << 3)));
+  _device.rtw_write<uint32_t>(0x0560, static_cast<uint32_t>(nt));
+  _device.rtw_write<uint32_t>(0x0564, static_cast<uint32_t>(nt >> 32));
+  _device.rtw_write8(0x0550, static_cast<uint8_t>(bc | (1u << 3)));  // re-latch
+  uint64_t back = read_tsf() + static_cast<uint64_t>(off);  // original timeline
+  _device.rtw_write<uint32_t>(0x0560, static_cast<uint32_t>(back));
+  _device.rtw_write<uint32_t>(0x0564, static_cast<uint32_t>(back >> 32));
+  /* The J2 engine dropped its bcn-valid latch on the re-latch — re-arm it. */
+  if (!redownload_beacon_locked())
+    return 0;
+  /* The TBTT grid now sits at TSF % period == off (vs the restored TSF) —
+   * record it for the coarse path's phase alignment. */
+  _tbtt_off_us = off;
+  _logger->info("beacon(J2): TBTT pinned to TSF%%interval == {} us "
+                "(TSF-preserving; requested {})", (long long)off, offset_us);
+  return static_cast<int32_t>(off);
+}
+
 void RtlJaguar2Device::SetCcaMode(bool disabled) {
   std::lock_guard<std::mutex> lk(_reg_mu);
   uint32_t v520 = _device.rtw_read<uint32_t>(0x0520);

--- a/src/jaguar2/RtlJaguar2Device.h
+++ b/src/jaguar2/RtlJaguar2Device.h
@@ -94,6 +94,10 @@ public:
    * re-arm the latch — one skipped beacon per correction. */
   int32_t AdjustBeaconTiming(int32_t microseconds) override;
   int32_t AdjustBeaconTimingFine(int32_t microseconds) override;
+  /* TSF-preserving absolute TBTT pin (IRtlDevice contract): steer via the
+   * shift + re-latch, then write the TSF back onto its original timeline so
+   * a controller fitting against this port's TSF sees a continuous clock. */
+  int32_t PinBeaconTbtt(int32_t offset_us) override;
   void Stop() override;
   void SetTxMode(const devourer::TxMode &mode) override;
   void ClearTxMode() override;

--- a/tests/beacon_steer_check.cpp
+++ b/tests/beacon_steer_check.cpp
@@ -15,7 +15,12 @@
 //   -o build/beacon_steer_check
 // Run: sudo DEVOURER_PID=0x012d DEVOURER_VID=0x2357 DEVOURER_CHANNEL=36 \
 //   build/beacon_steer_check [n_steers] [steer_us] [period_s]
-//   STEER_MODE=coarse selects AdjustBeaconTiming (TU-quantized) instead.
+//   STEER_MODE=coarse selects AdjustBeaconTiming (TU-quantized) instead;
+//   STEER_MODE=pin selects PinBeaconTbtt (TSF-preserving absolute pin —
+//   steer_us is then the absolute TBTT offset vs the TSF grid; successive
+//   steers alternate offset/offset+|steer_us| so the observer sees a step).
+//   TSF_WATCH=1: sample ReadTsf every ~20 ms around each steer and report the
+//   worst TSF-timeline discontinuity (the fit-corruption a controller sees).
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
@@ -46,9 +51,12 @@ int main(int argc, char **argv) {
   int n_steers = argc > 1 ? atoi(argv[1]) : 5;
   int steer_us = argc > 2 ? atoi(argv[2]) : -5000;
   int period_s = argc > 3 ? atoi(argv[3]) : 5;
-  const bool coarse = [] {
-    const char *m = std::getenv("STEER_MODE");
-    return m && std::strcmp(m, "coarse") == 0;
+  const char *steer_mode = std::getenv("STEER_MODE");
+  const bool coarse = steer_mode && std::strcmp(steer_mode, "coarse") == 0;
+  const bool pin = steer_mode && std::strcmp(steer_mode, "pin") == 0;
+  const bool tsf_watch = [] {
+    const char *w = std::getenv("TSF_WATCH");
+    return w && *w && std::strcmp(w, "0") != 0;
   }();
   uint8_t ch = 36;
   if (const char *c = std::getenv("DEVOURER_CHANNEL")) ch = (uint8_t)atoi(c);
@@ -108,19 +116,45 @@ int main(int argc, char **argv) {
     return 1;
   }
   printf("BEACON_MS %ld ch=%d interval_tu=%d mode=%s n=%d steer_us=%d period_s=%d\n",
-         now_ms(), ch, interval_tu, coarse ? "coarse" : "fine", n_steers,
-         steer_us, period_s);
+         now_ms(), ch, interval_tu,
+         coarse ? "coarse" : (pin ? "pin" : "fine"), n_steers, steer_us,
+         period_s);
   fflush(stdout);
   std::this_thread::sleep_for(std::chrono::seconds(period_s));
 
   for (int i = 0; i < n_steers; ++i) {
+    /* TSF_WATCH: bracket the steer with a TSF sample train; a controller's
+     * ref = a·tsf + b fit sees exactly these discontinuities. */
+    uint64_t pre_tsf = 0;
+    long long pre_us = 0;
+    if (tsf_watch) {
+      pre_tsf = dev->ReadTsf();
+      pre_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                   std::chrono::steady_clock::now().time_since_epoch())
+                   .count();
+    }
     long t0 = now_ms();
-    int applied = coarse ? dev->AdjustBeaconTiming(steer_us)
-                         : dev->AdjustBeaconTimingFine(steer_us);
+    int req = steer_us;
+    if (pin && (i & 1))
+      req = steer_us + std::abs(steer_us); /* alternate so the phase steps */
+    int applied = coarse ? dev->AdjustBeaconTiming(req)
+                 : pin   ? dev->PinBeaconTbtt(req)
+                         : dev->AdjustBeaconTimingFine(req);
     printf("STEER_MS %ld n=%d req_us=%d applied_us=%d dur_ms=%ld\n", t0, i + 1,
-           steer_us, applied, now_ms() - t0);
+           req, applied, now_ms() - t0);
+    if (tsf_watch) {
+      uint64_t post_tsf = dev->ReadTsf();
+      long long post_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                              std::chrono::steady_clock::now().time_since_epoch())
+                              .count();
+      /* Discontinuity = TSF advance minus wall-clock advance across the
+       * steer (host jitter ~tens of µs; the fine steer's jump is the steer
+       * magnitude, the pin's is ~register-write latency). */
+      long long disc = (long long)(post_tsf - pre_tsf) - (post_us - pre_us);
+      printf("TSFJUMP_MS %ld n=%d disc_us=%lld\n", now_ms(), i + 1, disc);
+    }
     fflush(stdout);
-    if (applied == 0) {
+    if (applied == 0 && !(pin && req % (interval_tu * 1024) == 0)) {
       fprintf(stderr, "steer %d refused/failed (applied=0)\n", i + 1);
       return 1;
     }


### PR DESCRIPTION
Follow-up to #242/#243, driven by bench feedback from the 8821CE AP↔PTP discipline loop.

## The problem (bench-observed)

`AdjustBeaconTimingFine` necessarily jumps the reported TSF — that's the steering mechanism (the TBTT re-derives from a shifted TSF). But the discipline loop's phase estimate is a fit against that same TSF (`ref = a·tsf + b`), so **every steer corrupts the controller's own sensor**:

- high-authority controllers (PI, ±200 µs clamped steps) chase the corrupted estimate into a limit cycle
- the working ~60 µs proportional loop is a **sweet spot, not a floor** — its ~0.5·e steers are just small enough not to wreck the fit; more authority = more fit corruption = worse
- `SetXtalCap` can't buy a lower steer cadence: the AFE trim moves only ~10 of the ~42 ppm crystal offset

## The fix

`IRtlDevice::PinBeaconTbtt(offset_us)` inverts the oldest finding in this feature — *a bare TSF write does not move the TBTT* (why `WriteTsf` failed as an actuator). Do the shift + re-latch, then **immediately write the TSF back onto its original timeline**: the steered TBTT phase survives, the clock the loop reads stays continuous.

Semantics are **absolute**: the TBTT fires at `TSF % interval == offset`. The controller commands the target offset directly (no step integration), and a PTP-disciplined TSF drags the pinned TBTT with it between corrections.

## Bench (8821CE PCIe, `TSF_WATCH=1` probe)

| actuator | TSF discontinuity / steer | on-air phase | beacons lost |
|---|---|---|---|
| `AdjustBeaconTimingFine` | **+4996 µs** (the full steer) | steers | 0–1 |
| `PinBeaconTbtt` | **−9…−11 µs** | pins within ±150 µs of the commanded offset, both directions | **0** |

~500× less fit disturbance — full control authority is safe again.

## Scope & caveats

- Jaguar2 implementation (the loop hardware); base virtual is a no-op. The same pattern ports to J3/J1 when hardware is on the bench to validate.
- USB caveat documented: the restore write costs ~0.5–1 ms there (worse than a small steer) — `docs/time-distribution.md` documents the controller-side **steering ledger** as the everywhere-fallback (add cumulative commanded shifts back onto the raw TSF before fitting).
- `tests/beacon_steer_check.cpp` grows `STEER_MODE=pin` and `TSF_WATCH=1` (µs-resolution steady_clock-vs-ReadTsf discontinuity probe).
- Docs record the sweet-spot and XtalCap findings so they aren't re-discovered.

`ctest` 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)