### PR TITLE
SetCcaMode on Jaguar1: bench-refuted as unnecessary — document the deliberate no-op

### DIFF
--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -111,16 +111,21 @@ diverge by ~hundreds of µs on a shared channel. In a time-distribution setup th
 master **owns** the channel, so that backoff is pure loss — the master disables
 EDCCA (`SetCcaMode`, on by default here; opt out with `DEVOURER_TSYNC_CSMA=1`)
 and the beacon airs exactly on schedule. `SetCcaMode` is implemented on
-Jaguar2/3; a Jaguar1 hardware-beacon master still defers to CSMA (expect the
-backoff-jitter row below on a busy channel).
+Jaguar2/3 and is a deliberate no-op on Jaguar1: the J1 baseband EDCCA is
+already disabled by its init table (`0x8A4 = 0x7F7F7F7F`, thresholds
+unreachable), and the measured J1 downlink needs no MAC-side gate — see the
+bench row below. (Porting the J2 MAC-register recipe to J1 was bench-refuted:
+no improvement, and its `0x524[11]` clear conflicts with the vendor
+beacon-enable state.)
 
 Bench (HW-beacon master + slave, **crowded** ch6, 100 ms beacons):
 
 | config | downlink residual |
 |--------|-------------------|
 | software stamp | ~94 µs RMS |
-| HW beacon, CSMA on | ~470 µs RMS (backoff jitter) |
+| HW beacon, CSMA on (J2/J3) | ~470 µs RMS (backoff jitter) |
 | HW beacon + no-CSMA (default) | **0.31 µs RMS** (8822C) / 0.39 µs (8812BU) |
+| HW beacon, Jaguar1 (no gate needed) | **0.34–0.40 µs RMS** (8821AU master, 8822CU slave) |
 
 So the master↔slave clocks track to sub-µs on any channel — the offset moves
 only with the crystal drift. `DEVOURER_TSYNC_HWBEACON=1` on both master and

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -294,7 +294,12 @@ public:
    * TBTT beacon airs exactly on schedule instead of after a CSMA backoff — the
    * lever that collapses the hardware-beacon downlink residual to sub-µs on a
    * shared channel (the master owns the channel). Also DEVOURER_DIS_CCA at
-   * construction. No-op where unimplemented. */
+   * construction. Implemented on Jaguar2/3; a DELIBERATE no-op on Jaguar1,
+   * whose baseband EDCCA is already disabled by its init table (0x8A4 =
+   * 0x7F7F7F7F) — its hardware-beacon downlink measures ~0.34 µs RMS on a
+   * crowded channel with no MAC-side gate, and porting the J2 register
+   * recipe was bench-refuted (no gain; the 0x524[11] clear conflicts with
+   * the vendor beacon-enable state). */
   virtual void SetCcaMode(bool disabled) { (void)disabled; }
 
   /* Shift the next hardware beacon TBTT by `microseconds` (>0 = later/retard,

--- a/tests/beacon_steer_check.cpp
+++ b/tests/beacon_steer_check.cpp
@@ -95,7 +95,11 @@ int main(int argc, char **argv) {
 
   dev->InitWrite(SelectedChannel{ch, 0, CHANNEL_WIDTH_20});
   std::this_thread::sleep_for(std::chrono::seconds(2));
-  dev->SetCcaMode(true);  // beacon airs exactly at TBTT (master owns channel)
+  /* KEEP_CSMA=1: leave carrier-sense deferral on (A/B lever for measuring
+   * SetCcaMode's effect on TBTT punctuality). Default: EDCCA off — the beacon
+   * airs exactly at TBTT, the master owns the channel. */
+  if (const char *k = std::getenv("KEEP_CSMA"); !(k && *k && std::strcmp(k, "0") != 0))
+    dev->SetCcaMode(true);
 
   // Minimal beacon, canonical SA 57:42:75:05:d6:00 (rx.txhit matcher).
   std::vector<uint8_t> f = {


### PR DESCRIPTION
Set out to port `SetCcaMode` to Jaguar1; the bench flipped the fix from code to documentation.

## Why no code ships

- Gen1 EDCCA is a **baseband** mechanism, and devourer's J1 init table already disables it (`0x8A4 = 0x7F7F7F7F`, thresholds unreachable) — the J2/J3 lever is MAC-side (`0x520[15]` + `0x524[11]`, the shared legacy 0x5xx block).
- Measured with the real methodology (timesync HWBEACON downlink fit residual — the same measurement behind the 0.31/470 µs table; 8821AU master → 8822CU slave, crowded ch6):

| J1 configuration | downlink residual |
|---|---|
| default, **no gate at all** | **0.34–0.40 µs RMS** — already the J2/J3 class |
| ported J2 MAC-bit recipe | 1.15 µs RMS (no gain, worse tail) |

The ported bits plausibly *hurt*: clearing `0x524[11]` conflicts with the vendor beacon-enable state (`RD_CTRL+1 = 0x6F` sets that bit). The override was reverted rather than shipped.

## What lands

- `IRtlDevice.h`: `SetCcaMode` contract — **deliberate no-op on Jaguar1**, with the why, so the port isn't re-attempted
- `docs/time-distribution.md`: the wrong "a Jaguar1 hardware-beacon master still defers to CSMA" claim replaced with the measured truth + a J1 row in the downlink bench table
- `tests/beacon_steer_check.cpp`: `KEEP_CSMA=1` A/B lever (the knob that settled this)

Method note for posterity (also in the doc history via this PR): a quick raw-arrival-phase A/B over single 25 s windows has no discriminating power — its J2 control came out inverted vs the documented 470→0.39 µs effect; trust the fit-residual methodology for TBTT punctuality.

`ctest` 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)