### PR TITLE
docs: J1 timesync slave validated (0.30 µs RMS); pin-based UE actuator bench-refuted

### DIFF
--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -54,8 +54,10 @@ Bench (master RTL8812AU, slaves RTL8822CU + RTL8822EU, ch36, 50 ms beacons):
 
 The inter-slave agreement tightens with beacon rate (≈18 µs at 100 ms → ≈5 µs at
 50 ms) as the fits densify and balance. Every generation exposes the per-frame
-`tsfl` a slave needs; the slave role is bench-validated on Jaguar2/3, and the
-master can be any transmitter (`ReadTsf()`, including Jaguar1).
+`tsfl` a slave needs and the slave role is bench-validated on all three
+(Jaguar2/3, and Jaguar1: an 8821AU slave locks at **0.30 µs RMS** to a
+hardware-beacon master); the master can be any transmitter (`ReadTsf()`,
+including Jaguar1).
 
 The ~94 µs absolute bound is the **transport's submit-to-air floor**, not a
 protocol property: measured with an embedded-submit-TSF frame stream and a
@@ -187,7 +189,12 @@ zero at **~1.25 ms RMS steady-state** (gain 0.30) — a 4× improvement over the
 non-converging `send_packet` baseline. The residual is the fine actuator's USB
 read→write jitter (~0.5–1.2 ms per correction, §Microsecond-fine steering); it is
 the floor for a userspace-USB TSF write (over the PCIe transport the same
-actuator's register path is µs-scale — see the 8821CE row below). Harness:
+actuator's register path is µs-scale — see the 8821CE row below). A
+`PinBeaconTbtt`-based UE actuator was **bench-refuted on USB** (equal at steer
+cadence, unstable-to-worse at low cadence with matched loop gain: every pin
+re-rolls the ~1 ms USB placement error, so the noise the fine steer pays per
+correction the pin pays per pin) — the fine steer remains the right USB UE
+actuator, and the µs-class UE path is a PCIe UE. Harness:
 `tests/timesync_ta_demo.sh` with `HWBEACON=1`.
 
 **Steering the TBTT.** The actuator is `AdjustBeaconTiming(microseconds)`, not a

--- a/tests/timesync_demo.sh
+++ b/tests/timesync_demo.sh
@@ -6,7 +6,8 @@
 #
 #   MASTER = 8812AU (0x8812)      SLAVE_A = 8822CU (0xc812)
 #                                 SLAVE_B = 8822BU (2357:012d)
-# Slaves must be Jaguar2/3 (per-frame tsfl); the master can be any TX (ReadTsf).
+# Slaves work on every generation (per-frame tsfl; J1 8821AU bench: 0.30 µs RMS
+# lock); the defaults below are the J2/3 pair. Master can be any TX (ReadTsf).
 #
 #   sudo tests/timesync_demo.sh [secs] [channel] [interval_ms]
 set -uo pipefail


### PR DESCRIPTION
Two gap-closing bench results, folded into the docs (doc-only — the experimental code was reverted before commit, nothing bench-refuted ships).

## J1 as timesync slave — validated ✓

8821AU slave locking to a hardware-beacon master (ch36): **0.30 µs RMS** (max 0.74 µs, −5.2 ppm) — indistinguishable from the J2/J3 slaves. The "slaves must be Jaguar2/3 (per-frame tsfl)" claim was stale: J1 fills `tsfl` on every frame (`FrameParser.cpp`). `docs/time-distribution.md` and the `tests/timesync_demo.sh` header now say all generations, with the number.

## Pin-based UE uplink actuator — bench-refuted on USB

Implemented and A/B'd three configurations against the fine-steer baseline (8812AU full-duplex master + 8822CU UE, 20 ms slots, 90–120 s runs):

| UE actuator | steady-state RMS |
|---|---|
| `AdjustBeaconTimingFine` (baseline) | **1.48 ms** |
| `PinBeaconTbtt` at steer cadence | 1.79 ms |
| pin at 2 s cadence, default gain 0.3 | 4.9 ms — integrator windup (~20 uplinks × 0.3 between pins → loop gain ~6) |
| pin at 2 s cadence, matched gain 0.02 | 5.4 ms — placement excursions alias into the ±10 ms slot modulo |

**Why**: the pin's win is TSF-timeline *preservation* (sensor protection — what fixed the AP↔PTP loop), not actuation precision. Its USB TBTT placement noise is the same read→write latency the fine steer pays, and the UE-TA loop's sensor is the *master's* measurement — never corrupted in the first place. The doc records this as a guardrail and points the µs-class UE path at a PCIe UE (~10 µs pin placement on the 8821CE).

`ctest` 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)