### PR TITLE
timesync PCIe master, land the AP-beacon↔PTP discipline loop, end-to-end bench

### DIFF
--- a/docs/time-distribution.md
+++ b/docs/time-distribution.md
@@ -67,7 +67,12 @@ RMS** (the residual MAC TX pipeline — the transport stops being the limiter).
 A PCIe master (8821CE) therefore lifts every slave's *absolute* software-path
 lock ~8×; the inter-slave difference and the hardware-beacon path below are
 unaffected (already transport-free). Tool: `tests/pcie_txegress_tx.cpp` +
-`tests/txegress_witness.cpp`.
+`tests/txegress_witness.cpp`. The `timesync` demo drives a PCIe master via
+`DEVOURER_PCIE_BDF` — but note the ~12 µs floor is a *robust-fit* transport
+number: on a busy channel the raw slave lock is deferral-limited regardless of
+transport (radxa bench, crowded ch6: 420 µs RMS — the channel, not the bus),
+and the radxa↔bench RF path only reaches on 2.4 GHz, so prefer the hardware
+beacon below for PCIe masters.
 
 Run it with `tests/timesync_demo.sh` (one master + two slaves; joins the two
 `{"ev":"timesync.lock"}` streams by beacon seq into the inter-UE error).
@@ -329,11 +334,22 @@ board's Intel I226 (a full IEEE-1588 NIC):
 The ~290 ns residual is the TSF's own **1 µs-quantization floor** (uniform
 ±0.5 µs → 289 ns RMS) — once the crystal offset is servoed out, the Wi-Fi MAC
 TSF holds like genuine PTP hardware. Combined with `PinBeaconTbtt` above, this
-closes the loop: network PTP disciplines the master's TSF, the pinned
-(TSF-locked) hardware beacon distributes it over the air at ~±1 µs, and the
-slaves inherit the wired timebase at the sub-µs beacon floor. Validation:
-`tests/pcie_phc/ptp_crosscheck.sh` (the Wi-Fi side must be in monitor mode so
-the MAC/TSF is clocked).
+closes the loop, and the closed loop is a shipped tool:
+`tests/pcie_ptp_beacon.cpp` runs the hardware beacon on the 8821CE and holds
+its TBTT to the I226 PHC (read via `FD_TO_CLOCKID`, no system-clock detour)
+with a full-gain PI on the pin actuator. End-to-end bench, everything running
+concurrently (radxa loop + a USB slave over the air):
+
+| link in the chain | measured |
+|-------------------|----------|
+| radxa TBTT vs the I226 PTP reference | **1.24 µs RMS**, max 5.5 µs (156 pins, ~90 s) |
+| USB slave lock through the live discipline | 13.9 µs RMS (575 beacons, ~0 lost through 160+ pins) |
+
+The slave number carries a caveat: its all-history least-squares fit assumes a
+free-running master, so it *measures the discipline corrections themselves*;
+a tracking filter (PLL-style) at the slave would follow the pinned timebase
+tighter. PHC validation: `tests/pcie_phc/ptp_crosscheck.sh` (the Wi-Fi side
+must be in monitor mode so the MAC/TSF is clocked).
 
 ## Env knobs
 

--- a/examples/timesync/main.cpp
+++ b/examples/timesync/main.cpp
@@ -61,6 +61,9 @@
 #include "env_config.h"
 #include "logger.h"
 #include "timesync.h"
+#if defined(DEVOURER_HAVE_PCIE)
+#include "PcieTransport.h"
+#endif
 
 #define USB_VENDOR_ID 0x0bda
 static constexpr uint16_t kRealtekProductIds[] = {
@@ -477,13 +480,31 @@ int main() {
   timesync::Config c = timesync::config_from_env();
   g_hwbeacon = c.hwbeacon;   // slave reads the standard 802.11 beacon timestamp
 
-  libusb_context* ctx = nullptr;
-  std::shared_ptr<devourer::UsbDeviceLock> lock;
-  auto* handle = open_device(logger, &ctx, lock);
-  if (!handle) { if (ctx) libusb_exit(ctx); return 1; }
-
   WiFiDriver wifi(logger);
-  auto dev = wifi.CreateRtlDevice(handle, ctx, lock, devourer_config_from_env());
+  std::unique_ptr<IRtlDevice> dev;
+  libusb_context* ctx = nullptr;
+  /* DEVOURER_PCIE_BDF=0000:01:00.0 — drive a PCIe adapter (RTL8821CE) through
+   * the vfio transport instead of libusb (DEVOURER_PCIE builds; mirrors the
+   * RX/TX demos). A PCIe master collapses the software-downlink stamp→air
+   * floor from ~93 µs (USB submit path) to ~12 µs (the MAC TX pipeline). */
+  const char* pcie_bdf = std::getenv("DEVOURER_PCIE_BDF");
+#if defined(DEVOURER_HAVE_PCIE)
+  if (pcie_bdf) {
+    auto transport = devourer::PcieTransport::Open(pcie_bdf, logger);
+    if (!transport) return 1;
+    dev = wifi.CreateRtlDevicePcie(std::move(transport), devourer_config_from_env());
+  } else
+#endif
+  {
+    if (pcie_bdf) {
+      logger->error("DEVOURER_PCIE_BDF set but this build has DEVOURER_PCIE=OFF");
+      return 1;
+    }
+    std::shared_ptr<devourer::UsbDeviceLock> lock;
+    auto* handle = open_device(logger, &ctx, lock);
+    if (!handle) { if (ctx) libusb_exit(ctx); return 1; }
+    dev = wifi.CreateRtlDevice(handle, ctx, lock, devourer_config_from_env());
+  }
   if (!dev) { logger->error("no driver for this chip"); return 1; }
 
   if (c.role == timesync::Role::Ue) run_ue(dev.get(), c);

--- a/tests/pcie_ptp_beacon.cpp
+++ b/tests/pcie_ptp_beacon.cpp
@@ -1,0 +1,113 @@
+// pcie_ptp_beacon.cpp — the AP-beacon → PTP discipline loop, on a PCIe adapter.
+//
+// Runs a hardware beacon on the 8821CE and holds its TBTT to a network PTP
+// reference (the Intel I226 PHC, read directly via FD_TO_CLOCKID — nothing
+// disciplines the system clock). Uses PinBeaconTbtt (#245): an ABSOLUTE,
+// TSF-preserving actuator, so steering doesn't corrupt the ref=a*tsf+b fit the
+// loop reads — which lets a full-gain PI controller hold tight, unlike the
+// incremental AdjustBeaconTimingFine (which jumped the TSF ~5 ms/steer and drove
+// a PI into a limit cycle; the proportional-only sweet spot there was ~60 µs).
+//
+// Build (DEVOURER_PCIE=ON tree):
+//   g++ -std=c++20 -O2 -DDEVOURER_HAVE_PCIE -Isrc tests/pcie_ptp_beacon.cpp \
+//     build-pcie/libdevourer.a $(pkg-config --cflags --libs libusb-1.0) \
+//     -lpthread -o build-pcie/pcie_ptp_beacon
+// Run: sudo DEVOURER_PCIE_BDF=0000:01:00.0 DEVOURER_CHANNEL=6 REF_PTP=/dev/ptp0 \
+//        build-pcie/pcie_ptp_beacon [secs]
+#include <fcntl.h>
+#include <time.h>
+#include <cmath>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "PcieTransport.h"
+#include "SelectedChannel.h"
+#include "WiFiDriver.h"
+#include "logger.h"
+
+#define FD_TO_CLOCKID(fd) ((~(clockid_t)(fd) << 3) | 3)
+
+static int64_t phc_us(clockid_t c) {
+  struct timespec t; clock_gettime(c, &t);
+  return (int64_t)t.tv_sec * 1000000 + t.tv_nsec / 1000;
+}
+
+int main(int argc, char **argv) {
+  const char *bdf = std::getenv("DEVOURER_PCIE_BDF");
+  if (!bdf) { fprintf(stderr, "set DEVOURER_PCIE_BDF\n"); return 2; }
+  const char *ref = std::getenv("REF_PTP"); if (!ref) ref = "/dev/ptp0";
+  uint8_t ch = 6; if (const char *c = std::getenv("DEVOURER_CHANNEL")) ch = atoi(c);
+  int secs = argc > 1 ? atoi(argv[1]) : 180;
+  int interval_tu = 100; if (const char *i = std::getenv("BCN_TU")) interval_tu = atoi(i);
+  const int64_t interval = (int64_t)interval_tu * 1024;             // µs
+  double gain = 0.9; if (const char *g = std::getenv("GAIN")) gain = atof(g);
+  double ki = 0.10; if (const char *k = std::getenv("KI")) ki = atof(k);
+  double capture = 300; if (const char *ca = std::getenv("CAPTURE_US")) capture = atof(ca);
+  int loop_ms = 500; if (const char *l = std::getenv("LOOP_MS")) loop_ms = atoi(l);
+
+  int fd = open(ref, O_RDONLY);
+  if (fd < 0) { fprintf(stderr, "open %s failed\n", ref); return 1; }
+  clockid_t refclk = FD_TO_CLOCKID(fd);
+
+  auto logger = std::make_shared<Logger>();
+  auto t = devourer::PcieTransport::Open(bdf, logger);
+  if (!t) { fprintf(stderr, "pcie open failed\n"); return 1; }
+  WiFiDriver wifi(logger);
+  auto dev = wifi.CreateRtlDevicePcie(std::move(t));
+  if (!dev) { fprintf(stderr, "create failed\n"); return 1; }
+  dev->InitWrite(SelectedChannel{ch, 0, CHANNEL_WIDTH_20});
+
+  std::vector<uint8_t> bcn = {
+      0x80,0x00,0x00,0x00, 0xff,0xff,0xff,0xff,0xff,0xff,
+      0x57,0x42,0x75,0x05,0xd6,0x00, 0x57,0x42,0x75,0x05,0xd6,0x00, 0x00,0x00,
+      0,0,0,0,0,0,0,0,
+      (uint8_t)(interval_tu & 0xff), (uint8_t)(interval_tu >> 8), 0x00,0x00,
+      0x00,0x03,'P','T','P', 0x01,0x01,0x82};
+  if (!dev->StartBeacon(bcn.data(), bcn.size(), interval_tu)) {
+    fprintf(stderr, "StartBeacon UNSUPPORTED\n"); return 1;
+  }
+  dev->SetCcaMode(true);
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+
+  // running least-squares ref = a*tsf + b (offset coords) — stays clean because
+  // PinBeaconTbtt preserves the TSF timeline.
+  bool init = false; double x0 = 0, y0 = 0, sx = 0, sy = 0, sxx = 0, sxy = 0; long n = 0;
+  double cur = 0;                              // current commanded TBTT offset (µs into interval)
+  dev->PinBeaconTbtt(0);
+  double integ = 0;
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(secs);
+  while (std::chrono::steady_clock::now() < deadline) {
+    int64_t tsf = (int64_t)dev->ReadTsf();
+    int64_t r = phc_us(refclk);
+    if (!init) { x0 = tsf; y0 = r; init = true; }
+    double xi = tsf - x0, yi = r - y0;
+    ++n; sx += xi; sy += yi; sxx += xi * xi; sxy += xi * yi;
+    if (n >= 8) {
+      double den = n * sxx - sx * sx;
+      double a = den ? (n * sxy - sx * sy) / den : 1.0;
+      double b = (sy - a * sx) / n;
+      // next TBTT (TSF) with tsf ≡ cur (mod interval); its reference time via the fit
+      int64_t next_tbtt = ((int64_t)((tsf - (int64_t)cur) / interval) + 1) * interval + (int64_t)cur;
+      double tbtt_ref = y0 + a * (next_tbtt - x0) + b;
+      double e = fmod(tbtt_ref, (double)interval);
+      if (e > interval / 2.0) e -= interval; else if (e < -interval / 2.0) e += interval;
+      // PI (integral only near lock — anti-windup); full gain is safe now.
+      if (std::fabs(e) < capture) { integ += e; if (integ > 1500) integ = 1500; if (integ < -1500) integ = -1500; }
+      else integ = 0;
+      cur -= (gain * e + ki * integ);
+      cur = fmod(cur, (double)interval); if (cur < 0) cur += interval;   // normalize into period
+      int32_t applied = dev->PinBeaconTbtt((int32_t)llround(cur));
+      printf("{\"ev\":\"ptpbcn\",\"i\":%ld,\"phase_us\":%.1f,\"offset_us\":%.0f,\"applied\":%d,\"ppm\":%.1f}\n",
+             n, e, cur, applied, (a - 1.0) * 1e6);
+      fflush(stdout);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(loop_ms));
+  }
+  fprintf(stderr, "pcie_ptp_beacon: %ld iterations\n", n);
+  return 0;
+}


### PR DESCRIPTION
Closes the last three gaps around the wired-PTP → Wi-Fi-beacon time bridge.

## 1. PCIe master for `timesync` (`DEVOURER_PCIE_BDF`)

`examples/timesync` gains the vfio open path (txdemo pattern) — a PCIe adapter can now be the timesync master. Doc scoping kept honest: the ~12 µs submit-to-air floor is a *robust-fit transport* number; on a busy channel the raw software-downlink lock is deferral-limited regardless of bus (radxa bench, crowded ch6: 420 µs RMS — and the radxa↔bench RF path only reaches on 2.4 GHz). PCIe masters should prefer the hardware beacon, which is transport-free anyway.

## 2. `tests/pcie_ptp_beacon.cpp` lands

The AP-beacon → network-PTP discipline loop on the 8821CE: hardware beacon held to the I226 PHC (read via `FD_TO_CLOCKID` — no system-clock detour) with a full-gain PI on the `PinBeaconTbtt` actuator. This is the tool #245 was built for, now in-tree with build/run instructions in the header.

## 3. End-to-end integration bench (everything concurrent)

Radxa discipline loop + a USB slave locking over the air, at the same time:

| link in the chain | measured |
|---|---|
| radxa TBTT vs the I226 PTP reference | **1.24 µs RMS**, max 5.5 µs (156 pins, ~90 s) |
| USB slave lock through the live discipline | 13.9 µs RMS (575 beacons, ~0 lost through 160+ pins) |

The slave caveat is documented: its all-history least-squares fit assumes a free-running master, so it measures the discipline corrections themselves — a PLL-style tracking filter at the slave would follow the pinned timebase tighter.

`ctest` 17/17; USB build byte-identical when `DEVOURER_PCIE=OFF` (the new path is `#if defined(DEVOURER_HAVE_PCIE)`-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)