### PR TITLE
Discover composite Wi-Fi interfaces and standardize RX FCS

### DIFF
--- a/examples/doctor/main.cpp
+++ b/examples/doctor/main.cpp
@@ -203,7 +203,7 @@ int main(int argc, char **argv) {
   }
 
   std::shared_ptr<devourer::UsbDeviceLock> lock;
-  if (devourer::claim_interface_then_reset(handle, 0, logger, true, lock) !=
+  if (devourer::claim_interface_then_reset(handle, devourer::find_wifi_interface(handle), logger, true, lock) !=
       0) {
     libusb_close(handle);
     libusb_exit(ctx);

--- a/examples/duplex/main.cpp
+++ b/examples/duplex/main.cpp
@@ -346,8 +346,7 @@ int main(int argc, char **argv) {
    * guard — a second devourer on this adapter gets BUSY here and bails before
    * the reset, so it can't re-enumerate the adapter out from under the owner. */
   std::shared_ptr<devourer::UsbDeviceLock> usb_lock;
-  rc = devourer::claim_interface_then_reset(
-      handle, 0, logger,
+  rc = devourer::claim_interface_then_reset(handle, devourer::find_wifi_interface(handle), logger,
       termux_fd == 0 && std::getenv("DEVOURER_SKIP_RESET") == nullptr, usb_lock);
   if (rc != 0) {
     libusb_close(handle);

--- a/examples/precoder/main.cpp
+++ b/examples/precoder/main.cpp
@@ -199,8 +199,7 @@ int main(int argc, char **argv) {
    * guard — a second devourer on this adapter gets BUSY here and bails before
    * the reset, so it can't re-enumerate the adapter out from under the owner. */
   std::shared_ptr<devourer::UsbDeviceLock> usb_lock;
-  rc = devourer::claim_interface_then_reset(
-      handle, 0, logger,
+  rc = devourer::claim_interface_then_reset(handle, devourer::find_wifi_interface(handle), logger,
       termux_fd == 0 && std::getenv("DEVOURER_SKIP_RESET") == nullptr, usb_lock);
   if (rc != 0) {
     libusb_close(handle);

--- a/examples/rx/main.cpp
+++ b/examples/rx/main.cpp
@@ -1011,8 +1011,7 @@ int main() {
    * still suppresses the reset for a warm pickup (firmware already running).
    * See src/UsbOpen.h. */
   std::shared_ptr<devourer::UsbDeviceLock> usb_lock;
-  rc = devourer::claim_interface_then_reset(
-      dev_handle, 0, logger, std::getenv("DEVOURER_SKIP_RESET") == nullptr,
+  rc = devourer::claim_interface_then_reset(dev_handle, devourer::find_wifi_interface(dev_handle), logger, std::getenv("DEVOURER_SKIP_RESET") == nullptr,
       usb_lock);
   devourer::Ev(*g_ev, "init.timing")
       .f("stage", "demo.usb_reset")

--- a/examples/sense/main.cpp
+++ b/examples/sense/main.cpp
@@ -348,7 +348,8 @@ static bool open_adapter(Adapter &a, uint16_t vid, uint16_t pid,
                   vid, pid);
     return false;
   }
-  int rc = devourer::claim_interface_then_reset(a.handle, 0, logger, true, a.lock);
+  int rc = devourer::claim_interface_then_reset(
+      a.handle, devourer::find_wifi_interface(a.handle), logger, true, a.lock);
   if (rc != 0)
     return false;
   WiFiDriver driver(logger);

--- a/examples/streamtx/main.cpp
+++ b/examples/streamtx/main.cpp
@@ -195,8 +195,7 @@ int main(int argc, char **argv) {
    * guard — a second devourer on this adapter gets BUSY here and bails before
    * the reset, so it can't re-enumerate the adapter out from under the owner. */
   std::shared_ptr<devourer::UsbDeviceLock> usb_lock;
-  rc = devourer::claim_interface_then_reset(
-      handle, 0, logger,
+  rc = devourer::claim_interface_then_reset(handle, devourer::find_wifi_interface(handle), logger,
       termux_fd == 0 && std::getenv("DEVOURER_SKIP_RESET") == nullptr, usb_lock);
   if (rc != 0) {
     libusb_close(handle);

--- a/examples/svctx/main.cpp
+++ b/examples/svctx/main.cpp
@@ -152,8 +152,7 @@ int main(int argc, char** argv) {
    * guard — a second devourer on this adapter gets BUSY here and bails before
    * the reset, so it can't re-enumerate the adapter out from under the owner. */
   std::shared_ptr<devourer::UsbDeviceLock> usb_lock;
-  rc = devourer::claim_interface_then_reset(
-      handle, 0, logger,
+  rc = devourer::claim_interface_then_reset(handle, devourer::find_wifi_interface(handle), logger,
       termux_fd == 0 && std::getenv("DEVOURER_SKIP_RESET") == nullptr, usb_lock);
   if (rc != 0) {
     libusb_close(handle);

--- a/examples/tdma/main.cpp
+++ b/examples/tdma/main.cpp
@@ -93,8 +93,7 @@ static libusb_device_handle* open_device(
   }
   if (!h && pid != 0) h = libusb_open_device_with_vid_pid(*ctx, vid, pid);
   if (!h) { logger->error("no device {:04x}:{:04x}", vid, pid); return nullptr; }
-  if (devourer::claim_interface_then_reset(
-          h, 0, logger, std::getenv("DEVOURER_SKIP_RESET") == nullptr, lock) != 0) {
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, std::getenv("DEVOURER_SKIP_RESET") == nullptr, lock) != 0) {
     logger->error("claim failed (busy?)");
     return nullptr;
   }

--- a/examples/timesync/main.cpp
+++ b/examples/timesync/main.cpp
@@ -92,8 +92,7 @@ static libusb_device_handle* open_device(
   }
   if (!h && pid != 0) h = libusb_open_device_with_vid_pid(*ctx, vid, pid);
   if (!h) { logger->error("no device {:04x}:{:04x}", vid, pid); return nullptr; }
-  if (devourer::claim_interface_then_reset(
-          h, 0, logger, std::getenv("DEVOURER_SKIP_RESET") == nullptr, lock) != 0) {
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, std::getenv("DEVOURER_SKIP_RESET") == nullptr, lock) != 0) {
     logger->error("claim failed (busy?)");
     return nullptr;
   }

--- a/examples/tx/main.cpp
+++ b/examples/tx/main.cpp
@@ -316,8 +316,7 @@ int main(int argc, char **argv) {
      * bail here before the reset, so it can't re-enumerate the adapter out from
      * under the owner. Reset skipped in termux_mode (forked child shares the
      * fd) and for DEVOURER_SKIP_RESET (warm pickup). */
-    rc = devourer::claim_interface_then_reset(
-        handle, 0, logger,
+    rc = devourer::claim_interface_then_reset(handle, devourer::find_wifi_interface(handle), logger,
         !termux_mode && std::getenv("DEVOURER_SKIP_RESET") == nullptr, usb_lock);
     devourer::Ev(*g_ev, "init.timing")
         .f("stage", "txdemo.usb_reset")

--- a/examples/txpower/main.cpp
+++ b/examples/txpower/main.cpp
@@ -208,7 +208,7 @@ int main(int argc, char **argv) {
   }
 
   std::shared_ptr<devourer::UsbDeviceLock> lock;
-  if (devourer::claim_interface_then_reset(handle, 0, logger, true, lock) !=
+  if (devourer::claim_interface_then_reset(handle, devourer::find_wifi_interface(handle), logger, true, lock) !=
       0) {
     libusb_close(handle);
     libusb_exit(ctx);

--- a/src/RxPacket.h
+++ b/src/RxPacket.h
@@ -79,6 +79,8 @@ struct rx_pkt_attrib
 struct Packet
 {
     rx_pkt_attrib RxAtrib;
+    /* Full 802.11 frame including the trailing FCS. Every Realtek RX parser
+     * follows this contract */
     std::span<uint8_t> Data;
 
     /* The transmitter's hardware TX-egress TSF, when the frame carries one.

--- a/src/RxPacket.h
+++ b/src/RxPacket.h
@@ -80,7 +80,11 @@ struct Packet
 {
     rx_pkt_attrib RxAtrib;
     /* Full 802.11 frame including the trailing FCS. Every Realtek RX parser
-     * follows this contract */
+     * follows this contract; consumers remove the FCS at their protocol
+     * boundary rather than making the frame length chip-specific. Retaining it
+     * also lets DEVOURER_RX_KEEP_CORRUPTED and fused-FEC salvage inspect a
+     * failed frame, while tools/bf_report_decode.py trims the trailing four
+     * bytes when decoding beamforming reports. */
     std::span<uint8_t> Data;
 
     /* The transmitter's hardware TX-egress TSF, when the frame carries one.

--- a/src/UsbOpen.cpp
+++ b/src/UsbOpen.cpp
@@ -12,6 +12,61 @@
 
 namespace devourer {
 
+int find_wifi_interface(libusb_device_handle *handle) {
+  if (handle == nullptr)
+    return 0;
+
+  libusb_device *device = libusb_get_device(handle);
+  libusb_device_descriptor device_descriptor{};
+  if (libusb_get_device_descriptor(device, &device_descriptor) != LIBUSB_SUCCESS)
+    return 0;
+
+  for (uint8_t config_index = 0;
+       config_index < device_descriptor.bNumConfigurations; ++config_index) {
+    libusb_config_descriptor *config = nullptr;
+    if (libusb_get_config_descriptor(device, config_index, &config) !=
+        LIBUSB_SUCCESS)
+      continue;
+
+    for (uint8_t interface_index = 0;
+         interface_index < config->bNumInterfaces; ++interface_index) {
+      const libusb_interface *interface = &config->interface[interface_index];
+      if (interface->num_altsetting == 0)
+        continue;
+
+      /* libusb uses altsetting 0 unless a caller explicitly selects another.
+       * Match that active layout rather than discovering endpoints that are not
+       * live on the wire. */
+      const libusb_interface_descriptor *candidate = &interface->altsetting[0];
+      if (candidate->bInterfaceClass != LIBUSB_CLASS_VENDOR_SPEC)
+        continue;
+
+      bool has_bulk_in = false;
+      bool has_bulk_out = false;
+      for (uint8_t endpoint_index = 0;
+           endpoint_index < candidate->bNumEndpoints; ++endpoint_index) {
+        const libusb_endpoint_descriptor *endpoint =
+            &candidate->endpoint[endpoint_index];
+        if ((endpoint->bmAttributes & LIBUSB_TRANSFER_TYPE_MASK) !=
+            LIBUSB_TRANSFER_TYPE_BULK)
+          continue;
+        if (endpoint->bEndpointAddress & LIBUSB_ENDPOINT_IN)
+          has_bulk_in = true;
+        else
+          has_bulk_out = true;
+      }
+      if (has_bulk_in && has_bulk_out) {
+        const int interface_number = candidate->bInterfaceNumber;
+        libusb_free_config_descriptor(config);
+        return interface_number;
+      }
+    }
+    libusb_free_config_descriptor(config);
+  }
+
+  return 0;
+}
+
 int claim_interface_then_reset(libusb_device_handle *handle, int iface,
                                const Logger_t &logger, bool do_reset,
                                std::shared_ptr<UsbDeviceLock> &out_lock,

--- a/src/UsbOpen.h
+++ b/src/UsbOpen.h
@@ -12,6 +12,13 @@ namespace devourer {
 
 class UsbDeviceLock;
 
+/* Return the vendor Wi-Fi interface that owns bulk IN and OUT endpoints. This
+ * must run before claim_interface_then_reset(): composite RTL8822BU adapters
+ * expose Bluetooth on interfaces 0/1 and Wi-Fi on interface 2. Fall back to
+ * interface 0 for legacy single-interface adapters whose descriptor does not
+ * identify a vendor bulk interface. */
+int find_wifi_interface(libusb_device_handle *handle);
+
 /* Prepare an already-opened USB handle for use with the OS-friendly ordering —
  * *lock and claim before reset*:
  *

--- a/src/UsbTransport.cpp
+++ b/src/UsbTransport.cpp
@@ -46,6 +46,11 @@ UsbTransport::UsbTransport(libusb_device_handle *dev_handle, Logger_t logger,
     _info.pid = desc.idProduct;
     _logger->info("USB device {:04x}:{:04x}", _info.vid, _info.pid);
   }
+  // Endpoint addresses are not stable across Realtek USB variants. In
+  // particular, RTL8822BU/"RTL8812BU" is composite: interfaces 0 and 1 are
+  // Bluetooth, while Wi-Fi uses interface 2 with bulk IN endpoint 0x84 rather
+  // than the 0x81 used by RTL8812AU. Discovering the active bulk interface is
+  // therefore required before firmware download, RX, or TX can work.
   discover_endpoints();
   _info.valid = true;
 }
@@ -189,16 +194,42 @@ void UsbTransport::discover_endpoints() {
       continue;
     }
 
-    if (!config->bNumInterfaces) {
-      continue;
+    // Do not assume config->interface[0]. Composite adapters expose Bluetooth
+    // first; select the vendor Wi-Fi interface by its bulk IN and OUT pipes.
+    const libusb_interface_descriptor *interface_desc = nullptr;
+    for (uint8_t interface_index = 0;
+         interface_index < config->bNumInterfaces && interface_desc == nullptr;
+         interface_index++) {
+      const libusb_interface *interface = &config->interface[interface_index];
+      for (int alt_index = 0; alt_index < interface->num_altsetting;
+           alt_index++) {
+        const libusb_interface_descriptor *candidate =
+            &interface->altsetting[alt_index];
+        bool has_bulk_in = false;
+        bool has_bulk_out = false;
+        for (uint8_t endpoint_index = 0;
+             endpoint_index < candidate->bNumEndpoints; endpoint_index++) {
+          const libusb_endpoint_descriptor *endpoint =
+              &candidate->endpoint[endpoint_index];
+          if ((endpoint->bmAttributes & LIBUSB_TRANSFER_TYPE_MASK) !=
+              LIBUSB_TRANSFER_TYPE_BULK)
+            continue;
+          if (endpoint->bEndpointAddress & LIBUSB_ENDPOINT_IN)
+            has_bulk_in = true;
+          else
+            has_bulk_out = true;
+        }
+        if (candidate->bInterfaceClass == LIBUSB_CLASS_VENDOR_SPEC &&
+            has_bulk_in && has_bulk_out)
+          interface_desc = candidate;
+      }
     }
-    const libusb_interface *interface = &config->interface[0];
 
-    if (!interface->altsetting) {
+    if (interface_desc == nullptr) {
+      libusb_free_config_descriptor(config);
       continue;
     }
-    const libusb_interface_descriptor *interface_desc =
-        &interface->altsetting[0];
+    _logger->info("selected USB interface {}", interface_desc->bInterfaceNumber);
 
     bool found_bulk_in = false;
     for (uint8_t j = 0; j < interface_desc->bNumEndpoints; j++) {

--- a/src/UsbTransport.cpp
+++ b/src/UsbTransport.cpp
@@ -8,6 +8,7 @@
 
 #include "Event.h"
 #include "UsbDeviceLock.h"
+#include "UsbOpen.h"
 
 namespace devourer {
 
@@ -195,34 +196,18 @@ void UsbTransport::discover_endpoints() {
     }
 
     // Do not assume config->interface[0]. Composite adapters expose Bluetooth
-    // first; select the vendor Wi-Fi interface by its bulk IN and OUT pipes.
+    // first; reuse the interface selected before the caller claimed the device.
     const libusb_interface_descriptor *interface_desc = nullptr;
+    const int wifi_interface = find_wifi_interface(_dev_handle);
     for (uint8_t interface_index = 0;
          interface_index < config->bNumInterfaces && interface_desc == nullptr;
          interface_index++) {
       const libusb_interface *interface = &config->interface[interface_index];
-      for (int alt_index = 0; alt_index < interface->num_altsetting;
-           alt_index++) {
-        const libusb_interface_descriptor *candidate =
-            &interface->altsetting[alt_index];
-        bool has_bulk_in = false;
-        bool has_bulk_out = false;
-        for (uint8_t endpoint_index = 0;
-             endpoint_index < candidate->bNumEndpoints; endpoint_index++) {
-          const libusb_endpoint_descriptor *endpoint =
-              &candidate->endpoint[endpoint_index];
-          if ((endpoint->bmAttributes & LIBUSB_TRANSFER_TYPE_MASK) !=
-              LIBUSB_TRANSFER_TYPE_BULK)
-            continue;
-          if (endpoint->bEndpointAddress & LIBUSB_ENDPOINT_IN)
-            has_bulk_in = true;
-          else
-            has_bulk_out = true;
-        }
-        if (candidate->bInterfaceClass == LIBUSB_CLASS_VENDOR_SPEC &&
-            has_bulk_in && has_bulk_out)
-          interface_desc = candidate;
-      }
+      if (interface->num_altsetting == 0)
+        continue;
+      const libusb_interface_descriptor *candidate = &interface->altsetting[0];
+      if (candidate->bInterfaceNumber == wifi_interface)
+        interface_desc = candidate;
     }
 
     if (interface_desc == nullptr) {

--- a/src/jaguar2/HalJaguar2.cpp
+++ b/src/jaguar2/HalJaguar2.cpp
@@ -2298,7 +2298,7 @@ void HalJaguar2::enable_rx() {
    * (rtw88's own default RCR never sets them). Injected canonical-SA beacons
    * passed even WITH the bits set, which is how regress.py stayed green while
    * every real AP's beacons were silently dropped. */
-  uint32_t rcr = 0x7000002Fu;
+  uint32_t rcr = 0xF000002Fu;
   /* 8821C: drop APP_PHYST_RXFF (BIT28). The 8821C appends a 32-byte PHY-status
    * block before each RX frame in the RXFF, but its RX descriptor reports
    * drv_info_size=0 (unlike the 8822B, which counts it) — so the shared parser

--- a/src/jaguar2/HalJaguar2.cpp
+++ b/src/jaguar2/HalJaguar2.cpp
@@ -2286,6 +2286,9 @@ void HalJaguar2::enable_rx() {
   _device.rtw_write16(0x0100, 0x06FF);
   /* Promiscuous RX for monitor: the vendor monitor RCR (hal_com.c:
    * RCR_AAP|APM|AM|AB|APWRMGT|APP_PHYST_RXFF|APP_MIC|APP_ICV = 0x7000002F)
+   * plus APP_FCS (BIT31) = 0xF000002F. Jaguar1 already uses RCR_APPFCS and
+   * Jaguar3 has BIT31 in RCR 0xF410400F; this parity makes Packet::Data carry
+   * the trailing FCS on every Realtek generation.
    * WITHOUT the legacy "accept" trio at bits 11/12/13. On this MAC generation
    * those are NOT the Jaguar1 ADF/ACF/AMF accept bits — rtw88 reg.h names
    * BIT(11) BIT_TA_BCN (TA-gated beacon accept) and BIT(12)

--- a/tests/ap_responder.cpp
+++ b/tests/ap_responder.cpp
@@ -244,7 +244,7 @@ int main(int argc, char** argv) {
   auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
   if (!h) { fprintf(stderr, "open %04x:%04x fail\n", vid, pid); return 1; }
   std::shared_ptr<devourer::UsbDeviceLock> lk;
-  if (devourer::claim_interface_then_reset(h, 0, logger, true, lk) != 0) return 1;
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, true, lk) != 0) return 1;
   WiFiDriver wifi(logger);
   auto dev = wifi.CreateRtlDevice(h, ctx, lk, devourer_config_from_env());
   g_dev = dev.get();

--- a/tests/ap_wpa2.cpp
+++ b/tests/ap_wpa2.cpp
@@ -392,7 +392,7 @@ int main(int argc, char** argv) {
   auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
   if (!h) { fprintf(stderr, "open %04x:%04x fail\n", vid, pid); return 1; }
   std::shared_ptr<devourer::UsbDeviceLock> lk;
-  if (devourer::claim_interface_then_reset(h, 0, logger, true, lk) != 0) return 1;
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, true, lk) != 0) return 1;
   WiFiDriver wifi(logger);
   auto dev = wifi.CreateRtlDevice(h, ctx, lk, devourer_config_from_env());
   g_dev = dev.get(); if (!g_dev) return 1;

--- a/tests/beacon_fullbody.cpp
+++ b/tests/beacon_fullbody.cpp
@@ -76,7 +76,7 @@ int main(int argc, char** argv) {
   auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
   if (!h) { fprintf(stderr, "open %04x:%04x failed\n", vid, pid); return 1; }
   std::shared_ptr<devourer::UsbDeviceLock> lock;
-  if (devourer::claim_interface_then_reset(h, 0, logger, true, lock) != 0) return 1;
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, true, lock) != 0) return 1;
   WiFiDriver wifi(logger);
   auto dev = wifi.CreateRtlDevice(h, ctx, lock, devourer_config_from_env());
   if (!dev) { fprintf(stderr, "no driver\n"); return 1; }

--- a/tests/beacon_interval_shift.sh
+++ b/tests/beacon_interval_shift.sh
@@ -77,7 +77,7 @@ int main(int argc,char**argv){
   auto*h=libusb_open_device_with_vid_pid(ctx,vid,pid);
   if(!h){fprintf(stderr,"master open fail\n");return 1;}
   std::shared_ptr<devourer::UsbDeviceLock> lk;
-  if(devourer::claim_interface_then_reset(h,0,logger,true,lk)!=0)return 1;
+  if(devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h),logger,true,lk)!=0)return 1;
   WiFiDriver wifi(logger);
   auto dev=wifi.CreateRtlDevice(h,ctx,lk,devourer_config_from_env());
   if(!dev)return 1;
@@ -135,7 +135,7 @@ int main(){
   auto*h=libusb_open_device_with_vid_pid(ctx,vid,pid);
   if(!h){fprintf(stderr,"obs open fail\n");return 1;}
   std::shared_ptr<devourer::UsbDeviceLock> lk;
-  if(devourer::claim_interface_then_reset(h,0,logger,true,lk)!=0)return 1;
+  if(devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h),logger,true,lk)!=0)return 1;
   WiFiDriver wifi(logger);
   auto dev=wifi.CreateRtlDevice(h,ctx,lk,devourer_config_from_env());
   if(!dev)return 1;

--- a/tests/beacon_steer_check.cpp
+++ b/tests/beacon_steer_check.cpp
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
     auto *h = libusb_open_device_with_vid_pid(ctx, vid, pid);
     if (!h) { fprintf(stderr, "open %04x:%04x failed\n", vid, pid); return 1; }
     std::shared_ptr<devourer::UsbDeviceLock> lock;
-    if (devourer::claim_interface_then_reset(h, 0, logger, true, lock) != 0)
+    if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, true, lock) != 0)
       return 1;
     dev = wifi.CreateRtlDevice(h, ctx, lock, devourer_config_from_env());
   }

--- a/tests/beacon_steer_survival.sh
+++ b/tests/beacon_steer_survival.sh
@@ -74,7 +74,7 @@ int main(int argc,char**argv){
   auto*h=libusb_open_device_with_vid_pid(ctx,vid,pid);
   if(!h){fprintf(stderr,"obs open %04x:%04x fail\n",vid,pid);return 1;}
   std::shared_ptr<devourer::UsbDeviceLock> lk;
-  if(devourer::claim_interface_then_reset(h,0,logger,true,lk)!=0)return 1;
+  if(devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h),logger,true,lk)!=0)return 1;
   WiFiDriver wifi(logger);
   auto dev=wifi.CreateRtlDevice(h,ctx,lk,devourer_config_from_env());
   if(!dev)return 1;

--- a/tests/beacon_tbtt.cpp
+++ b/tests/beacon_tbtt.cpp
@@ -43,7 +43,7 @@ int main(int argc, char** argv) {
   auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
   if (!h) { fprintf(stderr, "open %04x:%04x failed\n", vid, pid); return 1; }
   std::shared_ptr<devourer::UsbDeviceLock> lock;
-  if (devourer::claim_interface_then_reset(h, 0, logger, true, lock) != 0) return 1;
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, true, lock) != 0) return 1;
   WiFiDriver wifi(logger);
   auto dev = wifi.CreateRtlDevice(h, ctx, lock, devourer_config_from_env());
   if (!dev) { fprintf(stderr, "no driver\n"); return 1; }

--- a/tests/beacon_ts_check.cpp
+++ b/tests/beacon_ts_check.cpp
@@ -32,7 +32,7 @@ int main() {
   auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
   if (!h) { fprintf(stderr, "open fail\n"); return 1; }
   std::shared_ptr<devourer::UsbDeviceLock> lk;
-  if (devourer::claim_interface_then_reset(h, 0, logger, true, lk) != 0) return 1;
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, true, lk) != 0) return 1;
   WiFiDriver wifi(logger);
   auto dev = wifi.CreateRtlDevice(h, ctx, lk, devourer_config_from_env());
   if (!dev) return 1;

--- a/tests/beacon_update_probe.cpp
+++ b/tests/beacon_update_probe.cpp
@@ -137,7 +137,7 @@ int main(int argc, char** argv) {
   auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
   if (!h) { fprintf(stderr, "open %04x:%04x failed\n", vid, pid); return 1; }
   std::shared_ptr<devourer::UsbDeviceLock> lock;
-  if (devourer::claim_interface_then_reset(h, 0, logger, true, lock) != 0)
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, true, lock) != 0)
     return 1;
   WiFiDriver wifi(logger);
   auto dev = wifi.CreateRtlDevice(h, ctx, lock, devourer_config_from_env());

--- a/tests/beacon_wire_check.cpp
+++ b/tests/beacon_wire_check.cpp
@@ -47,7 +47,7 @@ int main() {
   auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
   if (!h) { fprintf(stderr, "open fail\n"); return 1; }
   std::shared_ptr<devourer::UsbDeviceLock> lk;
-  if (devourer::claim_interface_then_reset(h, 0, logger, true, lk) != 0) return 1;
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, true, lk) != 0) return 1;
   WiFiDriver wifi(logger);
   auto dev = wifi.CreateRtlDevice(h, ctx, lk, devourer_config_from_env());
   if (!dev) return 1;

--- a/tests/dl_departure_tx.cpp
+++ b/tests/dl_departure_tx.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
   auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
   if (!h) { fprintf(stderr, "open fail %04x:%04x\n", vid, pid); return 1; }
   std::shared_ptr<devourer::UsbDeviceLock> lk;
-  if (devourer::claim_interface_then_reset(h, 0, logger, true, lk) != 0) return 1;
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, true, lk) != 0) return 1;
   WiFiDriver wifi(logger);
   auto dev = wifi.CreateRtlDevice(h, ctx, lk, devourer_config_from_env());
   if (!dev) return 1;

--- a/tests/fast_bw_rxcheck.cpp
+++ b/tests/fast_bw_rxcheck.cpp
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
   auto *h = libusb_open_device_with_vid_pid(ctx, vid, pid);
   if (!h) { fprintf(stderr, "open %04x:%04x failed\n", vid, pid); return 1; }
   std::shared_ptr<devourer::UsbDeviceLock> lock;
-  if (devourer::claim_interface_then_reset(h, 0, logger, true, lock) != 0) return 1;
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, true, lock) != 0) return 1;
   WiFiDriver wifi(logger);
   auto dev = wifi.CreateRtlDevice(h, ctx, lock, devourer_config_from_env());
   if (!dev) return 1;

--- a/tests/probe_responder.cpp
+++ b/tests/probe_responder.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
   auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
   if (!h) { fprintf(stderr, "open %04x:%04x fail\n", vid, pid); return 1; }
   std::shared_ptr<devourer::UsbDeviceLock> lk;
-  if (devourer::claim_interface_then_reset(h, 0, logger, true, lk) != 0) return 1;
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, true, lk) != 0) return 1;
   WiFiDriver wifi(logger);
   auto dev = wifi.CreateRtlDevice(h, ctx, lk, devourer_config_from_env());
   g_dev = dev.get();

--- a/tests/reglat.cpp
+++ b/tests/reglat.cpp
@@ -81,7 +81,7 @@ int main() {
     return 1;
   }
   std::shared_ptr<devourer::UsbDeviceLock> lk;
-  if (devourer::claim_interface_then_reset(h, 0, lg, true, lk) != 0) return 1;
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), lg, true, lk) != 0) return 1;
   RtlAdapter a(h, lg, ctx, lk, {});
   report("USB ctrl-xfer", a);
   return 0;

--- a/tests/retune_bench.cpp
+++ b/tests/retune_bench.cpp
@@ -57,8 +57,7 @@ int main(int argc, char **argv) {
   if (!h) { fprintf(stderr, "open %04x:%04x failed\n", vid, pid); return 1; }
 
   std::shared_ptr<devourer::UsbDeviceLock> lock;
-  if (devourer::claim_interface_then_reset(
-          h, 0, logger, std::getenv("DEVOURER_SKIP_RESET") == nullptr, lock) != 0) {
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, std::getenv("DEVOURER_SKIP_RESET") == nullptr, lock) != 0) {
     fprintf(stderr, "claim failed (adapter busy?)\n");
     return 1;
   }

--- a/tests/tsf_probe.cpp
+++ b/tests/tsf_probe.cpp
@@ -52,7 +52,7 @@ int main(int argc, char** argv) {
   auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
   if (!h) { fprintf(stderr, "open %04x:%04x failed\n", vid, pid); return 1; }
   std::shared_ptr<devourer::UsbDeviceLock> lock;
-  if (devourer::claim_interface_then_reset(h, 0, logger, true, lock) != 0) return 1;
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, true, lock) != 0) return 1;
   WiFiDriver wifi(logger);
   auto dev = wifi.CreateRtlDevice(h, ctx, lock, devourer_config_from_env());
   if (!dev) return 1;

--- a/tests/tsf_tdoa_probe.cpp
+++ b/tests/tsf_tdoa_probe.cpp
@@ -70,7 +70,7 @@ static libusb_device_handle* open_pid(libusb_context* ctx, uint16_t vid,
                                        std::shared_ptr<devourer::UsbDeviceLock>& lk) {
   auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
   if (!h) { fprintf(stderr, "open %04x:%04x failed\n", vid, pid); return nullptr; }
-  if (devourer::claim_interface_then_reset(h, 0, lg, true, lk) != 0) {
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), lg, true, lk) != 0) {
     fprintf(stderr, "claim %04x:%04x failed\n", vid, pid); return nullptr;
   }
   return h;

--- a/tests/txegress_witness.cpp
+++ b/tests/txegress_witness.cpp
@@ -67,7 +67,7 @@ int main(int argc, char** argv) {
   auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
   if (!h) { fprintf(stderr, "open fail %04x:%04x\n", vid, pid); return 1; }
   std::shared_ptr<devourer::UsbDeviceLock> lk;
-  if (devourer::claim_interface_then_reset(h, 0, logger, true, lk) != 0) return 1;
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, true, lk) != 0) return 1;
   WiFiDriver wifi(logger);
   auto dev = wifi.CreateRtlDevice(h, ctx, lk, devourer_config_from_env());
   if (!dev) return 1;

--- a/tests/ue_rx_probe.cpp
+++ b/tests/ue_rx_probe.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
   auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
   if (!h) { fprintf(stderr, "open fail %04x:%04x\n", vid, pid); return 1; }
   std::shared_ptr<devourer::UsbDeviceLock> lk;
-  if (devourer::claim_interface_then_reset(h, 0, logger, true, lk) != 0) return 1;
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, true, lk) != 0) return 1;
   WiFiDriver wifi(logger);
   auto dev = wifi.CreateRtlDevice(h, ctx, lk, devourer_config_from_env());
   if (!dev) return 1;


### PR DESCRIPTION
RTL8822BU support and standardize RX FCS

- discover the Wi-Fi bulk interface/endpoints on composite BT/Wi-Fi adapters
- retain the trailing FCS in Packet::Data across Realtek RX paths
- enable APPFCS for Jaguar2 monitor reception


<img width="409" height="361" alt="image" src="https://github.com/user-attachments/assets/bbeaf4a4-e10e-4beb-93df-327090fef216" />

Tested in PixelPilot and hx-esp32-cam android gs.