### PR TITLE
radiotap TX: honour HT LDPC/STBC known bits on Jaguar2/3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,6 +459,11 @@ target_link_libraries(ToneMaskSelftest PRIVATE devourer)
 
 add_test(NAME tone_mask_math COMMAND ToneMaskSelftest)
 
+add_executable(RadiotapTxFlagsSelftest tests/radiotap_txflags_selftest.cpp)
+target_compile_features(RadiotapTxFlagsSelftest PRIVATE cxx_std_20)
+target_link_libraries(RadiotapTxFlagsSelftest PRIVATE devourer)
+add_test(NAME radiotap_txflags COMMAND RadiotapTxFlagsSelftest)
+
 # Headless guard for the burst-TDMA example's pure logic (examples/tdma/tdma.h):
 # the TsfClock host<->TSF least-squares fit, the frame-tag round-trip, and the
 # schedule phase math. No hardware — the tsf_probe / tsf_tdoa_probe /

--- a/src/RadiotapTxFlags.h
+++ b/src/RadiotapTxFlags.h
@@ -1,0 +1,45 @@
+#pragma once
+
+/* Decoded view of the 3-byte radiotap MCS field (known, flags, index) on the
+ * TX/inject path — one shared reading for the per-generation send_packet
+ * parsers, so the HT LDPC/STBC known/flag bits can't silently diverge again
+ * (J2/J3 historically ignored them; only the VHT case honoured them; J1
+ * carried its own correct copy). Bit positions per the radiotap MCS spec and
+ * RadiotapBuilder::build_ht. */
+
+#include <cstdint>
+
+extern "C" {
+#include "ieee80211_radiotap.h"
+}
+
+namespace devourer {
+
+struct RadiotapMcsField {
+  bool have_mcs = false;
+  uint8_t mcs = 0;   /* HT MCS index 0..31, valid when have_mcs */
+  bool bw40 = false; /* MCS BW subfield == 40 MHz */
+  uint8_t sgi = 0;
+  uint8_t ldpc = 0;
+  uint8_t stbc = 0;  /* STBC stream count 0..3 */
+};
+
+inline RadiotapMcsField decode_radiotap_mcs_field(const uint8_t *arg) {
+  RadiotapMcsField f;
+  const uint8_t known = arg[0];
+  const uint8_t flags = arg[1];
+  if ((flags & IEEE80211_RADIOTAP_MCS_BW_MASK) == IEEE80211_RADIOTAP_MCS_BW_40)
+    f.bw40 = true;
+  f.sgi = (flags & 0x04) ? 1 : 0;
+  if ((known & 0x10) && (flags & 0x10)) /* FEC-type known + LDPC flag */
+    f.ldpc = 1;
+  if (known & 0x20) /* STBC known: flags bits [6:5] = stream count */
+    f.stbc = (flags >> 5) & 0x3;
+  if ((known & IEEE80211_RADIOTAP_MCS_HAVE_MCS) && arg[2] <= 31) {
+    f.have_mcs = true;
+    f.mcs = arg[2];
+  }
+  return f;
+}
+
+}  // namespace devourer

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -15,6 +15,7 @@
 
 #include "AckResponder.h"
 #include "RadiotapPeek.h"
+#include "RadiotapTxFlags.h" /* HT MCS field decoder (LDPC/STBC) */
 #include "TxAggPlan.h"
 #include "TxReport.h"
 
@@ -1221,17 +1222,16 @@ size_t RtlJaguar2Device::build_tx_block(const uint8_t *packet, size_t length,
       radiotap_pkt_pwr_db = static_cast<int8_t>(*it.this_arg);
       break;
     case IEEE80211_RADIOTAP_MCS: {
-      uint8_t mcs_flags = it.this_arg[1];
-      if ((mcs_flags & IEEE80211_RADIOTAP_MCS_BW_MASK) ==
-          IEEE80211_RADIOTAP_MCS_BW_40)
+      const devourer::RadiotapMcsField m =
+          devourer::decode_radiotap_mcs_field(it.this_arg);
+      if (m.bw40)
         bwidth = CHANNEL_WIDTH_40;
-      sgi = (mcs_flags & 0x04) ? 1 : 0;
-      if (it.this_arg[0] & IEEE80211_RADIOTAP_MCS_HAVE_MCS) {
-        uint8_t idx = it.this_arg[2];
-        if (idx <= 31) {
-          fixed_rate = MGN_MCS0 + idx;
-          rate_from_radiotap = true;
-        }
+      sgi = m.sgi;
+      ldpc = m.ldpc;
+      stbc = m.stbc;
+      if (m.have_mcs) {
+        fixed_rate = MGN_MCS0 + m.mcs;
+        rate_from_radiotap = true;
       }
     } break;
     case IEEE80211_RADIOTAP_VHT: {

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -8,8 +8,9 @@
 #include <vector>
 
 #include "AckResponder.h"
-#include "RadiotapPeek.h" /* send_packets batch pre-parse */
-#include "TxAggPlan.h"    /* USB TX aggregation URB packing */
+#include "RadiotapPeek.h"   /* send_packets batch pre-parse */
+#include "RadiotapTxFlags.h" /* HT MCS field decoder (LDPC/STBC) */
+#include "TxAggPlan.h"      /* USB TX aggregation URB packing */
 #include "TxReport.h"     /* CCX TX-status report decode + tx.report event */
 
 #include "BeamformingSounder.h" /* generation-neutral BF self-sounding recipe */
@@ -17,6 +18,7 @@
 #include "ChannelFreq.h" /* radiotap CHANNEL freq -> channel (per-packet hop) */
 #include "FrameParserJaguar3.h"
 #include "NhmReader.h"       /* frame-free NHM power histogram (shared) */
+#include "RadiotapTxFlags.h" /* shared HT MCS known/flag decode (LDPC/STBC) */
 #include "RateDefinitions.h" /* MGN_* rate enum (shared across the family) */
 #include "SignalStop.h" /* g_devourer_should_stop — set by demo signal handlers */
 #include "ToneMask.h"   /* DEVOURER_RX_CSI_MASK / DEVOURER_RX_NBI knobs */
@@ -1444,18 +1446,22 @@ size_t RtlJaguar3Device::build_tx_block(const uint8_t *packet, size_t length,
           devourer::freq_to_chan(get_unaligned_le16(it.this_arg));
       break;
     case IEEE80211_RADIOTAP_MCS: {
-      uint8_t mcs_known = it.this_arg[0];
-      uint8_t mcs_flags = it.this_arg[1];
-      if ((mcs_flags & IEEE80211_RADIOTAP_MCS_BW_MASK) ==
-          IEEE80211_RADIOTAP_MCS_BW_40)
+      /* One shared reading of the HT MCS known/flag/index bytes (bw/sgi/mcs +
+       * LDPC/STBC). The J3 path historically read bw/sgi/mcs only and dropped
+       * the FEC/STBC known bits, so an HT frame requesting LDPC/STBC aired as
+       * plain BCC/no-STBC — only VHT frames were honoured. Mirrors the Jaguar2
+       * path (decode_radiotap_mcs_field, RadiotapTxFlags.h); the STBC-cap guard
+       * below still clamps to what the chip can do. */
+      const devourer::RadiotapMcsField m =
+          devourer::decode_radiotap_mcs_field(it.this_arg);
+      if (m.bw40)
         bwidth = CHANNEL_WIDTH_40;
-      sgi = (mcs_flags & 0x04) ? 1 : 0;
-      if (mcs_known & IEEE80211_RADIOTAP_MCS_HAVE_MCS) {
-        uint8_t idx = it.this_arg[2];
-        if (idx <= 31) {
-          fixed_rate = MGN_MCS0 + idx;
-          rate_from_radiotap = true;
-        }
+      sgi = m.sgi;
+      ldpc = m.ldpc;
+      stbc = m.stbc;
+      if (m.have_mcs) {
+        fixed_rate = MGN_MCS0 + m.mcs;
+        rate_from_radiotap = true;
       }
     } break;
     case IEEE80211_RADIOTAP_VHT: {

--- a/tests/radiotap_txflags_selftest.cpp
+++ b/tests/radiotap_txflags_selftest.cpp
@@ -1,0 +1,96 @@
+/* Headless wire-contract guard for the radiotap TX-flag path: what
+ * build_stream_radiotap() emits must decode back to the TxMode that went in.
+ * Guards the J2/J3 regression where HT LDPC/STBC known/flag bits were
+ * silently ignored (only the VHT case honoured them). No device is opened. */
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "RadiotapBuilder.h"
+#include "RadiotapTxFlags.h"
+#include "ieee80211_radiotap.h"
+
+static int failures = 0;
+
+#define CHECK_EQ(expr, want)                                                   \
+  do {                                                                         \
+    long got_ = long(expr);                                                    \
+    if (got_ != long(want)) {                                                  \
+      std::fprintf(stderr, "FAIL %s:%d: %s = %ld, want %ld\n", __FILE__,       \
+                   __LINE__, #expr, got_, long(want));                         \
+      failures++;                                                              \
+    }                                                                          \
+  } while (0)
+
+/* Walk a built radiotap header and return the decoded MCS field. */
+static devourer::RadiotapMcsField decode_ht(const std::vector<uint8_t> &rt) {
+  struct ieee80211_radiotap_iterator it;
+  auto *hdr = reinterpret_cast<struct ieee80211_radiotap_header *>(
+      const_cast<uint8_t *>(rt.data()));
+  devourer::RadiotapMcsField f;
+  if (ieee80211_radiotap_iterator_init(&it, hdr, rt.size(), nullptr) != 0) {
+    std::fprintf(stderr, "FAIL: iterator init\n");
+    failures++;
+    return f;
+  }
+  while (ieee80211_radiotap_iterator_next(&it) == 0) {
+    if (it.this_arg_index == IEEE80211_RADIOTAP_MCS)
+      f = devourer::decode_radiotap_mcs_field(it.this_arg);
+  }
+  return f;
+}
+
+int main() {
+  /* HT MCS0/20, LDPC+STBC (mabur's MAX_RANGE control mode). */
+  devourer::TxMode m;
+  m.mode = devourer::TxMode::Mode::HT;
+  m.ht_mcs = 0;
+  m.bw_mhz = 20;
+  m.ldpc = true;
+  m.stbc = true;
+  auto f = decode_ht(devourer::build_stream_radiotap(m));
+  CHECK_EQ(f.have_mcs, 1);
+  CHECK_EQ(f.mcs, 0);
+  CHECK_EQ(f.bw40, 0);
+  CHECK_EQ(f.sgi, 0);
+  CHECK_EQ(f.ldpc, 1);
+  CHECK_EQ(f.stbc, 1);
+
+  /* HT MCS7/40/SGI, no LDPC/STBC. */
+  m = devourer::TxMode{};
+  m.mode = devourer::TxMode::Mode::HT;
+  m.ht_mcs = 7;
+  m.bw_mhz = 40;
+  m.sgi = true;
+  f = decode_ht(devourer::build_stream_radiotap(m));
+  CHECK_EQ(f.have_mcs, 1);
+  CHECK_EQ(f.mcs, 7);
+  CHECK_EQ(f.bw40, 1);
+  CHECK_EQ(f.sgi, 1);
+  CHECK_EQ(f.ldpc, 0);
+  CHECK_EQ(f.stbc, 0);
+
+  /* VHT wire contract: pin the byte positions the device parsers read
+   * (known bit0 = STBC, arg[2] bit0 = STBC flag, arg[8] bit0 = LDPC). */
+  m = devourer::TxMode{};
+  m.mode = devourer::TxMode::Mode::VHT;
+  m.vht_mcs = 3;
+  m.vht_nss = 1;
+  m.bw_mhz = 80;
+  m.ldpc = true;
+  m.stbc = true;
+  auto rt = devourer::build_stream_radiotap(m);
+  /* 22-byte VHT radiotap: header(8) + TX_FLAGS(2) + VHT info(12) at off 10. */
+  CHECK_EQ(rt.size(), 22);
+  CHECK_EQ(rt[10] & 0x01, 0x01); /* known: STBC        */
+  CHECK_EQ(rt[12] & 0x01, 0x01); /* flags: STBC        */
+  CHECK_EQ(rt[18] & 0x01, 0x01); /* coding[u0]: LDPC   */
+  CHECK_EQ(rt[13], 4);           /* bw code: 80 MHz    */
+
+  if (failures) {
+    std::fprintf(stderr, "%d failure(s)\n", failures);
+    return 1;
+  }
+  std::printf("radiotap_txflags: OK\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

`build_tx_block` on Jaguar2/3 read only bw/sgi/mcs from the HT MCS radiotap field and dropped the FEC/STBC known bits, so an HT frame requesting **LDPC** or **STBC** aired as plain BCC / no-STBC — only VHT frames were honoured. This adds a shared decode helper and wires it into both the Jaguar2 and Jaguar3 HT paths so HT injects apply LDPC/STBC too.

The descriptor fill and STBC-cap guard were already correct: `DATA_LDPC` dword5[7], `DATA_STBC` dword5[9:8] & 0x3 — byte-identical to the vendor driver (`rtl88x2eu-20230815` `hal/rtl8822e/usb/rtl8822eu_xmit.c`, `SET_TX_DESC_DATA_STBC_8822E(.., pattrib->stbc & 3)`).

## Changes

- **`src/RadiotapTxFlags.h`** — `decode_radiotap_mcs_field()`: one shared reading of the HT MCS known/flag/index bytes (bw/sgi/mcs + LDPC/STBC).
- **Jaguar2 + Jaguar3** `build_tx_block` `IEEE80211_RADIOTAP_MCS` cases now use it; the STBC-cap guard below still clamps to what the chip can do.

## Testing

- New host selftest `tests/radiotap_txflags_selftest.cpp` covers the decode. `ctest` 21/21 green.
- Bench-verified on 8822E hardware via `rxdemo`: HT MCS0 injects decoded `stbc=0 ldpc=0` before this change and `stbc=1 ldpc=1` after; live video stayed clean at MCS5 with STBC+LDPC active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)