### PR TITLE
radiotap TX: single shared HT MCS decode across all three generations

### DIFF
--- a/src/RadiotapTxFlags.h
+++ b/src/RadiotapTxFlags.h
@@ -1,10 +1,9 @@
 #pragma once
 
 /* Decoded view of the 3-byte radiotap MCS field (known, flags, index) on the
- * TX/inject path — one shared reading for the per-generation send_packet
- * parsers, so the HT LDPC/STBC known/flag bits can't silently diverge again
- * (J2/J3 historically ignored them; only the VHT case honoured them; J1
- * carried its own correct copy). Bit positions per the radiotap MCS spec and
+ * TX/inject path — the one shared reading for all three generations'
+ * send_packet parsers (J1/J2/J3), so the HT LDPC/STBC known/flag bits can't
+ * silently diverge again. Bit positions per the radiotap MCS spec and
  * RadiotapBuilder::build_ht. */
 
 #include <cstdint>
@@ -30,11 +29,13 @@ inline RadiotapMcsField decode_radiotap_mcs_field(const uint8_t *arg) {
   const uint8_t flags = arg[1];
   if ((flags & IEEE80211_RADIOTAP_MCS_BW_MASK) == IEEE80211_RADIOTAP_MCS_BW_40)
     f.bw40 = true;
-  f.sgi = (flags & 0x04) ? 1 : 0;
-  if ((known & 0x10) && (flags & 0x10)) /* FEC-type known + LDPC flag */
+  f.sgi = (flags & IEEE80211_RADIOTAP_MCS_SGI) ? 1 : 0;
+  if ((known & IEEE80211_RADIOTAP_MCS_HAVE_FEC) &&
+      (flags & IEEE80211_RADIOTAP_MCS_FEC_LDPC))
     f.ldpc = 1;
-  if (known & 0x20) /* STBC known: flags bits [6:5] = stream count */
-    f.stbc = (flags >> 5) & 0x3;
+  if (known & IEEE80211_RADIOTAP_MCS_HAVE_STBC) /* flags [6:5] = stream count */
+    f.stbc = (flags & IEEE80211_RADIOTAP_MCS_STBC_MASK) >>
+             IEEE80211_RADIOTAP_MCS_STBC_SHIFT;
   if ((known & IEEE80211_RADIOTAP_MCS_HAVE_MCS) && arg[2] <= 31) {
     f.have_mcs = true;
     f.mcs = arg[2];

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -7,6 +7,7 @@
 #include "RadioManagementModule.h"
 #include "AckResponder.h" /* hardware ACK responder recipe */
 #include "RadiotapPeek.h" /* send_packets batch pre-parse */
+#include "RadiotapTxFlags.h" /* shared HT MCS known/flag decode (LDPC/STBC) */
 #include "SignalStop.h"
 #include "ToneMask.h"
 #include "TxAggPlan.h" /* USB TX aggregation URB packing */
@@ -883,48 +884,22 @@ size_t RtlJaguarDevice::build_tx_block(const uint8_t *packet, size_t length,
       break;
 
     case IEEE80211_RADIOTAP_MCS: {
-      u8 mcs_known = iterator.this_arg[0];
-      u8 mcs_flags = iterator.this_arg[1];
-
-      uint8_t mcs_bw_field = mcs_flags & IEEE80211_RADIOTAP_MCS_BW_MASK;
-      if (mcs_bw_field == IEEE80211_RADIOTAP_MCS_BW_40) {
+      /* One shared reading of the HT MCS known/flag/index bytes — bw/sgi/mcs
+       * plus FEC=LDPC and the STBC stream count (RadiotapTxFlags.h, the same
+       * decode the Jaguar2/3 paths use, so the three copies can't diverge).
+       * The radiotap is authoritative for per-packet rate; the SetTxMode
+       * default applies after this loop only when no rate is present.
+       * bwidth starts at 20 MHz, so the BW_20/20L/20U codes need no branch. */
+      const devourer::RadiotapMcsField m =
+          devourer::decode_radiotap_mcs_field(iterator.this_arg);
+      if (m.bw40)
         bwidth = CHANNEL_WIDTH_40;
-      } else if (mcs_bw_field == IEEE80211_RADIOTAP_MCS_BW_20 ||
-                 mcs_bw_field == IEEE80211_RADIOTAP_MCS_BW_20L ||
-                 mcs_bw_field == IEEE80211_RADIOTAP_MCS_BW_20U) {
-        bwidth = CHANNEL_WIDTH_20;
-      }
-
-      if (mcs_flags & 0x04) {
-        sgi = 1;
-      } else {
-        sgi = 0;
-      }
-
-      /* STBC (radiotap MCS known bit5 / flags bits5-6) and FEC=LDPC (known bit4 /
-       * flags bit4). The HT branch previously read neither, so an HT frame tagged
-       * STBC/LDPC in radiotap silently transmitted as BCC SISO -- only the VHT
-       * branch honoured them. Reading them here lets txdemo emit a real
-       * HT STBC / HT LDPC frame (needed as a chip reference for the gr-ieee802-11
-       * fork's modern-format TX). */
-      if (mcs_known & 0x20) {
-        stbc = (mcs_flags >> 5) & 0x3;
-      }
-      if ((mcs_known & 0x10) && (mcs_flags & 0x10)) {
-        ldpc = 1;
-      }
-
-      /* The radiotap is authoritative for per-packet rate: honour the HT MCS
-       * index from byte 2 unconditionally. (Previously gated behind the
-       * DEVOURER_TX_HT_MCS env var, so a valid HT radiotap silently fell back
-       * to 1M CCK — now replaced by the programmatic SetTxMode default, applied
-       * after this loop only when no rate is present in the radiotap.) */
-      if (mcs_known & IEEE80211_RADIOTAP_MCS_HAVE_MCS) {
-        uint8_t mcs_index = iterator.this_arg[2];
-        if (mcs_index <= 31) {
-          fixed_rate = MGN_MCS0 + mcs_index;
-          rate_from_radiotap = true;
-        }
+      sgi = m.sgi;
+      ldpc = m.ldpc;
+      stbc = m.stbc;
+      if (m.have_mcs) {
+        fixed_rate = MGN_MCS0 + m.mcs;
+        rate_from_radiotap = true;
       }
     } break;
 

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -18,7 +18,6 @@
 #include "ChannelFreq.h" /* radiotap CHANNEL freq -> channel (per-packet hop) */
 #include "FrameParserJaguar3.h"
 #include "NhmReader.h"       /* frame-free NHM power histogram (shared) */
-#include "RadiotapTxFlags.h" /* shared HT MCS known/flag decode (LDPC/STBC) */
 #include "RateDefinitions.h" /* MGN_* rate enum (shared across the family) */
 #include "SignalStop.h" /* g_devourer_should_stop — set by demo signal handlers */
 #include "ToneMask.h"   /* DEVOURER_RX_CSI_MASK / DEVOURER_RX_NBI knobs */

--- a/tests/radiotap_txflags_selftest.cpp
+++ b/tests/radiotap_txflags_selftest.cpp
@@ -70,6 +70,28 @@ int main() {
   CHECK_EQ(f.ldpc, 0);
   CHECK_EQ(f.stbc, 0);
 
+  /* Raw 3-byte MCS field (bypasses the builder): BW code 20U (not 40 MHz),
+   * STBC stream count 2, FEC known + LDPC, GI not short, MCS 5. Pins the
+   * decoder's bit positions independently of what build_stream_radiotap can
+   * emit. */
+  {
+    const uint8_t raw[3] = {
+        /* known */ IEEE80211_RADIOTAP_MCS_HAVE_BW |
+            IEEE80211_RADIOTAP_MCS_HAVE_MCS | IEEE80211_RADIOTAP_MCS_HAVE_FEC |
+            IEEE80211_RADIOTAP_MCS_HAVE_STBC,
+        /* flags */ IEEE80211_RADIOTAP_MCS_BW_20U |
+            IEEE80211_RADIOTAP_MCS_FEC_LDPC |
+            (2 << IEEE80211_RADIOTAP_MCS_STBC_SHIFT),
+        /* index */ 5};
+    const auto g = devourer::decode_radiotap_mcs_field(raw);
+    CHECK_EQ(g.have_mcs, 1);
+    CHECK_EQ(g.mcs, 5);
+    CHECK_EQ(g.bw40, 0);
+    CHECK_EQ(g.sgi, 0);
+    CHECK_EQ(g.ldpc, 1);
+    CHECK_EQ(g.stbc, 2);
+  }
+
   /* VHT wire contract: pin the byte positions the device parsers read
    * (known bit0 = STBC, arg[2] bit0 = STBC flag, arg[8] bit0 = LDPC). */
   m = devourer::TxMode{};


### PR DESCRIPTION
## Summary

Follow-ups from the #291 review, in one pass:

- **Jaguar1 adopts `decode_radiotap_mcs_field()`** — the last private copy of the HT MCS known/flag reading is gone, so the three generations' `send_packet` parsers genuinely can't diverge. Behavior-identical: `bwidth` starts at 20 MHz, so J1's explicit BW_20/20L/20U branch was a no-op, and its ldpc/stbc/sgi semantics already matched the shared decode.
- **Named constants** — the decoder spells its bit tests with `IEEE80211_RADIOTAP_MCS_HAVE_FEC`/`FEC_LDPC`/`HAVE_STBC`/`STBC_MASK`/`STBC_SHIFT`/`SGI` instead of raw masks and shifts.
- **Duplicate include dropped** — `RadiotapTxFlags.h` was included twice in `RtlJaguar3Device.cpp`.
- **Selftest**: new raw 3-byte MCS field case (BW code 20U, STBC stream count 2, LDPC, no SGI) pinning the decoder's bit positions independently of what `build_stream_radiotap` can emit — a direct guard on the constants refactor.

## Testing

- `ctest` 21/21 green.
- Bench-verified on air (streamtx `MCS1/LDPC/STBC` → `rx.txhit` decode):
  - 8812AU (J1 — the swapped path) → 8822B RX, ch6: **107/107** frames `ldpc=1 stbc=1`, rate MCS1.
  - 8812EU (J3 regression on the refactored decoder) → 8812AU RX, ch36: **19/19** `ldpc=1 stbc=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
