### PR TITLE
Fix 5 GHz AP rate set + Kestrel H2C thread-safety

### DIFF
--- a/src/kestrel/KestrelFw.cpp
+++ b/src/kestrel/KestrelFw.cpp
@@ -576,6 +576,11 @@ bool KestrelFw::fw_send_beacon(const uint8_t *body, uint32_t len, uint8_t macid,
 
 bool KestrelFw::send_h2c_cmd(uint8_t cat, uint8_t h2c_class, uint8_t func,
                              const uint8_t *content, uint32_t len) {
+  /* Serialize: this mutates the shared _txbuf scratch + the _h2c_seq counter and
+   * sends one bulk-OUT. Concurrent callers (an H2C issued from the RX/C2H thread
+   * while the control thread issues another) would corrupt the scratch buffer
+   * and desync the firmware H2C-queue sequence. */
+  std::lock_guard<std::mutex> lk(_h2c_mu);
   /* Packet = [descriptor][fwcmd_hdr 8B][content]. Same framing as the FWDL
    * header path but with a caller-supplied cat/class/func and the content inline
    * (no FWDL_EN). The descriptor is the 8852C's 16-byte rxd_short_t

--- a/src/kestrel/KestrelFw.h
+++ b/src/kestrel/KestrelFw.h
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <mutex>
 #include <vector>
 
 #include "ChipVariant.h"
@@ -125,6 +126,12 @@ private:
   uint8_t _ch12_ep = 0; /* resolved bulk-OUT endpoint for CH12 (BULKOUTID2) */
   std::vector<uint8_t> _txbuf; /* reused H2C packet scratch */
   uint8_t _h2c_seq = 0; /* fwinfo->h2c_seq: 8-bit rolling, all runtime H2Cs */
+  /* Serializes send_h2c_cmd: it mutates the shared _txbuf scratch + _h2c_seq
+   * counter and issues one bulk-OUT, and the firmware's H2C-queue parser expects
+   * whole packets in sequence. Concurrent callers (e.g. an H2C issued from the
+   * RX/C2H thread while the control thread issues another) would otherwise
+   * corrupt the scratch buffer and desync the sequence. */
+  std::mutex _h2c_mu;
   bool _is_sec_ic = false; /* OTP 0x5ED[7]: gates the non-secure FWDL patch */
 };
 

--- a/tests/ap_responder.cpp
+++ b/tests/ap_responder.cpp
@@ -124,11 +124,21 @@ static std::vector<uint8_t> build_dhcp_reply(const uint8_t* sta, const uint8_t* 
   return build_data(sta, 0x0800, pl.data(), (int)pl.size());
 }
 
+// Supported Rates IE, band-correct: CCK+OFDM on 2.4 GHz, OFDM-only on 5 GHz.
+// CCK basic rates (1/2/5.5/11) do not exist on 5 GHz — advertising them makes a
+// 5 GHz station skip the BSS with "rate sets do not match" (silent, only in
+// wpa_supplicant -d), so no association on any 5 GHz channel.
+static void append_rates(std::vector<uint8_t>& m) {
+  if (g_chan <= 14)  // 2.4 GHz: 1*,2*,5.5*,11*,18,24,36,54
+    m.insert(m.end(), {0x01, 0x08, 0x82, 0x84, 0x8b, 0x96, 0x24, 0x30, 0x48, 0x6c});
+  else               // 5 GHz: 6*,9,12*,18,24*,36,48,54 (basic = high bit set)
+    m.insert(m.end(), {0x01, 0x08, 0x8c, 0x12, 0x98, 0x24, 0xb0, 0x48, 0x60, 0x6c});
+}
 // Common: [SSID + rates + DS] IE tail for probe/assoc responses.
 static void append_ies(std::vector<uint8_t>& m, bool with_ssid) {
   if (with_ssid) { const char* s = "devourerAP";
     m.insert(m.end(), {0x00, 0x0a}); m.insert(m.end(), s, s + 10); }
-  m.insert(m.end(), {0x01, 0x08, 0x82, 0x84, 0x8b, 0x96, 0x24, 0x30, 0x48, 0x6c});
+  append_rates(m);
   m.insert(m.end(), {0x03, 0x01, g_chan});
 }
 static void enqueue(std::vector<uint8_t> mpdu) {
@@ -260,7 +270,7 @@ int main(int argc, char** argv) {
       0x00,0x00, 0,0,0,0,0,0,0,0, 0x64,0x00, 0x01,0x00};
   { const char* s = "devourerAP"; bcn.insert(bcn.end(), {0x00,0x0a});
     bcn.insert(bcn.end(), s, s + 10);
-    bcn.insert(bcn.end(), {0x01,0x08,0x82,0x84,0x8b,0x96,0x24,0x30,0x48,0x6c});
+    append_rates(bcn);
     bcn.insert(bcn.end(), {0x03,0x01,g_chan}); }
   int bcn_tu = 100;
   if (const char* iv = std::getenv("DEVOURER_BCN_TU")) bcn_tu = atoi(iv);

--- a/tests/ap_wpa2.cpp
+++ b/tests/ap_wpa2.cpp
@@ -90,7 +90,13 @@ static std::vector<uint8_t> mgmt_hdr(uint8_t fc, const uint8_t* sta) {
 static void append_ies(std::vector<uint8_t>& m, bool ssid) {
   if (ssid) { m.insert(m.end(), {0x00,(uint8_t)strlen(kSsid)});
     m.insert(m.end(), kSsid, kSsid+strlen(kSsid)); }
-  m.insert(m.end(), {0x01,0x08,0x82,0x84,0x8b,0x96,0x24,0x30,0x48,0x6c});
+  // Band-correct Supported Rates: CCK+OFDM on 2.4 GHz, OFDM-only on 5 GHz. CCK
+  // basic rates (1/2/5.5/11) do not exist on 5 GHz — advertising them makes a
+  // 5 GHz station skip the BSS ("rate sets do not match"), so no association.
+  if (g_chan <= 14)
+    m.insert(m.end(), {0x01,0x08,0x82,0x84,0x8b,0x96,0x24,0x30,0x48,0x6c});
+  else
+    m.insert(m.end(), {0x01,0x08,0x8c,0x12,0x98,0x24,0xb0,0x48,0x60,0x6c});
   m.insert(m.end(), {0x03,0x01,g_chan});
   m.insert(m.end(), kRsn, kRsn+sizeof(kRsn));           // RSN IE -> advertise WPA2
 }


### PR DESCRIPTION
Two independent latent bugs, surfaced while bringing up an HE AP on a 5 GHz channel. Both are self-contained and unrelated to any feature work.

## 1. AP harnesses advertise CCK basic rates on 5 GHz → no association
`tests/ap_responder.cpp` and `tests/ap_wpa2.cpp` always put CCK basic rates (1/2/5.5/11 Mbps) in the Supported Rates IE. CCK does not exist on 5 GHz, so a 5 GHz station skips the BSS with **"rate sets do not match"** and never associates. The failure is silent — it only appears under `wpa_supplicant -d`. Both harnesses default to 2.4 GHz (ch 6), so they never hit it, but any `DEVOURER_CHANNEL` on 5 GHz fails to associate.

Fix: advertise band-correct Supported Rates — CCK+OFDM on 2.4 GHz, OFDM-only (6\*/12\*/24\* basic) on 5 GHz.

## 2. `KestrelFw::send_h2c_cmd` is not thread-safe
It mutates the shared `_txbuf` scratch buffer + the `_h2c_seq` rolling counter and issues one bulk-OUT, with no synchronization. An H2C issued from the RX/C2H thread concurrently with one from the control thread corrupts the scratch buffer and desyncs the firmware H2C-queue sequence (observed as a silently-failing H2C). Serialize the method with a mutex; the firmware's H2C-queue parser already expects whole packets in sequence.

## Verification
- `ctest` green (24/24) on the built library.
- `tests/ap_responder.cpp` and `tests/ap_wpa2.cpp` compile clean with the fix.
- The 5 GHz rate fix was confirmed on-air: with band-correct OFDM rates, a real kernel station associates to the devourer AP on ch 36 (it was skipping the BSS before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)