### PR TITLE
Kestrel: 802.11ax trigger-based UL, TWT, and HE sounding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,8 @@ if(DEVOURER_KESTREL)
         src/kestrel/MacRegAx.h
         src/kestrel/HalKestrel.cpp src/kestrel/HalKestrel.h
         src/kestrel/KestrelFw.cpp src/kestrel/KestrelFw.h
+        src/kestrel/KestrelFwSched.cpp
+        src/kestrel/KestrelLe.h
         src/kestrel/RtlKestrelDevice.cpp src/kestrel/RtlKestrelDevice.h)
     target_compile_definitions(devourer PUBLIC DEVOURER_HAVE_KESTREL=1)
 endif()
@@ -619,6 +621,17 @@ target_include_directories(HeRadiotapSelftest PRIVATE
 
 add_test(NAME he_radiotap COMMAND HeRadiotapSelftest)
 
+# Headless round-trip guard for the 802.11ax Trigger frame path (src/TriggerTwt.h
+# build_basic_trigger + he_ru_alloc, src/TriggerParse.h parse_trigger): build ->
+# parse a Basic Trigger, RU-allocation golden vectors. Generation-neutral (the
+# fw F2P encoders are guarded separately below); the on-air half (witness decode
+# of an fw-aired trigger) is tier-A validation.
+add_executable(TriggerParseSelftest tests/trigger_parse_selftest.cpp)
+target_compile_features(TriggerParseSelftest PRIVATE cxx_std_20)
+target_include_directories(TriggerParseSelftest PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src)
+add_test(NAME trigger_parse COMMAND TriggerParseSelftest)
+
 # Headless guard for the Kestrel (11ax) RX descriptor parser
 # (src/kestrel/FrameParserKestrel.h): rxd field extraction + aggregate walk
 # (on-air decode is hardware-validated out-of-band). Compiled only when a
@@ -635,6 +648,15 @@ if(DEVOURER_KESTREL)
     target_include_directories(KestrelTxReportSelftest PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src)
     add_test(NAME kestrel_txreport COMMAND KestrelTxReportSelftest)
+
+    # Golden-bytes guard for the trigger-UL + TWT H2C content encoders
+    # (src/kestrel/SchedEncode.h): each config's emitted LE dwords vs the
+    # hand-computed vendor SET_WORD layout (F2P v0/v1, TWT, UL_FIXINFO).
+    add_executable(KestrelSchedSelftest tests/kestrel_sched_selftest.cpp)
+    target_compile_features(KestrelSchedSelftest PRIVATE cxx_std_20)
+    target_include_directories(KestrelSchedSelftest PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    add_test(NAME kestrel_sched COMMAND KestrelSchedSelftest)
 endif()
 
 add_executable(RadiotapTxFlagsSelftest tests/radiotap_txflags_selftest.cpp)

--- a/docs/he-trigger-ul.md
+++ b/docs/he-trigger-ul.md
@@ -1,0 +1,157 @@
+# HE trigger-based uplink (Kestrel)
+
+This document describes devourer's 802.11ax trigger-based uplink support on the
+Kestrel generation (RTL8852BU/8832BU and RTL8852CU/8832CU) — how a Trigger frame
+is put on the air, what the shipped firmware does and does not do with it, the
+device API, and how the mechanism is used to build an adaptive link. Pre-AX
+generations (Jaguar1/2/3, 802.11n/ac) have no Trigger-frame concept and report
+`AdapterCaps.trigger_ul_ok = false`.
+
+## What a Trigger frame is
+
+802.11ax moves uplink scheduling into the MAC/PHY. An access point sends a
+**Trigger frame** — an 802.11 control frame (frame-control byte `0x24`) whose
+Common Info carries the uplink bandwidth, GI/LTF and AP TX power, and whose
+per-user Info fields each grant one station a **resource unit**, an MCS, a
+spatial-stream allocation, and a **target RSSI**. A compliant station that finds
+its AID in a Trigger answers a fixed SIFS (~16 µs) later with an **HE TB PPDU**
+(trigger-based PPDU) on exactly the granted resource — hardware-scheduled and
+contention-free. This is the standard's mechanism for coordinated, low-jitter
+uplink, and the forward path to cellular-style scheduled access on Wi-Fi.
+
+A **BFRP** (Beamforming Report Poll) is a Trigger-frame variant that solicits a
+compressed-beamforming report; the sounding sequence (NDPA → NDP → BFRP) that
+carries it is the firmware's own use of the Trigger primitive.
+
+## Two ways to put a Trigger on the air
+
+There are two distinct transmit paths, and on the shipped RTL8852 *client*
+firmware they behave very differently.
+
+### Firmware-scheduled
+
+The driver hands the firmware a command and the firmware assembles and schedules
+the Trigger itself:
+
+| Command | Class / func | Role |
+|---|---|---|
+| F2P trigger | `CL_FR_EXCHG` / `F2P_TEST` | one-shot Basic Trigger |
+| UL_FIXINFO | `CL_FR_EXCHG` / `TBLUD` | autonomous periodic UL-OFDMA scheduler table |
+| Sounding | `CL_SOUND` / `SET_SND_PARA` | NDPA → NDP → BFRP sequence, arms RX for the report |
+| TWT | `CL_TWT` / `*` | wake/service-period agreements |
+
+These are byte-exact ports of the vendor `mac_ax` command encoders and are
+firmware-accepted (no SER). **On the shipped client firmware, none of them put a
+Trigger on the air.** The F2P command is a manufacturing/hardware-verification
+entry with no production caller and is silently dropped. The sounding command is
+accepted and *engaged* — the firmware holds a resource per one-shot sounding, and
+the command queue stalls after seven un-completed soundings — but it does not
+transmit the NDPA/BFRP. This was confirmed on-air: a monitor that decoded 139,532
+frames from the AP and station (beacons, RTS, auth/assoc, data, ACKs) decoded
+zero Trigger frames while the sounding command was firing. The firmware exposes
+the command surface but not the trigger-transmit scheduler that AP-class firmware
+runs.
+
+### Host-injected
+
+Instead of asking the firmware to build the Trigger, the driver builds the raw
+802.11ax Trigger-frame bytes on the host and transmits them through the ordinary
+packet path — the same path that airs beacons, authentication/association
+responses and data frames:
+
+1. `build_basic_trigger()` (`src/TriggerTwt.h`) assembles the frame from a
+   `TriggerConfig`: frame-control `0x24`, duration, RA/TA, the HE Common Info
+   field, and one User Info field per granted user (AID, RU allocation, MCS,
+   spatial streams, target RSSI).
+2. `IRtlDevice::SendTrigger()` prepends a radiotap header (legacy OFDM, so any
+   monitor decodes it) and calls the normal `send_packet()` transmit path. The
+   firmware's trigger scheduler is bypassed entirely.
+
+This works on the client firmware because it rides the plain management-frame
+transmit path, which functions normally. On-air validation: with an associated
+station granted by AID, the AP injected Basic Triggers and an independent monitor
+decoded them with the exact commanded parameters (AP power, AID, RU, MCS, NSS),
+confirming well-formed HE Trigger frames on the air.
+
+A group-addressed (broadcast) Trigger is marked BMC in the transmit descriptor so
+the firmware transmits it once rather than retrying an unacknowledged frame to the
+retry limit; unicast frames are unaffected and still retried normally.
+
+## What closes and what does not
+
+Host-injection puts a real, correctly-decodable HE Trigger on the air. It does
+**not**, on its own, elicit an HE TB PPDU from a standard station: a host-injected
+frame does not arm the MAC's SIFS-scheduled receive window, so the receiving
+station gets no hardware timing cue to answer at trigger+SIFS. The
+hardware-scheduled response requires a firmware-scheduled Trigger, which the
+client firmware does not air. In short:
+
+- **Trigger on the air** — delivered (host-injection).
+- **Hardware SIFS-timed TB PPDU response** — not available on client firmware.
+
+## Device API
+
+The surface is on `IRtlDevice`; each call returns `false` on pre-AX generations.
+
+- `SendTrigger(const TriggerConfig&)` — air one Basic Trigger. Default path is
+  host-injection; set `DeviceConfig.debug.kestrel_trigger_f2p` (env
+  `DEVOURER_KESTREL_TRIGGER_F2P=1`) to route through the firmware F2P command
+  instead, for comparison.
+- `RegisterPeerSta(mac, macid, addr_cam_idx)` — register an associated station so
+  a Trigger's per-user grant resolves against it.
+- `ConfigureUlOfdma`, `ConfigureTwt` / `TwtBindSta` / `ConfigureTwtOfdma`,
+  `StartSounding` / `RegisterBeamformee` — the firmware-scheduled commands above.
+
+`TriggerConfig` (`src/TriggerTwt.h`) holds the uplink bandwidth, GI/LTF, AP TX
+power and up to eight `TrigUser` grants; `he_ru_alloc()` builds the RU-allocation
+subfield and `he_tgt_rssi_enc()` the target-RSSI subfield. A frame carrying its
+own rate radiotap overrides the mode per packet, so rate, bandwidth and channel
+are per-Trigger selectable like any injected frame.
+
+## Adaptive-link use
+
+The Trigger frame is a per-user control channel: every grant independently
+carries the RU, MCS, spatial-stream count and target RSSI the transmitter should
+use. That makes it the natural carrier for a closed-loop adaptive uplink.
+
+- **Rate and RU adaptation.** The AP tracks each transmitter's link quality (RSSI,
+  SNR and EVM are available per received frame, and `GetRxQuality()` /
+  `cell::UeRxAttribution` aggregate them per station) and encodes the chosen MCS
+  and RU width into the next Trigger's User Info. A degrading link is granted a
+  lower MCS or a narrower RU; a recovering one is stepped back up.
+- **Uplink power control.** The target-RSSI subfield asks the transmitter to hit a
+  specific receive level, moving the AGC operating point off the near-field
+  saturation region (strong RSSI with poor EVM) or up out of the noise — the same
+  distinction `LinkHealth` classifies from the RX sensor tuple.
+- **Per-packet steering.** Because injection is radiotap-driven, the Trigger's own
+  PHY rate, bandwidth and channel are chosen per packet, and combine with
+  `SetTxPowerOffsetQdb()` and `FastRetune()` for a link that adapts rate, power and
+  frequency together.
+
+Two link topologies use this today:
+
+- **Software-timed devourer↔devourer link.** Both ends run devourer. The AP injects
+  a Trigger with the desired uplink parameters; the peer decodes it (the RX path
+  emits an `rx.trigger` event with the full Common/User info) and adapts its next
+  uplink transmission accordingly. The response is software-scheduled rather than
+  hardware-SIFS, which fits the millisecond-scale cadence of a long-range video
+  link and sidesteps the client-firmware TB-response gap entirely.
+- **Signaling to standard stations.** A broadcast Trigger is a low-overhead way for
+  the AP to publish per-user uplink parameters that a cooperating station reads and
+  applies, independent of whether that station's hardware answers at SIFS.
+
+For a fixed-schedule beacon-timed link, the beacon engine (`StartBeacon`,
+`PinBeaconTbtt`) remains the hardware-timed primitive; the Trigger path adds the
+per-user, per-packet uplink-parameter channel on top of it. See
+`docs/scheduled-mac.md` for the beacon-timed scheduling contracts and
+`docs/time-distribution.md` for the TSF/timestamp primitives.
+
+## Validation
+
+`tests/ul_sounding_e2e.sh` brings up a devourer HE software-AP on a Kestrel
+adapter, associates a real `rtw89` station, and drives either the sounding
+command (default) or host-injection (`INJECT=1`), with a separate-bus monitor and
+a USRP B210 as on-air witnesses. It reports the injected-vs-decoded Trigger
+counts, the B210 preamble-classifier delta, and `ul_tb` (the station's TB-PPDU
+response, observed via the AP's own RX). The headless golden-byte encoder checks
+run under `ctest` (`kestrel_sched`).

--- a/examples/common/env_config.cpp
+++ b/examples/common/env_config.cpp
@@ -158,6 +158,7 @@ devourer::DeviceConfig devourer_config_from_env() {
   cfg.debug.log_txpwr = env_flag("DEVOURER_LOG_TXPWR");
   cfg.debug.kestrel_fw_log = env_flag("DEVOURER_KESTREL_FWLOG");
   cfg.debug.kestrel_cca_on = env_flag("DEVOURER_KESTREL_CCA_ON");
+  cfg.debug.kestrel_trigger_f2p = env_flag("DEVOURER_KESTREL_TRIGGER_F2P");
   if (const char *e = env_str("DEVOURER_REPLAY_WSEQ"))
     cfg.debug.replay_wseq = e;
   if (env_long("DEVOURER_TX_QSEL", &v))

--- a/examples/kestrelprobe/main.cpp
+++ b/examples/kestrelprobe/main.cpp
@@ -27,14 +27,17 @@
 #include <libusb-1.0/libusb.h>
 #endif
 
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <string>
+#include <thread>
 
 #include "Event.h"
 #include "RtlAdapter.h"
+#include "SignalStop.h" /* g_devourer_should_stop — SIGINT/SIGTERM flag */
 #include "UsbOpen.h"
 #include "logger.h"
 
@@ -64,7 +67,8 @@ int main(int argc, char **argv) {
   uint16_t want_vid = 0, want_pid = 0; /* 0 = scan the Kestrel PID table */
   for (int i = 1; i < argc; ++i) {
     const std::string k = argv[i];
-    if (k == "id" || k == "power" || k == "fw" || k == "trx" || k == "phy")
+    if (k == "id" || k == "power" || k == "fw" || k == "trx" || k == "phy" ||
+        k == "trig" || k == "twt")
       stage = k;
     else if (k == "--vid" && i + 1 < argc && parse_hex16(argv[++i], want_vid))
       ;
@@ -72,15 +76,23 @@ int main(int argc, char **argv) {
       ;
     else {
       std::fprintf(stderr,
-                   "usage: %s [id|power|fw|trx] [--vid 0xNNNN] [--pid 0xNNNN]\n",
+                   "usage: %s [id|power|fw|trx|phy|trig|twt] "
+                   "[--vid 0xNNNN] [--pid 0xNNNN]\n",
                    argv[0]);
       return 2;
     }
   }
-  const int want = stage == "phy" ? 4 : stage == "trx" ? 3
+  /* trig/twt (5/6) go past phy to a full TX bring-up (InitWrite) + fire the
+   * scheduled-UL command; a 5 GHz channel where trigger-UL matters. */
+  const int want = stage == "twt" ? 6 : stage == "trig" ? 5
+                                    : stage == "phy" ? 4
+                                    : stage == "trx" ? 3
                                     : stage == "fw" ? 2
                                     : stage == "power" ? 1
                                                        : 0;
+  int chan = 36;
+  if (const char *e = std::getenv("DEVOURER_CHANNEL"))
+    chan = std::atoi(e);
 
   auto logger = std::make_shared<Logger>();
 
@@ -193,10 +205,19 @@ int main(int argc, char **argv) {
   bool fw_ok = false;
   try {
     /* Re-run the whole sequence so the stage is self-contained (power-on is
-     * cheap and idempotent from a clean handle). trx re-runs fw internally. */
-    fw_ok = (want >= 4)   ? dev.PowerOnTrxAndPhy(efuse)
-            : (want >= 3) ? dev.PowerOnFwAndTrx(efuse)
-                          : dev.PowerOnEfuseAndFw(efuse);
+     * cheap and idempotent from a clean handle). trx re-runs fw internally.
+     * trig/twt (>=5) take the full TX bring-up (InitWrite = phy + scheduler +
+     * self-STA role) so the fw can accept the scheduled-UL H2Cs. */
+    if (want >= 5) {
+      dev.InitWrite(SelectedChannel{.Channel = static_cast<uint8_t>(chan),
+                                    .ChannelOffset = 0,
+                                    .ChannelWidth = CHANNEL_WIDTH_20});
+      fw_ok = true;
+    } else {
+      fw_ok = (want >= 4)   ? dev.PowerOnTrxAndPhy(efuse)
+              : (want >= 3) ? dev.PowerOnFwAndTrx(efuse)
+                            : dev.PowerOnEfuseAndFw(efuse);
+    }
   } catch (const std::exception &e) {
     logger->error("fw/trx/phy: bring-up threw: {}", e.what());
   }
@@ -216,10 +237,146 @@ int main(int argc, char **argv) {
     return fw_ok ? 0 : 1;
   }
 
-  /* ---- stage phy: BB + RF table apply ---- */
-  logger->info("phy: phy_ok={}", fw_ok);
-  devourer::Ev(logger->events(), "kestrel.phy").f("ok", fw_ok);
+  if (want < 5) {
+    /* ---- stage phy: BB + RF table apply ---- */
+    logger->info("phy: phy_ok={}", fw_ok);
+    devourer::Ev(logger->events(), "kestrel.phy").f("ok", fw_ok);
+    libusb_close(handle);
+    libusb_exit(ctx);
+    return fw_ok ? 0 : 1;
+  }
+
+  /* ---- stage trig: air a Basic Trigger (UL-OFDMA grant) via the F2P command.
+   * Self-contained fw probe — no associated STA needed; a HE monitor (or an
+   * 11ac witness on the legacy PPDU) decodes the aired trigger as rx.trigger.
+   * Fires a short burst so an SDR reads a duty cycle. ---- */
+  if (want == 5) {
+    int count = 200;
+    if (const char *e = std::getenv("DEVOURER_TRIGGER_COUNT"))
+      count = std::atoi(e);
+    /* Register the self MACID as an AP role (not the CLIENT role InitWrite set)
+     * so the fw runs its AP-side scheduler — the beacon port NET_TYPE is AP but
+     * the fw role must be AP too for the trigger transmitter to engage
+     * (role.c). SMA=TMA=BSSID for an AP self_role. */
+    const uint8_t ap_bssid[6] = {0x02, 0x42, 0x75, 0x05, 0xd6, 0x00};
+    bool aprole = dev.hal().register_ap_role(ap_bssid);
+    logger->info("trig: register_ap_role -> {}", aprole);
+
+    devourer::TriggerConfig cfg;
+    cfg.ul_bw = 0;      /* 20 MHz */
+    cfg.n_users = 1;
+    cfg.users[0].aid12 = 1;
+    cfg.users[0].macid = 0;
+    cfg.users[0].ru_alloc = devourer::he_ru_alloc(242, 0); /* full 20 MHz */
+    cfg.users[0].ul_mcs = 0;
+    cfg.users[0].ss = 1;
+    cfg.users[0].tgt_rssi_dbm = -60;
+    /* The trigger frame's OWN PPDU rate (tf_wd.datarate). Must be an OFDM rate
+     * on 5 GHz — rate 0 is CCK 1 Mbps, which does not exist above ch14, so the
+     * fw cannot air the trigger there (same CCK-on-5GHz trap as the AP rate
+     * set). OFDM 6M (AX rate code 4) airs on both bands. */
+    cfg.trig_rate = chan > 14 ? 4 : 0;
+    if (const char *e = std::getenv("DEVOURER_TRIG_RATE"))
+      cfg.trig_rate = static_cast<uint16_t>(std::atoi(e));
+    /* mode/frexch_type are the runtime-discovered fw fields; DEVOURER_TRIG_MODE
+     * sweeps the 2-bit mode to find the one that airs a Basic Trigger. */
+    if (const char *e = std::getenv("DEVOURER_TRIG_MODE"))
+      cfg.mode = static_cast<uint8_t>(std::atoi(e) & 0x3);
+
+    /* DEVOURER_UL_FIXINFO=1 programs the production UL-OFDMA scheduler table
+     * (mode=tf_periodic) instead of the F2P test command — the fw then airs
+     * Triggers autonomously at `interval` for the granted macid. This is the
+     * canonical path (F2P_TEST has no vendor production caller). */
+    if (std::getenv("DEVOURER_UL_FIXINFO")) {
+      /* DEVOURER_UL_PEER=1 registers a distinct peer STA (macid 1) first, so the
+       * scheduler grants to a peer rather than the self-STA — a cheap probe of
+       * whether the UL-OFDMA engine airs a trigger for a registered (but not
+       * associated) peer, short of the full tier-C association. */
+      uint8_t grant_macid = 0;
+      if (std::getenv("DEVOURER_UL_PEER")) {
+        const uint8_t peer_mac[6] = {0x02, 0x11, 0x22, 0x33, 0x44, 0x55};
+        const bool pok = dev.RegisterPeerSta(peer_mac, /*macid=*/1,
+                                             /*addr_cam_idx=*/1);
+        logger->info("trig: register_peer_sta(macid=1) -> {}", pok);
+        grant_macid = 1;
+      }
+      devourer::UlOfdmaConfig ul;
+      ul.mode = 3;        /* tf_periodic */
+      ul.interval_s = 1;
+      ul.tf_type = 0;     /* Basic */
+      ul.ppdu_bw = 0;
+      ul.n_stas = 1;
+      ul.stas[0].macid = grant_macid;
+      ul.stas[0].ru_pos = 61; /* full 20 MHz */
+      ul.stas[0].mcs = 0;
+      ul.stas[0].ss = 1;
+      ul.stas[0].tgt_rssi_dbm = -60;
+      const bool ulok = dev.ConfigureUlOfdma(ul);
+      logger->info("trig: ul_fixinfo(tf_periodic) -> {}", ulok);
+      /* Hold so the fw's periodic engine airs several rounds for the witness. */
+      for (int i = 0; i < 40 && !g_devourer_should_stop; ++i)
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      devourer::Ev(logger->events(), "kestrel.trig")
+          .f("ok", ulok)
+          .f("mode", "ul_fixinfo")
+          .f("chan", chan);
+      dev.Stop();
+      libusb_close(handle);
+      libusb_exit(ctx);
+      return ulok ? 0 : 1;
+    }
+
+    int sent = 0;
+    for (int i = 0; i < count && !g_devourer_should_stop; ++i) {
+      if (dev.SendTrigger(cfg))
+        ++sent;
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    const bool ok = sent > 0;
+    logger->info("trig: sent {}/{} triggers (mode={})", sent, count, cfg.mode);
+    devourer::Ev(logger->events(), "kestrel.trig")
+        .f("ok", ok)
+        .f("sent", sent)
+        .f("count", count)
+        .f("mode", cfg.mode)
+        .f("chan", chan);
+    /* InitWrite started the WP-drain thread — join it before libusb_exit or a
+     * thread still inside libusb trips usbi_mutex_destroy (SIGABRT). */
+    dev.Stop();
+    libusb_close(handle);
+    libusb_exit(ctx);
+    return ok ? 0 : 1;
+  }
+
+  /* ---- stage twt: create an individual TWT agreement + (attempt) TWT-OFDMA
+   * cadence, and drain any TWT C2H the fw emits. Discovery: whether the shipped
+   * fw honors the (non-canonical) TWT-OFDMA func 0x03. ---- */
+  devourer::TwtConfig twt;
+  twt.broadcast = false;
+  twt.trigger = true;
+  twt.config_id = 0;
+  twt.flow_id = 0;
+  twt.ap_role = true;
+  twt.wake_exp = 10;
+  twt.wake_man = 512;
+  twt.trgt_tsf = dev.ReadTsf() + 100000; /* 100 ms out */
+  const bool twt_ok = dev.ConfigureTwt(twt);
+  devourer::TwtOfdmaConfig ofd;
+  ofd.twt_id = 0;
+  ofd.round_num = 4;
+  ofd.round_interval_us = 2000;
+  ofd.max_tf_retry = 3;
+  const bool ofdma_ok = dev.ConfigureTwtOfdma(ofd);
+  /* Drain the bulk-IN briefly so any TWT_NOTIFY / WAIT_ANNOUNCE C2H is routed
+   * (handle_c2h logs twt.notify / twt.wait_anno on the diagnostic plane). */
+  logger->info("twt: configure={} ofdma_cmd={} (watch for twt.notify C2H)",
+               twt_ok, ofdma_ok);
+  devourer::Ev(logger->events(), "kestrel.twt")
+      .f("ok", twt_ok)
+      .f("ofdma_cmd", ofdma_ok)
+      .f("chan", chan);
+  dev.Stop(); /* join the WP-drain thread before libusb teardown (see trig) */
   libusb_close(handle);
   libusb_exit(ctx);
-  return fw_ok ? 0 : 1;
+  return twt_ok ? 0 : 1;
 }

--- a/examples/rx/main.cpp
+++ b/examples/rx/main.cpp
@@ -19,6 +19,7 @@
 #include "LinkHealth.h"
 #include "RxPacket.h"
 #include "SweepSpec.h"
+#include "TriggerParse.h"
 #include "caps_event.h"
 #if defined(DEVOURER_HAVE_JAGUAR1)
 #include "jaguar1/RtlJaguarDevice.h"
@@ -529,6 +530,29 @@ static void packetProcessor(const Packet &packet) {
   }
 
   ++g_rx_count;
+
+  /* HE Trigger frame (802.11 control, FC=0x24) — aired in a legacy PPDU, so
+   * even an 11ac witness captures the bytes. Decode + surface it as rx.trigger
+   * so a monitor validates what an AX AP's F2P / UL_FIXINFO scheduler airs
+   * (fields vs the commanded config) and resolves the fw RU/mode encoding. */
+  if (devourer::is_trigger_frame(packet.Data.data(), packet.Data.size())) {
+    devourer::TriggerInfo ti;
+    if (devourer::parse_trigger(packet.Data.data(), packet.Data.size(), ti)) {
+      auto ev = devourer::Ev(*g_ev, "rx.trigger");
+      ev.f("ttype", ti.trigger_type)
+          .f("ul_bw", ti.ul_bw)
+          .f("gi_ltf", ti.gi_ltf)
+          .f("nltf", ti.num_he_ltf)
+          .f("ap_pwr", ti.ap_tx_power)
+          .f("users", ti.n_users);
+      if (ti.n_users > 0)
+        ev.f("u0_aid", ti.users[0].aid12)
+            .f("u0_ru", ti.users[0].ru_alloc)
+            .f("u0_mcs", ti.users[0].mcs)
+            .f("u0_ss", ti.users[0].ss);
+    }
+    return; /* a trigger is not a data/mgmt frame — nothing else to match */
+  }
 
   if (g_hop_schedule && packet.Data.size() >= 16 &&
       std::memcmp(packet.Data.data() + 10, kTxSa, 6) == 0) {

--- a/src/AdapterCaps.h
+++ b/src/AdapterCaps.h
@@ -162,6 +162,18 @@ struct AdapterCaps {
    * hardware time distribution (see TsfSync). */
   bool hw_rx_timestamp = false;
   bool hw_beacon_txtsf = false;
+  /* 802.11ax scheduled UL (Kestrel/RTL8852 only). trigger_ul_ok: the adapter
+   * can air an HE Trigger frame (UL-OFDMA grant) and program the fw UL-OFDMA
+   * scheduler (SendTrigger / ConfigureUlOfdma). twt_ok: the fw exposes the TWT
+   * agreement surface (ConfigureTwt / TwtBindSta). Pre-AX generations have no
+   * trigger/TWT firmware surface. */
+  bool trigger_ul_ok = false;
+  bool twt_ok = false;
+  /* sounding_ok: the adapter can air an HE sounding sequence (NDPA -> NDP ->
+   * BFRP) and receive the beamformee's report as a hardware-scheduled HE TB
+   * PPDU — the production trigger-airing path (StartSounding / RegisterBeamformee).
+   * This is what the shipped client fw actually runs, vs the MP-only F2P path. */
+  bool sounding_ok = false;
 };
 
 inline void set_standard_freq_ranges(AdapterCaps &c) {

--- a/src/AdapterCaps.h
+++ b/src/AdapterCaps.h
@@ -169,10 +169,11 @@ struct AdapterCaps {
    * trigger/TWT firmware surface. */
   bool trigger_ul_ok = false;
   bool twt_ok = false;
-  /* sounding_ok: the adapter can air an HE sounding sequence (NDPA -> NDP ->
-   * BFRP) and receive the beamformee's report as a hardware-scheduled HE TB
-   * PPDU — the production trigger-airing path (StartSounding / RegisterBeamformee).
-   * This is what the shipped client fw actually runs, vs the MP-only F2P path. */
+  /* sounding_ok: the adapter exposes the HE sounding command surface (NDPA ->
+   * NDP -> BFRP via StartSounding / RegisterBeamformee). NB the shipped client
+   * NIC firmware accepts SET_SND_PARA but does not air the sequence (the fw
+   * sounding-transmit engine is AP-firmware-only, like the MP-only F2P path);
+   * host-injected SendTrigger is what puts a Trigger on the air. */
   bool sounding_ok = false;
 };
 

--- a/src/DeviceConfig.h
+++ b/src/DeviceConfig.h
@@ -298,6 +298,13 @@ struct DeviceConfig {
      * medium-busy gates enabled (carrier-sense TX) instead of clearing them,
      * to test whether the ported RX-DCK calibration fixed the perpetual-busy. */
     bool kestrel_cca_on = false;
+    /* env: DEVOURER_KESTREL_TRIGGER_F2P — force SendTrigger down the fw F2P_TEST
+     * command instead of host-injecting the raw Basic Trigger through the mgmt
+     * TX path. F2P is an MP-only entry the shipped client fw silently drops (it
+     * airs nothing on-air), so the default (false) host-injects a real Basic
+     * Trigger frame that actually leaves the antenna. Set true only to reproduce
+     * the F2P no-op for comparison. */
+    bool kestrel_trigger_f2p = false;
   } debug;
 
   /* ---- USB / process environment -------------------------------------- */

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -285,12 +285,13 @@ public:
     return false;
   }
 
-  /* Drive one HE sounding: the fw builds and airs the NDPA -> NDP -> BFRP
-   * sequence (a BFRP is an 802.11ax Trigger-frame variant) and receives the
-   * beamformee's report as a hardware-scheduled HE TB PPDU
-   * (RxAtrib.ppdu_type == 10) — the production contention-free UL primitive.
-   * This is the trigger-airing path the shipped client fw actually runs (unlike
-   * SendTrigger's F2P command). Returns false where unsupported. */
+  /* Drive one HE sounding: hand the fw the NDPA -> NDP -> BFRP descriptor set (a
+   * BFRP is an 802.11ax Trigger-frame variant) to build and air, soliciting the
+   * beamformee's report as a hardware-scheduled HE TB PPDU (RxAtrib.ppdu_type ==
+   * 10). Measured: the shipped client NIC firmware accepts the H2C but does not
+   * air the sequence (the fw sounding-transmit engine is AP-firmware-only) — the
+   * path that actually airs a Trigger on this firmware is host-injection
+   * (SendTrigger). Returns false where unsupported. See docs/he-trigger-ul.md. */
   virtual bool StartSounding(const devourer::SoundingConfig & /*cfg*/) {
     return false;
   }

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -13,6 +13,8 @@
 #include "RxSense.h"
 #include "SelectedChannel.h"
 #include "ThermalStatus.h"
+#include "Sounding.h"
+#include "TriggerTwt.h"
 #include "TxCaps.h"
 #include "TxMode.h"
 #include "TxPower.h"
@@ -229,6 +231,69 @@ public:
   }
   virtual void ClearAmpduMode() {}
   virtual devourer::AmpduMode GetAmpduMode() { return {}; }
+
+  /* 802.11ax trigger-based UL + TWT (src/TriggerTwt.h) — the standards-native
+   * scheduled, contention-free UL access. Kestrel (RTL8852) only: the AP airs
+   * an HE Trigger frame that grants each STA a resource unit and a start time
+   * (SIFS after the trigger), and the STA MAC fires its UL-OFDMA TX at that
+   * instant in hardware. Every method returns false where unsupported (the
+   * Jaguar generations have no HE trigger/TWT firmware surface). */
+
+  /* Air one HE Basic Trigger (UL-OFDMA grant) via the firmware F2P command. */
+  virtual bool SendTrigger(const devourer::TriggerConfig & /*cfg*/) {
+    return false;
+  }
+
+  /* Create/modify a TWT agreement (wake window, interval, absolute target-wake
+   * TSF); TeardownTwt deletes it. The AP owns the timetable. */
+  virtual bool ConfigureTwt(const devourer::TwtConfig & /*cfg*/) { return false; }
+  virtual bool TeardownTwt(const devourer::TwtConfig & /*cfg*/) { return false; }
+  /* Bind/unbind a STA (macid) to a TWT config (add/del/terminate/...). */
+  virtual bool TwtBindSta(const devourer::TwtStaAct & /*act*/) { return false; }
+
+  /* Program the fw-autonomous trigger cadence inside a TWT service period
+   * (TWT-OFDMA). Returns false where the fw lacks the (non-canonical) command —
+   * ConfigureUlOfdma is the canonical fallback. */
+  virtual bool ConfigureTwtOfdma(const devourer::TwtOfdmaConfig & /*cfg*/) {
+    return false;
+  }
+
+  /* Program the production UL-OFDMA scheduler table (UL_FIXINFO). With
+   * mode=tf_periodic the fw airs Triggers autonomously at the configured
+   * interval — the transport-independent scheduled-UL primitive. */
+  virtual bool ConfigureUlOfdma(const devourer::UlOfdmaConfig & /*cfg*/) {
+    return false;
+  }
+
+  /* Register an associated peer STA (a scheduled-UL client): its macid + ADDR_CAM
+   * so a Trigger's per-user grant scores against it. `peer_mac` is the STA's
+   * address, `addr_cam_idx` must be unique per peer. The AP-side companion to
+   * SendTrigger/ConfigureUlOfdma for the end-to-end UL path. Returns false where
+   * unsupported. */
+  virtual bool RegisterPeerSta(const uint8_t /*peer_mac*/[6], uint8_t /*macid*/,
+                               uint8_t /*addr_cam_idx*/) {
+    return false;
+  }
+
+  /* Register an associated HE STA (macid) as a beamformee to sound: program its
+   * per-STA CSI/bf params (nc/nr/ng/cb/cs) + the sounding-status/CSI-buffer maps
+   * so a BFRP to it solicits a decodable compressed-beamforming report. The
+   * AP-side companion to StartSounding. Returns false where unsupported. */
+  virtual bool RegisterBeamformee(const uint8_t /*peer_mac*/[6], uint8_t /*macid*/,
+                                  uint8_t /*addr_cam_idx*/,
+                                  const devourer::StaBfCaps & /*bf*/) {
+    return false;
+  }
+
+  /* Drive one HE sounding: the fw builds and airs the NDPA -> NDP -> BFRP
+   * sequence (a BFRP is an 802.11ax Trigger-frame variant) and receives the
+   * beamformee's report as a hardware-scheduled HE TB PPDU
+   * (RxAtrib.ppdu_type == 10) — the production contention-free UL primitive.
+   * This is the trigger-airing path the shipped client fw actually runs (unlike
+   * SendTrigger's F2P command). Returns false where unsupported. */
+  virtual bool StartSounding(const devourer::SoundingConfig & /*cfg*/) {
+    return false;
+  }
 
   /* Batch TX: submit `count` frames (each buffer = radiotap header + 802.11
    * MPDU, the send_packet contract) in one call. With USB TX aggregation

--- a/src/Sounding.h
+++ b/src/Sounding.h
@@ -1,24 +1,24 @@
 #pragma once
 
-/* Sounding — the 802.11ax HE sounding (NDPA -> NDP -> BFRP) session knobs.
+/* Sounding — the 802.11ax HE sounding (NDPA -> NDP -> BFRP) command surface.
  *
- * This is the *production* trigger-airing path on the RTL8852 client firmware:
- * the fw builds and airs the NDPA/NDP/BFRP frames from a single H2C
- * (CL_SOUND / SET_SND_PARA, content-in-H2C, no pkt_ofld) and arms RX for the
- * beamforming-report HE TB PPDU. A BFRP (Beamforming Report Poll) is an
- * 802.11ax Trigger-frame variant, so it solicits a genuine hardware-scheduled,
- * contention-free UL transmission (the STA's compressed beamforming report,
- * sent as an HE TB PPDU at trigger+SIFS).
+ * A BFRP (Beamforming Report Poll) is an 802.11ax Trigger-frame variant, so the
+ * sounding sequence is the firmware's own use of the Trigger primitive: the H2C
+ * (CL_SOUND / SET_SND_PARA, content-in-H2C, no pkt_ofld) hands the fw the whole
+ * NDPA/NDP/BFRP descriptor set for it to build and air.
  *
- * Unlike the F2P_TEST command (an MP/hardware-verification entry with no
- * shipped-fw handler), sounding is a normal client feature. These aggregates
- * are devourer-native; the Kestrel HAL maps them onto the vendor
- * mac_ax_fwcmd_snd via the SchedEncode.h encoder. The raw 72-/98-dword vendor
- * struct never surfaces here.
+ * On-air status (measured, both dies): the shipped client NIC firmware ACCEPTS
+ * SET_SND_PARA (no SER) but does NOT air the sequence — the fw-command sounding-
+ * transmit engine is present only in the vendor's AP-firmware image, and the
+ * NIC-firmware host-NDPA path is unwired in the vendor tree. So, like the
+ * F2P_TEST command, this is a byte-exact command surface the shipped fw does not
+ * act on. The path that actually puts a Trigger on the air on this firmware is
+ * host-injection (IRtlDevice::SendTrigger, src/TriggerTwt.h). See
+ * docs/he-trigger-ul.md.
  *
- * The plane split mirrors the rest of the AX MAC surface: the AP (this driver)
- * owns the sounding schedule and the fw airs the frames; the STA MAC fires its
- * TB-PPDU report at trigger+SIFS in hardware. */
+ * These aggregates are devourer-native; the Kestrel HAL maps them onto the
+ * vendor mac_ax_fwcmd_snd via the SchedEncode.h encoder. The raw 72-/98-dword
+ * vendor struct never surfaces here. */
 
 #include <array>
 #include <cstdint>

--- a/src/Sounding.h
+++ b/src/Sounding.h
@@ -1,0 +1,225 @@
+#pragma once
+
+/* Sounding — the 802.11ax HE sounding (NDPA -> NDP -> BFRP) session knobs.
+ *
+ * This is the *production* trigger-airing path on the RTL8852 client firmware:
+ * the fw builds and airs the NDPA/NDP/BFRP frames from a single H2C
+ * (CL_SOUND / SET_SND_PARA, content-in-H2C, no pkt_ofld) and arms RX for the
+ * beamforming-report HE TB PPDU. A BFRP (Beamforming Report Poll) is an
+ * 802.11ax Trigger-frame variant, so it solicits a genuine hardware-scheduled,
+ * contention-free UL transmission (the STA's compressed beamforming report,
+ * sent as an HE TB PPDU at trigger+SIFS).
+ *
+ * Unlike the F2P_TEST command (an MP/hardware-verification entry with no
+ * shipped-fw handler), sounding is a normal client feature. These aggregates
+ * are devourer-native; the Kestrel HAL maps them onto the vendor
+ * mac_ax_fwcmd_snd via the SchedEncode.h encoder. The raw 72-/98-dword vendor
+ * struct never surfaces here.
+ *
+ * The plane split mirrors the rest of the AX MAC surface: the AP (this driver)
+ * owns the sounding schedule and the fw airs the frames; the STA MAC fires its
+ * TB-PPDU report at trigger+SIFS in hardware. */
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+
+namespace devourer {
+
+/* One beamformee's STA Info in the HE NDPA (802.11ax NDP Announcement). */
+struct SoundingStaInfo {
+  uint16_t aid = 0;     /* 11-bit AID of the beamformee */
+  uint16_t bw = 0;      /* Sounding bandwidth (0 = 20 MHz) */
+  uint8_t fb_ng = 0;    /* Feedback Ng (subcarrier grouping: 0 = Ng4) */
+  bool cb = false;      /* Codebook size */
+  uint8_t nc = 0;       /* Nc-1 (number of columns of the feedback matrix) */
+};
+
+/* One beamformee's User Info in the HE BFRP Trigger (what TB PPDU to send). */
+struct SoundingBfrpUser {
+  uint16_t aid12 = 0;    /* 12-bit AID of the polled STA */
+  uint8_t ru_pos = 0;    /* 8-bit RU Allocation subfield (61 = full 20 MHz) */
+  bool ul_fec_code = false; /* false = BCC, true = LDPC */
+  uint8_t ul_mcs = 0;    /* 0..11 */
+  bool ul_dcm = false;
+  uint8_t ss_alloc = 0;  /* SS Allocation subfield (0 = 1 SS starting at SS0) */
+  uint8_t fbseg_rexmit_bmp = 0;
+  uint8_t ul_tgt_rssi = 127; /* 7-bit target RSSI (127 = transmit at max power) */
+};
+
+/* One entry of the sounding WD list (the TX descriptor the fw uses for each
+ * frame in the NDPA/NDP/BFRP sequence). The frexgtype-specific fields
+ * (txpktsize / snd_pkt_sel / ndpa / sifs_tx) are set by make_he_bfrp_sounding
+ * to match the vendor mac_set_snd_para AX_MU_BFRP1 case. */
+struct SoundingWd {
+  uint16_t txpktsize = 0;
+  uint16_t ndpa_duration = 0;
+  uint16_t datarate = 0;  /* AX 9-bit rate code the frame airs at (0 = OFDM6) */
+  uint8_t macid = 0;
+  uint8_t data_bw = 0;
+  uint8_t gi_ltf = 0;
+  bool stf_mode = false;
+  bool disdatafb = false;
+  bool data_txcnt_lmt_sel = false;
+  uint8_t data_txcnt_lmt = 0;
+  bool sifs_tx = false;
+  uint8_t snd_pkt_sel = 0; /* 1 = NDPA, 3 = NDP, 5 = BFRP (fw frame selector) */
+  uint8_t ndpa = 0;        /* 0 = none, 2 = VHT, 3 = HE */
+};
+
+/* HE BFRP Trigger common info (the Trigger frame Common Info field). */
+struct SoundingBfrpCommon {
+  uint8_t trigger_type = 0; /* 1 = BFRP */
+  uint16_t ul_len = 0;      /* L-SIG length of the solicited TB PPDU */
+  uint8_t ul_bw = 0;        /* 0 = 20 MHz */
+  uint8_t gi_ltf = 0;
+  uint8_t num_he_ltf = 0;
+  uint8_t ap_tx_pwr = 0;
+  uint16_t ul_sr = 0;
+};
+
+/* A complete HE sounding command (mirrors mac_ax_fwcmd_snd for the devourer
+ * surface). Defaults are zero; use make_he_bfrp_sounding() to build a valid
+ * single-user HE BFRP sounding. */
+struct SoundingConfig {
+  uint8_t frexgtype = 36; /* FRAME_EXCHANGE_SND_AX_MU_BFRP1 */
+  uint8_t mode = 0;
+  uint8_t bfrp0_user_num = 0;
+  uint8_t bfrp1_user_num = 0;
+  std::array<uint8_t, 16> macid{}; /* beamformee macids (macid[0] = STA) */
+
+  /* NDPA frame + STA-info list. */
+  uint16_t ndpa_frame_ctl = 0x0054;
+  uint16_t ndpa_duration = 0;
+  std::array<uint8_t, 6> ndpa_addr1{}; /* RA (the beamformee / broadcast) */
+  std::array<uint8_t, 6> ndpa_addr2{}; /* TA (AP SA) */
+  std::array<uint8_t, 6> ndpa_addr3{}; /* BSSID */
+  uint16_t ndpa_seq_control = 0;
+  bool ndpa_dialog_he = true;
+  uint8_t ndpa_dialog_token = 0;
+  std::array<SoundingStaInfo, 8> he_sta{}; /* HE NDPA STA Info (index 0..7) */
+
+  /* BFRP frame headers (up to 3: BFRP0/1/2) + per-BFRP common+user. */
+  std::array<uint16_t, 3> bfrp_frame_ctl{{0x0024, 0x0024, 0x0024}};
+  std::array<uint16_t, 3> bfrp_duration{};
+  std::array<std::array<uint8_t, 6>, 3> bfrp_addr1{}; /* RA */
+  std::array<std::array<uint8_t, 6>, 3> bfrp_addr2{}; /* TA (AP SA) */
+  std::array<SoundingBfrpCommon, 2> bfrp_common{};
+  std::array<std::array<SoundingBfrpUser, 8>, 2> bfrp_user{};
+
+  /* WD list (5 entries) + F2P(BFRP) + SFP. */
+  std::array<SoundingWd, 5> wd{};
+  std::array<uint16_t, 2> csi_len_bfrp{};    /* f2p[0/1].csi_len_bfrp */
+  std::array<uint8_t, 2> tb_t_pe_bfrp{};
+  uint8_t f2p_type = 0;   /* sfp.f2p_type (0 = add/one-shot) */
+  uint8_t f2p_index = 0;
+  uint16_t f2p_period = 0; /* 0 = one-shot; >0 = periodic sounding (units of TU) */
+  bool sounding_en = false; /* sfp.sounding_en (periodic-sounding enable) */
+};
+
+/* Per-STA beamformee capability the AP programs into the CCTL bf fields so a
+ * BFRP to this STA solicits a decodable report. Values are the STA's advertised
+ * HE beamformee params (Nc, Ng, codebook) + the CSI report rate/BW. */
+struct StaBfCaps {
+  uint8_t nc = 0;   /* Nc-1 */
+  uint8_t nr = 0;   /* Nr-1 (AP receive chains - 1) */
+  uint8_t ng = 0;   /* subcarrier grouping (0 = Ng4) */
+  uint8_t cb = 1;   /* codebook */
+  uint8_t cs = 0;   /* codebook subset */
+  uint8_t csi_bw = 0;      /* 0 = 20 MHz */
+  uint8_t csi_gi_ltf = 0;  /* CSI report GI/LTF */
+  uint16_t csi_fix_rate = 0; /* 0 = auto (from RRSC) */
+};
+
+/* Build a single-user HE BFRP sounding: the AP (ap_mac / bssid) sounds one
+ * associated beamformee (sta_mac, aid, fw macid). Fills the NDPA + BFRP frame
+ * content and the WD list per the vendor mac_set_snd_para AX_MU_BFRP1 case
+ * (wd[0]=NDPA, wd[1]=NDP, wd[2]=BFRP). `dialog` is the rolling sounding dialog
+ * token; `csi_bw` selects the sounding bandwidth (0 = 20 MHz). `air_rate` is
+ * the AX rate code the NDPA/NDP/BFRP air at (0 = OFDM6, non-HT so any monitor
+ * decodes the trigger). */
+/* `period` selects the fw sounding cadence: 0 = a one-shot sounding (SNDF2P_ONCE,
+ * the caller re-issues each time — beware flooding the CH12 H2C queue if fast);
+ * >0 = fw-autonomous periodic sounding (SNDF2P_ADD + sounding_en), so ONE H2C
+ * arms repeated soundings at the fw's own cadence (units are the vendor
+ * f2p_period field) — the analogue of UL_FIXINFO tf_periodic and the way to
+ * sustain sounding without per-sounding H2Cs. */
+inline SoundingConfig make_he_bfrp_sounding(const uint8_t ap_mac[6],
+                                            const uint8_t bssid[6],
+                                            const uint8_t sta_mac[6],
+                                            uint16_t aid, uint8_t macid,
+                                            uint8_t dialog,
+                                            uint16_t period = 0,
+                                            uint8_t ap_macid = 0,
+                                            uint16_t air_rate = 0,
+                                            uint8_t ul_mcs = 0) {
+  SoundingConfig c;
+  c.frexgtype = 36; /* AX_MU_BFRP1 */
+  c.bfrp0_user_num = 1;
+  c.macid[0] = macid;
+
+  /* NDPA (type1/subtype5, FC 0x0054): RA = STA, TA = AP, BSSID. */
+  c.ndpa_frame_ctl = 0x0054;
+  std::memcpy(c.ndpa_addr1.data(), sta_mac, 6);
+  std::memcpy(c.ndpa_addr2.data(), ap_mac, 6);
+  std::memcpy(c.ndpa_addr3.data(), bssid, 6);
+  c.ndpa_dialog_he = true;
+  c.ndpa_dialog_token = dialog & 0x3f;
+  c.he_sta[0].aid = aid & 0x7ff;
+  c.he_sta[0].bw = 0;
+  c.he_sta[0].fb_ng = 0;
+  c.he_sta[0].cb = false;
+  c.he_sta[0].nc = 0; /* Nc-1 = 0 -> 1 column */
+
+  /* BFRP0 Trigger (type1/subtype2, FC 0x0024): RA = STA, TA = AP. */
+  c.bfrp_frame_ctl[0] = 0x0024;
+  std::memcpy(c.bfrp_addr1[0].data(), sta_mac, 6);
+  std::memcpy(c.bfrp_addr2[0].data(), ap_mac, 6);
+  c.bfrp_common[0].trigger_type = 1; /* BFRP */
+  c.bfrp_common[0].ul_len = 0x1ff;   /* placeholder L-SIG len (tuned on-air) */
+  c.bfrp_common[0].ul_bw = 0;
+  c.bfrp_common[0].gi_ltf = 0;
+  c.bfrp_common[0].num_he_ltf = 0;
+  c.bfrp_common[0].ap_tx_pwr = 0x3f;
+  c.bfrp_user[0][0].aid12 = aid & 0xfff;
+  c.bfrp_user[0][0].ru_pos = 61; /* full 20 MHz (242-tone) */
+  c.bfrp_user[0][0].ul_mcs = ul_mcs & 0xf;
+  c.bfrp_user[0][0].ss_alloc = 0; /* 1 SS */
+  c.bfrp_user[0][0].ul_tgt_rssi = 127; /* max power */
+  c.csi_len_bfrp[0] = 0x1ff;
+
+  /* WD list per mac_set_snd_para AX_MU_BFRP1 (users = 1):
+   * wd[0]=NDPA, wd[1]=NDP, wd[2]=BFRP. */
+  const uint8_t users = 1;
+  auto &w0 = c.wd[0];
+  w0.txpktsize = static_cast<uint16_t>(17 + 4 * users);
+  w0.stf_mode = true; w0.disdatafb = true;
+  w0.data_txcnt_lmt_sel = true; w0.data_txcnt_lmt = 1;
+  w0.sifs_tx = true; w0.snd_pkt_sel = 1; w0.ndpa = 3;
+  w0.datarate = air_rate; w0.macid = ap_macid;
+  auto &w1 = c.wd[1];
+  w1.txpktsize = 0;
+  w1.stf_mode = true; w1.disdatafb = true;
+  w1.data_txcnt_lmt_sel = true; w1.data_txcnt_lmt = 1;
+  w1.sifs_tx = true; w1.snd_pkt_sel = 3; w1.ndpa = 3;
+  w1.datarate = air_rate; w1.macid = ap_macid;
+  auto &w2 = c.wd[2];
+  w2.txpktsize = static_cast<uint16_t>(24 + 6 * users);
+  w2.stf_mode = true; w2.disdatafb = true;
+  w2.data_txcnt_lmt_sel = true; w2.data_txcnt_lmt = 1;
+  w2.sifs_tx = false; w2.snd_pkt_sel = 5; w2.ndpa = 3;
+  w2.datarate = air_rate; w2.macid = ap_macid;
+
+  if (period > 0) {
+    c.f2p_type = 1;          /* SNDF2P_ADD — fw-autonomous periodic sounding */
+    c.f2p_period = period;
+    c.sounding_en = true;
+  } else {
+    c.f2p_type = 0;          /* SNDF2P_ONCE — one-shot (caller re-issues) */
+    c.f2p_period = 0;
+    c.sounding_en = false;
+  }
+  return c;
+}
+
+} /* namespace devourer */

--- a/src/TriggerParse.h
+++ b/src/TriggerParse.h
@@ -1,0 +1,105 @@
+#pragma once
+
+/* TriggerParse — decode a received 802.11ax Trigger frame.
+ *
+ * A Trigger is an 802.11 CONTROL frame (FC type 1, subtype 2) aired in a
+ * legacy/non-HT PPDU, so ANY monitor — including an 11ac witness that cannot
+ * decode HE data — captures the bytes and this parser reads them. That is the
+ * validation lever for the F2P/UL_FIXINFO scheduled-UL path: point rxdemo at
+ * the AP and confirm the aired trigger's fields match what was commanded, which
+ * also empirically resolves the fw's RU/mode encoding.
+ *
+ * Symmetric with build_basic_trigger() (TriggerTwt.h); the round-trip is a
+ * headless selftest (tests/trigger_parse_selftest.cpp). Header-only, no deps,
+ * neutral namespace — same shape as RxPacket.h / RadiotapPeek.h. */
+
+#include <cstddef>
+#include <cstdint>
+
+namespace devourer {
+
+struct TriggerUserInfo {
+  uint16_t aid12 = 0;
+  uint8_t ru_alloc = 0;
+  bool ldpc = false;
+  uint8_t mcs = 0;
+  bool dcm = false;
+  uint8_t ss = 0;
+  int8_t tgt_rssi_dbm = 0;
+};
+
+struct TriggerInfo {
+  uint8_t trigger_type = 0; /* 0 = Basic, 1 = Beamforming Report Poll, ... */
+  uint16_t ul_length = 0;
+  uint8_t ul_bw = 0;        /* 0 = 20, 1 = 40, 2 = 80, 3 = 160 */
+  uint8_t gi_ltf = 0;
+  uint8_t num_he_ltf = 0;
+  uint8_t ap_tx_power = 0;
+  uint8_t ta[6] = {0};      /* transmitter (AP) address */
+  uint8_t ra[6] = {0};      /* receiver address */
+  uint8_t n_users = 0;      /* User Info fields decoded (capped at cap below) */
+  TriggerUserInfo users[8];
+};
+
+/* True iff `frame` (an 802.11 frame body, no radiotap, no FCS) is a Trigger
+ * control frame. Cheap FC check for an RX-loop fast path. */
+inline bool is_trigger_frame(const uint8_t *frame, size_t len) {
+  /* FC byte0: version[1:0]=0, type[3:2]=01(control), subtype[7:4]=0010 -> 0x24. */
+  return frame != nullptr && len >= 2 && frame[0] == 0x24;
+}
+
+/* Parse a Basic-Trigger-style frame into `out`. Returns false if the frame is
+ * not a trigger or is too short for the fixed header + one User Info. The FCS
+ * (last 4 bytes on a monitor capture that includes it) is ignored; pass either
+ * with or without it. Up to 8 User Info fields are decoded. */
+inline bool parse_trigger(const uint8_t *frame, size_t len, TriggerInfo &out) {
+  /* FC(2) + Duration(2) + RA(6) + TA(6) + Common(8) = 24, then >=1 user (5). */
+  if (!is_trigger_frame(frame, len) || len < 24 + 5)
+    return false;
+  out = TriggerInfo{};
+  for (int i = 0; i < 6; ++i) {
+    out.ra[i] = frame[4 + i];
+    out.ta[i] = frame[10 + i];
+  }
+  /* Common Info: little-endian 8-byte bitfield (see build_basic_trigger). */
+  uint64_t common = 0;
+  for (int i = 0; i < 8; ++i)
+    common |= static_cast<uint64_t>(frame[16 + i]) << (8 * i);
+  out.trigger_type = static_cast<uint8_t>(common & 0xf);
+  out.ul_length = static_cast<uint16_t>((common >> 4) & 0xfff);
+  out.ul_bw = static_cast<uint8_t>((common >> 18) & 0x3);
+  out.gi_ltf = static_cast<uint8_t>((common >> 20) & 0x3);
+  out.num_he_ltf = static_cast<uint8_t>((common >> 23) & 0x7);
+  out.ap_tx_power = static_cast<uint8_t>((common >> 28) & 0x3f);
+  /* User Info fields (5 bytes each) until the frame ends. A capture that still
+   * carries the 4-byte FCS leaves a <5-byte tail, which the loop simply drops;
+   * a Padding field (all-ones AID12) would too, but Basic Triggers from this
+   * driver carry no padding. */
+  size_t o = 24;
+  out.n_users = 0;
+  while (o + 5 <= len && out.n_users < 8) {
+    uint64_t ui = 0;
+    for (int i = 0; i < 5; ++i)
+      ui |= static_cast<uint64_t>(frame[o + i]) << (8 * i);
+    const uint16_t aid = static_cast<uint16_t>(ui & 0xfff);
+    /* AID12 == 0xFFF marks a Padding User Info — end of the user list. */
+    if (aid == 0xfff)
+      break;
+    TriggerUserInfo &u = out.users[out.n_users];
+    u.aid12 = aid;
+    u.ru_alloc = static_cast<uint8_t>((ui >> 12) & 0xff);
+    u.ldpc = ((ui >> 20) & 0x1) != 0;
+    u.mcs = static_cast<uint8_t>((ui >> 21) & 0xf);
+    u.dcm = ((ui >> 25) & 0x1) != 0;
+    u.ss = static_cast<uint8_t>((ui >> 26) & 0x3f);
+    /* Target RSSI subfield [38:32]: 0..90 = -110..-20 dBm; 127 = max power (0). */
+    uint8_t rssi7 = static_cast<uint8_t>((ui >> 32) & 0x7f);
+    u.tgt_rssi_dbm =
+        (rssi7 >= 91) ? 0 : static_cast<int8_t>(static_cast<int>(rssi7) - 110);
+    out.n_users++;
+    o += 5;
+  }
+  return out.n_users > 0;
+}
+
+} /* namespace devourer */

--- a/src/TriggerParse.h
+++ b/src/TriggerParse.h
@@ -71,13 +71,15 @@ inline bool parse_trigger(const uint8_t *frame, size_t len, TriggerInfo &out) {
   out.gi_ltf = static_cast<uint8_t>((common >> 20) & 0x3);
   out.num_he_ltf = static_cast<uint8_t>((common >> 23) & 0x7);
   out.ap_tx_power = static_cast<uint8_t>((common >> 28) & 0x3f);
-  /* User Info fields (5 bytes each) until the frame ends. A capture that still
-   * carries the 4-byte FCS leaves a <5-byte tail, which the loop simply drops;
-   * a Padding field (all-ones AID12) would too, but Basic Triggers from this
-   * driver carry no padding. */
+  /* User Info fields until the frame ends. Each is 5 common bytes + a
+   * Trigger-Dependent User Info whose size is set by the trigger type (Basic=1
+   * byte, per 802.11ax). A Padding field (AID12 == 4095) or a sub-6-byte tail
+   * (a capture's trailing FCS) ends the list. */
+  const size_t tdep = out.trigger_type == 0 ? 1 : 0; /* Basic Trigger: 1 byte */
+  const size_t ustride = 5 + tdep;
   size_t o = 24;
   out.n_users = 0;
-  while (o + 5 <= len && out.n_users < 8) {
+  while (o + ustride <= len && out.n_users < 8) {
     uint64_t ui = 0;
     for (int i = 0; i < 5; ++i)
       ui |= static_cast<uint64_t>(frame[o + i]) << (8 * i);
@@ -97,7 +99,7 @@ inline bool parse_trigger(const uint8_t *frame, size_t len, TriggerInfo &out) {
     u.tgt_rssi_dbm =
         (rssi7 >= 91) ? 0 : static_cast<int8_t>(static_cast<int>(rssi7) - 110);
     out.n_users++;
-    o += 5;
+    o += ustride;
   }
   return out.n_users > 0;
 }

--- a/src/TriggerTwt.h
+++ b/src/TriggerTwt.h
@@ -1,0 +1,245 @@
+#pragma once
+
+/* TriggerTwt — the 802.11ax trigger-based UL + TWT session knobs.
+ *
+ * These are devourer-native aggregates: the small set of fields a caller
+ * actually sets to make the firmware air an HE Trigger frame (UL-OFDMA grant)
+ * or to program a TWT / UL-OFDMA schedule. The Kestrel HAL maps them onto the
+ * vendor fw command surface (F2P trigger, TWT info/act/announce/OFDMA,
+ * UL_FIXINFO); the raw 46-/72-dword vendor structs never surface here.
+ *
+ * The plane split, same as the rest of the AX MAC surface:
+ *   - The AP (this driver) owns the schedule and builds the frames the fw airs.
+ *   - The STA MAC fires its UL-OFDMA transmission at trigger+SIFS in hardware.
+ * TWT negotiation (the S1G Action frames) is host-built like any mgmt frame;
+ * what the fw provides is the *scheduling* machinery these structs drive.
+ *
+ * Only trigger frames are 802.11 CONTROL frames (FC type 1, subtype 2), aired
+ * in a legacy/non-HT PPDU — so any monitor, including an 11ac witness, captures
+ * and decodes the bytes (see TriggerParse.h); no HE PHY is needed to validate
+ * what flew.  Docs: docs/he-extended-range.md is the sibling per-packet path;
+ * this is the scheduled-UL path. */
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace devourer {
+
+/* One user's UL grant inside a Basic Trigger (one HE User Info field). */
+struct TrigUser {
+  uint16_t aid12 = 0;  /* 12-bit association id of the granted STA (0 = the
+                        * unassociated/random-access slot) */
+  uint8_t macid = 0;   /* fw macid the grant is scored against */
+  /* 8-bit RU Allocation subfield (802.11ax Trigger User Info). 61 = 242-tone =
+   * a full 20 MHz RU. Build it with he_ru_alloc(). NOTE: whether the fw's
+   * ru_pos field wants this exact 802.11 code or its own RU index is verified
+   * on-air from the aired trigger's decoded User Info (runtime discovery). */
+  uint8_t ru_alloc = 61;
+  uint8_t ul_mcs = 0;  /* 0..11 */
+  uint8_t ss = 1;      /* spatial-stream count for this user (1..8) */
+  bool ldpc = false;   /* UL FEC: false = BCC, true = LDPC */
+  bool dcm = false;    /* dual-carrier modulation */
+  int8_t tgt_rssi_dbm = -60; /* AP's requested UL receive level (dBm) */
+  uint8_t pref_ac = 0; /* 0 = BE, 1 = BK, 2 = VI, 3 = VO */
+};
+
+/* A Basic Trigger (UL-OFDMA) — the one-shot F2P command config. Defaults air a
+ * single-user, full-20 MHz, MCS0 Basic Trigger, so a demo needs only a macid /
+ * aid to fire one. */
+struct TriggerConfig {
+  uint8_t ul_bw = 0;         /* solicited UL BW: 0 = 20, 1 = 40, 2 = 80, 3 = 160 */
+  uint8_t gi_ltf = 0;        /* HE GI+LTF combo (0 = 1x/1.6us short) */
+  uint8_t num_he_ltf = 1;    /* HE-LTF symbol count (0..7) */
+  uint8_t ap_tx_power = 20;  /* AP TX power field, 0..63 (Common Info) */
+  uint8_t pri20_bitmap = 0x1; /* primary-20 punctured-channel bitmap */
+  uint16_t trig_rate = 0;    /* the trigger frame's OWN legacy-PPDU TX rate
+                              * (AX 9-bit rate code; 0 = lowest OFDM). Trigger
+                              * frames air non-HT so any RX can decode them. */
+  uint8_t mode = 0;          /* fw f2p "mode" (2-bit) — undocumented, swept in
+                              * kestrelprobe (runtime discovery) */
+  uint8_t frexch_type = 0;   /* fw frame-exchange type (6-bit) — undocumented */
+  std::array<TrigUser, 8> users{}; /* up to 4 on the 8852B (v0), 8 on the 8852C
+                                    * (v1); n_users above the die max is clamped */
+  uint8_t n_users = 1;
+};
+
+/* Encode a target-RSSI dBm into the 7-bit 802.11ax Target RSSI subfield:
+ * 0..90 = -110..-20 dBm (encoded = dBm + 110); 127 = "transmit at max power"
+ * (no RSSI target, selected by dbm >= 0). Out-of-range dBm clamps into 0..90. */
+inline uint8_t he_tgt_rssi_enc(int dbm) {
+  if (dbm >= 0)
+    return 127;
+  int v = dbm + 110;
+  if (v < 0)
+    v = 0;
+  if (v > 90)
+    v = 90;
+  return static_cast<uint8_t>(v);
+}
+
+/* Encode the 8-bit RU Allocation subfield (802.11ax Trigger User Info) for a
+ * whole-RU-size allocation. `index` selects among equal-size RUs in the BW.
+ * 242-tone (index 0) = a full 20 MHz RU = 61 (the TriggerConfig default). This
+ * is the 802.11 standard code; the fw's own ru_pos convention is verified
+ * on-air (see TrigUser::ru_alloc). */
+inline uint8_t he_ru_alloc(unsigned tones, unsigned index = 0) {
+  switch (tones) {
+  case 26:
+    return static_cast<uint8_t>(index <= 36 ? index : 0); /* 26-tone RU #index */
+  case 52:
+    return static_cast<uint8_t>(37 + (index & 0xf));  /* 52-tone */
+  case 106:
+    return static_cast<uint8_t>(53 + (index & 0x7));  /* 106-tone */
+  case 242:
+    return static_cast<uint8_t>(61 + (index & 0x3));  /* 242-tone / full 20 MHz */
+  case 484:
+    return static_cast<uint8_t>(65 + (index & 0x1));  /* 484-tone / full 40 MHz */
+  case 996:
+    return 67;                                        /* 996-tone / full 80 MHz */
+  default:
+    return 61;                                        /* fallback: full 20 MHz */
+  }
+}
+
+/* TWT agreement config (mac_twt_info_upd). The AP owns the timetable; trgt_tsf
+ * is an absolute 64-bit TSF instant (read ReadTsf(), add lead time). */
+struct TwtConfig {
+  bool broadcast = false; /* false = individual TWT, true = broadcast TWT */
+  bool trigger = true;    /* trigger-enabled TWT (AP sends triggers in the SP) */
+  bool announced = false; /* announced (true) vs unannounced (false) flow */
+  bool protection = false;
+  uint8_t flow_id = 0;    /* TWT flow id (0..7) */
+  uint8_t config_id = 0;  /* fw TWT config slot (0..7) */
+  uint8_t port = 0;       /* MAC port (0..3) */
+  uint8_t band = 0;       /* 0 = band0/2.4-5G, 1 = band1 */
+  uint8_t wake_exp = 10;  /* wake-interval exponent (interval = man << exp us) */
+  uint16_t wake_man = 512; /* wake-interval mantissa */
+  uint8_t min_wake_dur = 255; /* nominal minimum wake duration (unit below) */
+  bool wake_dur_us256 = false; /* dur unit: false = 256us, true = 1 TU */
+  uint64_t trgt_tsf = 0;  /* absolute target wake time (TSF microseconds) */
+  bool ap_role = true;    /* nic_role: AP (true) vs STA (false) */
+};
+
+/* Bind / unbind a STA (macid) to a TWT agreement (mac_twt_act). */
+struct TwtStaAct {
+  uint8_t macid = 0;
+  uint8_t config_id = 0;
+  uint8_t action = 0; /* 0 add, 1 del, 2 terminate, 3 suspend, 4 resume */
+};
+
+/* TWT-OFDMA cadence (mac_twt_ofdma_info_upd, fw func 0x03). This is the "fw
+ * autonomously airs trigger rounds inside the TWT SP" lever. The func is
+ * non-canonical in the vendor tree (gated MAC_FEAT_TWT_OFDMA_EN, default 0) —
+ * whether the shipped fw implements it is a runtime discovery; UlOfdmaConfig is
+ * the canonical fallback. */
+struct TwtOfdmaConfig {
+  uint8_t option = 0;
+  uint8_t twt_id = 0;         /* which TWT config to schedule */
+  uint8_t max_tf_retry = 3;   /* max Basic-Trigger retries per round */
+  uint8_t max_dl_retry = 0;
+  uint8_t round_num = 1;      /* UL-OFDMA rounds per TWT service period */
+  uint8_t preferred_ac = 0;   /* 0 BE / 1 BK / 2 VI / 3 VO */
+  bool htc_bsr_ctrl_en = false;
+  uint16_t round_interval_us = 0; /* spacing between rounds */
+};
+
+/* One STA in the UL_FIXINFO scheduler table. */
+struct UlOfdmaSta {
+  uint8_t macid = 0;
+  uint8_t pref_ac = 0;
+  uint8_t ru_pos = 0;          /* fw RU index (verified on-air, see he_ru_alloc) */
+  int8_t tgt_rssi_dbm = -60;
+  uint8_t mcs = 0;
+  uint8_t ss = 1;
+  bool ldpc = false;
+  bool dcm = false;
+  uint16_t bsr_length = 0;     /* buffer-status hint (0 = fw decides) */
+};
+
+/* UL_FIXINFO — the fw's production UL-OFDMA scheduler table (mac_upd_ul_fixinfo,
+ * CLASS_UL_FIXINFO). mode=tf_periodic makes the fw air Triggers autonomously at
+ * `interval` seconds. Canonical (MAC_FEAT_ULOFDMA), so it is the fallback when
+ * TWT-OFDMA is absent from the shipped fw. */
+struct UlOfdmaConfig {
+  uint8_t mode = 3;      /* 0 periodic, 1 normal, 2 non-trigger, 3 tf_periodic */
+  uint8_t interval_s = 1; /* schedule interval (seconds) */
+  uint8_t bsr_thold = 0;
+  uint8_t store_mode = 0;
+  uint8_t tf_type = 0;   /* trigger type (0 = Basic) */
+  uint16_t data_rate = 0; /* trigger PPDU rate (AX 9-bit code) */
+  uint16_t apep_len = 0;
+  bool istwt = false;
+  uint8_t ppdu_bw = 0;   /* 0 = 20, 1 = 40, 2 = 80, 3 = 160 */
+  uint8_t gi_ltf = 0;
+  uint8_t multiport_id = 0;
+  std::array<UlOfdmaSta, 8> stas{};
+  uint8_t n_stas = 1;
+};
+
+/* Decoded TWT C2H event (twt.notify / twt.wait_anno), emitted by the RX loop. */
+struct TwtNotify {
+  uint8_t type = 0;    /* fw notify type (TWT_NOTIFY_EVT) */
+  uint8_t twt_id = 0;
+  uint64_t tsf = 0;    /* TSF-stamped notify instant */
+  bool wait_anno = false; /* true = WAIT_ANNOUNCE (macid list), false = NOTIFY */
+  uint8_t wait_case = 0;
+  uint8_t macid0 = 0, macid1 = 0, macid2 = 0;
+};
+
+/* -------- host-side Basic Trigger frame builder (step-0 raw injection) --------
+ *
+ * Assembles an 802.11 Basic Trigger control frame body (no radiotap, no FCS —
+ * the caller prepends radiotap for send_packet and the MAC appends the FCS)
+ * into `out` (>= 32 bytes for one user). Returns the byte length written, or 0
+ * on overflow. Symmetric with parse_trigger() (TriggerParse.h); the round-trip
+ * is a headless selftest. This path exists to (a) validate witness tooling
+ * before the fw path, and (b) probe whether the Kestrel TX path even accepts a
+ * control-frame subtype. The fw F2P path (SendTrigger) is the production one. */
+inline size_t build_basic_trigger(const TriggerConfig &cfg,
+                                  const uint8_t ra[6], const uint8_t ta[6],
+                                  uint8_t *out, size_t cap) {
+  const uint8_t nuser = cfg.n_users == 0 ? 1 : cfg.n_users;
+  const size_t need = 2 /*FC*/ + 2 /*dur*/ + 6 /*RA*/ + 6 /*TA*/ + 8 /*common*/ +
+                      static_cast<size_t>(nuser) * 5 /*user info*/;
+  if (out == nullptr || cap < need)
+    return 0;
+  size_t o = 0;
+  out[o++] = 0x24; /* FC: version0 | type1(control) | subtype2(trigger) */
+  out[o++] = 0x00; /* FC flags */
+  out[o++] = 0x00; /* Duration lo (fw/HW may overwrite) */
+  out[o++] = 0x00; /* Duration hi */
+  for (int i = 0; i < 6; ++i)
+    out[o++] = ra ? ra[i] : 0xff; /* RA (default broadcast) */
+  for (int i = 0; i < 6; ++i)
+    out[o++] = ta ? ta[i] : 0x00; /* TA */
+  /* Common Info (8 bytes, little-endian bitfield): Trigger Type[3:0]=0 (Basic),
+   * UL Length[15:4], More TF[16], CS Required[17], UL BW[19:18], GI/LTF[21:20],
+   * MU-MIMO LTF[22], Num HE-LTF[25:23], ... AP TX Power[33:28]. */
+  uint64_t common = 0;
+  common |= (static_cast<uint64_t>(cfg.ul_bw) & 0x3) << 18;
+  common |= (static_cast<uint64_t>(cfg.gi_ltf) & 0x3) << 20;
+  common |= (static_cast<uint64_t>(cfg.num_he_ltf) & 0x7) << 23;
+  common |= (static_cast<uint64_t>(cfg.ap_tx_power) & 0x3f) << 28;
+  for (int i = 0; i < 8; ++i)
+    out[o++] = static_cast<uint8_t>((common >> (8 * i)) & 0xff);
+  /* Per-user info (5 bytes = 40 bits, little-endian): AID12[11:0],
+   * RU Alloc[19:12], UL FEC/coding[20], UL MCS[24:21], UL DCM[25],
+   * SS Alloc[31:26], Target RSSI[38:32]. */
+  for (uint8_t u = 0; u < nuser; ++u) {
+    const TrigUser &tu = cfg.users[u];
+    uint64_t ui = 0;
+    ui |= static_cast<uint64_t>(tu.aid12) & 0xfff;
+    ui |= (static_cast<uint64_t>(tu.ru_alloc) & 0xff) << 12;
+    ui |= (static_cast<uint64_t>(tu.ldpc ? 1 : 0)) << 20;
+    ui |= (static_cast<uint64_t>(tu.ul_mcs) & 0xf) << 21;
+    ui |= (static_cast<uint64_t>(tu.dcm ? 1 : 0)) << 25;
+    ui |= (static_cast<uint64_t>(tu.ss) & 0x3f) << 26;
+    ui |= (static_cast<uint64_t>(he_tgt_rssi_enc(tu.tgt_rssi_dbm)) & 0x7f) << 32;
+    for (int i = 0; i < 5; ++i)
+      out[o++] = static_cast<uint8_t>((ui >> (8 * i)) & 0xff);
+  }
+  return o;
+}
+
+} /* namespace devourer */

--- a/src/TriggerTwt.h
+++ b/src/TriggerTwt.h
@@ -52,6 +52,12 @@ struct TriggerConfig {
   uint8_t gi_ltf = 0;        /* HE GI+LTF combo (0 = 1x/1.6us short) */
   uint8_t num_he_ltf = 1;    /* HE-LTF symbol count (0..7) */
   uint8_t ap_tx_power = 20;  /* AP TX power field, 0..63 (Common Info) */
+  /* UL Length (Common Info B4-B15): the L-SIG Length the solicited TB PPDU
+   * carries — a station computes its TB-PPDU duration from it, so a Basic
+   * Trigger with UL Length 0 elicits NO response. 0x1F4 (~a few-hundred-us TB
+   * PPDU, enough for a QoS-Null even with no buffered data) is a safe default;
+   * tune to the granted RU/MCS/duration for a data grant. */
+  uint16_t ul_length = 0x1F4;
   uint8_t pri20_bitmap = 0x1; /* primary-20 punctured-channel bitmap */
   uint16_t trig_rate = 0;    /* the trigger frame's OWN legacy-PPDU TX rate
                               * (AX 9-bit rate code; 0 = lowest OFDM). Trigger
@@ -59,6 +65,13 @@ struct TriggerConfig {
   uint8_t mode = 0;          /* fw f2p "mode" (2-bit) — undocumented, swept in
                               * kestrelprobe (runtime discovery) */
   uint8_t frexch_type = 0;   /* fw frame-exchange type (6-bit) — undocumented */
+  /* Transmitter Address of the aired Trigger (host-injection path). A station
+   * only answers a Trigger whose TA equals the BSSID it associated to, so this
+   * MUST be the AP's own address; all-zero falls back to the injection SA. */
+  std::array<uint8_t, 6> ta{};
+  /* Receiver Address. Zero = broadcast (a Basic Trigger addresses its users by
+   * AID12, so broadcast RA is standard); set to a STA MAC to unicast. */
+  std::array<uint8_t, 6> ra{};
   std::array<TrigUser, 8> users{}; /* up to 4 on the 8852B (v0), 8 on the 8852C
                                     * (v1); n_users above the die max is clamped */
   uint8_t n_users = 1;
@@ -200,8 +213,13 @@ inline size_t build_basic_trigger(const TriggerConfig &cfg,
                                   const uint8_t ra[6], const uint8_t ta[6],
                                   uint8_t *out, size_t cap) {
   const uint8_t nuser = cfg.n_users == 0 ? 1 : cfg.n_users;
+  /* Basic-Trigger User Info is 6 bytes (5 common + 1 Trigger Dependent). A
+   * Padding field (a User Info with AID12=4095 then 0xFF octets) marks the end
+   * of the list and gives the responder preparation time. */
+  const size_t kPad = 4;
   const size_t need = 2 /*FC*/ + 2 /*dur*/ + 6 /*RA*/ + 6 /*TA*/ + 8 /*common*/ +
-                      static_cast<size_t>(nuser) * 5 /*user info*/;
+                      static_cast<size_t>(nuser) * 6 /*user info*/ +
+                      2 /*pad marker*/ + kPad /*padding*/;
   if (out == nullptr || cap < need)
     return 0;
   size_t o = 0;
@@ -217,6 +235,7 @@ inline size_t build_basic_trigger(const TriggerConfig &cfg,
    * UL Length[15:4], More TF[16], CS Required[17], UL BW[19:18], GI/LTF[21:20],
    * MU-MIMO LTF[22], Num HE-LTF[25:23], ... AP TX Power[33:28]. */
   uint64_t common = 0;
+  common |= (static_cast<uint64_t>(cfg.ul_length) & 0xfff) << 4;
   common |= (static_cast<uint64_t>(cfg.ul_bw) & 0x3) << 18;
   common |= (static_cast<uint64_t>(cfg.gi_ltf) & 0x3) << 20;
   common |= (static_cast<uint64_t>(cfg.num_he_ltf) & 0x7) << 23;
@@ -238,7 +257,16 @@ inline size_t build_basic_trigger(const TriggerConfig &cfg,
     ui |= (static_cast<uint64_t>(he_tgt_rssi_enc(tu.tgt_rssi_dbm)) & 0x7f) << 32;
     for (int i = 0; i < 5; ++i)
       out[o++] = static_cast<uint8_t>((ui >> (8 * i)) & 0xff);
+    /* Trigger Dependent User Info (Basic Trigger): MPDU MU Spacing Factor[1:0],
+     * TID Aggregation Limit[4:2], reserved[5], Preferred AC[7:6]. */
+    out[o++] = static_cast<uint8_t>((tu.pref_ac & 0x3) << 6);
   }
+  /* Padding: a User Info whose AID12 = 4095 marks the end of the user list,
+   * then 0xFF octets give the responder time to prepare its TB PPDU. */
+  out[o++] = 0xff;
+  out[o++] = 0x0f; /* AID12 = 0xFFF (4095) in the low 12 bits */
+  for (size_t i = 0; i < kPad; ++i)
+    out[o++] = 0xff;
   return o;
 }
 

--- a/src/kestrel/HalKestrel.h
+++ b/src/kestrel/HalKestrel.h
@@ -219,6 +219,174 @@ public:
     return ok;
   }
 
+  /* Register the self MACID as an ACCESS POINT role (self_role=AP,
+   * wifi_role=AP, net_type=AP), not a client. The fw's AP-side machinery — the
+   * beacon engine AND the UL-OFDMA trigger scheduler — keys off the fw role;
+   * with a CLIENT role the fw ignores AP-side scheduling even though the port
+   * NET_TYPE register is set to AP for beaconing (role.c requires net_type=AP
+   * to pair with an AP self_role). The vendor constraint (role.c): for an AP
+   * self_role the SMA and TMA must equal the BSSID, so `bssid` is used for all
+   * three in the ADDR_CAM entry. Call in place of register_sta_role +
+   * add_self_sta when the device acts as an AP. */
+  bool register_ap_role(const uint8_t bssid[6], uint8_t macid = 0,
+                        uint8_t band = 0, uint8_t port = 0) {
+    bool ok = _fw.fw_role_maintain(macid, reg::MAC_AX_SELF_ROLE_AP,
+                                   reg::MAC_AX_WIFI_ROLE_AP,
+                                   reg::MAC_AX_ROLE_CREATE, band, port);
+    ok = _fw.fw_upd_addr_cam(macid, bssid, reg::MAC_AX_NET_TYPE_AP,
+                             /*addr_cam_idx=*/0, /*bssid_cam_idx=*/0) &&
+         ok;
+    ok = _fw.fw_upd_cctl_basic(macid, /*addr_cam_idx=*/0, reg::MAC_AX_OFDM6,
+                               /*ntx_path_en=*/1, /*path_map_a=*/0,
+                               /*bmc=*/false) &&
+         ok;
+    return ok;
+  }
+
+  /* Register an associated peer STA (an AP-mode client we schedule UL for):
+   * the same role + ADDR_CAM + CMAC-control chain as add_self_sta but for a
+   * distinct macid and net_type=AP, so the fw tracks the peer and a Trigger's
+   * per-user grant scores against its macid. `peer_mac` is the peer's address
+   * (the trigger's RA / the grant's target); `addr_cam_idx` must be unique per
+   * peer. The 802.11 AID the grant uses is carried per-frame in the trigger
+   * (TriggerConfig user aid12), independent of this CAM entry. */
+  bool register_peer_sta(const uint8_t peer_mac[6], uint8_t macid,
+                         uint8_t addr_cam_idx,
+                         uint8_t net_type = reg::MAC_AX_NET_TYPE_AP) {
+    bool ok = _fw.fw_role_maintain(macid, reg::MAC_AX_SELF_ROLE_CLIENT,
+                                   reg::MAC_AX_WIFI_ROLE_STATION,
+                                   reg::MAC_AX_ROLE_CREATE, /*band=*/0,
+                                   /*port=*/0);
+    ok = _fw.fw_upd_addr_cam(macid, peer_mac, net_type, addr_cam_idx,
+                             /*bssid_cam_idx=*/0) &&
+         ok;
+    ok = _fw.fw_upd_cctl_basic(macid, addr_cam_idx, reg::MAC_AX_OFDM6,
+                               /*ntx_path_en=*/1, /*path_map_a=*/0,
+                               /*bmc=*/false) &&
+         ok;
+    return ok;
+  }
+
+  /* ---- 802.11ax scheduled-UL levers (KestrelFwSched.cpp encoders) ---- */
+
+  /* Fire one HE Basic Trigger (UL-OFDMA grant) via the F2P command. */
+  bool send_trigger(const devourer::TriggerConfig &cfg) {
+    return _fw.f2p_trigger(cfg);
+  }
+
+  /* Create (act=ADD) / modify (act=MOD) a TWT agreement. mac_ax_twt_act_tp:
+   * ADD=0, DEL=1, MOD=2. */
+  bool configure_twt(const devourer::TwtConfig &cfg) {
+    return _fw.twt_info_upd(cfg, /*act=ADD*/ 0);
+  }
+  bool teardown_twt(const devourer::TwtConfig &cfg) {
+    return _fw.twt_info_upd(cfg, /*act=DEL*/ 1);
+  }
+  /* Bind / unbind a STA macid to a TWT config (add/del/terminate/suspend/
+   * resume — see TwtStaAct::action). */
+  bool twt_bind_sta(const devourer::TwtStaAct &act) { return _fw.twt_act(act); }
+  bool twt_announce(uint8_t macid) { return _fw.twt_announce(macid); }
+
+  /* TWT-OFDMA autonomous trigger cadence (fw func 0x03 — may be absent from the
+   * shipped fw; the caller falls back to configure_ul_ofdma). */
+  bool configure_twt_ofdma(const devourer::TwtOfdmaConfig &cfg) {
+    return _fw.twt_ofdma_info_upd(cfg);
+  }
+
+  /* Program the production UL-OFDMA scheduler table (mode=tf_periodic makes the
+   * fw air Triggers autonomously). */
+  bool configure_ul_ofdma(const devourer::UlOfdmaConfig &cfg) {
+    return _fw.ul_fixinfo(cfg);
+  }
+
+  /* ---- HE sounding (mac_init_snd_mer/_mee + mac_set_snd_para) ----
+   * The production trigger-airing path: arm the BB/MAC sounding engine, register
+   * the beamformee, then drive a sounding that airs NDPA -> NDP -> BFRP and
+   * receives the report HE TB PPDU. Band 0 only. */
+
+  /* mac_init_snd_mer + mac_init_snd_mee: arm the beamformer CSI-parse offsets +
+   * the beamformee response/CSI options so the AP can send NDPA/BFRP and parse
+   * the returned compressed-beamforming report. Idempotent register writes;
+   * call once in InitWrite (after phy_bb_rf_init). */
+  bool init_sounding() {
+    namespace k = kestrel::reg;
+    /* mer: BFMER_CTRL_0 = NDP_BFEN | HT/VHT/HE CSI payload offsets. */
+    _device.rtw_write32(
+        k::R_AX_BFMER_CTRL_0,
+        k::B_AX_BFMER_NDP_BFEN |
+            (static_cast<uint32_t>(k::HT_PAYLOAD_OFFSET)
+             << k::B_AX_BFMER_HT_CSI_OFFSET_SH) |
+            (static_cast<uint32_t>(k::VHT_PAYLOAD_OFFSET)
+             << k::B_AX_BFMER_VHT_CSI_OFFSET_SH) |
+            (static_cast<uint32_t>(k::HE_PAYLOAD_OFFSET)
+             << k::B_AX_BFMER_HE_CSI_OFFSET_SH));
+    /* mee: CSI rate set. */
+    _device.rtw_write32(k::R_AX_TRXPTCL_RESP_CSI_RRSC, k::CSI_RRSC_BMAP);
+    /* 8852C: unmask the RMAC CSI error indication (else the fw drops the
+     * incoming report as an error). */
+    if (_variant == ChipVariant::C8852C)
+      clr32(k::R_AX_TRXPTCL_ERROR_INDICA_MASK, k::B_AX_RMAC_CSI);
+    /* RESP_OPTION: NDPA response enable + zero the NDP/BFRP report-wait standby
+     * timers (the _patch_snd_ple_modify / _patch_snd_mu_err patches). Zeroing
+     * both is load-bearing: otherwise the fw holds a hardware slot per sounding
+     * waiting for a report that never returns, and the sounding pipeline backs
+     * up after ~7 pending soundings, wedging the CH12 H2C queue (rc=-7). */
+    field32(k::R_AX_BFMEE_RESP_OPTION, k::NDP_RX_STANDBY_TIMER,
+            k::B_AX_BFMEE_NDP_RX_STANDBY_TIMER_MSK,
+            k::B_AX_BFMEE_NDP_RX_STANDBY_TIMER_SH);
+    field32(k::R_AX_BFMEE_RESP_OPTION, k::BFRP_RX_STANDBY_TIMER,
+            k::B_AX_BFMEE_BFRP_RX_STANDBY_TIMER_MSK,
+            k::B_AX_BFMEE_BFRP_RX_STANDBY_TIMER_SH);
+    set32(k::R_AX_BFMEE_RESP_OPTION, k::B_AX_BFMEE_HT_NDPA_EN |
+                                         k::B_AX_BFMEE_VHT_NDPA_EN |
+                                         k::B_AX_BFMEE_HE_NDPA_EN);
+    /* CSI_CTRL_0: use the per-STA CCTL bf params (BFPARAM_SEL) + NSTS/GID/force. */
+    set32(k::R_AX_TRXPTCL_RESP_CSI_CTRL_0,
+          k::B_AX_BFMEE_BFPARAM_SEL | k::B_AX_BFMEE_USE_NSTS |
+              k::B_AX_BFMEE_CSI_GID_SEL | k::B_AX_BFMEE_CSI_FORCE_RETE_EN);
+    /* CSIRPT_OPTION: match the report by AID (VHT-SU + HE-SU) + clear the
+     * empty-report append-zero (the _patch_csi_append_zero patch). */
+    set32(k::R_AX_CSIRPT_OPTION,
+          k::B_AX_CSIPRT_VHTSU_AID_EN | k::B_AX_CSIPRT_HESU_AID_EN);
+    clr32(k::R_AX_CSIRPT_OPTION, k::B_AX_CSIRPT_EMPTY_APPZERO);
+    _logger->info("Kestrel: init_sounding ({}) done",
+                  _variant == ChipVariant::C8852C ? "8852C" : "8852B");
+    return true;
+  }
+
+  /* Register `macid` as a beamformee to sound: program the per-STA CSI/bf CCTL
+   * fields (nc/nr/ng/cb/cs + csi_para_en) and map the sounding-status + CSI
+   * buffer index registers to the macid. `snd_idx`/`csi_buf` are the hw
+   * resource slots (0 for the first beamformee). */
+  bool register_beamformee(uint8_t macid, uint8_t addr_cam_idx,
+                           const devourer::StaBfCaps &bf, uint8_t snd_idx = 0,
+                           uint16_t csi_buf = 0) {
+    namespace k = kestrel::reg;
+    bool ok = _fw.fw_upd_cctl_bf(macid, addr_cam_idx, bf);
+    /* snd-status index -> macid (R_AX_BFMER_ASSOCIATED_SU0 + SND_SH*idx). */
+    _device.rtw_write32(
+        static_cast<uint16_t>(k::R_AX_BFMER_ASSOCIATED_SU0 +
+                              k::SND_STS_SH * snd_idx),
+        k::B_AX_MER_SU_BFMEE0_EN | macid);
+    /* CSI buffer index -> macid (R_AX_BFMER_CSI_BUFF_IDX0 + CSI_SH*buf). */
+    _device.rtw_write32(
+        static_cast<uint16_t>(k::R_AX_BFMER_CSI_BUFF_IDX0 +
+                              k::CSI_BUFF_SH * csi_buf),
+        ((static_cast<uint32_t>(csi_buf) & k::B_AX_MER_CSI_BUFF_IDX_MSK)
+         << k::B_AX_MER_CSI_BUFF_IDX_SH) |
+            (macid & k::B_AX_MER_CSI_BUFF_MACID_MSK));
+    _logger->info("Kestrel: register_beamformee (macid={} a_idx={} snd_idx={} "
+                  "csi_buf={}) -> {}",
+                  macid, addr_cam_idx, snd_idx, csi_buf, ok ? "ok" : "FAILED");
+    return ok;
+  }
+
+  /* Drive one HE sounding (mac_set_snd_para): the fw airs NDPA -> NDP -> BFRP
+   * and receives the beamformee's report HE TB PPDU. */
+  bool start_sounding(const devourer::SoundingConfig &cfg) {
+    return _fw.set_snd_para(cfg);
+  }
+
   /* Firmware SER probe: returns the latched mac_ax_err_info code if the fw has
    * posted a halt error (HALT_C2H_CTRL set), else 0. Logs a labeled line so the
    * bring-up can pinpoint which init step crashes the running fw. */

--- a/src/kestrel/HalKestrel.h
+++ b/src/kestrel/HalKestrel.h
@@ -300,9 +300,11 @@ public:
   }
 
   /* ---- HE sounding (mac_init_snd_mer/_mee + mac_set_snd_para) ----
-   * The production trigger-airing path: arm the BB/MAC sounding engine, register
-   * the beamformee, then drive a sounding that airs NDPA -> NDP -> BFRP and
-   * receives the report HE TB PPDU. Band 0 only. */
+   * The HE sounding command surface: arm the BB/MAC sounding engine, register
+   * the beamformee, then drive a sounding intended to air NDPA -> NDP -> BFRP
+   * and receive the report HE TB PPDU. Band 0 only. NB the shipped client NIC
+   * firmware accepts the SET_SND_PARA H2C but does not air the sequence (the fw
+   * sounding-transmit engine is AP-firmware-only); see docs/he-trigger-ul.md. */
 
   /* mac_init_snd_mer + mac_init_snd_mee: arm the beamformer CSI-parse offsets +
    * the beamformee response/CSI options so the AP can send NDPA/BFRP and parse

--- a/src/kestrel/KestrelFw.cpp
+++ b/src/kestrel/KestrelFw.cpp
@@ -5,6 +5,7 @@
 #include <thread>
 #include <utility>
 
+#include "KestrelLe.h"
 #include "MacRegAx.h"
 #include "SignalStop.h" /* g_devourer_should_stop — set by demo signal handlers */
 #if defined(DEVOURER_HAVE_KESTREL_8852B)
@@ -23,18 +24,11 @@ void delay_us(uint32_t us) {
   std::this_thread::sleep_for(std::chrono::microseconds(us));
 }
 
-uint32_t le32(const uint8_t *p) {
-  return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
-         (static_cast<uint32_t>(p[2]) << 16) |
-         (static_cast<uint32_t>(p[3]) << 24);
-}
-
-void put_le32(uint8_t *p, uint32_t v) {
-  p[0] = v & 0xFF;
-  p[1] = (v >> 8) & 0xFF;
-  p[2] = (v >> 16) & 0xFF;
-  p[3] = (v >> 24) & 0xFF;
-}
+/* le32 / put_le32 now live in KestrelLe.h (shared with KestrelFwSched.cpp);
+ * pull them into this anonymous namespace so existing unqualified uses below
+ * resolve unchanged. */
+using kestrel::le32;
+using kestrel::put_le32;
 
 } /* namespace */
 

--- a/src/kestrel/KestrelFw.h
+++ b/src/kestrel/KestrelFw.h
@@ -124,13 +124,15 @@ public:
    * Triggers autonomously at the configured interval. */
   bool ul_fixinfo(const devourer::UlOfdmaConfig &cfg);
 
-  /* mac_set_snd_para (class=CL_SOUND, func=SET_SND_PARA v0 / _V1 0xD): the
-   * *production* trigger-airing path. The fw builds and airs the NDPA -> NDP ->
-   * BFRP sequence from this H2C content and arms RX for the beamforming-report
-   * HE TB PPDU. A BFRP is an 802.11ax Trigger-frame variant, so this solicits a
-   * genuine hardware-scheduled UL transmission — unlike f2p_trigger (the MP-only
-   * F2P_TEST entry the shipped client fw has no handler for). 8852B lays out the
-   * v0 (72-dword) content, the 8852C the v1 (98-dword), selected by _variant. */
+  /* mac_set_snd_para (class=CL_SOUND, func=SET_SND_PARA v0 / _V1 0xD): the HE
+   * sounding command — hands the fw the NDPA -> NDP -> BFRP descriptor set to
+   * build and air. A BFRP is an 802.11ax Trigger-frame variant. Measured (both
+   * dies): the shipped client NIC fw ACCEPTS this H2C (no SER) but does NOT air
+   * the sequence — the fw-command sounding-transmit engine is AP-firmware-only,
+   * so like f2p_trigger this is a byte-exact command surface the shipped fw does
+   * not act on (host-injection via SendTrigger is what airs a Trigger on this
+   * firmware). 8852B lays out the v0 (72-dword) content, the 8852C the v1
+   * (98-dword), selected by _variant. */
   bool set_snd_para(const devourer::SoundingConfig &cfg);
 
   /* mac_set_csi_para_cctl (mac_upd_cctl_info with the CSI/bf dword): program the

--- a/src/kestrel/KestrelFw.h
+++ b/src/kestrel/KestrelFw.h
@@ -7,6 +7,8 @@
 
 #include "ChipVariant.h"
 #include "RtlAdapter.h"
+#include "Sounding.h"
+#include "TriggerTwt.h"
 #include "logger.h"
 
 namespace kestrel {
@@ -87,6 +89,56 @@ public:
    * timestamp). 9-dword header (port/band, macid/rate, ntx_path) + body. */
   bool fw_send_beacon(const uint8_t *body, uint32_t len, uint8_t macid,
                       uint16_t rate_ax, uint8_t ntx_path_en, uint8_t path_map_a);
+
+  /* ---- 802.11ax trigger-based UL + TWT ----
+   * The encoders below are implemented in KestrelFwSched.cpp (a second TU of
+   * this class) to keep this file focused on FWDL/bring-up. They all funnel
+   * through send_h2c_cmd, so the per-die descriptor + rolling seq are shared. */
+
+  /* mac_f2p_test_cmd: H2C cat=MAC, class=FR_EXCHG, func=F2P_TEST — makes the fw
+   * build and air one HE Trigger frame (UL-OFDMA grant) as a frame exchange.
+   * The 8852B lays out the v0 (4-user, 236B) content, the 8852C the v1 (8-user,
+   * 288B) — selected by _variant. Only the trigger-frame parameters are set;
+   * the DL-burst / SIG-B dwords stay zero for a plain UL Basic Trigger. */
+  bool f2p_trigger(const devourer::TriggerConfig &cfg);
+
+  /* mac_twt_info_upd (class=TWT, func=TWTINFO_UPD): create/modify a TWT
+   * agreement (wake window, interval, absolute target-wake TSF). */
+  bool twt_info_upd(const devourer::TwtConfig &cfg, uint8_t act);
+
+  /* mac_twt_act (class=TWT, func=TWT_STANSP_UPD): bind/unbind a STA macid to a
+   * TWT config (add/del/terminate/suspend/resume). */
+  bool twt_act(const devourer::TwtStaAct &act);
+
+  /* mac_twt_staanno (class=TWT, func=TWT_ANNOUNCE_UPD): tell the fw to send a
+   * TWT announce to a macid (AP-side). */
+  bool twt_announce(uint8_t macid);
+
+  /* mac_twt_ofdma_info_upd (class=TWT, func=0x03): the fw-autonomous trigger
+   * cadence inside a TWT SP. func 0x03 is non-canonical (may be absent from the
+   * shipped fw) — the caller treats a fw-ignore as "fall back to ul_fixinfo". */
+  bool twt_ofdma_info_upd(const devourer::TwtOfdmaConfig &cfg);
+
+  /* mac_upd_ul_fixinfo (class=FR_EXCHG, func=TBLUD, table CLASS_UL_FIXINFO):
+   * the production UL-OFDMA scheduler table. mode=tf_periodic makes the fw air
+   * Triggers autonomously at the configured interval. */
+  bool ul_fixinfo(const devourer::UlOfdmaConfig &cfg);
+
+  /* mac_set_snd_para (class=CL_SOUND, func=SET_SND_PARA v0 / _V1 0xD): the
+   * *production* trigger-airing path. The fw builds and airs the NDPA -> NDP ->
+   * BFRP sequence from this H2C content and arms RX for the beamforming-report
+   * HE TB PPDU. A BFRP is an 802.11ax Trigger-frame variant, so this solicits a
+   * genuine hardware-scheduled UL transmission — unlike f2p_trigger (the MP-only
+   * F2P_TEST entry the shipped client fw has no handler for). 8852B lays out the
+   * v0 (72-dword) content, the 8852C the v1 (98-dword), selected by _variant. */
+  bool set_snd_para(const devourer::SoundingConfig &cfg);
+
+  /* mac_set_csi_para_cctl (mac_upd_cctl_info with the CSI/bf dword): program the
+   * per-macid CSI/beamformee params (nc/nr/ng/cb/cs + csi_para_en) so a BFRP to
+   * this STA solicits a decodable compressed-beamforming report. csi_txbf_en is
+   * forced 0 (vendor BB HW-bug note). */
+  bool fw_upd_cctl_bf(uint8_t macid, uint8_t addr_cam_idx,
+                      const devourer::StaBfCaps &bf);
 
 private:
   /* Generic H2C over CH12: [WD 24B][fwcmd_hdr 8B][content]. */

--- a/src/kestrel/KestrelFwSched.cpp
+++ b/src/kestrel/KestrelFwSched.cpp
@@ -1,0 +1,176 @@
+/* KestrelFwSched — the 802.11ax trigger-based UL + TWT H2C senders, a second
+ * translation unit of the KestrelFw class (declared in KestrelFw.h). Kept
+ * apart from KestrelFw.cpp (the FWDL/bring-up plane) so each file stays
+ * focused; both share the private send_h2c_cmd + _variant.
+ *
+ * The byte encoding lives in SchedEncode.h (pure, device-free, unit-tested by
+ * tests/kestrel_sched_selftest.cpp); each method here is encode_* +
+ * send_h2c_cmd + a log line. */
+
+#include "KestrelFw.h"
+
+#include <vector>
+
+#include "MacRegAx.h"
+#include "SchedEncode.h"
+
+namespace kestrel {
+
+namespace {
+namespace r = kestrel::reg;
+} /* namespace */
+
+bool KestrelFw::f2p_trigger(const devourer::TriggerConfig &cfg) {
+  const bool v1 = (_variant == ChipVariant::C8852C);
+  std::vector<uint8_t> c = sched::encode_f2p_trigger(cfg, v1);
+  uint8_t n = cfg.n_users == 0 ? 1 : cfg.n_users;
+  const uint8_t max_users = v1 ? r::F2P_V1_MAX_USERS : r::F2P_V0_MAX_USERS;
+  if (n > max_users)
+    n = max_users;
+  bool ok = send_h2c_cmd(r::FWCMD_H2C_CAT_MAC, r::FWCMD_H2C_CL_FR_EXCHG,
+                         r::FWCMD_H2C_FUNC_F2P_TEST, c.data(),
+                         static_cast<uint32_t>(c.size()));
+  _logger->info("Kestrel: f2p_trigger ({} v{} users={} bw={} rate=0x{:x} mode={}"
+                " frexch={}) -> {}",
+                v1 ? "8852C" : "8852B", v1 ? 1 : 0, n, cfg.ul_bw, cfg.trig_rate,
+                cfg.mode, cfg.frexch_type, ok ? "sent" : "FAILED");
+  return ok;
+}
+
+bool KestrelFw::twt_info_upd(const devourer::TwtConfig &cfg, uint8_t act) {
+  std::vector<uint8_t> c = sched::encode_twtinfo(cfg, act);
+  bool ok = send_h2c_cmd(r::FWCMD_H2C_CAT_MAC, r::FWCMD_H2C_CL_TWT,
+                         r::FWCMD_H2C_FUNC_TWTINFO_UPD, c.data(),
+                         static_cast<uint32_t>(c.size()));
+  _logger->info("Kestrel: twt_info_upd (act={} {} id={} flow={} trig={} "
+                "wake_exp={} man={} tsf=0x{:x}) -> {}",
+                act, cfg.broadcast ? "bcast" : "indiv", cfg.config_id,
+                cfg.flow_id, cfg.trigger, cfg.wake_exp, cfg.wake_man,
+                cfg.trgt_tsf, ok ? "sent" : "FAILED");
+  return ok;
+}
+
+bool KestrelFw::twt_act(const devourer::TwtStaAct &a) {
+  std::vector<uint8_t> c = sched::encode_twt_act(a);
+  bool ok = send_h2c_cmd(r::FWCMD_H2C_CAT_MAC, r::FWCMD_H2C_CL_TWT,
+                         r::FWCMD_H2C_FUNC_TWT_STANSP_UPD, c.data(),
+                         static_cast<uint32_t>(c.size()));
+  _logger->info("Kestrel: twt_act (macid={} id={} act={}) -> {}", a.macid,
+                a.config_id, a.action, ok ? "sent" : "FAILED");
+  return ok;
+}
+
+bool KestrelFw::twt_announce(uint8_t macid) {
+  std::vector<uint8_t> c = sched::encode_twt_announce(macid);
+  bool ok = send_h2c_cmd(r::FWCMD_H2C_CAT_MAC, r::FWCMD_H2C_CL_TWT,
+                         r::FWCMD_H2C_FUNC_TWT_ANNOUNCE_UPD, c.data(),
+                         static_cast<uint32_t>(c.size()));
+  _logger->info("Kestrel: twt_announce (macid={}) -> {}", macid,
+                ok ? "sent" : "FAILED");
+  return ok;
+}
+
+bool KestrelFw::twt_ofdma_info_upd(const devourer::TwtOfdmaConfig &cfg) {
+  std::vector<uint8_t> c = sched::encode_twt_ofdma(cfg);
+  bool ok = send_h2c_cmd(r::FWCMD_H2C_CAT_MAC, r::FWCMD_H2C_CL_TWT,
+                         r::FWCMD_H2C_FUNC_TWT_OFDMA_INFO_UPD, c.data(),
+                         static_cast<uint32_t>(c.size()));
+  _logger->info("Kestrel: twt_ofdma_info_upd (twt_id={} rounds={} interval={}us "
+                "tf_retry={}) -> {} [func 0x03 non-canonical: fw may ignore]",
+                cfg.twt_id, cfg.round_num, cfg.round_interval_us,
+                cfg.max_tf_retry, ok ? "sent" : "FAILED");
+  return ok;
+}
+
+bool KestrelFw::ul_fixinfo(const devourer::UlOfdmaConfig &cfg) {
+  std::vector<uint8_t> c = sched::encode_ul_fixinfo(cfg);
+  uint8_t nsta = cfg.n_stas == 0 ? 1 : cfg.n_stas;
+  if (nsta > r::UL_FIXINFO_MAX_RU_NUM)
+    nsta = r::UL_FIXINFO_MAX_RU_NUM;
+  bool ok = send_h2c_cmd(r::FWCMD_H2C_CAT_MAC, r::FWCMD_H2C_CL_FR_EXCHG,
+                         r::FWCMD_H2C_FUNC_TBLUD, c.data(),
+                         static_cast<uint32_t>(c.size()));
+  _logger->info("Kestrel: ul_fixinfo (mode={} interval={}s stas={} bw={} "
+                "tf_type={}) -> {}",
+                cfg.mode, cfg.interval_s, nsta, cfg.ppdu_bw, cfg.tf_type,
+                ok ? "sent" : "FAILED");
+  return ok;
+}
+
+bool KestrelFw::set_snd_para(const devourer::SoundingConfig &cfg) {
+  const bool v1 = (_variant == ChipVariant::C8852C);
+  std::vector<uint8_t> c = sched::encode_set_snd_para(cfg, v1);
+  const uint8_t func =
+      v1 ? r::FWCMD_H2C_FUNC_SET_SND_PARA_V1 : r::FWCMD_H2C_FUNC_SET_SND_PARA;
+  bool ok = send_h2c_cmd(r::FWCMD_H2C_CAT_MAC, r::FWCMD_H2C_CL_SOUND, func,
+                         c.data(), static_cast<uint32_t>(c.size()));
+  _logger->info("Kestrel: set_snd_para ({} v{} frexch={} bfrp0_users={} "
+                "sta0_aid={} macid0={}) -> {}",
+                v1 ? "8852C" : "8852B", v1 ? 1 : 0, cfg.frexgtype,
+                cfg.bfrp0_user_num, cfg.he_sta[0].aid, cfg.macid[0],
+                ok ? "sent" : "FAILED");
+  return ok;
+}
+
+bool KestrelFw::fw_upd_cctl_bf(uint8_t macid, uint8_t addr_cam_idx,
+                               const devourer::StaBfCaps &bf) {
+  /* mac_set_csi_para_cctl: the CSI/bf fields live in CCTL value dword8 (byte
+   * 32) with the matching mask in dword16 (byte 64). We also re-assert
+   * addr_cam_index (value dword7 / mask dword15) so the entry resolves. */
+  uint8_t c[68] = {0};
+  auto sw = [](uint32_t v, uint32_t msk, uint32_t sh) {
+    return (v & msk) << sh;
+  };
+  put_le32(c + 0, (macid & r::FWCMD_H2C_CCTLINFO_UD_MACID_MSK) |
+                      r::FWCMD_H2C_CCTLINFO_UD_OP);
+  /* value dword7: addr_cam_index. */
+  put_le32(c + 28, sw(addr_cam_idx, r::FWCMD_H2C_CCTRL_ADDR_CAM_INDEX_MSK,
+                      r::FWCMD_H2C_CCTRL_ADDR_CAM_INDEX_SH));
+  /* value dword8: nc/nr/ng/cb/cs + csi_para_en=1 (csi_txbf_en stays 0). */
+  const uint32_t dw8 =
+      sw(bf.nc, r::FWCMD_H2C_CCTRL_NC_MSK, r::FWCMD_H2C_CCTRL_NC_SH) |
+      sw(bf.nr, r::FWCMD_H2C_CCTRL_NR_MSK, r::FWCMD_H2C_CCTRL_NR_SH) |
+      sw(bf.ng, r::FWCMD_H2C_CCTRL_NG_MSK, r::FWCMD_H2C_CCTRL_NG_SH) |
+      sw(bf.cb, r::FWCMD_H2C_CCTRL_CB_MSK, r::FWCMD_H2C_CCTRL_CB_SH) |
+      sw(bf.cs, r::FWCMD_H2C_CCTRL_CS_MSK, r::FWCMD_H2C_CCTRL_CS_SH) |
+      r::FWCMD_H2C_CCTRL_CSI_PARA_EN |
+      sw(bf.csi_fix_rate, r::FWCMD_H2C_CCTRL_CSI_FIX_RATE_MSK,
+         r::FWCMD_H2C_CCTRL_CSI_FIX_RATE_SH) |
+      sw(bf.csi_gi_ltf, r::FWCMD_H2C_CCTRL_CSI_GI_LTF_MSK,
+         r::FWCMD_H2C_CCTRL_CSI_GI_LTF_SH) |
+      sw(bf.csi_bw, r::FWCMD_H2C_CCTRL_CSI_BW_MSK, r::FWCMD_H2C_CCTRL_CSI_BW_SH);
+  put_le32(c + 32, dw8);
+  /* mask dword15 <- dword7 addr_cam_index; mask dword16 <- dword8 fields. */
+  put_le32(c + 60, sw(r::FWCMD_H2C_CCTRL_ADDR_CAM_INDEX_MSK,
+                      r::FWCMD_H2C_CCTRL_ADDR_CAM_INDEX_MSK,
+                      r::FWCMD_H2C_CCTRL_ADDR_CAM_INDEX_SH));
+  put_le32(c + 64,
+           sw(r::FWCMD_H2C_CCTRL_NC_MSK, r::FWCMD_H2C_CCTRL_NC_MSK,
+              r::FWCMD_H2C_CCTRL_NC_SH) |
+               sw(r::FWCMD_H2C_CCTRL_NR_MSK, r::FWCMD_H2C_CCTRL_NR_MSK,
+                  r::FWCMD_H2C_CCTRL_NR_SH) |
+               sw(r::FWCMD_H2C_CCTRL_NG_MSK, r::FWCMD_H2C_CCTRL_NG_MSK,
+                  r::FWCMD_H2C_CCTRL_NG_SH) |
+               sw(r::FWCMD_H2C_CCTRL_CB_MSK, r::FWCMD_H2C_CCTRL_CB_MSK,
+                  r::FWCMD_H2C_CCTRL_CB_SH) |
+               sw(r::FWCMD_H2C_CCTRL_CS_MSK, r::FWCMD_H2C_CCTRL_CS_MSK,
+                  r::FWCMD_H2C_CCTRL_CS_SH) |
+               r::FWCMD_H2C_CCTRL_CSI_PARA_EN |
+               sw(r::FWCMD_H2C_CCTRL_CSI_FIX_RATE_MSK,
+                  r::FWCMD_H2C_CCTRL_CSI_FIX_RATE_MSK,
+                  r::FWCMD_H2C_CCTRL_CSI_FIX_RATE_SH) |
+               sw(r::FWCMD_H2C_CCTRL_CSI_GI_LTF_MSK,
+                  r::FWCMD_H2C_CCTRL_CSI_GI_LTF_MSK,
+                  r::FWCMD_H2C_CCTRL_CSI_GI_LTF_SH) |
+               sw(r::FWCMD_H2C_CCTRL_CSI_BW_MSK, r::FWCMD_H2C_CCTRL_CSI_BW_MSK,
+                  r::FWCMD_H2C_CCTRL_CSI_BW_SH));
+  bool ok = send_h2c_cmd(r::FWCMD_H2C_CAT_MAC, r::FWCMD_H2C_CL_FR_EXCHG,
+                         r::FWCMD_H2C_FUNC_CCTLINFO_UD, c, sizeof(c));
+  _logger->info("Kestrel: upd_cctl_bf (macid={} a_idx={} nc={} nr={} ng={} "
+                "cb={} bw={}) -> {}",
+                macid, addr_cam_idx, bf.nc, bf.nr, bf.ng, bf.cb, bf.csi_bw,
+                ok ? "sent" : "FAILED");
+  return ok;
+}
+
+} /* namespace kestrel */

--- a/src/kestrel/KestrelLe.h
+++ b/src/kestrel/KestrelLe.h
@@ -1,0 +1,29 @@
+#ifndef KESTREL_LE_H
+#define KESTREL_LE_H
+
+#include <cstdint>
+
+/* Little-endian 32-bit pack/unpack helpers for the Kestrel mac_ax plane. The
+ * H2C content buffers and RX descriptors are all LE dword-packed; these are the
+ * one-liners every encoder/parser uses. Shared by KestrelFw.cpp and
+ * KestrelFwSched.cpp (the trigger/TWT encoders) so the definition lives in
+ * exactly one place. */
+
+namespace kestrel {
+
+inline uint32_t le32(const uint8_t *p) {
+  return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
+         (static_cast<uint32_t>(p[2]) << 16) |
+         (static_cast<uint32_t>(p[3]) << 24);
+}
+
+inline void put_le32(uint8_t *p, uint32_t v) {
+  p[0] = v & 0xFF;
+  p[1] = (v >> 8) & 0xFF;
+  p[2] = (v >> 16) & 0xFF;
+  p[3] = (v >> 24) & 0xFF;
+}
+
+} /* namespace kestrel */
+
+#endif /* KESTREL_LE_H */

--- a/src/kestrel/MacRegAx.h
+++ b/src/kestrel/MacRegAx.h
@@ -953,13 +953,13 @@ constexpr uint32_t FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_MCS_MSK = 0xf;
 
 /* ===================================================================
  * HE sounding (mac_set_snd_para / build_snd_h2c): CL_SOUND / FUNC_SET_SND_PARA.
- * This is the *production* trigger-airing path — the fw builds and airs the
- * NDPA -> NDP -> BFRP sequence from the H2C content (content-in-H2C, no
- * pkt_ofld) and arms RX for the beamforming-report HE TB PPDU. A BFRP
- * (Beamforming Report Poll) is an 802.11ax Trigger-frame variant, so this
- * solicits a genuine hardware-scheduled, contention-free UL transmission.
- * Unlike F2P_TEST (MP-only, no shipped-fw handler), the sounding cmd is a
- * normal client feature (CONFIG_PHL_BEAMFORM). Field layout verbatim from
+ * Hands the fw the NDPA -> NDP -> BFRP descriptor set (content-in-H2C, no
+ * pkt_ofld) to build and air, arming RX for the beamforming-report HE TB PPDU.
+ * A BFRP (Beamforming Report Poll) is an 802.11ax Trigger-frame variant.
+ * Measured: the shipped client NIC fw accepts this H2C but does NOT air the
+ * sequence (the fw sounding-transmit engine is AP-firmware-only) — like
+ * F2P_TEST, a byte-exact command surface the shipped fw does not act on. Field
+ * layout verbatim from
  * fw_ax/inc_hdr/fwcmd_intf.h (the SET_SND_PARA_* block) and the packing order
  * from mac_ax/sounding.c build_snd_h2c. The per-index vendor macros (STA0..7,
  * U0..3, WD0..4) are bit-identical, so each repeating structure collapses to

--- a/src/kestrel/MacRegAx.h
+++ b/src/kestrel/MacRegAx.h
@@ -1,6 +1,7 @@
 #ifndef KESTREL_MAC_REG_AX_H
 #define KESTREL_MAC_REG_AX_H
 
+#include <cstddef>
 #include <cstdint>
 
 /* Register + bitfield constants for the Kestrel (Wi-Fi 6 / G6 "phl") MAC,
@@ -697,6 +698,510 @@ constexpr uint8_t FWCMD_H2C_CCTRL_PATH_MAP_A_SH = 20; /* dword6 */
 constexpr uint32_t FWCMD_H2C_CCTRL_PATH_MAP_A_MSK = 0x3;
 constexpr uint8_t FWCMD_H2C_CCTRL_ADDR_CAM_INDEX_SH = 0; /* dword7 */
 constexpr uint32_t FWCMD_H2C_CCTRL_ADDR_CAM_INDEX_MSK = 0xff;
+/* CCTL dword8 (value) / dword16 (mask): CSI / beamformee params. Programmed so
+ * a BFRP to this macid solicits a decodable HE compressed-beamforming report
+ * (csi_para_en=1 makes the HW use these per-STA values; csi_txbf_en stays 0 per
+ * the vendor BB HW-bug note). */
+constexpr uint8_t FWCMD_H2C_CCTRL_NC_SH = 0;
+constexpr uint32_t FWCMD_H2C_CCTRL_NC_MSK = 0x7;
+constexpr uint8_t FWCMD_H2C_CCTRL_NR_SH = 3;
+constexpr uint32_t FWCMD_H2C_CCTRL_NR_MSK = 0x7;
+constexpr uint8_t FWCMD_H2C_CCTRL_NG_SH = 6;
+constexpr uint32_t FWCMD_H2C_CCTRL_NG_MSK = 0x3;
+constexpr uint8_t FWCMD_H2C_CCTRL_CB_SH = 8;
+constexpr uint32_t FWCMD_H2C_CCTRL_CB_MSK = 0x3;
+constexpr uint8_t FWCMD_H2C_CCTRL_CS_SH = 10;
+constexpr uint32_t FWCMD_H2C_CCTRL_CS_MSK = 0x3;
+constexpr uint32_t FWCMD_H2C_CCTRL_CSI_TXBF_EN = 1u << 12;
+constexpr uint32_t FWCMD_H2C_CCTRL_CSI_STBC_EN = 1u << 13;
+constexpr uint32_t FWCMD_H2C_CCTRL_CSI_LDPC_EN = 1u << 14;
+constexpr uint32_t FWCMD_H2C_CCTRL_CSI_PARA_EN = 1u << 15;
+constexpr uint8_t FWCMD_H2C_CCTRL_CSI_FIX_RATE_SH = 16;
+constexpr uint32_t FWCMD_H2C_CCTRL_CSI_FIX_RATE_MSK = 0x1ff;
+constexpr uint8_t FWCMD_H2C_CCTRL_CSI_GI_LTF_SH = 25;
+constexpr uint32_t FWCMD_H2C_CCTRL_CSI_GI_LTF_MSK = 0x7;
+constexpr uint8_t FWCMD_H2C_CCTRL_CSI_BW_SH = 30;
+constexpr uint32_t FWCMD_H2C_CCTRL_CSI_BW_MSK = 0x3;
+
+/* ===================================================================
+ * 802.11ax trigger-based UL + TWT — F2P trigger, TWT, and UL_FIXINFO H2C/C2H
+ * field layouts. All values verbatim from the vendor tree:
+ * F2P = mac_ax/fwcmd_intf_f2p.h, TWT = fw_ax/inc_hdr/fwcmd_intf.h +
+ * mac_ax/fwcmd.h, UL_FIXINFO = fw_ax/inc_hdr/fwcmd_intf.h. The encoders that
+ * consume these live in kestrel/KestrelFwSched.cpp.
+ * =================================================================== */
+
+/* ---- F2P trigger (mac_f2p_test_cmd): CL_FR_EXCHG / FUNC_F2P_TEST ----
+ * The 8852B airs a v0 (4-user, 236-byte fwcmd_test_para) frame; the 8852C a v1
+ * (8-user, 288-byte fwcmd_test_para_v1). Both share these bit layouts; only the
+ * user count + tf_wd dword offset differ (handled in the encoder). */
+constexpr uint8_t FWCMD_H2C_FUNC_F2P_TEST = 0x3;
+constexpr std::size_t F2P_V0_CONTENT_LEN = 236; /* sizeof(fwcmd_test_para) */
+constexpr std::size_t F2P_V1_CONTENT_LEN = 288; /* sizeof(fwcmd_test_para_v1) */
+/* dword0 — trigger-frame packet common. */
+constexpr uint8_t FWCMD_F2PTEST_ULBW_SH = 0;
+constexpr uint32_t FWCMD_F2PTEST_ULBW_MSK = 0x3;
+constexpr uint8_t FWCMD_F2PTEST_GILTF_SH = 2;
+constexpr uint32_t FWCMD_F2PTEST_GILTF_MSK = 0x3;
+constexpr uint8_t FWCMD_F2PTEST_NUMLTF_SH = 4;
+constexpr uint32_t FWCMD_F2PTEST_NUMLTF_MSK = 0x7;
+constexpr uint8_t FWCMD_F2PTEST_ULSTBC_SH = 7;
+constexpr uint32_t FWCMD_F2PTEST_ULSTBC_MSK = 0x1;
+constexpr uint8_t FWCMD_F2PTEST_DPLR_SH = 8;
+constexpr uint32_t FWCMD_F2PTEST_DPLR_MSK = 0x1;
+constexpr uint8_t FWCMD_F2PTEST_TXPWR_SH = 9;
+constexpr uint32_t FWCMD_F2PTEST_TXPWR_MSK = 0x3f;
+constexpr uint8_t FWCMD_F2PTEST_USERNUM_SH = 16;
+constexpr uint32_t FWCMD_F2PTEST_USERNUM_MSK = 0xf;
+constexpr uint8_t FWCMD_F2PTEST_PKTNUM_SH = 20;
+constexpr uint32_t FWCMD_F2PTEST_PKTNUM_MSK = 0xf;
+constexpr uint8_t FWCMD_F2PTEST_BITMAP_SH = 24;
+constexpr uint32_t FWCMD_F2PTEST_BITMAP_MSK = 0xff;
+/* per-user dword A — aid12 / ul_mcs / macid / ru_pos. */
+constexpr uint8_t FWCMD_F2PTEST_AID12_SH = 0;
+constexpr uint32_t FWCMD_F2PTEST_AID12_MSK = 0xfff;
+constexpr uint8_t FWCMD_F2PTEST_ULMCS_SH = 12;
+constexpr uint32_t FWCMD_F2PTEST_ULMCS_MSK = 0xf;
+constexpr uint8_t FWCMD_F2PTEST_MACID_SH = 16;
+constexpr uint32_t FWCMD_F2PTEST_MACID_MSK = 0xff;
+constexpr uint8_t FWCMD_F2PTEST_RUPOS_SH = 24;
+constexpr uint32_t FWCMD_F2PTEST_RUPOS_MSK = 0xff;
+/* per-user dword B — ul_fec / ul_dcm / ss_alloc / ul_tgt_rssi. */
+constexpr uint8_t FWCMD_F2PTEST_ULFEC_SH = 0;
+constexpr uint32_t FWCMD_F2PTEST_ULFEC_MSK = 0x1;
+constexpr uint8_t FWCMD_F2PTEST_ULDCM_SH = 1;
+constexpr uint32_t FWCMD_F2PTEST_ULDCM_MSK = 0x1;
+constexpr uint8_t FWCMD_F2PTEST_SS_ALLOC_SH = 2;
+constexpr uint32_t FWCMD_F2PTEST_SS_ALLOC_MSK = 0x3f;
+constexpr uint8_t FWCMD_F2PTEST_UL_TGTRSSI_SH = 8;
+constexpr uint32_t FWCMD_F2PTEST_UL_TGTRSSI_MSK = 0x7f;
+/* dep-user pref_AC (packed one-per-byte). */
+constexpr uint8_t FWCMD_F2PTEST_PREF_AC_SH = 0;
+constexpr uint32_t FWCMD_F2PTEST_PREF_AC_MSK = 0x3;
+/* tf_wd dword — trigger frame's own TX rate + mode/frexch/sigb_len. */
+constexpr uint8_t FWCMD_F2PTEST_DATARATE_SH = 0;
+constexpr uint32_t FWCMD_F2PTEST_DATARATE_MSK = 0x1ff;
+constexpr uint8_t FWCMD_F2PTEST_MULPORT_SH = 9;
+constexpr uint32_t FWCMD_F2PTEST_MULPORT_MSK = 0x7;
+constexpr uint8_t FWCMD_F2PTEST_PWR_OFSET_SH = 12;
+constexpr uint32_t FWCMD_F2PTEST_PWR_OFSET_MSK = 0x7;
+constexpr uint8_t FWCMD_F2PTEST_MODE_SH = 16;
+constexpr uint32_t FWCMD_F2PTEST_MODE_MSK = 0x3;
+constexpr uint8_t FWCMD_F2PTEST_TYPE_SH = 18;
+constexpr uint32_t FWCMD_F2PTEST_TYPE_MSK = 0x3f;
+constexpr uint8_t FWCMD_F2PTEST_SIGB_LEN_SH = 24;
+constexpr uint32_t FWCMD_F2PTEST_SIGB_LEN_MSK = 0xff;
+/* f2p_wd — the TX descriptor for the trigger frame the fw builds+airs (v0
+ * dword14, v1 dword20 = tf_wd dword + 4). A single complete frame on the mgmt
+ * queue needs fs=ls=1, total_number=1, a valid cmd_qsel, and a non-zero
+ * length; a zeroed WD (length 0) makes the fw build nothing. */
+constexpr uint8_t F2P_WD_CMD_QSEL_SH = 0;
+constexpr uint32_t F2P_WD_CMD_QSEL_MSK = 0x3f;
+constexpr uint32_t F2P_WD_LS = 1u << 10;
+constexpr uint32_t F2P_WD_FS = 1u << 11;
+constexpr uint8_t F2P_WD_TOTAL_NUMBER_SH = 12;
+constexpr uint32_t F2P_WD_TOTAL_NUMBER_MSK = 0xf;
+constexpr uint8_t F2P_WD_SEQ_SH = 16;
+constexpr uint32_t F2P_WD_SEQ_MSK = 0xff;
+constexpr uint8_t F2P_WD_LENGTH_SH = 24;
+constexpr uint32_t F2P_WD_LENGTH_MSK = 0xff;
+constexpr uint8_t MAC_AX_MG0_SEL = 18; /* band-0 management TX queue (type.h) */
+/* v0: byte offsets of the tf_wd dword (dword13) and user block. */
+constexpr std::size_t F2P_V0_TFWD_OFF = 40;  /* dword13 */
+constexpr std::size_t F2P_V0_DEPUSER_OFF = 36; /* byte9..12 */
+constexpr uint8_t F2P_V0_MAX_USERS = 4;
+/* v1: tf_wd is dword19; dep-user pref_AC bytes at dword17_0..18_3 (68..75). */
+constexpr std::size_t F2P_V1_TFWD_OFF = 76;  /* dword19 */
+constexpr std::size_t F2P_V1_DEPUSER_OFF = 68; /* dword17_0 */
+constexpr uint8_t F2P_V1_MAX_USERS = 8;
+
+/* ---- TWT (mac_twt_*): CL_TWT ---- */
+constexpr uint8_t FWCMD_H2C_CL_TWT = 0x4;
+constexpr uint8_t FWCMD_H2C_FUNC_TWT_ANNOUNCE_UPD = 0x0;
+constexpr uint8_t FWCMD_H2C_FUNC_TWTINFO_UPD = 0x1;
+constexpr uint8_t FWCMD_H2C_FUNC_TWT_STANSP_UPD = 0x2;
+constexpr uint8_t FWCMD_H2C_FUNC_TWT_OFDMA_INFO_UPD = 0x3;
+/* twtinfo_upd dword0. */
+constexpr uint8_t FWCMD_H2C_TWTINFO_UPD_NEGOTYPE_SH = 0;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_NEGOTYPE_MSK = 0x3;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_TRIGGER = 1u << 2;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_FLOWTYPE = 1u << 3;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_IMPT = 1u << 4;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_WAKEDURUNIT = 1u << 5;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_RSPPM = 1u << 6;
+constexpr uint8_t FWCMD_H2C_TWTINFO_UPD_FLOWID_SH = 7;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_FLOWID_MSK = 0x7;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_PROT = 1u << 10;
+constexpr uint8_t FWCMD_H2C_TWTINFO_UPD_ACT_SH = 11;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_ACT_MSK = 0x7;
+constexpr uint8_t FWCMD_H2C_TWTINFO_UPD_ID_SH = 14;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_ID_MSK = 0x7;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_BAND = 1u << 17;
+constexpr uint8_t FWCMD_H2C_TWTINFO_UPD_PORT_SH = 18;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_PORT_MSK = 0x7;
+constexpr uint8_t FWCMD_H2C_TWTINFO_UPD_TWT_TYPE_SH = 21;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_TWT_TYPE_MSK = 0x7;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_NIC_ROLE = 1u << 25;
+/* twtinfo_upd dword1. */
+constexpr uint8_t FWCMD_H2C_TWTINFO_UPD_WAKE_MAN_SH = 0;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_WAKE_MAN_MSK = 0xffff;
+constexpr uint8_t FWCMD_H2C_TWTINFO_UPD_WAKE_EXP_SH = 16;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_WAKE_EXP_MSK = 0x1f;
+constexpr uint8_t FWCMD_H2C_TWTINFO_UPD_DUR_SH = 24;
+constexpr uint32_t FWCMD_H2C_TWTINFO_UPD_DUR_MSK = 0xff;
+/* twt_stansp_upd (act) dword0. */
+constexpr uint8_t FWCMD_H2C_TWT_STANSP_UPD_MACID_SH = 0;
+constexpr uint32_t FWCMD_H2C_TWT_STANSP_UPD_MACID_MSK = 0xff;
+constexpr uint8_t FWCMD_H2C_TWT_STANSP_UPD_ID_SH = 8;
+constexpr uint32_t FWCMD_H2C_TWT_STANSP_UPD_ID_MSK = 0x7;
+constexpr uint8_t FWCMD_H2C_TWT_STANSP_UPD_ACT_SH = 11;
+constexpr uint32_t FWCMD_H2C_TWT_STANSP_UPD_ACT_MSK = 0xf;
+/* twt_announce_upd dword0. */
+constexpr uint8_t FWCMD_H2C_TWT_ANNOUNCE_UPD_MACID_SH = 0;
+constexpr uint32_t FWCMD_H2C_TWT_ANNOUNCE_UPD_MACID_MSK = 0xff;
+/* twt_ofdma_info_upd (fw func 0x03, non-canonical: mac_ax/fwcmd.h). */
+constexpr uint8_t FWCMD_H2C_TWT_OFDMA_OPTION_SH = 0;
+constexpr uint32_t FWCMD_H2C_TWT_OFDMA_OPTION_MSK = 0x3;
+constexpr uint8_t FWCMD_H2C_TWT_OFDMA_TWT_ID_SH = 2;
+constexpr uint32_t FWCMD_H2C_TWT_OFDMA_TWT_ID_MSK = 0x7;
+constexpr uint8_t FWCMD_H2C_TWT_OFDMA_MAX_TF_RETRY_SH = 5;
+constexpr uint32_t FWCMD_H2C_TWT_OFDMA_MAX_TF_RETRY_MSK = 0xff;
+constexpr uint8_t FWCMD_H2C_TWT_OFDMA_MAX_DL_RETRY_SH = 13;
+constexpr uint32_t FWCMD_H2C_TWT_OFDMA_MAX_DL_RETRY_MSK = 0xff;
+constexpr uint8_t FWCMD_H2C_TWT_OFDMA_ROUND_NUM_SH = 21;
+constexpr uint32_t FWCMD_H2C_TWT_OFDMA_ROUND_NUM_MSK = 0xff;
+constexpr uint8_t FWCMD_H2C_TWT_OFDMA_PREFERRED_AC_SH = 29;
+constexpr uint32_t FWCMD_H2C_TWT_OFDMA_PREFERRED_AC_MSK = 0x3;
+constexpr uint32_t FWCMD_H2C_TWT_OFDMA_HTC_BSR_CTRL_EN = 1u << 31;
+constexpr uint8_t FWCMD_H2C_TWT_OFDMA_ROUND_INTERVAL_SH = 0;
+constexpr uint32_t FWCMD_H2C_TWT_OFDMA_ROUND_INTERVAL_MSK = 0xffff;
+/* TWT C2H (CL_TWT=0x2 on the C2H side). */
+constexpr uint8_t FWCMD_C2H_CL_TWT = 0x2;
+constexpr uint8_t FWCMD_C2H_FUNC_WAIT_ANNOUNCE = 0x0;
+constexpr uint8_t FWCMD_C2H_FUNC_TWT_NOTIFY_EVT = 0x2;
+
+/* ---- UL_FIXINFO (mac_upd_ul_fixinfo): CL_FR_EXCHG / FUNC_TBLUD, table
+ * CLASS_UL_FIXINFO — the production UL-OFDMA scheduler table. 27-dword content
+ * (5 header + 4 sta-pairs + 2 ulrua + 16 per-RU entries) for 8 RU slots. ---- */
+constexpr uint8_t FWCMD_H2C_FUNC_TBLUD = 0x0;
+constexpr uint8_t CLASS_UL_FIXINFO = 7;
+constexpr uint8_t UL_FIXINFO_MAX_RU_NUM = 8;
+/* tbl_hdr dword0. */
+constexpr uint32_t FWCMD_H2C_TBLUD_R_W = 1u << 0;
+constexpr uint8_t FWCMD_H2C_TBLUD_MACID_GROUP_SH = 1;
+constexpr uint32_t FWCMD_H2C_TBLUD_MACID_GROUP_MSK = 0x7f;
+constexpr uint8_t FWCMD_H2C_TBLUD_OFFSET_SH = 8;
+constexpr uint32_t FWCMD_H2C_TBLUD_OFFSET_MSK = 0x1f;
+constexpr uint8_t FWCMD_H2C_TBLUD_LENGTH_SH = 13;
+constexpr uint32_t FWCMD_H2C_TBLUD_LENGTH_MSK = 0x3ff;
+constexpr uint32_t FWCMD_H2C_TBLUD_TYPE = 1u << 23;
+constexpr uint8_t FWCMD_H2C_TBLUD_TABLE_CLASS_SH = 24;
+constexpr uint32_t FWCMD_H2C_TBLUD_TABLE_CLASS_MSK = 0xff;
+/* cfg dword1. */
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_CFG_MODE_SH = 0;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_CFG_MODE_MSK = 0x3;
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_CFG_INTERVAL_SH = 2;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_CFG_INTERVAL_MSK = 0x3f;
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_CFG_BSR_THOLD_SH = 8;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_CFG_BSR_THOLD_MSK = 0xff;
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_CFG_STOREMODE_SH = 16;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_CFG_STOREMODE_MSK = 0x3;
+/* ulinfo dword2 (tf_type / gi_ltf) + dword3 (data_rate / apep_len / istwt). */
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_ULINFO_TF_TYPE_SH = 16;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_ULINFO_TF_TYPE_MSK = 0x7;
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_ULINFO_GI_LTF_SH = 29;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_ULINFO_GI_LTF_MSK = 0x7;
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_ULINFO_DATART_SH = 0;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_ULINFO_DATART_MSK = 0x1ff;
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_ULINFO_APEPLEN_SH = 16;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_ULINFO_APEPLEN_MSK = 0xfff;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_ULINFO_ISTWT = 1u << 30;
+/* ulinfo dword4 (multiport_id). */
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_ULINFO_MULTIPORT_SH = 0;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_ULINFO_MULTIPORT_MSK = 0x7;
+/* sta_info pair (2 STAs per dword). */
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_STA_INFO_MACID_0_SH = 0;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_STA_INFO_MACID_0_MSK = 0xff;
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_STA_INFO_PREF_AC_0_SH = 8;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_STA_INFO_PREF_AC_0_MSK = 0x3;
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_STA_INFO_MACID_1_SH = 16;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_STA_INFO_MACID_1_MSK = 0xff;
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_STA_INFO_PREF_AC_1_SH = 24;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_STA_INFO_PREF_AC_1_MSK = 0x3;
+/* ulrua header (ppdu_bw / sta_num). */
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_ULRUA_PPDU_BW_SH = 1;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_ULRUA_PPDU_BW_MSK = 0x3;
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_ULRUA_GI_LTF_SH = 3;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_ULRUA_GI_LTF_MSK = 0x7;
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_ULRUA_STANUM_SH = 11;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_ULRUA_STANUM_MSK = 0xf;
+/* per-RU entry dword A (tgt_rssi / mac_id / ru_pos) + dword B (bsr / ss / mcs). */
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_TGT_RSSI_SH = 1;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_TGT_RSSI_MSK = 0x7f;
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_MAC_ID_SH = 8;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_MAC_ID_MSK = 0xff;
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_RU_POS_SH = 16;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_RU_POS_MSK = 0xff;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_CODE = 1u << 24;
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_BSRLEN_SH = 0;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_BSRLEN_MSK = 0x7fff;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_DCM = 1u << 16;
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_SS_SH = 17;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_SS_MSK = 0x7;
+constexpr uint8_t FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_MCS_SH = 20;
+constexpr uint32_t FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_MCS_MSK = 0xf;
+
+/* ===================================================================
+ * HE sounding (mac_set_snd_para / build_snd_h2c): CL_SOUND / FUNC_SET_SND_PARA.
+ * This is the *production* trigger-airing path — the fw builds and airs the
+ * NDPA -> NDP -> BFRP sequence from the H2C content (content-in-H2C, no
+ * pkt_ofld) and arms RX for the beamforming-report HE TB PPDU. A BFRP
+ * (Beamforming Report Poll) is an 802.11ax Trigger-frame variant, so this
+ * solicits a genuine hardware-scheduled, contention-free UL transmission.
+ * Unlike F2P_TEST (MP-only, no shipped-fw handler), the sounding cmd is a
+ * normal client feature (CONFIG_PHL_BEAMFORM). Field layout verbatim from
+ * fw_ax/inc_hdr/fwcmd_intf.h (the SET_SND_PARA_* block) and the packing order
+ * from mac_ax/sounding.c build_snd_h2c. The per-index vendor macros (STA0..7,
+ * U0..3, WD0..4) are bit-identical, so each repeating structure collapses to
+ * one field set here; the encoder places it in the right dword per index.
+ * =================================================================== */
+constexpr uint8_t FWCMD_H2C_CL_SOUND = 0xB;
+constexpr uint8_t FWCMD_H2C_FUNC_SET_SND_PARA = 0x0;    /* 8852B (v0) */
+constexpr uint8_t FWCMD_H2C_FUNC_SET_SND_PARA_V1 = 0xD; /* 8852C (v1) */
+constexpr std::size_t SND_PARA_V0_LEN = 288; /* sizeof(fwcmd_set_snd_para): 72 dw */
+constexpr std::size_t SND_PARA_V1_LEN = 392; /* sizeof(fwcmd_set_snd_para_v1): 98 dw */
+/* mac_ax frame-exchange types (sounding.h). AX_MU_BFRP1 = the HE MU case that
+ * airs NDPA(wd0) -> NDP(wd1) -> BFRP-Trigger(wd2) and solicits a TB PPDU. */
+constexpr uint8_t FRAME_EXCHANGE_SND_AX_SU = 35;
+constexpr uint8_t FRAME_EXCHANGE_SND_AX_MU_BFRP1 = 36;
+constexpr uint8_t FRAME_EXCHANGE_SND_AX_MU_BFRP2 = 37;
+constexpr uint8_t FRAME_EXCHANGE_SND_N_SU = 38;
+/* snd_pkt_sel values the fw uses to pick which frame a WD drives. */
+constexpr uint8_t SND_PKT_SEL_NDPA = 1;
+constexpr uint8_t SND_PKT_SEL_NDP = 3;
+constexpr uint8_t SND_PKT_SEL_BFRP_LAST = 5;
+/* dword0. */
+constexpr uint8_t SND_FREXCH_TYPE_SH = 0;
+constexpr uint32_t SND_FREXCH_TYPE_MSK = 0x3f;
+constexpr uint8_t SND_MODE_SH = 6;
+constexpr uint32_t SND_MODE_MSK = 0x3;
+constexpr uint8_t SND_BFRP0_USER_NUM_SH = 8;
+constexpr uint32_t SND_BFRP0_USER_NUM_MSK = 0x7;
+constexpr uint8_t SND_BFRP1_USER_NUM_SH = 11;
+constexpr uint32_t SND_BFRP1_USER_NUM_MSK = 0x7;
+/* byte-slot packing (the vendor MACID0..3 macros): 4 bytes per dword, LSB
+ * first. Reused verbatim for macid[], addr1/2/3 of NDPA/BFRP headers. */
+constexpr uint8_t SND_BYTE0_SH = 0;
+constexpr uint8_t SND_BYTE1_SH = 8;
+constexpr uint8_t SND_BYTE2_SH = 16;
+constexpr uint8_t SND_BYTE3_SH = 24;
+constexpr uint32_t SND_BYTE_MSK = 0xff;
+/* NDPA header (dword3, dword7, dword9). frame_ctl/dur/dialog/seq. */
+constexpr uint8_t SND_NDPA_FRAME_CTRL_SH = 0;
+constexpr uint32_t SND_NDPA_FRAME_CTRL_MSK = 0xffff;
+constexpr uint8_t SND_NDPA_DURATION_SH = 16;
+constexpr uint32_t SND_NDPA_DURATION_MSK = 0xffff;
+constexpr uint32_t SND_NDPA_SND_DLG_HE = 1u << 0;
+constexpr uint8_t SND_NDPA_SND_DLG_DIALOG_SH = 1;
+constexpr uint32_t SND_NDPA_SND_DLG_DIALOG_MSK = 0x3f;
+constexpr uint8_t SND_HT_SEQ_CONTROL_SH = 16;
+constexpr uint32_t SND_HT_SEQ_CONTROL_MSK = 0xffff;
+/* NDPA VHT STA-info (2 per dword: STA0/2 low @0, STA1/3 high @16). */
+constexpr uint8_t SND_VHT_STA_AID12_LO_SH = 0;
+constexpr uint8_t SND_VHT_STA_AID12_HI_SH = 16;
+constexpr uint32_t SND_VHT_STA_AID12_MSK = 0xfff;
+constexpr uint32_t SND_VHT_STA_FB_TYPE_LO = 1u << 12;
+constexpr uint32_t SND_VHT_STA_FB_TYPE_HI = 1u << 28;
+constexpr uint8_t SND_VHT_STA_NC_LO_SH = 13;
+constexpr uint8_t SND_VHT_STA_NC_HI_SH = 29;
+constexpr uint32_t SND_VHT_STA_NC_MSK = 0x7;
+/* NDPA HE STA-info (one per dword, STA0..7). */
+constexpr uint8_t SND_HE_STA_AID11_SH = 0;
+constexpr uint32_t SND_HE_STA_AID11_MSK = 0x7ff;
+constexpr uint8_t SND_HE_STA_BW_SH = 11;
+constexpr uint32_t SND_HE_STA_BW_MSK = 0x3fff;
+constexpr uint8_t SND_HE_STA_FB_NG_SH = 25;
+constexpr uint32_t SND_HE_STA_FB_NG_MSK = 0x3;
+constexpr uint32_t SND_HE_STA_DISAMBIGUATION = 1u << 27;
+constexpr uint32_t SND_HE_STA_CB = 1u << 28;
+constexpr uint8_t SND_HE_STA_NC_SH = 29;
+constexpr uint32_t SND_HE_STA_NC_MSK = 0x7;
+/* BFRP header frame_ctl/duration (dword20/24/28; addr via byte slots). */
+constexpr uint8_t SND_BFRP_FRAME_CTL_SH = 0;
+constexpr uint32_t SND_BFRP_FRAME_CTL_MSK = 0xffff;
+constexpr uint8_t SND_BFRP_DURATION_SH = 16;
+constexpr uint32_t SND_BFRP_DURATION_MSK = 0xffff;
+/* HE BFRP Common Info dword A (the Trigger frame common info). */
+constexpr uint8_t SND_HE_BFRP_TRIGGER_INFO_SH = 0;
+constexpr uint32_t SND_HE_BFRP_TRIGGER_INFO_MSK = 0xf;
+constexpr uint8_t SND_HE_BFRP_UL_LENGTH_SH = 4;
+constexpr uint32_t SND_HE_BFRP_UL_LENGTH_MSK = 0xfff;
+constexpr uint32_t SND_HE_BFRP_MORE_TF = 1u << 16;
+constexpr uint32_t SND_HE_BFRP_CS_REQUIRED = 1u << 17;
+constexpr uint8_t SND_HE_BFRP_UL_BW_SH = 18;
+constexpr uint32_t SND_HE_BFRP_UL_BW_MSK = 0x3;
+constexpr uint8_t SND_HE_BFRP_GI_LTF_SH = 20;
+constexpr uint32_t SND_HE_BFRP_GI_LTF_MSK = 0x3;
+constexpr uint32_t SND_HE_BFRP_MU_MIMO_LTF_MODE = 1u << 22;
+constexpr uint8_t SND_HE_BFRP_NUM_OF_HE_LTF_SH = 23;
+constexpr uint32_t SND_HE_BFRP_NUM_OF_HE_LTF_MSK = 0x7;
+constexpr uint8_t SND_HE_BFRP_UL_PKTEXT_SH = 26;
+constexpr uint32_t SND_HE_BFRP_UL_PKTEXT_MSK = 0x7;
+constexpr uint32_t SND_HE_BFRP_UL_STBC = 1u << 29;
+constexpr uint32_t SND_HE_BFRP_LDPC_EXTRA_SYMBOL = 1u << 30;
+constexpr uint32_t SND_HE_BFRP_DOPPLER = 1u << 31;
+/* HE BFRP Common Info dword B. */
+constexpr uint8_t SND_HE_BFRP_AP_TX_POWER_SH = 0;
+constexpr uint32_t SND_HE_BFRP_AP_TX_POWER_MSK = 0x3f;
+constexpr uint8_t SND_HE_BFRP_UL_SPATIAL_REUSE_SH = 6;
+constexpr uint32_t SND_HE_BFRP_UL_SPATIAL_REUSE_MSK = 0xffff;
+/* HE BFRP per-user dword A/B (User Info of the Trigger frame). */
+constexpr uint8_t SND_HE_BFRP_U_AID12_SH = 0;
+constexpr uint32_t SND_HE_BFRP_U_AID12_MSK = 0xfff;
+constexpr uint8_t SND_HE_BFRP_U_RU_POS_SH = 12;
+constexpr uint32_t SND_HE_BFRP_U_RU_POS_MSK = 0xff;
+constexpr uint32_t SND_HE_BFRP_U_UL_FEC_CODE = 1u << 20;
+constexpr uint8_t SND_HE_BFRP_U_UL_MCS_SH = 21;
+constexpr uint32_t SND_HE_BFRP_U_UL_MCS_MSK = 0xf;
+constexpr uint32_t SND_HE_BFRP_U_UL_DCM = 1u << 25;
+constexpr uint8_t SND_HE_BFRP_U_SS_ALLOC_SH = 26;
+constexpr uint32_t SND_HE_BFRP_U_SS_ALLOC_MSK = 0x3f;
+constexpr uint8_t SND_HE_BFRP_U_FB_REXMIT_SH = 0;
+constexpr uint32_t SND_HE_BFRP_U_FB_REXMIT_MSK = 0xff;
+constexpr uint8_t SND_HE_BFRP_U_UL_TGT_RSSI_SH = 8;
+constexpr uint32_t SND_HE_BFRP_U_UL_TGT_RSSI_MSK = 0x7f;
+/* VHT BFRP retransmission bitmap (dword52: BFRP0@0, BFRP1@8, BFRP2@16). */
+constexpr uint8_t SND_VHT_BFRP0_FB_REXMIT_SH = 0;
+constexpr uint8_t SND_VHT_BFRP1_FB_REXMIT_SH = 8;
+constexpr uint8_t SND_VHT_BFRP2_FB_REXMIT_SH = 16;
+constexpr uint32_t SND_VHT_BFRP_FB_REXMIT_MSK = 0xff;
+/* WD dword A/B/C (one per WD entry, WD0..4; 3 dwords each). */
+constexpr uint8_t SND_WD_TXPKTSIZE_SH = 0;
+constexpr uint32_t SND_WD_TXPKTSIZE_MSK = 0xffff;
+constexpr uint8_t SND_WD_NDPA_DURATION_SH = 16;
+constexpr uint32_t SND_WD_NDPA_DURATION_MSK = 0xffff;
+constexpr uint8_t SND_WD_DATARATE_SH = 0;
+constexpr uint32_t SND_WD_DATARATE_MSK = 0x1ff;
+constexpr uint8_t SND_WD_MACID_SH = 9;
+constexpr uint32_t SND_WD_MACID_MSK = 0x7f;
+constexpr uint32_t SND_WD_FORCE_TXOP = 1u << 16;
+constexpr uint8_t SND_WD_DATA_BW_SH = 17;
+constexpr uint32_t SND_WD_DATA_BW_MSK = 0x3;
+constexpr uint8_t SND_WD_GI_LTF_SH = 19;
+constexpr uint32_t SND_WD_GI_LTF_MSK = 0x7;
+constexpr uint32_t SND_WD_DATA_ER = 1u << 22;
+constexpr uint32_t SND_WD_DATA_DCM = 1u << 23;
+constexpr uint32_t SND_WD_DATA_STBC = 1u << 24;
+constexpr uint32_t SND_WD_DATA_LDPC = 1u << 25;
+constexpr uint32_t SND_WD_DATA_BW_ER = 1u << 26;
+constexpr uint32_t SND_WD_MULTIPORT_ID = 1u << 27;
+constexpr uint8_t SND_WD_MBSSID_SH = 28;
+constexpr uint32_t SND_WD_MBSSID_MSK = 0xf;
+constexpr uint8_t SND_WD_SIGNALING_TA_PKT_SC_SH = 0;
+constexpr uint32_t SND_WD_SIGNALING_TA_PKT_SC_MSK = 0xf;
+constexpr uint8_t SND_WD_SW_DEFINE_SH = 4;
+constexpr uint32_t SND_WD_SW_DEFINE_MSK = 0xf;
+constexpr uint8_t SND_WD_TXPWR_OFSET_TYPE_SH = 8;
+constexpr uint32_t SND_WD_TXPWR_OFSET_TYPE_MSK = 0x7;
+constexpr uint8_t SND_WD_LIFETIME_SEL_SH = 11;
+constexpr uint32_t SND_WD_LIFETIME_SEL_MSK = 0x7;
+constexpr uint32_t SND_WD_STF_MODE = 1u << 14;
+constexpr uint32_t SND_WD_DISDATAFB = 1u << 15;
+constexpr uint32_t SND_WD_DATA_TXCNT_LMT_SEL = 1u << 16;
+constexpr uint8_t SND_WD_DATA_TXCNT_LMT_SH = 17;
+constexpr uint32_t SND_WD_DATA_TXCNT_LMT_MSK = 0x3f;
+constexpr uint32_t SND_WD_SIFS_TX = 1u << 23;
+constexpr uint8_t SND_WD_SND_PKT_SEL_SH = 24;
+constexpr uint32_t SND_WD_SND_PKT_SEL_MSK = 0x7;
+constexpr uint8_t SND_WD_NDPA_SH = 27;
+constexpr uint32_t SND_WD_NDPA_MSK = 0x3;
+/* F2P (BFRP) sub-content dword (dword68/69). */
+constexpr uint8_t SND_F2P_CSI_LEN_BFRP_SH = 0;
+constexpr uint32_t SND_F2P_CSI_LEN_BFRP_MSK = 0xfff;
+constexpr uint8_t SND_F2P_TB_T_PE_BFRP_SH = 12;
+constexpr uint32_t SND_F2P_TB_T_PE_BFRP_MSK = 0x3;
+constexpr uint8_t SND_F2P_TRI_PAD_BFRP_SH = 14;
+constexpr uint32_t SND_F2P_TRI_PAD_BFRP_MSK = 0x3;
+constexpr uint32_t SND_F2P_UL_CQI_RPT_TRI_BFRP = 1u << 16;
+constexpr uint8_t SND_F2P_RF_GAIN_IDX_BFRP_SH = 17;
+constexpr uint32_t SND_F2P_RF_GAIN_IDX_BFRP_MSK = 0x3ff;
+constexpr uint32_t SND_F2P_FIX_GAIN_EN_BFRP = 1u << 27;
+/* SFP (F2P period) dword70/71. */
+constexpr uint8_t SND_SFP_F2P_TYPE_SH = 0;
+constexpr uint32_t SND_SFP_F2P_TYPE_MSK = 0xff;
+constexpr uint8_t SND_SFP_F2P_INDEX_SH = 8;
+constexpr uint32_t SND_SFP_F2P_INDEX_MSK = 0xff;
+constexpr uint8_t SND_SFP_F2P_PERIOD_SH = 16;
+constexpr uint32_t SND_SFP_F2P_PERIOD_MSK = 0xffff;
+constexpr uint8_t SND_SFP_F2P_UPDCNT_SH = 0;
+constexpr uint32_t SND_SFP_F2P_UPDCNT_MSK = 0xff;
+constexpr uint8_t SND_SFP_CR_IDX_SH = 8;
+constexpr uint32_t SND_SFP_CR_IDX_MSK = 0x3fffff;
+constexpr uint32_t SND_SFP_SOUNDING_EN = 1u << 31;
+/* NDPA/BFRP frame-control constants (802.11 control frames). NDPA =
+ * type1/subtype5 (0x54), BFRP Trigger = type1/subtype2 (0x24). */
+constexpr uint16_t SND_FC_NDPA = 0x0054;
+constexpr uint16_t SND_FC_TRIGGER = 0x0024;
+/* HE Trigger Type subfield: 1 = Beamforming Report Poll (BFRP). */
+constexpr uint8_t SND_TRIGGER_TYPE_BFRP = 1;
+/* sfp.f2p_type (mac_ax_snd_f2p_type, sounding.h): ONCE = one-shot sounding;
+ * ADD = fw-autonomous periodic sounding (requires f2p_period != 0 +
+ * sounding_en) so a single H2C arms repeated soundings instead of flooding the
+ * CH12 H2C queue; DEL removes a periodic entry. */
+constexpr uint8_t SNDF2P_ONCE = 0;
+constexpr uint8_t SNDF2P_ADD = 1;
+constexpr uint8_t SNDF2P_DEL = 2;
+
+/* ---- Sounding hardware init (mac_init_snd_mee/_mer) + per-STA beamformee
+ * registration. Registers are band-0; band-1 adds the _C1 offset (unused here,
+ * we are band 0). Values verbatim from mac_ax/sounding.c + mac_reg_ax.h. ---- */
+constexpr uint16_t R_AX_BFMER_CTRL_0 = 0xCD78;
+constexpr uint32_t B_AX_BFMER_NDP_BFEN = 1u << 2;
+constexpr uint8_t B_AX_BFMER_HT_CSI_OFFSET_SH = 16;
+constexpr uint8_t B_AX_BFMER_VHT_CSI_OFFSET_SH = 8;
+constexpr uint8_t B_AX_BFMER_HE_CSI_OFFSET_SH = 24;
+constexpr uint8_t HT_PAYLOAD_OFFSET = 0x10;
+constexpr uint8_t VHT_PAYLOAD_OFFSET = 0xd;
+constexpr uint8_t HE_PAYLOAD_OFFSET = 0xf;
+constexpr uint16_t R_AX_BFMEE_RESP_OPTION = 0xCD80;
+constexpr uint32_t B_AX_BFMEE_HT_NDPA_EN = 1u << 0;
+constexpr uint32_t B_AX_BFMEE_VHT_NDPA_EN = 1u << 1;
+constexpr uint32_t B_AX_BFMEE_HE_NDPA_EN = 1u << 2;
+constexpr uint8_t B_AX_BFMEE_NDP_RX_STANDBY_TIMER_SH = 24;
+constexpr uint32_t B_AX_BFMEE_NDP_RX_STANDBY_TIMER_MSK = 0xff;
+/* The vendor _patch_snd_ple_modify / _patch_snd_mu_err set BOTH the NDP and
+ * BFRP report-wait standby timers to 0 so a sounding does not hold a hardware
+ * slot waiting for a report — without this the fw's sounding pipeline backs up
+ * after ~7 pending soundings (no report returns) and the CH12 H2C queue wedges
+ * (rc=-7). PATCH_{NDP,BFRP}_RX_STANDBY_TIMER = 0x0 (sounding.h). */
+constexpr uint8_t NDP_RX_STANDBY_TIMER = 0x0;
+constexpr uint8_t B_AX_BFMEE_BFRP_RX_STANDBY_TIMER_SH = 20;
+constexpr uint32_t B_AX_BFMEE_BFRP_RX_STANDBY_TIMER_MSK = 0xf;
+constexpr uint8_t BFRP_RX_STANDBY_TIMER = 0x0;
+constexpr uint16_t R_AX_TRXPTCL_RESP_CSI_CTRL_0 = 0xCD88;
+constexpr uint32_t B_AX_BFMEE_BFPARAM_SEL = 1u << 28;
+constexpr uint32_t B_AX_BFMEE_USE_NSTS = 1u << 22;
+constexpr uint32_t B_AX_BFMEE_CSI_GID_SEL = 1u << 20;
+constexpr uint32_t B_AX_BFMEE_CSI_FORCE_RETE_EN = 1u << 17;
+constexpr uint16_t R_AX_TRXPTCL_RESP_CSI_RRSC = 0xCD8C;
+constexpr uint32_t CSI_RRSC_BMAP = 0x29292911; /* OFDM 6/12/24 for HT/VHT/HE CSI */
+constexpr uint16_t R_AX_CSIRPT_OPTION = 0xCE64;
+constexpr uint32_t B_AX_CSIPRT_VHTSU_AID_EN = 1u << 24;
+constexpr uint32_t B_AX_CSIPRT_HESU_AID_EN = 1u << 25;
+constexpr uint32_t B_AX_CSIRPT_EMPTY_APPZERO = 1u << 1; /* _patch_csi_append_zero clears */
+/* Per-STA sounding-status + CSI-buffer maps (mac_set_snd_sts_index /
+ * mac_set_csi_buffer_index). SND_SH/CSI_SH step the register per index. */
+constexpr uint16_t R_AX_BFMER_ASSOCIATED_SU0 = 0xCD00;
+constexpr uint32_t B_AX_MER_SU_BFMEE0_EN = 1u << 8;
+constexpr uint16_t SND_STS_SH = 0x2; /* per snd-sts index (SND_SH) */
+constexpr uint16_t R_AX_TRXPTCL_ERROR_INDICA_MASK = 0xCCBC; /* 8852C CSI unmask */
+constexpr uint32_t B_AX_RMAC_CSI = 1u << 7;
+constexpr uint16_t R_AX_BFMER_CSI_BUFF_IDX0 = 0xCD2C;
+constexpr uint16_t CSI_BUFF_SH = 0x4; /* per csi-buffer id (CSI_SH) */
+constexpr uint8_t B_AX_MER_CSI_BUFF_IDX_SH = 8; /* buffer_idx << 8 */
+constexpr uint32_t B_AX_MER_CSI_BUFF_IDX_MSK = 0xfff;
+constexpr uint32_t B_AX_MER_CSI_BUFF_MACID_MSK = 0xff; /* macid in [7:0] */
+constexpr uint8_t SOUNDING_STS_MAX_IDX = 0x15;
 
 /* rtw_mac_src_cmd_ofld (mac_outsrc_def.h). */
 constexpr uint8_t OFLD_SRC_BB = 0;

--- a/src/kestrel/RtlKestrelDevice.cpp
+++ b/src/kestrel/RtlKestrelDevice.cpp
@@ -7,6 +7,8 @@
 #include <utility>
 
 #include "FrameParserKestrel.h"
+#include "KestrelLe.h"
+#include "RadiotapBuilder.h" /* build_stream_radiotap — host-injected trigger */
 #include "RadiotapPeek.h"
 #include "RateDefinitions.h" /* MGN_* rate enum */
 #include "MacRegAx.h"
@@ -17,6 +19,11 @@
 #include "ieee80211_radiotap.h" /* radiotap iterator + field ids */
 
 namespace {
+
+/* The canonical injection source address (examples/tx/main.cpp beacon SA); the
+ * WD macid-0 ADDR_CAM entry programmed in InitWrite resolves to it. Shared by
+ * the self-STA registration and the host-injected Basic Trigger's TA. */
+constexpr uint8_t kInjectSA[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
 
 /* mac_ax get_chip_info() register pair (reference/rtl8852bu
  * phl/hal_g6/mac/mac_ax.c + mac_reg_ax.h). R_AX_SYS_CHIPINFO shares the
@@ -224,13 +231,18 @@ void RtlKestrelDevice::InitWrite(SelectedChannel channel) {
    * queued frames air and their PLE pages release — without it the mgmt
    * bulk-OUT stalls deterministically at ~103. SA = the canonical injection
    * source address (examples/tx/main.cpp beacon SA). */
-  static const uint8_t kInjectSA[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
   _hal.add_self_sta(kInjectSA, /*macid=*/0);
   _hal.enable_tx_report(kestrel::reg::USR_TX_RPT_MODE_PERIOD, 0, 0);
   /* Diagnostic (DEVOURER_KESTREL_FWLOG): route the fw log to C2H packets to
    * probe whether async packet-C2H reaches the host at all (task #12/#236). */
   if (_cfg.debug.kestrel_fw_log)
     _hal.enable_fw_log_c2h();
+  /* Arm the HE sounding engine (mac_init_snd_mer/_mee): the beamformer CSI-parse
+   * offsets + beamformee response/CSI options so StartSounding can air an
+   * NDPA -> NDP -> BFRP sequence and receive the report HE TB PPDU. Idempotent
+   * register writes on otherwise-unused CMAC sounding regs; matches the vendor
+   * init order (mac_init_snd at bring-up). */
+  _hal.init_sounding();
   _logger->info("Kestrel: TX ready on ch{} — mgmt ep 0x{:02x} data ep 0x{:02x}",
                 channel.Channel, _tx_mgmt_ep, _tx_data_ep);
   /* One-shot thermal snapshot at bring-up (RF 0x42 meter vs efuse baseline) —
@@ -384,6 +396,26 @@ void RtlKestrelDevice::handle_c2h(const uint8_t *payload, uint32_t len) {
                     rpt.freerun_last_out, rpt.pending_1k[0], rpt.pending_1k[1],
                     rpt.pending_1k[2], rpt.pending_1k[3]);
     }
+  } else if (cls == r::FWCMD_C2H_CL_TWT) {
+    /* TWT C2H (content after the 8-byte fwcmd header). WAIT_ANNOUNCE: dword0 =
+     * wait_case[3:0] | macid0[15:8] | macid1[23:16] | macid2[31:24].
+     * TWT_NOTIFY_EVT: dword0 = type[7:0] | twt_id[10:8]; dword1/2 = TSF lo/hi —
+     * the TSF-stamped notify instant (cross-check against ReadTsf). */
+    const uint8_t *c = payload + 8;
+    const uint32_t clen = len - 8;
+    if (func == r::FWCMD_C2H_FUNC_WAIT_ANNOUNCE && clen >= 4) {
+      const uint32_t d0 = kestrel::le32(c);
+      _logger->info("Kestrel twt.wait_anno: wait_case={} macid0={} macid1={} "
+                    "macid2={}",
+                    d0 & 0xf, (d0 >> 8) & 0xff, (d0 >> 16) & 0xff,
+                    (d0 >> 24) & 0xff);
+    } else if (func == r::FWCMD_C2H_FUNC_TWT_NOTIFY_EVT && clen >= 12) {
+      const uint32_t d0 = kestrel::le32(c);
+      const uint64_t tsf = static_cast<uint64_t>(kestrel::le32(c + 4)) |
+                           (static_cast<uint64_t>(kestrel::le32(c + 8)) << 32);
+      _logger->info("Kestrel twt.notify: type={} twt_id={} tsf=0x{:016x}",
+                    d0 & 0xff, (d0 >> 8) & 0x7, tsf);
+    }
   }
 }
 
@@ -475,6 +507,109 @@ bool RtlKestrelDevice::StartBeacon(const uint8_t *beacon, size_t len,
                            /*bss_color=*/0, kestrel::reg::MAC_AX_OFDM6);
 }
 
+bool RtlKestrelDevice::SendTrigger(const devourer::TriggerConfig &cfg) {
+  if (_tx_mgmt_ep == 0) {
+    _logger->error("Kestrel: SendTrigger before InitWrite");
+    return false;
+  }
+  /* F2P_TEST is an MP-only fw entry the shipped client fw silently drops (it
+   * airs nothing). The default path host-builds a raw 802.11ax Basic Trigger and
+   * injects it through the proven mgmt TX path — the same path StartBeacon-less
+   * send_packet uses to actually put frames on the air. RA = broadcast (a Basic
+   * Trigger addresses its users by AID12 in the User Info, so an associated STA
+   * matches on its AID regardless of the broadcast RA); TA = our injection SA. */
+  if (!_cfg.debug.kestrel_trigger_f2p) {
+    static const uint8_t kBcast[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+    uint8_t frame[2 + 2 + 6 + 6 + 8 + 8 * 5]; /* FC+dur+RA+TA+common+8 users */
+    size_t flen = devourer::build_basic_trigger(cfg, kBcast, kInjectSA, frame,
+                                                 sizeof(frame));
+    if (flen == 0) {
+      _logger->error("Kestrel: SendTrigger build_basic_trigger failed");
+      return false;
+    }
+    /* Trigger frames air non-HT (legacy OFDM 6M — the default TxMode). Prepend
+     * the radiotap the send_packet contract expects, then the raw trigger. */
+    devourer::TxMode m; /* Legacy 6M, 20 MHz */
+    std::vector<uint8_t> pkt = devourer::build_stream_radiotap(m);
+    pkt.insert(pkt.end(), frame, frame + flen);
+    send_packet(pkt.data(), static_cast<uint32_t>(pkt.size()));
+    _logger->info("Kestrel: SendTrigger injected Basic Trigger ({} B, {} users, "
+                  "u0_aid={}) via mgmt ep",
+                  flen, cfg.n_users == 0 ? 1 : cfg.n_users, cfg.users[0].aid12);
+    return true;
+  }
+  return _hal.send_trigger(cfg);
+}
+
+bool RtlKestrelDevice::ConfigureTwt(const devourer::TwtConfig &cfg) {
+  if (_tx_mgmt_ep == 0) {
+    _logger->error("Kestrel: ConfigureTwt before InitWrite");
+    return false;
+  }
+  return _hal.configure_twt(cfg);
+}
+
+bool RtlKestrelDevice::TeardownTwt(const devourer::TwtConfig &cfg) {
+  if (_tx_mgmt_ep == 0)
+    return false;
+  return _hal.teardown_twt(cfg);
+}
+
+bool RtlKestrelDevice::TwtBindSta(const devourer::TwtStaAct &act) {
+  if (_tx_mgmt_ep == 0) {
+    _logger->error("Kestrel: TwtBindSta before InitWrite");
+    return false;
+  }
+  return _hal.twt_bind_sta(act);
+}
+
+bool RtlKestrelDevice::ConfigureTwtOfdma(const devourer::TwtOfdmaConfig &cfg) {
+  if (_tx_mgmt_ep == 0) {
+    _logger->error("Kestrel: ConfigureTwtOfdma before InitWrite");
+    return false;
+  }
+  return _hal.configure_twt_ofdma(cfg);
+}
+
+bool RtlKestrelDevice::ConfigureUlOfdma(const devourer::UlOfdmaConfig &cfg) {
+  if (_tx_mgmt_ep == 0) {
+    _logger->error("Kestrel: ConfigureUlOfdma before InitWrite");
+    return false;
+  }
+  return _hal.configure_ul_ofdma(cfg);
+}
+
+bool RtlKestrelDevice::RegisterPeerSta(const uint8_t peer_mac[6], uint8_t macid,
+                                       uint8_t addr_cam_idx) {
+  if (_tx_mgmt_ep == 0) {
+    _logger->error("Kestrel: RegisterPeerSta before InitWrite");
+    return false;
+  }
+  return _hal.register_peer_sta(peer_mac, macid, addr_cam_idx);
+}
+
+bool RtlKestrelDevice::RegisterBeamformee(const uint8_t peer_mac[6],
+                                          uint8_t macid, uint8_t addr_cam_idx,
+                                          const devourer::StaBfCaps &bf) {
+  if (_tx_mgmt_ep == 0) {
+    _logger->error("Kestrel: RegisterBeamformee before InitWrite");
+    return false;
+  }
+  /* The peer must exist as a fw role/ADDR_CAM entry first (same as a scheduled-
+   * UL peer); then layer the CSI/bf params + hw sounding maps on top. */
+  bool ok = _hal.register_peer_sta(peer_mac, macid, addr_cam_idx);
+  ok = _hal.register_beamformee(macid, addr_cam_idx, bf) && ok;
+  return ok;
+}
+
+bool RtlKestrelDevice::StartSounding(const devourer::SoundingConfig &cfg) {
+  if (_tx_mgmt_ep == 0) {
+    _logger->error("Kestrel: StartSounding before InitWrite");
+    return false;
+  }
+  return _hal.start_sounding(cfg);
+}
+
 devourer::AdapterCaps RtlKestrelDevice::GetAdapterCaps() {
   devourer::AdapterCaps c;
   c.supported = true;
@@ -494,6 +629,13 @@ devourer::AdapterCaps RtlKestrelDevice::GetAdapterCaps() {
   /* HE ER SU + DCM: both dies (AX_TXD_DATA_ER/_BW_ER/_DCM in the TX WD; RX
    * classifies via the descriptor ppdu_type nibble). */
   c.he_er_su_ok = true;
+  /* 802.11ax scheduled UL: HE Trigger (F2P) + UL_FIXINFO scheduler + the TWT
+   * agreement surface — the fw command surface both dies expose. */
+  c.trigger_ul_ok = true;
+  c.twt_ok = true;
+  /* HE sounding (NDPA/NDP/BFRP -> report HE TB PPDU): the production trigger
+   * path armed in InitWrite (init_sounding) + StartSounding / RegisterBeamformee. */
+  c.sounding_ok = true;
   c.hw_rx_timestamp = true;     /* rx freerun_cnt -> RxAtrib.tsfl */
   /* The AX beacon engine (StartBeacon) airs a HW-timed beacon with the live TSF
    * inserted by the MAC at TX — on-air validated on the 8852BU. */

--- a/src/kestrel/RtlKestrelDevice.cpp
+++ b/src/kestrel/RtlKestrelDevice.cpp
@@ -515,13 +515,20 @@ bool RtlKestrelDevice::SendTrigger(const devourer::TriggerConfig &cfg) {
   /* F2P_TEST is an MP-only fw entry the shipped client fw silently drops (it
    * airs nothing). The default path host-builds a raw 802.11ax Basic Trigger and
    * injects it through the proven mgmt TX path — the same path StartBeacon-less
-   * send_packet uses to actually put frames on the air. RA = broadcast (a Basic
-   * Trigger addresses its users by AID12 in the User Info, so an associated STA
-   * matches on its AID regardless of the broadcast RA); TA = our injection SA. */
+   * send_packet uses to actually put frames on the air. RA = broadcast unless
+   * cfg.ra is set (a Basic Trigger addresses its users by AID12, so an
+   * associated STA matches on its AID). TA MUST be the AP's BSSID — a station
+   * rejects a Trigger whose TA is not the AP it associated to — so use cfg.ta;
+   * fall back to the injection SA only when the caller left it unset. */
   if (!_cfg.debug.kestrel_trigger_f2p) {
     static const uint8_t kBcast[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
-    uint8_t frame[2 + 2 + 6 + 6 + 8 + 8 * 5]; /* FC+dur+RA+TA+common+8 users */
-    size_t flen = devourer::build_basic_trigger(cfg, kBcast, kInjectSA, frame,
+    const bool have_ta = cfg.ta != std::array<uint8_t, 6>{};
+    const bool have_ra = cfg.ra != std::array<uint8_t, 6>{};
+    const uint8_t *ta = have_ta ? cfg.ta.data() : kInjectSA;
+    const uint8_t *ra = have_ra ? cfg.ra.data() : kBcast;
+    /* FC+dur+RA+TA+common + 8 users x 6B (Basic) + pad marker(2) + padding(4). */
+    uint8_t frame[2 + 2 + 6 + 6 + 8 + 8 * 6 + 2 + 4];
+    size_t flen = devourer::build_basic_trigger(cfg, ra, ta, frame,
                                                  sizeof(frame));
     if (flen == 0) {
       _logger->error("Kestrel: SendTrigger build_basic_trigger failed");

--- a/src/kestrel/RtlKestrelDevice.h
+++ b/src/kestrel/RtlKestrelDevice.h
@@ -125,9 +125,10 @@ public:
   bool RegisterPeerSta(const uint8_t peer_mac[6], uint8_t macid,
                        uint8_t addr_cam_idx) override;
 
-  /* HE sounding (the production trigger-airing path): register an associated
-   * beamformee, then air an NDPA -> NDP -> BFRP sequence and receive the report
-   * HE TB PPDU. */
+  /* HE sounding command surface: register an associated beamformee, then drive a
+   * sounding intended to air NDPA -> NDP -> BFRP and receive the report HE TB
+   * PPDU. NB the shipped client NIC fw accepts SET_SND_PARA but does not air it
+   * (AP-firmware-only transmit engine); see docs/he-trigger-ul.md. */
   bool RegisterBeamformee(const uint8_t peer_mac[6], uint8_t macid,
                           uint8_t addr_cam_idx,
                           const devourer::StaBfCaps &bf) override;

--- a/src/kestrel/RtlKestrelDevice.h
+++ b/src/kestrel/RtlKestrelDevice.h
@@ -109,6 +109,30 @@ public:
    * `interval_tu` TU with the live TSF inserted. */
   bool StartBeacon(const uint8_t *beacon, size_t len, int interval_tu) override;
 
+  /* 802.11ax scheduled UL: air an HE Basic Trigger (UL-OFDMA grant), program
+   * TWT agreements + STA binds, and the fw-autonomous trigger cadence
+   * (TWT-OFDMA or the UL_FIXINFO table). Require a prior InitWrite. */
+  bool SendTrigger(const devourer::TriggerConfig &cfg) override;
+  bool ConfigureTwt(const devourer::TwtConfig &cfg) override;
+  bool TeardownTwt(const devourer::TwtConfig &cfg) override;
+  bool TwtBindSta(const devourer::TwtStaAct &act) override;
+  bool ConfigureTwtOfdma(const devourer::TwtOfdmaConfig &cfg) override;
+  bool ConfigureUlOfdma(const devourer::UlOfdmaConfig &cfg) override;
+
+  /* Register an associated peer STA (macid/addr-cam) so a Trigger's per-user
+   * grant scores against it — the AP-side companion to SendTrigger for the
+   * end-to-end UL path. */
+  bool RegisterPeerSta(const uint8_t peer_mac[6], uint8_t macid,
+                       uint8_t addr_cam_idx) override;
+
+  /* HE sounding (the production trigger-airing path): register an associated
+   * beamformee, then air an NDPA -> NDP -> BFRP sequence and receive the report
+   * HE TB PPDU. */
+  bool RegisterBeamformee(const uint8_t peer_mac[6], uint8_t macid,
+                          uint8_t addr_cam_idx,
+                          const devourer::StaBfCaps &bf) override;
+  bool StartSounding(const devourer::SoundingConfig &cfg) override;
+
   /* AX-native identity read (no power-on needed — the identity block is alive
    * as soon as the USB function enumerates). kestrelprobe stage "id" and the
    * constructor's confirmation log both come through here. */

--- a/src/kestrel/SchedEncode.h
+++ b/src/kestrel/SchedEncode.h
@@ -1,0 +1,471 @@
+#ifndef KESTREL_SCHED_ENCODE_H
+#define KESTREL_SCHED_ENCODE_H
+
+#include <cstdint>
+#include <vector>
+
+#include "KestrelLe.h"
+#include "MacRegAx.h"
+#include "Sounding.h"
+#include "TriggerTwt.h"
+
+/* Pure LE-byte encoders for the 802.11ax trigger-UL + TWT H2C content buffers.
+ * Split out of the KestrelFw methods so the byte layout is unit-testable
+ * without a device (tests/kestrel_sched_selftest.cpp) — the KestrelFw methods
+ * are just encode_* + send_h2c_cmd + a log line. Every function mirrors a
+ * vendor mac_ax command byte-for-byte; field layouts are the MacRegAx.h
+ * constants (verbatim from the vendor headers). */
+
+namespace kestrel::sched {
+
+namespace r = kestrel::reg;
+
+/* SET_WORD(v, FIELD) == (v & FIELD_MSK) << FIELD_SH. */
+inline uint32_t sw(uint32_t v, uint32_t msk, uint8_t sh) {
+  return (v & msk) << sh;
+}
+
+/* 802.11ax SS Allocation subfield: bits[2:0]=start SS(0), bits[5:3]=NSS-1. */
+inline uint32_t ss_alloc_enc(uint8_t ss) {
+  uint32_t nss = ss == 0 ? 0 : static_cast<uint32_t>(ss - 1);
+  return (nss & 0x7) << 3;
+}
+
+/* F2P trigger content (mac_f2p_test_cmd): v1=true lays out the 8852C 8-user
+ * 288-byte fwcmd_test_para_v1; v1=false the 8852B 4-user 236-byte
+ * fwcmd_test_para. Only the trigger-frame parameters are set; the DL-burst /
+ * SIG-B dwords stay zero (a plain UL Basic Trigger). */
+inline std::vector<uint8_t> encode_f2p_trigger(const devourer::TriggerConfig &cfg,
+                                              bool v1) {
+  const size_t content_len = v1 ? r::F2P_V1_CONTENT_LEN : r::F2P_V0_CONTENT_LEN;
+  const uint8_t max_users = v1 ? r::F2P_V1_MAX_USERS : r::F2P_V0_MAX_USERS;
+  const size_t tfwd_off = v1 ? r::F2P_V1_TFWD_OFF : r::F2P_V0_TFWD_OFF;
+  const size_t depuser_off = v1 ? r::F2P_V1_DEPUSER_OFF : r::F2P_V0_DEPUSER_OFF;
+  uint8_t n = cfg.n_users == 0 ? 1 : cfg.n_users;
+  if (n > max_users)
+    n = max_users;
+
+  std::vector<uint8_t> c(content_len, 0);
+  uint8_t *b = c.data();
+
+  /* dword0 — trigger-frame packet common. pktnum=0 (no paired DL data). */
+  put_le32(b + 0,
+           sw(cfg.ul_bw, r::FWCMD_F2PTEST_ULBW_MSK, r::FWCMD_F2PTEST_ULBW_SH) |
+               sw(cfg.gi_ltf, r::FWCMD_F2PTEST_GILTF_MSK,
+                  r::FWCMD_F2PTEST_GILTF_SH) |
+               sw(cfg.num_he_ltf, r::FWCMD_F2PTEST_NUMLTF_MSK,
+                  r::FWCMD_F2PTEST_NUMLTF_SH) |
+               sw(cfg.ap_tx_power, r::FWCMD_F2PTEST_TXPWR_MSK,
+                  r::FWCMD_F2PTEST_TXPWR_SH) |
+               sw(n, r::FWCMD_F2PTEST_USERNUM_MSK, r::FWCMD_F2PTEST_USERNUM_SH) |
+               sw(cfg.pri20_bitmap, r::FWCMD_F2PTEST_BITMAP_MSK,
+                  r::FWCMD_F2PTEST_BITMAP_SH));
+
+  /* Per-user pair: dwordA at (1+2u), dwordB at (2+2u) — same in v0 and v1. */
+  for (uint8_t u = 0; u < n; ++u) {
+    const devourer::TrigUser &tu = cfg.users[u];
+    const size_t a = static_cast<size_t>(1 + 2 * u) * 4;
+    const size_t bb = static_cast<size_t>(2 + 2 * u) * 4;
+    put_le32(b + a,
+             sw(tu.aid12, r::FWCMD_F2PTEST_AID12_MSK, r::FWCMD_F2PTEST_AID12_SH) |
+                 sw(tu.ul_mcs, r::FWCMD_F2PTEST_ULMCS_MSK,
+                    r::FWCMD_F2PTEST_ULMCS_SH) |
+                 sw(tu.macid, r::FWCMD_F2PTEST_MACID_MSK,
+                    r::FWCMD_F2PTEST_MACID_SH) |
+                 sw(tu.ru_alloc, r::FWCMD_F2PTEST_RUPOS_MSK,
+                    r::FWCMD_F2PTEST_RUPOS_SH));
+    put_le32(b + bb,
+             sw(tu.ldpc ? 1 : 0, r::FWCMD_F2PTEST_ULFEC_MSK,
+                r::FWCMD_F2PTEST_ULFEC_SH) |
+                 sw(tu.dcm ? 1 : 0, r::FWCMD_F2PTEST_ULDCM_MSK,
+                    r::FWCMD_F2PTEST_ULDCM_SH) |
+                 sw(ss_alloc_enc(tu.ss), r::FWCMD_F2PTEST_SS_ALLOC_MSK,
+                    r::FWCMD_F2PTEST_SS_ALLOC_SH) |
+                 sw(devourer::he_tgt_rssi_enc(tu.tgt_rssi_dbm),
+                    r::FWCMD_F2PTEST_UL_TGTRSSI_MSK,
+                    r::FWCMD_F2PTEST_UL_TGTRSSI_SH));
+    /* dep-user pref_AC — one byte per user (v0: byte9..; v1: dword17_0..). */
+    b[depuser_off + u] = tu.pref_ac & 0x3;
+  }
+
+  /* tf_wd dword — the trigger frame's own legacy-PPDU rate + mode/frexch. */
+  put_le32(b + tfwd_off,
+           sw(cfg.trig_rate, r::FWCMD_F2PTEST_DATARATE_MSK,
+              r::FWCMD_F2PTEST_DATARATE_SH) |
+               sw(cfg.mode, r::FWCMD_F2PTEST_MODE_MSK, r::FWCMD_F2PTEST_MODE_SH) |
+               sw(cfg.frexch_type, r::FWCMD_F2PTEST_TYPE_MSK,
+                  r::FWCMD_F2PTEST_TYPE_SH));
+
+  /* f2p_wd (dword14 v0 / dword20 v1) — the TX descriptor for the frame the fw
+   * builds. Without it (length 0, fs/ls clear) the fw airs nothing. One
+   * complete Basic Trigger on the band-0 mgmt queue: fs=ls=1, one segment,
+   * length = the built frame's dwords (16 B MAC hdr + 8 B Common Info + 5 B per
+   * User Info + 4 B FCS, rounded up). */
+  const uint32_t frame_bytes = 16u + 8u + 5u * n + 4u;
+  const uint32_t frame_dwords = (frame_bytes + 3u) / 4u;
+  put_le32(b + tfwd_off + 4,
+           sw(r::MAC_AX_MG0_SEL, r::F2P_WD_CMD_QSEL_MSK, r::F2P_WD_CMD_QSEL_SH) |
+               r::F2P_WD_FS | r::F2P_WD_LS |
+               sw(1, r::F2P_WD_TOTAL_NUMBER_MSK, r::F2P_WD_TOTAL_NUMBER_SH) |
+               sw(frame_dwords, r::F2P_WD_LENGTH_MSK, r::F2P_WD_LENGTH_SH));
+  return c;
+}
+
+/* TWT info (mac_twt_info_upd) — 6-dword fwcmd_twtinfo_upd (vendor sets 0..4). */
+inline std::vector<uint8_t> encode_twtinfo(const devourer::TwtConfig &cfg,
+                                          uint8_t act) {
+  std::vector<uint8_t> c(24, 0);
+  uint8_t *b = c.data();
+  const uint32_t nego = cfg.broadcast ? 2u : 0u;
+  put_le32(b + 0,
+           sw(nego, r::FWCMD_H2C_TWTINFO_UPD_NEGOTYPE_MSK,
+              r::FWCMD_H2C_TWTINFO_UPD_NEGOTYPE_SH) |
+               (cfg.trigger ? r::FWCMD_H2C_TWTINFO_UPD_TRIGGER : 0) |
+               (cfg.announced ? r::FWCMD_H2C_TWTINFO_UPD_FLOWTYPE : 0) |
+               (cfg.wake_dur_us256 ? r::FWCMD_H2C_TWTINFO_UPD_WAKEDURUNIT : 0) |
+               sw(cfg.flow_id, r::FWCMD_H2C_TWTINFO_UPD_FLOWID_MSK,
+                  r::FWCMD_H2C_TWTINFO_UPD_FLOWID_SH) |
+               (cfg.protection ? r::FWCMD_H2C_TWTINFO_UPD_PROT : 0) |
+               sw(act, r::FWCMD_H2C_TWTINFO_UPD_ACT_MSK,
+                  r::FWCMD_H2C_TWTINFO_UPD_ACT_SH) |
+               sw(cfg.config_id, r::FWCMD_H2C_TWTINFO_UPD_ID_MSK,
+                  r::FWCMD_H2C_TWTINFO_UPD_ID_SH) |
+               (cfg.band ? r::FWCMD_H2C_TWTINFO_UPD_BAND : 0) |
+               sw(cfg.port, r::FWCMD_H2C_TWTINFO_UPD_PORT_MSK,
+                  r::FWCMD_H2C_TWTINFO_UPD_PORT_SH) |
+               (cfg.ap_role ? r::FWCMD_H2C_TWTINFO_UPD_NIC_ROLE : 0));
+  put_le32(b + 4,
+           sw(cfg.wake_man, r::FWCMD_H2C_TWTINFO_UPD_WAKE_MAN_MSK,
+              r::FWCMD_H2C_TWTINFO_UPD_WAKE_MAN_SH) |
+               sw(cfg.wake_exp, r::FWCMD_H2C_TWTINFO_UPD_WAKE_EXP_MSK,
+                  r::FWCMD_H2C_TWTINFO_UPD_WAKE_EXP_SH) |
+               sw(cfg.min_wake_dur, r::FWCMD_H2C_TWTINFO_UPD_DUR_MSK,
+                  r::FWCMD_H2C_TWTINFO_UPD_DUR_SH));
+  put_le32(b + 8, static_cast<uint32_t>(cfg.trgt_tsf & 0xffffffffu));
+  put_le32(b + 12, static_cast<uint32_t>(cfg.trgt_tsf >> 32));
+  /* dword4 (ptt/dma/early) + dword5 stay zero. */
+  return c;
+}
+
+/* TWT STA act (mac_twt_act) — 2-dword fwcmd_twt_stansp_upd. */
+inline std::vector<uint8_t> encode_twt_act(const devourer::TwtStaAct &a) {
+  std::vector<uint8_t> c(8, 0);
+  put_le32(c.data() + 0,
+           sw(a.macid, r::FWCMD_H2C_TWT_STANSP_UPD_MACID_MSK,
+              r::FWCMD_H2C_TWT_STANSP_UPD_MACID_SH) |
+               sw(a.config_id, r::FWCMD_H2C_TWT_STANSP_UPD_ID_MSK,
+                  r::FWCMD_H2C_TWT_STANSP_UPD_ID_SH) |
+               sw(a.action, r::FWCMD_H2C_TWT_STANSP_UPD_ACT_MSK,
+                  r::FWCMD_H2C_TWT_STANSP_UPD_ACT_SH));
+  return c;
+}
+
+/* TWT announce (mac_twt_staanno) — 1-dword fwcmd_twt_announce_upd. */
+inline std::vector<uint8_t> encode_twt_announce(uint8_t macid) {
+  std::vector<uint8_t> c(4, 0);
+  put_le32(c.data() + 0, sw(macid, r::FWCMD_H2C_TWT_ANNOUNCE_UPD_MACID_MSK,
+                            r::FWCMD_H2C_TWT_ANNOUNCE_UPD_MACID_SH));
+  return c;
+}
+
+/* TWT-OFDMA cadence (mac_twt_ofdma_info_upd) — 2-dword fwcmd_twt_ofdma_info_upd. */
+inline std::vector<uint8_t> encode_twt_ofdma(const devourer::TwtOfdmaConfig &cfg) {
+  std::vector<uint8_t> c(8, 0);
+  put_le32(c.data() + 0,
+           sw(cfg.option, r::FWCMD_H2C_TWT_OFDMA_OPTION_MSK,
+              r::FWCMD_H2C_TWT_OFDMA_OPTION_SH) |
+               sw(cfg.twt_id, r::FWCMD_H2C_TWT_OFDMA_TWT_ID_MSK,
+                  r::FWCMD_H2C_TWT_OFDMA_TWT_ID_SH) |
+               sw(cfg.max_tf_retry, r::FWCMD_H2C_TWT_OFDMA_MAX_TF_RETRY_MSK,
+                  r::FWCMD_H2C_TWT_OFDMA_MAX_TF_RETRY_SH) |
+               sw(cfg.max_dl_retry, r::FWCMD_H2C_TWT_OFDMA_MAX_DL_RETRY_MSK,
+                  r::FWCMD_H2C_TWT_OFDMA_MAX_DL_RETRY_SH) |
+               sw(cfg.round_num, r::FWCMD_H2C_TWT_OFDMA_ROUND_NUM_MSK,
+                  r::FWCMD_H2C_TWT_OFDMA_ROUND_NUM_SH) |
+               sw(cfg.preferred_ac, r::FWCMD_H2C_TWT_OFDMA_PREFERRED_AC_MSK,
+                  r::FWCMD_H2C_TWT_OFDMA_PREFERRED_AC_SH) |
+               (cfg.htc_bsr_ctrl_en ? r::FWCMD_H2C_TWT_OFDMA_HTC_BSR_CTRL_EN : 0));
+  put_le32(c.data() + 4, sw(cfg.round_interval_us,
+                            r::FWCMD_H2C_TWT_OFDMA_ROUND_INTERVAL_MSK,
+                            r::FWCMD_H2C_TWT_OFDMA_ROUND_INTERVAL_SH));
+  return c;
+}
+
+/* UL_FIXINFO table (mac_upd_ul_fixinfo) — 27-dword content for 8 RU slots. */
+inline std::vector<uint8_t> encode_ul_fixinfo(const devourer::UlOfdmaConfig &cfg) {
+  constexpr uint8_t RU = r::UL_FIXINFO_MAX_RU_NUM; /* 8 */
+  const size_t ndw = 5 + RU / 2 + 2 + RU * 2;
+  std::vector<uint8_t> c(ndw * 4, 0);
+  uint8_t *b = c.data();
+  size_t o = 0;
+  auto push = [&](uint32_t v) {
+    put_le32(b + o, v);
+    o += 4;
+  };
+  uint8_t nsta = cfg.n_stas == 0 ? 1 : cfg.n_stas;
+  if (nsta > RU)
+    nsta = RU;
+
+  /* dword0 — tbl_hdr: write, group 0, offset 0, length = ndw, table class. */
+  push(r::FWCMD_H2C_TBLUD_R_W |
+       sw(static_cast<uint32_t>(ndw), r::FWCMD_H2C_TBLUD_LENGTH_MSK,
+          r::FWCMD_H2C_TBLUD_LENGTH_SH) |
+       sw(r::CLASS_UL_FIXINFO, r::FWCMD_H2C_TBLUD_TABLE_CLASS_MSK,
+          r::FWCMD_H2C_TBLUD_TABLE_CLASS_SH));
+  /* dword1 — cfg: mode / interval / bsr_thold / storemode. */
+  push(sw(cfg.mode, r::FWCMD_H2C_UL_FIXINFO_CFG_MODE_MSK,
+          r::FWCMD_H2C_UL_FIXINFO_CFG_MODE_SH) |
+       sw(cfg.interval_s, r::FWCMD_H2C_UL_FIXINFO_CFG_INTERVAL_MSK,
+          r::FWCMD_H2C_UL_FIXINFO_CFG_INTERVAL_SH) |
+       sw(cfg.bsr_thold, r::FWCMD_H2C_UL_FIXINFO_CFG_BSR_THOLD_MSK,
+          r::FWCMD_H2C_UL_FIXINFO_CFG_BSR_THOLD_SH) |
+       sw(cfg.store_mode, r::FWCMD_H2C_UL_FIXINFO_CFG_STOREMODE_MSK,
+          r::FWCMD_H2C_UL_FIXINFO_CFG_STOREMODE_SH));
+  /* dword2 — ulinfo A: tf_type / gi_ltf. */
+  push(sw(cfg.tf_type, r::FWCMD_H2C_UL_FIXINFO_ULINFO_TF_TYPE_MSK,
+          r::FWCMD_H2C_UL_FIXINFO_ULINFO_TF_TYPE_SH) |
+       sw(cfg.gi_ltf, r::FWCMD_H2C_UL_FIXINFO_ULINFO_GI_LTF_MSK,
+          r::FWCMD_H2C_UL_FIXINFO_ULINFO_GI_LTF_SH));
+  /* dword3 — ulinfo B: data_rate / apep_len / istwt. */
+  push(sw(cfg.data_rate, r::FWCMD_H2C_UL_FIXINFO_ULINFO_DATART_MSK,
+          r::FWCMD_H2C_UL_FIXINFO_ULINFO_DATART_SH) |
+       sw(cfg.apep_len, r::FWCMD_H2C_UL_FIXINFO_ULINFO_APEPLEN_MSK,
+          r::FWCMD_H2C_UL_FIXINFO_ULINFO_APEPLEN_SH) |
+       (cfg.istwt ? r::FWCMD_H2C_UL_FIXINFO_ULINFO_ISTWT : 0));
+  /* dword4 — ulinfo C: multiport_id. */
+  push(sw(cfg.multiport_id, r::FWCMD_H2C_UL_FIXINFO_ULINFO_MULTIPORT_MSK,
+          r::FWCMD_H2C_UL_FIXINFO_ULINFO_MULTIPORT_SH));
+
+  /* sta_info pairs — macid/pref_AC, two STAs per dword, RU/2 dwords. */
+  for (uint8_t i = 0; i < RU; i += 2) {
+    const devourer::UlOfdmaSta &s0 = cfg.stas[i];
+    const devourer::UlOfdmaSta &s1 = cfg.stas[i + 1];
+    push(sw(s0.macid, r::FWCMD_H2C_UL_FIXINFO_STA_INFO_MACID_0_MSK,
+            r::FWCMD_H2C_UL_FIXINFO_STA_INFO_MACID_0_SH) |
+         sw(s0.pref_ac, r::FWCMD_H2C_UL_FIXINFO_STA_INFO_PREF_AC_0_MSK,
+            r::FWCMD_H2C_UL_FIXINFO_STA_INFO_PREF_AC_0_SH) |
+         sw(s1.macid, r::FWCMD_H2C_UL_FIXINFO_STA_INFO_MACID_1_MSK,
+            r::FWCMD_H2C_UL_FIXINFO_STA_INFO_MACID_1_SH) |
+         sw(s1.pref_ac, r::FWCMD_H2C_UL_FIXINFO_STA_INFO_PREF_AC_1_MSK,
+            r::FWCMD_H2C_UL_FIXINFO_STA_INFO_PREF_AC_1_SH));
+  }
+
+  /* ulrua header A — ppdu_bw / gi_ltf / sta_num. */
+  push(sw(cfg.ppdu_bw, r::FWCMD_H2C_UL_FIXINFO_ULRUA_PPDU_BW_MSK,
+          r::FWCMD_H2C_UL_FIXINFO_ULRUA_PPDU_BW_SH) |
+       sw(cfg.gi_ltf, r::FWCMD_H2C_UL_FIXINFO_ULRUA_GI_LTF_MSK,
+          r::FWCMD_H2C_UL_FIXINFO_ULRUA_GI_LTF_SH) |
+       sw(nsta, r::FWCMD_H2C_UL_FIXINFO_ULRUA_STANUM_MSK,
+          r::FWCMD_H2C_UL_FIXINFO_ULRUA_STANUM_SH));
+  /* ulrua header B — grp_mode/grp_id/fix_mode stay 0 (explicit per-RU list). */
+  push(0);
+
+  /* Per-RU entries — 2 dwords each, RU_NUM slots (unused slots stay zero). */
+  for (uint8_t i = 0; i < RU; ++i) {
+    const devourer::UlOfdmaSta &s = cfg.stas[i];
+    const bool used = i < nsta;
+    uint32_t a = 0, d = 0;
+    if (used) {
+      a = sw(devourer::he_tgt_rssi_enc(s.tgt_rssi_dbm),
+             r::FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_TGT_RSSI_MSK,
+             r::FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_TGT_RSSI_SH) |
+          sw(s.macid, r::FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_MAC_ID_MSK,
+             r::FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_MAC_ID_SH) |
+          sw(s.ru_pos, r::FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_RU_POS_MSK,
+             r::FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_RU_POS_SH) |
+          (s.ldpc ? r::FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_CODE : 0);
+      d = sw(s.bsr_length, r::FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_BSRLEN_MSK,
+             r::FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_BSRLEN_SH) |
+          (s.dcm ? r::FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_DCM : 0) |
+          sw(s.ss == 0 ? 0 : (s.ss - 1u),
+             r::FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_SS_MSK,
+             r::FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_SS_SH) |
+          sw(s.mcs, r::FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_MCS_MSK,
+             r::FWCMD_H2C_UL_FIXINFO_UL_RUA_STA_ENT_MCS_SH);
+    }
+    push(a);
+    push(d);
+  }
+  return c;
+}
+
+/* HE sounding content (mac_set_snd_para / build_snd_h2c): the 72-dword v0
+ * (8852B) or 98-dword v1 (8852C) fwcmd_set_snd_para. The two layouts differ
+ * only in section base offsets (v1 spreads macid over 4 dwords, carries 16 HE
+ * STA-info + 8 users/BFRP vs v0's 8 + 4) and the dword0 user-num field width;
+ * the per-field bit packing is identical, so one code path drives both via the
+ * `L` offset table. Airs NDPA -> NDP -> BFRP for frexgtype AX_MU_BFRP1. */
+inline std::vector<uint8_t> encode_set_snd_para(const devourer::SoundingConfig &cfg,
+                                               bool v1) {
+  const size_t ndw = v1 ? 98 : 72;
+  std::vector<uint8_t> c(ndw * 4, 0);
+  uint8_t *b = c.data();
+  auto put = [&](size_t dwi, uint32_t v) { put_le32(b + dwi * 4, v); };
+  auto pk4 = [](const uint8_t *p) {
+    return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
+           (static_cast<uint32_t>(p[2]) << 16) |
+           (static_cast<uint32_t>(p[3]) << 24);
+  };
+  auto pk2 = [](const uint8_t *p) {
+    return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8);
+  };
+
+  /* Section base dwords (v0 / v1). */
+  const size_t B_NDPA = v1 ? 5 : 3;      /* frame_ctl+dur, then 6 more dwords */
+  const size_t B_VHT = v1 ? 12 : 10;     /* 2 dwords */
+  const size_t B_HESTA = v1 ? 14 : 12;   /* v1:16 / v0:8 dwords (1 per STA) */
+  const size_t B_BFRP_HDR = v1 ? 30 : 20;/* 3 hdrs x 4 dwords */
+  const size_t B_BFRP0 = v1 ? 42 : 32;   /* common(2) + users(2 each) */
+  const uint8_t USERS_PER = v1 ? 8 : 4;
+  const size_t B_BFRP1 = B_BFRP0 + 2 + 2 * USERS_PER;
+  const size_t B_VHTBFRP = B_BFRP1 + 2 + 2 * USERS_PER;
+  const size_t B_WD = B_VHTBFRP + 1;     /* 5 WDs x 3 dwords */
+  const size_t B_F2P = B_WD + 15;        /* 2 dwords */
+  const size_t B_SFP = B_F2P + 2;        /* 2 dwords */
+
+  /* dword0. */
+  uint32_t d0 = sw(cfg.frexgtype, r::SND_FREXCH_TYPE_MSK, r::SND_FREXCH_TYPE_SH) |
+                sw(cfg.mode, r::SND_MODE_MSK, r::SND_MODE_SH);
+  if (v1)
+    d0 |= sw(cfg.bfrp0_user_num, 0xff, 8) | sw(cfg.bfrp1_user_num, 0xff, 16);
+  else
+    d0 |= sw(cfg.bfrp0_user_num, r::SND_BFRP0_USER_NUM_MSK,
+             r::SND_BFRP0_USER_NUM_SH) |
+          sw(cfg.bfrp1_user_num, r::SND_BFRP1_USER_NUM_MSK,
+             r::SND_BFRP1_USER_NUM_SH);
+  put(0, d0);
+
+  /* macid[] (v0: dwords 1,2 hold macid[0..3],[8..11]; v1: dwords 1..4 all 16). */
+  if (v1) {
+    put(1, pk4(&cfg.macid[0]));
+    put(2, pk4(&cfg.macid[4]));
+    put(3, pk4(&cfg.macid[8]));
+    put(4, pk4(&cfg.macid[12]));
+  } else {
+    put(1, pk4(&cfg.macid[0]));
+    put(2, pk4(&cfg.macid[8]));
+  }
+
+  /* NDPA: fc+dur, addr1/addr2 (byte-packed), dialog, addr3+seq. */
+  put(B_NDPA, sw(cfg.ndpa_frame_ctl, r::SND_NDPA_FRAME_CTRL_MSK,
+                 r::SND_NDPA_FRAME_CTRL_SH) |
+                  sw(cfg.ndpa_duration, r::SND_NDPA_DURATION_MSK,
+                     r::SND_NDPA_DURATION_SH));
+  put(B_NDPA + 1, pk4(&cfg.ndpa_addr1[0]));
+  put(B_NDPA + 2, pk2(&cfg.ndpa_addr1[4]) | (pk2(&cfg.ndpa_addr2[0]) << 16));
+  put(B_NDPA + 3, pk4(&cfg.ndpa_addr2[2]));
+  put(B_NDPA + 4, (cfg.ndpa_dialog_he ? r::SND_NDPA_SND_DLG_HE : 0) |
+                      sw(cfg.ndpa_dialog_token, r::SND_NDPA_SND_DLG_DIALOG_MSK,
+                         r::SND_NDPA_SND_DLG_DIALOG_SH));
+  put(B_NDPA + 5, pk4(&cfg.ndpa_addr3[0]));
+  put(B_NDPA + 6, pk2(&cfg.ndpa_addr3[4]) |
+                      sw(cfg.ndpa_seq_control, r::SND_HT_SEQ_CONTROL_MSK,
+                         r::SND_HT_SEQ_CONTROL_SH));
+
+  /* NDPA HE STA-info (one per dword). VHT sta-info left zero (HE path). */
+  const uint8_t nhe = v1 ? 16 : 8;
+  for (uint8_t i = 0; i < 8 && i < nhe; ++i) {
+    const devourer::SoundingStaInfo &s = cfg.he_sta[i];
+    put(B_HESTA + i,
+        sw(s.aid, r::SND_HE_STA_AID11_MSK, r::SND_HE_STA_AID11_SH) |
+            sw(s.bw, r::SND_HE_STA_BW_MSK, r::SND_HE_STA_BW_SH) |
+            sw(s.fb_ng, r::SND_HE_STA_FB_NG_MSK, r::SND_HE_STA_FB_NG_SH) |
+            r::SND_HE_STA_DISAMBIGUATION | /* vendor forces disambiguation=1 */
+            (s.cb ? r::SND_HE_STA_CB : 0) |
+            sw(s.nc, r::SND_HE_STA_NC_MSK, r::SND_HE_STA_NC_SH));
+  }
+
+  /* BFRP frame headers (3): fc+dur, addr1/addr2 byte-packed. */
+  for (uint8_t h = 0; h < 3; ++h) {
+    const size_t base = B_BFRP_HDR + static_cast<size_t>(h) * 4;
+    put(base, sw(cfg.bfrp_frame_ctl[h], r::SND_BFRP_FRAME_CTL_MSK,
+                 r::SND_BFRP_FRAME_CTL_SH) |
+                  sw(cfg.bfrp_duration[h], r::SND_BFRP_DURATION_MSK,
+                     r::SND_BFRP_DURATION_SH));
+    put(base + 1, pk4(&cfg.bfrp_addr1[h][0]));
+    put(base + 2, pk2(&cfg.bfrp_addr1[h][4]) | (pk2(&cfg.bfrp_addr2[h][0]) << 16));
+    put(base + 3, pk4(&cfg.bfrp_addr2[h][2]));
+  }
+
+  /* BFRP HE common + per-user (2 BFRP groups). */
+  auto enc_bfrp_para = [&](size_t base, uint8_t g) {
+    const devourer::SoundingBfrpCommon &cm = cfg.bfrp_common[g];
+    put(base,
+        sw(cm.trigger_type, r::SND_HE_BFRP_TRIGGER_INFO_MSK,
+           r::SND_HE_BFRP_TRIGGER_INFO_SH) |
+            sw(cm.ul_len, r::SND_HE_BFRP_UL_LENGTH_MSK,
+               r::SND_HE_BFRP_UL_LENGTH_SH) |
+            sw(cm.ul_bw, r::SND_HE_BFRP_UL_BW_MSK, r::SND_HE_BFRP_UL_BW_SH) |
+            sw(cm.gi_ltf, r::SND_HE_BFRP_GI_LTF_MSK, r::SND_HE_BFRP_GI_LTF_SH) |
+            sw(cm.num_he_ltf, r::SND_HE_BFRP_NUM_OF_HE_LTF_MSK,
+               r::SND_HE_BFRP_NUM_OF_HE_LTF_SH));
+    put(base + 1,
+        sw(cm.ap_tx_pwr, r::SND_HE_BFRP_AP_TX_POWER_MSK,
+           r::SND_HE_BFRP_AP_TX_POWER_SH) |
+            sw(cm.ul_sr, r::SND_HE_BFRP_UL_SPATIAL_REUSE_MSK,
+               r::SND_HE_BFRP_UL_SPATIAL_REUSE_SH));
+    for (uint8_t u = 0; u < USERS_PER; ++u) {
+      const devourer::SoundingBfrpUser &us = cfg.bfrp_user[g][u];
+      put(base + 2 + 2 * u,
+          sw(us.aid12, r::SND_HE_BFRP_U_AID12_MSK, r::SND_HE_BFRP_U_AID12_SH) |
+              sw(us.ru_pos, r::SND_HE_BFRP_U_RU_POS_MSK,
+                 r::SND_HE_BFRP_U_RU_POS_SH) |
+              (us.ul_fec_code ? r::SND_HE_BFRP_U_UL_FEC_CODE : 0) |
+              sw(us.ul_mcs, r::SND_HE_BFRP_U_UL_MCS_MSK,
+                 r::SND_HE_BFRP_U_UL_MCS_SH) |
+              (us.ul_dcm ? r::SND_HE_BFRP_U_UL_DCM : 0) |
+              sw(us.ss_alloc, r::SND_HE_BFRP_U_SS_ALLOC_MSK,
+                 r::SND_HE_BFRP_U_SS_ALLOC_SH));
+      put(base + 3 + 2 * u,
+          sw(us.fbseg_rexmit_bmp, r::SND_HE_BFRP_U_FB_REXMIT_MSK,
+             r::SND_HE_BFRP_U_FB_REXMIT_SH) |
+              sw(us.ul_tgt_rssi, r::SND_HE_BFRP_U_UL_TGT_RSSI_MSK,
+                 r::SND_HE_BFRP_U_UL_TGT_RSSI_SH));
+    }
+  };
+  enc_bfrp_para(B_BFRP0, 0);
+  enc_bfrp_para(B_BFRP1, 1);
+  /* VHT BFRP retransmission bitmap dword left zero (HE path). */
+
+  /* WD list (5 entries x 3 dwords). */
+  for (uint8_t i = 0; i < 5; ++i) {
+    const devourer::SoundingWd &w = cfg.wd[i];
+    const size_t base = B_WD + static_cast<size_t>(i) * 3;
+    put(base, sw(w.txpktsize, r::SND_WD_TXPKTSIZE_MSK, r::SND_WD_TXPKTSIZE_SH) |
+                  sw(w.ndpa_duration, r::SND_WD_NDPA_DURATION_MSK,
+                     r::SND_WD_NDPA_DURATION_SH));
+    put(base + 1,
+        sw(w.datarate, r::SND_WD_DATARATE_MSK, r::SND_WD_DATARATE_SH) |
+            sw(w.macid, r::SND_WD_MACID_MSK, r::SND_WD_MACID_SH) |
+            sw(w.data_bw, r::SND_WD_DATA_BW_MSK, r::SND_WD_DATA_BW_SH) |
+            sw(w.gi_ltf, r::SND_WD_GI_LTF_MSK, r::SND_WD_GI_LTF_SH));
+    put(base + 2,
+        (w.stf_mode ? r::SND_WD_STF_MODE : 0) |
+            (w.disdatafb ? r::SND_WD_DISDATAFB : 0) |
+            (w.data_txcnt_lmt_sel ? r::SND_WD_DATA_TXCNT_LMT_SEL : 0) |
+            sw(w.data_txcnt_lmt, r::SND_WD_DATA_TXCNT_LMT_MSK,
+               r::SND_WD_DATA_TXCNT_LMT_SH) |
+            (w.sifs_tx ? r::SND_WD_SIFS_TX : 0) |
+            sw(w.snd_pkt_sel, r::SND_WD_SND_PKT_SEL_MSK,
+               r::SND_WD_SND_PKT_SEL_SH) |
+            sw(w.ndpa, r::SND_WD_NDPA_MSK, r::SND_WD_NDPA_SH));
+  }
+
+  /* F2P(BFRP) sub-content (2 dwords) + SFP period (2 dwords). */
+  for (uint8_t i = 0; i < 2; ++i)
+    put(B_F2P + i, sw(cfg.csi_len_bfrp[i], r::SND_F2P_CSI_LEN_BFRP_MSK,
+                      r::SND_F2P_CSI_LEN_BFRP_SH) |
+                       sw(cfg.tb_t_pe_bfrp[i], r::SND_F2P_TB_T_PE_BFRP_MSK,
+                          r::SND_F2P_TB_T_PE_BFRP_SH));
+  put(B_SFP, sw(cfg.f2p_type, r::SND_SFP_F2P_TYPE_MSK, r::SND_SFP_F2P_TYPE_SH) |
+                 sw(cfg.f2p_index, r::SND_SFP_F2P_INDEX_MSK,
+                    r::SND_SFP_F2P_INDEX_SH) |
+                 sw(cfg.f2p_period, r::SND_SFP_F2P_PERIOD_MSK,
+                    r::SND_SFP_F2P_PERIOD_SH));
+  put(B_SFP + 1, cfg.sounding_en ? r::SND_SFP_SOUNDING_EN : 0);
+  return c;
+}
+
+} /* namespace kestrel::sched */
+
+#endif /* KESTREL_SCHED_ENCODE_H */

--- a/src/kestrel/TxDescKestrel.h
+++ b/src/kestrel/TxDescKestrel.h
@@ -41,6 +41,9 @@ constexpr uint8_t DATA_BW_SH = 28;         /* wd_info dword0 [29:28] */
 /* 8852C wd_body_t_v1 dword7: DCM rides the rate word (AX_TXD_DATA_DCM_V1);
  * DATA_ER/DATA_BW_ER stay in wd_info dword0 at the same bits as the 8852B. */
 constexpr uint32_t DATA_DCM_V1 = 1u << 30; /* wd_body dword7 (8852C) */
+constexpr uint32_t BMC = 1u << 11;         /* wd_info dword1: broadcast/multicast
+                                            * — group-addressed, no ACK expected,
+                                            * so the fw must not retry it */
 } /* namespace txd */
 
 /* Map a devourer MGN_* rate (RateDefinitions.h) to the AX_TXD_DATARATE encoding
@@ -170,6 +173,13 @@ inline std::vector<uint8_t> build_mgnt_txdesc(const uint8_t *frame,
   /* wd_body dword3: WIFI_SEQ (sw_seq). */
   txd_put_le32(wd + 12, static_cast<uint32_t>(seq & 0xfff) << txd::WIFI_SEQ_SH);
   /* dword4,5 (+ v1 dword6,7) = 0 */
+
+  /* wd_info dword1: mark a group-addressed frame (RA bit0 set — e.g. an injected
+   * broadcast Trigger) as BMC. Without it the fw treats the unacked broadcast as
+   * a failed unicast and retransmits it to the retry limit (~45x the airtime).
+   * The 802.11 RA (addr1) is at frame offset 4 (after FC + Duration). */
+  if (frame_len >= 5 && (frame[4] & 0x01))
+    txd_put_le32(wd + wd_body_len + 4, txd::BMC);
 
   /* Rate fields: force the rate (USERATE_SEL) + DATARATE + BW + GI/LTF +
    * LDPC/STBC + no fallback. On the 8852B (24-byte wd_body) these all live in

--- a/tests/kestrel_sched_selftest.cpp
+++ b/tests/kestrel_sched_selftest.cpp
@@ -1,0 +1,274 @@
+/* Headless golden-bytes guard for the Kestrel 802.11ax trigger-UL + TWT H2C
+ * content encoders (src/kestrel/SchedEncode.h). Each check builds a known
+ * config and asserts the emitted LE dwords equal the hand-computed vendor
+ * SET_WORD layout (mac_ax/tblupd.c, twt.c, mac_8852c/tblupd_8852c.c). Pure
+ * byte-level — no hardware. On-air validation (an fw-aired trigger decoded by a
+ * witness) is tier-A. Compiled only when a Kestrel variant is built. */
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "kestrel/SchedEncode.h"
+
+using namespace kestrel;
+
+static int failures = 0;
+
+#define CHECK(cond)                                                            \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);     \
+      failures++;                                                              \
+    }                                                                          \
+  } while (0)
+
+static uint32_t dw(const std::vector<uint8_t> &b, size_t i) {
+  return kestrel::le32(b.data() + i * 4);
+}
+
+int main() {
+  /* ---- F2P trigger, 8852B v0: 1 user, BW20, MCS0, full-20 RU (61), AID 1 ---- */
+  {
+    devourer::TriggerConfig cfg;
+    cfg.ul_bw = 0;
+    cfg.gi_ltf = 1;
+    cfg.num_he_ltf = 2;
+    cfg.ap_tx_power = 20;
+    cfg.pri20_bitmap = 0x1;
+    cfg.n_users = 1;
+    cfg.users[0].aid12 = 1;
+    cfg.users[0].macid = 3;
+    cfg.users[0].ru_alloc = 61;
+    cfg.users[0].ul_mcs = 0;
+    cfg.users[0].ss = 1;
+    cfg.users[0].tgt_rssi_dbm = -60; /* -> 50 */
+    cfg.users[0].pref_ac = 2;
+    cfg.trig_rate = 0;
+    cfg.mode = 1;
+    cfg.frexch_type = 0;
+
+    std::vector<uint8_t> b = sched::encode_f2p_trigger(cfg, /*v1=*/false);
+    CHECK(b.size() == 236); /* sizeof(fwcmd_test_para) */
+    /* dword0: ulbw[1:0]=0, giltf[3:2]=1, numltf[6:4]=2, txpwr[14:9]=20,
+     * usernum[19:16]=1, bitmap[31:24]=1. */
+    uint32_t d0 = (1u << 2) | (2u << 4) | (20u << 9) | (1u << 16) | (1u << 24);
+    CHECK(dw(b, 0) == d0);
+    /* dword1 (user A): aid12[11:0]=1, mcs[15:12]=0, macid[23:16]=3, ru[31:24]=61. */
+    uint32_t d1 = 1u | (3u << 16) | (61u << 24);
+    CHECK(dw(b, 1) == d1);
+    /* dword2 (user B): fec[0]=0, dcm[1]=0, ss_alloc[7:2]=0 (1 SS), tgtrssi[14:8]=50. */
+    uint32_t d2 = (50u << 8);
+    CHECK(dw(b, 2) == d2);
+    /* dep-user pref_AC byte at offset 36 (byte9). */
+    CHECK(b[36] == 2);
+    /* tf_wd dword13 at offset 40: datarate=0, mode[17:16]=1, frexch[23:18]=0. */
+    CHECK(dw(b, 10) == (1u << 16));
+    /* users 1..3 + DL-burst dwords stay zero. */
+    CHECK(dw(b, 3) == 0 && dw(b, 4) == 0);
+    /* f2p_wd dword14: cmd_qsel=MG0(18) | FS(bit11) | LS(bit10) |
+     * total_number=1(<<12) | length=9(<<24) — frame = 16+8+5+4 = 33 B = 9 dw. */
+    CHECK(dw(b, 11) == (18u | (1u << 10) | (1u << 11) | (1u << 12) | (9u << 24)));
+    CHECK(dw(b, 12) == 0); /* dword15 (rsvd) + DL-burst tx_cmd stay zero */
+  }
+
+  /* ---- F2P trigger, 8852C v1: user block extends to dword16, tf_wd at dword19,
+   * pref_AC bytes at offset 68, size 288. ---- */
+  {
+    devourer::TriggerConfig cfg;
+    cfg.ul_bw = 2; /* 80 MHz */
+    cfg.n_users = 2;
+    cfg.users[0].aid12 = 1;
+    cfg.users[0].macid = 5;
+    cfg.users[0].ru_alloc = 61;
+    cfg.users[0].pref_ac = 3;
+    cfg.users[1].aid12 = 2;
+    cfg.users[1].macid = 6;
+    cfg.users[1].ru_alloc = 65;
+    cfg.users[1].pref_ac = 1;
+    cfg.mode = 2;
+
+    std::vector<uint8_t> b = sched::encode_f2p_trigger(cfg, /*v1=*/true);
+    CHECK(b.size() == 288); /* sizeof(fwcmd_test_para_v1) */
+    CHECK(dw(b, 0) == ((2u << 0) | (1u << 4) /*numltf default 1*/ |
+                       (20u << 9) /*ap_tx default 20*/ | (2u << 16) | (1u << 24)));
+    /* user0 at dword1/2, user1 at dword3/4. */
+    CHECK(dw(b, 1) == (1u | (5u << 16) | (61u << 24)));
+    CHECK(dw(b, 3) == (2u | (6u << 16) | (65u << 24)));
+    /* pref_AC bytes at offset 68 (dword17_0) and 69. */
+    CHECK(b[68] == 3 && b[69] == 1);
+    /* tf_wd dword19 at offset 76: mode[17:16]=2. */
+    CHECK(dw(b, 19) == (2u << 16));
+  }
+
+  /* ---- TWT info: individual, trigger-enabled, AP role, config 1, flow 0 ---- */
+  {
+    devourer::TwtConfig cfg;
+    cfg.broadcast = false;
+    cfg.trigger = true;
+    cfg.config_id = 1;
+    cfg.flow_id = 0;
+    cfg.port = 0;
+    cfg.ap_role = true;
+    cfg.wake_exp = 10;
+    cfg.wake_man = 512;
+    cfg.min_wake_dur = 255;
+    cfg.trgt_tsf = 0x1122334455667788ull;
+
+    std::vector<uint8_t> b = sched::encode_twtinfo(cfg, /*act=*/0);
+    CHECK(b.size() == 24); /* 6-dword fwcmd_twtinfo_upd */
+    /* dword0: nego=0, trigger BIT(2), id[16:14]=1, nic_role BIT(25). */
+    uint32_t d0 = (1u << 2) | (1u << 14) | (1u << 25);
+    CHECK(dw(b, 0) == d0);
+    /* dword1: wake_man[15:0]=512, wake_exp[20:16]=10, dur[31:24]=255. */
+    uint32_t d1 = 512u | (10u << 16) | (255u << 24);
+    CHECK(dw(b, 1) == d1);
+    CHECK(dw(b, 2) == 0x55667788u); /* trgt_l */
+    CHECK(dw(b, 3) == 0x11223344u); /* trgt_h */
+    CHECK(dw(b, 4) == 0 && dw(b, 5) == 0);
+  }
+
+  /* ---- TWT act: bind macid 7 to config 1 (add) ---- */
+  {
+    devourer::TwtStaAct a;
+    a.macid = 7;
+    a.config_id = 1;
+    a.action = 0;
+    std::vector<uint8_t> b = sched::encode_twt_act(a);
+    CHECK(b.size() == 8);
+    CHECK(dw(b, 0) == (7u | (1u << 8))); /* macid | id<<8 | act(0)<<11 */
+    CHECK(dw(b, 1) == 0);
+  }
+
+  /* ---- TWT announce ---- */
+  {
+    std::vector<uint8_t> b = sched::encode_twt_announce(9);
+    CHECK(b.size() == 4);
+    CHECK(dw(b, 0) == 9u);
+  }
+
+  /* ---- TWT-OFDMA cadence ---- */
+  {
+    devourer::TwtOfdmaConfig cfg;
+    cfg.twt_id = 1;
+    cfg.max_tf_retry = 3;
+    cfg.max_dl_retry = 0;
+    cfg.round_num = 4;
+    cfg.preferred_ac = 2;
+    cfg.htc_bsr_ctrl_en = true;
+    cfg.round_interval_us = 1000;
+    std::vector<uint8_t> b = sched::encode_twt_ofdma(cfg);
+    CHECK(b.size() == 8);
+    /* dword0: twt_id[4:2]=1, max_tf[12:5]=3, round_num[28:21]=4,
+     * preferred_ac[30:29]=2, htc_bsr BIT(31). */
+    uint32_t d0 = (1u << 2) | (3u << 5) | (4u << 21) | (2u << 29) | (1u << 31);
+    CHECK(dw(b, 0) == d0);
+    CHECK(dw(b, 1) == 1000u); /* round_interval[15:0] */
+  }
+
+  /* ---- UL_FIXINFO: tf_periodic, 1 STA (macid 4, RU 61, MCS2, 1 SS) ---- */
+  {
+    devourer::UlOfdmaConfig cfg;
+    cfg.mode = 3; /* tf_periodic */
+    cfg.interval_s = 1;
+    cfg.tf_type = 0;
+    cfg.ppdu_bw = 0;
+    cfg.n_stas = 1;
+    cfg.stas[0].macid = 4;
+    cfg.stas[0].pref_ac = 0;
+    cfg.stas[0].ru_pos = 61;
+    cfg.stas[0].tgt_rssi_dbm = -60; /* -> 50 */
+    cfg.stas[0].mcs = 2;
+    cfg.stas[0].ss = 1;
+
+    std::vector<uint8_t> b = sched::encode_ul_fixinfo(cfg);
+    CHECK(b.size() == 27 * 4); /* 108 bytes */
+    /* dword0 tbl_hdr: R_W BIT(0), length[22:13]=27, table_class[31:24]=7. */
+    uint32_t d0 = 1u | (27u << 13) | (7u << 24);
+    CHECK(dw(b, 0) == d0);
+    /* dword1 cfg: mode[1:0]=3, interval[7:2]=1. */
+    CHECK(dw(b, 1) == (3u | (1u << 2)));
+    /* sta_info pair at dword5: macid_0[7:0]=4. */
+    CHECK(dw(b, 5) == 4u);
+    /* ulrua header A at dword9: sta_num[14:11]=1. */
+    CHECK(dw(b, 9) == (1u << 11));
+    /* first per-RU entry at dword11: tgt_rssi[7:1]=50, mac_id[15:8]=4,
+     * ru_pos[23:16]=61. */
+    uint32_t rua_a = (50u << 1) | (4u << 8) | (61u << 16);
+    CHECK(dw(b, 11) == rua_a);
+    /* per-RU entry B at dword12: ss[19:17]=0 (1 SS), mcs[23:20]=2. */
+    CHECK(dw(b, 12) == (2u << 20));
+    /* second RU slot (dword13/14) unused -> zero. */
+    CHECK(dw(b, 13) == 0 && dw(b, 14) == 0);
+  }
+
+  /* ---- HE sounding (SET_SND_PARA): single-user HE BFRP, AP sounds 1 STA ---- */
+  {
+    const uint8_t ap[6] = {0x02, 0x11, 0x22, 0x33, 0x44, 0x55};
+    const uint8_t sta[6] = {0x06, 0xaa, 0xbb, 0xcc, 0xdd, 0xee};
+    devourer::SoundingConfig cfg = devourer::make_he_bfrp_sounding(
+        ap, ap, sta, /*aid=*/1, /*macid=*/1, /*dialog=*/5);
+
+    /* --- v0 (8852B): 72 dwords / 288 B --- */
+    std::vector<uint8_t> b0 = sched::encode_set_snd_para(cfg, /*v1=*/false);
+    CHECK(b0.size() == 288);
+    /* dword0: frexgtype[5:0]=36, bfrp0_user_num[10:8]=1. */
+    CHECK(dw(b0, 0) == (36u | (1u << 8)));
+    /* dword1: macid[0]=1. */
+    CHECK(dw(b0, 1) == 1u);
+    /* dword3: NDPA frame_ctl=0x0054. */
+    CHECK(dw(b0, 3) == 0x0054u);
+    /* dword4: NDPA addr1 = sta[0..3] (LE). */
+    CHECK(dw(b0, 4) == 0xccbbaa06u);
+    /* dword7: dialog he(bit0) + token(5<<1). */
+    CHECK(dw(b0, 7) == (1u | (5u << 1)));
+    /* dword12: HE STA0 aid=1 + disambiguation(bit27). */
+    CHECK(dw(b0, 12) == (1u | (1u << 27)));
+    /* dword20: BFRP0 frame_ctl=0x0024 (trigger). */
+    CHECK(dw(b0, 20) == 0x0024u);
+    /* dword32: BFRP0 common A: trigger_type=1, ul_len=0x1ff<<4. */
+    CHECK(dw(b0, 32) == (1u | (0x1ffu << 4)));
+    /* dword33: BFRP0 common B: ap_tx_pwr=0x3f. */
+    CHECK(dw(b0, 33) == 0x3fu);
+    /* dword34: BFRP0 user0 A: aid12=1, ru_pos=61<<12. */
+    CHECK(dw(b0, 34) == (1u | (61u << 12)));
+    /* dword35: BFRP0 user0 B: ul_tgt_rssi=127<<8. */
+    CHECK(dw(b0, 35) == (127u << 8));
+    /* dword53: WD0 A txpktsize=21 (17+4*1, the NDPA). */
+    CHECK(dw(b0, 53) == 21u);
+    /* dword55: WD0 C: stf_mode|disdatafb|txcnt_lmt_sel|txcnt_lmt=1|sifs_tx|
+     * snd_pkt_sel=1(NDPA)|ndpa=3(HE). */
+    uint32_t wd0c = (1u << 14) | (1u << 15) | (1u << 16) | (1u << 17) |
+                    (1u << 23) | (1u << 24) | (3u << 27);
+    CHECK(dw(b0, 55) == wd0c);
+    /* dword58: WD1 C (NDP): snd_pkt_sel=3, else same as WD0 C. */
+    CHECK(dw(b0, 58) == ((wd0c & ~(7u << 24)) | (3u << 24)));
+    /* dword59: WD2 A txpktsize=30 (24+6*1, the BFRP). */
+    CHECK(dw(b0, 59) == 30u);
+    /* dword61: WD2 C (BFRP): snd_pkt_sel=5, no sifs_tx (last frame). */
+    CHECK(dw(b0, 61) ==
+          ((wd0c & ~((7u << 24) | (1u << 23))) | (5u << 24)));
+    /* dword68: F2P[0] csi_len_bfrp=0x1ff. */
+    CHECK(dw(b0, 68) == 0x1ffu);
+
+    /* --- v1 (8852C): 98 dwords / 392 B, sections shifted --- */
+    std::vector<uint8_t> b1 = sched::encode_set_snd_para(cfg, /*v1=*/true);
+    CHECK(b1.size() == 392);
+    /* dword0: frexgtype=36, bfrp0_user_num[15:8]=1 (8-bit field). */
+    CHECK(dw(b1, 0) == (36u | (1u << 8)));
+    CHECK(dw(b1, 1) == 1u);           /* macid[0] */
+    CHECK(dw(b1, 5) == 0x0054u);      /* NDPA frame_ctl (base 5) */
+    CHECK(dw(b1, 14) == (1u | (1u << 27))); /* HE STA0 (base 14) */
+    CHECK(dw(b1, 30) == 0x0024u);     /* BFRP0 frame_ctl (base 30) */
+    CHECK(dw(b1, 42) == (1u | (0x1ffu << 4))); /* BFRP0 common A (base 42) */
+    CHECK(dw(b1, 44) == (1u | (61u << 12)));   /* BFRP0 user0 A (base 44) */
+    CHECK(dw(b1, 79) == 21u);         /* WD0 A (base 79) */
+    CHECK(dw(b1, 81) == wd0c);        /* WD0 C */
+  }
+
+  if (failures) {
+    std::fprintf(stderr, "kestrel_sched: %d FAILURES\n", failures);
+    return 1;
+  }
+  std::printf("kestrel_sched: all checks passed\n");
+  return 0;
+}

--- a/tests/trigger_parse_selftest.cpp
+++ b/tests/trigger_parse_selftest.cpp
@@ -40,6 +40,7 @@ int main() {
   cfg.gi_ltf = 1;
   cfg.num_he_ltf = 2;
   cfg.ap_tx_power = 21;
+  cfg.ul_length = 0x1F4;
   cfg.n_users = 2;
   cfg.users[0].aid12 = 1;
   cfg.users[0].ru_alloc = he_ru_alloc(106, 0); /* 53 */
@@ -58,12 +59,14 @@ int main() {
 
   std::vector<uint8_t> buf(64, 0);
   size_t n = build_basic_trigger(cfg, ra, ta, buf.data(), buf.size());
-  CHECK(n == 24 + 2 * 5); /* fixed header + 2 user infos */
+  /* header(24) + 2 Basic user infos (6B each) + Padding (2B marker + 4B). */
+  CHECK(n == 24 + 2 * 6 + 2 + 4);
   CHECK(buf[0] == 0x24);  /* FC: control / trigger */
 
   TriggerInfo info;
   CHECK(parse_trigger(buf.data(), n, info));
   CHECK(info.trigger_type == 0); /* Basic */
+  CHECK(info.ul_length == 0x1F4);
   CHECK(info.ul_bw == 0);
   CHECK(info.gi_ltf == 1);
   CHECK(info.num_he_ltf == 2);

--- a/tests/trigger_parse_selftest.cpp
+++ b/tests/trigger_parse_selftest.cpp
@@ -1,0 +1,114 @@
+/* Headless regression guard for the 802.11ax Trigger frame build/parse path
+ * (src/TriggerTwt.h build_basic_trigger + src/TriggerParse.h parse_trigger) and
+ * the RU-allocation helper. Pure byte-level — no hardware. The on-air half
+ * (witness rxdemo decode of an fw-aired trigger vs the commanded config) is
+ * tier-A validation (tests/ul_trigger_airs.sh). */
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "TriggerParse.h"
+#include "TriggerTwt.h"
+
+using namespace devourer;
+
+static int failures = 0;
+
+#define CHECK(cond)                                                            \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);     \
+      failures++;                                                              \
+    }                                                                          \
+  } while (0)
+
+int main() {
+  /* RU-allocation helper golden vectors (802.11ax Trigger User Info subfield). */
+  CHECK(he_ru_alloc(242, 0) == 61); /* full 20 MHz */
+  CHECK(he_ru_alloc(106, 0) == 53);
+  CHECK(he_ru_alloc(52, 0) == 37);
+  CHECK(he_ru_alloc(26, 5) == 5);
+  CHECK(he_ru_alloc(484, 0) == 65); /* full 40 MHz */
+  CHECK(he_ru_alloc(996, 0) == 67); /* full 80 MHz */
+  CHECK(he_ru_alloc(999, 0) == 61); /* unknown -> full-20 fallback */
+
+  /* Round-trip a 2-user Basic Trigger through build -> parse. */
+  const uint8_t ta[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
+  const uint8_t ra[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+  TriggerConfig cfg;
+  cfg.ul_bw = 0;      /* 20 MHz */
+  cfg.gi_ltf = 1;
+  cfg.num_he_ltf = 2;
+  cfg.ap_tx_power = 21;
+  cfg.n_users = 2;
+  cfg.users[0].aid12 = 1;
+  cfg.users[0].ru_alloc = he_ru_alloc(106, 0); /* 53 */
+  cfg.users[0].ul_mcs = 4;
+  cfg.users[0].ss = 1;
+  cfg.users[0].ldpc = true;
+  cfg.users[0].dcm = false;
+  cfg.users[0].tgt_rssi_dbm = -60;
+  cfg.users[1].aid12 = 2;
+  cfg.users[1].ru_alloc = he_ru_alloc(106, 1); /* 54 */
+  cfg.users[1].ul_mcs = 7;
+  cfg.users[1].ss = 2;
+  cfg.users[1].ldpc = false;
+  cfg.users[1].dcm = true;
+  cfg.users[1].tgt_rssi_dbm = -75;
+
+  std::vector<uint8_t> buf(64, 0);
+  size_t n = build_basic_trigger(cfg, ra, ta, buf.data(), buf.size());
+  CHECK(n == 24 + 2 * 5); /* fixed header + 2 user infos */
+  CHECK(buf[0] == 0x24);  /* FC: control / trigger */
+
+  TriggerInfo info;
+  CHECK(parse_trigger(buf.data(), n, info));
+  CHECK(info.trigger_type == 0); /* Basic */
+  CHECK(info.ul_bw == 0);
+  CHECK(info.gi_ltf == 1);
+  CHECK(info.num_he_ltf == 2);
+  CHECK(info.ap_tx_power == 21);
+  for (int i = 0; i < 6; ++i) {
+    CHECK(info.ta[i] == ta[i]);
+    CHECK(info.ra[i] == ra[i]);
+  }
+  CHECK(info.n_users == 2);
+  CHECK(info.users[0].aid12 == 1);
+  CHECK(info.users[0].ru_alloc == 53);
+  CHECK(info.users[0].mcs == 4);
+  CHECK(info.users[0].ss == 1);
+  CHECK(info.users[0].ldpc == true);
+  CHECK(info.users[0].dcm == false);
+  CHECK(info.users[0].tgt_rssi_dbm == -60);
+  CHECK(info.users[1].aid12 == 2);
+  CHECK(info.users[1].ru_alloc == 54);
+  CHECK(info.users[1].mcs == 7);
+  CHECK(info.users[1].ss == 2);
+  CHECK(info.users[1].ldpc == false);
+  CHECK(info.users[1].dcm == true);
+  CHECK(info.users[1].tgt_rssi_dbm == -75);
+
+  /* A capture that still carries the 4-byte FCS tail parses the same (the <5B
+   * remainder is dropped). */
+  std::vector<uint8_t> withfcs(buf.begin(), buf.begin() + n);
+  withfcs.insert(withfcs.end(), {0xde, 0xad, 0xbe, 0xef});
+  TriggerInfo info2;
+  CHECK(parse_trigger(withfcs.data(), withfcs.size(), info2));
+  CHECK(info2.n_users == 2);
+
+  /* Non-trigger / too-short frames are rejected (no partial parse). */
+  TriggerInfo info3;
+  const uint8_t beacon_fc[30] = {0x80, 0x00}; /* mgmt beacon */
+  CHECK(!parse_trigger(beacon_fc, sizeof(beacon_fc), info3));
+  CHECK(!parse_trigger(buf.data(), 20, info3));
+  CHECK(!parse_trigger(nullptr, n, info3));
+  CHECK(!is_trigger_frame(beacon_fc, 2));
+  CHECK(is_trigger_frame(buf.data(), n));
+
+  if (failures) {
+    std::fprintf(stderr, "trigger_parse: %d FAILURES\n", failures);
+    return 1;
+  }
+  std::printf("trigger_parse: all checks passed\n");
+  return 0;
+}

--- a/tests/twt_fw_discovery.sh
+++ b/tests/twt_fw_discovery.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# twt_fw_discovery.sh — tier-B validation for the 802.11ax TWT surface: what
+# does the shipped RTL8852 firmware actually honor?
+#
+# Drives devourer's `kestrelprobe twt` on the 8852BU: creates an individual
+# TWT agreement (mac_twt_info_upd) and attempts the TWT-OFDMA cadence command
+# (func 0x03, non-canonical / gated MAC_FEAT_TWT_OFDMA_EN in the vendor tree —
+# so whether the shipped fw implements it is unknown). Then watches the bulk-IN
+# C2H stream for `twt.notify` / `twt.wait_anno` events (routed by handle_c2h).
+#
+# Classifies:
+#   TWT_OK        — the TWTINFO_UPD H2C is accepted (no fw SER halt).
+#   OFDMA_HONORED — a twt.notify C2H arrives (the fw runs the TWT-OFDMA engine);
+#                   its TSF stamp is cross-checked against ReadTsf for sanity.
+#   OFDMA_SILENT  — the func 0x03 H2C is accepted but no cadence/C2H — the fw
+#                   lacks the engine: use tests/ul_ofdma_e2e.sh (UL_FIXINFO).
+#
+#   sudo tests/twt_fw_discovery.sh [channel] [watch_seconds]
+set -u
+cd "$(dirname "$0")/.."
+[ "$(id -u)" -eq 0 ] || { echo "FAIL: needs root (USB claim + driver unbind)"; exit 2; }
+
+CH=${1:-36}
+WATCH=${2:-8}
+DUT_ID="35bc:0108"   # RTL8852BU
+KP="build/kestrelprobe"
+LOG="/tmp/twt_fw_discovery.jsonl"
+DBG="/tmp/twt_fw_discovery.dbg"
+[ -x "$KP" ] || { echo "FAIL: $KP not built (cmake --build build)"; exit 2; }
+lsusb -d "$DUT_ID" >/dev/null 2>&1 || { echo "SKIP: 8852BU ($DUT_ID) not plugged"; exit 0; }
+
+sysdir_for() {
+  local vid=${1%%:*} pid=${1##*:} d
+  for d in /sys/bus/usb/devices/*; do
+    [ -f "$d/idVendor" ] || continue
+    [ "$(cat "$d/idVendor")" = "$vid" ] && [ "$(cat "$d/idProduct")" = "$pid" ] \
+      && { echo "$d"; return; }
+  done
+}
+unbind_kernel() {
+  local d iface drv; d=$(sysdir_for "$1"); [ -n "$d" ] || return 0
+  for iface in "$d":*; do
+    [ -e "$iface/driver" ] || continue
+    drv=$(basename "$(readlink "$iface/driver")")
+    echo "$(basename "$iface")" > "/sys/bus/usb/drivers/$drv/unbind" 2>/dev/null || true
+  done
+}
+cleanup() { pkill -x kestrelprobe 2>/dev/null || true; }
+trap cleanup EXIT INT TERM
+
+echo "== twt_fw_discovery: 8852BU ch$CH, watch ${WATCH}s =="
+unbind_kernel "$DUT_ID"
+sleep 1
+
+# kestrelprobe twt brings up TX, configures TWT + TWT-OFDMA, then the process
+# exits after issuing the H2Cs — but the C2H (twt.notify) may arrive during a
+# short steady-state window, so run rxdemo briefly afterward to drain it.
+DEVOURER_CHANNEL="$CH" DEVOURER_EVENTS=stdout DEVOURER_LOG_LEVEL=debug \
+  "$KP" twt --pid 0x0108 >"$LOG" 2>"$DBG"
+TWT_RC=$?
+
+# Drain the bulk-IN for the notify window (rxdemo routes C2H through handle_c2h,
+# which logs twt.notify / twt.wait_anno on the diagnostic plane).
+timeout "$WATCH" env DEVOURER_PID=0x0108 DEVOURER_CHANNEL="$CH" \
+  DEVOURER_LOG_LEVEL=info build/rxdemo >>"$LOG" 2>>"$DBG" || true
+
+CONFIG_OK=$(grep -F '"ev":"kestrel.twt"' "$LOG" | grep -oE '"ok":(true|false)' | tail -1)
+OFDMA_CMD=$(grep -F '"ev":"kestrel.twt"' "$LOG" | grep -oE '"ofdma_cmd":(true|false)' | tail -1)
+# Match the actual handle_c2h output ("Kestrel twt.notify:" / "Kestrel
+# twt.wait_anno:"), NOT the descriptive "watch for twt.notify" reminder line.
+NOTIFY=$(grep -c "Kestrel twt.notify:" "$DBG" 2>/dev/null); NOTIFY=${NOTIFY:-0}
+WAITANNO=$(grep -c "Kestrel twt.wait_anno:" "$DBG" 2>/dev/null); WAITANNO=${WAITANNO:-0}
+SERHALT=$(grep -ciE "fw err|SER L[0-9]|fw halt|HALT_C2H" "$DBG" 2>/dev/null); SERHALT=${SERHALT:-0}
+
+echo "---"
+echo "kestrelprobe twt: rc=$TWT_RC  configure=$CONFIG_OK  ofdma_cmd=$OFDMA_CMD"
+echo "C2H: twt.notify=$NOTIFY  twt.wait_anno=$WAITANNO  (fw-err lines: $SERHALT)"
+[ "$NOTIFY" -gt 0 ] && { echo "sample twt.notify:"; grep "twt.notify" "$DBG" | head -1; }
+
+if [ "$NOTIFY" -gt 0 ]; then
+  echo "RESULT: OFDMA_HONORED — the fw runs the TWT-OFDMA engine (twt.notify C2H)."
+  echo "        Proceed to tier-C end-to-end via TWT-OFDMA cadence."
+  exit 0
+elif echo "$CONFIG_OK" | grep -q true; then
+  echo "RESULT: TWT_OK / OFDMA_SILENT — TWT agreement accepted, but no TWT-OFDMA"
+  echo "        cadence/C2H. Use tests/ul_ofdma_e2e.sh (UL_FIXINFO tf_periodic),"
+  echo "        the canonical scheduler, for autonomous trigger cadence."
+  exit 0
+else
+  echo "RESULT: FAIL — TWTINFO_UPD not accepted (see $DBG)."
+  exit 1
+fi

--- a/tests/ul_ofdma_e2e.sh
+++ b/tests/ul_ofdma_e2e.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# ul_ofdma_e2e.sh — tier-C end-to-end for 802.11ax scheduled UL:
+#   AP  = devourer HE access point on a Kestrel adapter (RTL8832CU, 35bc:0101),
+#         tests/ul_trigger_ap.cpp — beacons HT+VHT+HE IEs, associates a station,
+#         registers it as a peer, and drives the fw UL-OFDMA scheduler + Basic
+#         Triggers granting it UL opportunities.
+#   STA = a real kernel HE supplicant — the RTL8852BU (35bc:0108) under
+#         rtw89_8852bu — connects to devourerAP with wpa_supplicant, then
+#         generates UL traffic (DHCP + ping) so the AP fw has a BSR to grant.
+#
+# PASS  = the STA reaches "Connected to <BSSID>" (HE association to the devourer
+#         AP works) AND the AP's ap.summary shows ul_rx > 0 (the STA transmits
+#         uplink); ul_tb > 0 means HE TB PPDUs (the scheduled-UL response) were
+#         observed.
+# PARTIAL = associates but no UL / no TB — the fw accepts the grants but the STA
+#           doesn't answer triggers (or the RX doesn't classify TB); still proves
+#           the HE-AP + peer path.
+# FAIL  = no association — iterate the HE IEs in ul_trigger_ap.cpp (dmesg shows
+#         the supplicant's rejection reason).
+#
+#   sudo tests/ul_ofdma_e2e.sh [seconds] [channel]
+set -u
+cd "$(dirname "$0")/.."
+[ "$(id -u)" -eq 0 ] || { echo "FAIL: needs root"; exit 2; }
+
+SEC=${1:-40}
+CH=${2:-36}
+AP_ID="35bc:0101"   # RTL8832CU — devourer HE AP
+STA_ID="35bc:0108"  # RTL8852BU — rtw89 HE station
+WIT_ID="0bda:8812"  # RTL8812AU — monitor witness (decodes aired Triggers)
+SSID="devourerAP"
+BIN="/tmp/ul_trigger_ap"
+WPA="/tmp/ul_e2e_wpa.conf"
+APLOG="/tmp/ul_ofdma_e2e_ap.log"
+STALOG="/tmp/ul_ofdma_e2e_sta.log"
+WITLOG="/tmp/ul_ofdma_e2e_wit.jsonl"
+
+lsusb -d "$AP_ID" >/dev/null 2>&1 || { echo "SKIP: AP $AP_ID (8832CU) not plugged"; exit 0; }
+lsusb -d "$STA_ID" >/dev/null 2>&1 || { echo "SKIP: STA $STA_ID (8852BU) not plugged"; exit 0; }
+
+sysdir_for() {
+  local vid=${1%%:*} pid=${1##*:} d
+  for d in /sys/bus/usb/devices/*; do
+    [ -f "$d/idVendor" ] || continue
+    [ "$(cat "$d/idVendor")" = "$vid" ] && [ "$(cat "$d/idProduct")" = "$pid" ] \
+      && { echo "$d"; return; }
+  done
+}
+netdev_for() { local d; d=$(sysdir_for "$1"); [ -n "$d" ] && ls "$d"/*:*/net/ 2>/dev/null | head -1; }
+unbind_kernel() {
+  local d iface drv; d=$(sysdir_for "$1"); [ -n "$d" ] || return 0
+  for iface in "$d":*; do
+    [ -e "$iface/driver" ] || continue
+    drv=$(basename "$(readlink "$iface/driver")")
+    echo "$(basename "$iface")" > "/sys/bus/usb/drivers/$drv/unbind" 2>/dev/null || true
+  done
+}
+
+STA_IF=""
+cleanup() {
+  pkill -9 -x ul_trigger_ap 2>/dev/null || true
+  pkill -9 -x wpa_supplicant 2>/dev/null || true
+  pkill -9 -x rxdemo 2>/dev/null || true
+  [ -n "$STA_IF" ] && { ip addr flush dev "$STA_IF" 2>/dev/null; iw dev "$STA_IF" disconnect 2>/dev/null; }
+  rm -f "$WPA"
+}
+trap cleanup EXIT INT TERM
+
+echo "== ul_ofdma_e2e: AP 8832CU($AP_ID) <- STA 8852BU($STA_ID) ch$CH, ${SEC}s =="
+
+# --- build the AP harness ---
+[ -f build/libdevourer.a ] || cmake --build build -j --target devourer >/dev/null 2>&1
+g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/ul_trigger_ap.cpp \
+    examples/common/env_config.cpp build/libdevourer.a \
+    $(pkg-config --cflags --libs libusb-1.0) -lpthread -o "$BIN" || { echo "FAIL: build"; exit 1; }
+
+# --- STA side: 8852BU under rtw89_8852bu ---
+modprobe rtw89_8852bu 2>/dev/null || true
+unbind_kernel "$AP_ID"       # free the AP dongle for devourer
+sleep 2
+STA_IF=$(netdev_for "$STA_ID")
+[ -n "$STA_IF" ] || { echo "FAIL: 8852BU has no rtw89 netdev (STA)"; exit 1; }
+echo "STA netdev: $STA_IF"
+printf 'network={\n\tssid="%s"\n\tkey_mgmt=NONE\n\tscan_ssid=1\n}\n' "$SSID" > "$WPA"
+pkill -9 -x wpa_supplicant 2>/dev/null; iw dev "$STA_IF" disconnect 2>/dev/null; sleep 1
+
+# --- AP up (full-duplex, HE beacon + trigger loop) ---
+# TRIG_GAP_MS=0: rely on the UL_FIXINFO tf_periodic scheduler (the production
+# mechanism the fw airs autonomously) rather than the explicit F2P SendTrigger
+# loop — F2P is the dead test path and its per-50ms H2C was timing out (rc=-7)
+# and wedging the AP's CH12 queue.
+env DEVOURER_VID=0x35bc DEVOURER_PID=0x0101 DEVOURER_CHANNEL="$CH" \
+    DEVOURER_BCN_TU=25 DEVOURER_TX_WITH_RX=thread DEVOURER_TRIG_GAP_MS=0 \
+    DEVOURER_LOG_LEVEL=info "$BIN" "$SEC" >/dev/null 2>"$APLOG" &
+sleep 6
+grep -q "HE AP up" "$APLOG" || { echo "FAIL: AP did not come up"; tail -5 "$APLOG"; exit 1; }
+
+# --- optional monitor witness (8812AU): decodes any aired Trigger as rx.trigger,
+# so we can tell "fw airs a trigger, STA didn't answer" from "fw aired nothing". ---
+if lsusb -d "$WIT_ID" >/dev/null 2>&1; then
+  unbind_kernel "$WIT_ID"
+  env DEVOURER_PID=0x8812 DEVOURER_VID=0x0bda DEVOURER_CHANNEL="$CH" \
+      DEVOURER_EVENTS=stdout DEVOURER_LOG_LEVEL=warn build/rxdemo >"$WITLOG" 2>/dev/null &
+  echo "witness 8812AU on ch$CH (rx.trigger decode)"
+  sleep 4
+fi
+
+# --- STA connects ---
+dmesg -C 2>/dev/null || true
+wpa_supplicant -i "$STA_IF" -c "$WPA" -B >/dev/null 2>&1
+echo "-- waiting for HE association --"
+LINK=""
+for i in $(seq 1 20); do
+  LINK=$(iw dev "$STA_IF" link 2>&1 | grep -oE 'Connected to [0-9a-f:]+') && { echo "   $LINK (after ${i}s)"; break; }
+  sleep 1
+done
+
+# --- generate UL traffic so the fw has a BSR to grant ---
+if [ -n "$LINK" ]; then
+  ip addr flush dev "$STA_IF" 2>/dev/null
+  ip addr add 192.168.99.2/24 dev "$STA_IF" 2>/dev/null
+  ( for k in $(seq 1 20); do ping -c 1 -W 1 -I "$STA_IF" 192.168.99.1 >/dev/null 2>&1; sleep 0.3; done ) &
+fi
+
+# --- B210 ground truth: while the AP grants the associated STA, is any trigger
+# on air? Strong bursts (>+20 dB) that appear only with the grant (vs the
+# AP-beacon-only baseline) would be the aired trigger / the STA's TB PPDU. Runs
+# on a QUIET channel so the co-located AP+STA stand out; needs the B210. ---
+# sdr2wifi lives in the invoking user's home — NOT $HOME, which is /root under
+# sudo (so "$HOME/git/sdr2wifi" silently fails to exist and the scan never runs).
+SDR2WIFI="${SDR2WIFI:-/home/${SUDO_USER:-$USER}/git/sdr2wifi}"
+B210LOG="/tmp/ul_ofdma_e2e_b210.txt"; : > "$B210LOG"
+if [ -n "$LINK" ] && uhd_find_devices 2>/dev/null | grep -qi B210; then
+  echo "-- B210 burst scan on ch$CH during the grant window (8 s) --"
+  python3 "$SDR2WIFI/iq_burst_scan.py" --freq "$(( (5000 + 5*CH) ))e6" \
+      --secs 8 --gain 60 2>/dev/null | grep -E "iq-scan|bursts/sec" | tee "$B210LOG" || true
+fi
+
+# --- let the trigger loop run, then collect ---
+sleep $((SEC - 22 > 6 ? SEC - 22 : 6))
+iw dev "$STA_IF" link > "$STALOG" 2>&1 || true
+sleep 4
+pkill -9 -x ul_trigger_ap 2>/dev/null || true
+sleep 1
+
+echo "--- AP summary ---"
+grep -F '"ev":"ap.assoc"' "$APLOG" | tail -1
+grep -F '"ev":"ap.ul_ofdma"' "$APLOG" | tail -1
+grep -F '"ev":"ul.rx"' "$APLOG" | head -3
+SUMM=$(grep -F '"ev":"ap.summary"' "$APLOG" | tail -1); echo "$SUMM"
+WITTRIG=$(grep -cF '"ev":"rx.trigger"' "$WITLOG" 2>/dev/null); WITTRIG=${WITTRIG:-0}
+echo "--- witness: aired Triggers decoded = $WITTRIG ---"
+[ "$WITTRIG" -gt 0 ] && grep -F '"ev":"rx.trigger"' "$WITLOG" | head -1
+echo "--- STA link ---"; grep -iE "Connected|freq|signal|tx bitrate|rx bitrate" "$STALOG" | head
+echo "--- STA assoc dmesg ---"; dmesg 2>/dev/null | grep -iE "rtw89|assoc|he |802.11ax" | tail -6
+
+# --- verdict ---
+ULRX=$(echo "$SUMM" | grep -oE '"ul_rx":[0-9]+' | grep -oE '[0-9]+'); ULRX=${ULRX:-0}
+ULTB=$(echo "$SUMM" | grep -oE '"ul_tb":[0-9]+' | grep -oE '[0-9]+'); ULTB=${ULTB:-0}
+if [ -n "$LINK" ] && [ "$ULTB" -gt 0 ]; then
+  echo "RESULT: PASS — HE association + $ULTB HE TB PPDU(s): scheduled UL closed."
+elif [ -n "$LINK" ] && [ "$WITTRIG" -gt 0 ]; then
+  echo "RESULT: PARTIAL(trigger-airs) — associated + the fw AIRS Triggers ($WITTRIG"
+  echo "        decoded by the witness), but the STA answered with $ULRX contention"
+  echo "        UL frames and no HE TB PPDU. Gap is the STA-side TB response."
+elif [ -n "$LINK" ] && [ "$ULRX" -gt 0 ]; then
+  echo "RESULT: PARTIAL — associated + $ULRX uplink frames, but no aired Trigger"
+  echo "        (witness=$WITTRIG) and no TB PPDU: fw isn't scheduling triggers."
+elif [ -n "$LINK" ]; then
+  echo "RESULT: PARTIAL — HE association works, but no uplink observed after grants."
+else
+  echo "RESULT: FAIL — no association (iterate HE IEs; see STA dmesg above)."
+fi

--- a/tests/ul_sounding_e2e.sh
+++ b/tests/ul_sounding_e2e.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# ul_sounding_e2e.sh — the production 802.11ax trigger-airing path, end-to-end.
+#
+# Unlike ul_ofdma_e2e.sh (which drives the F2P / UL_FIXINFO command surface the
+# shipped client fw silently drops), this drives HE SOUNDING: the AP fw builds
+# and airs an NDPA -> NDP -> BFRP sequence and arms RX for the beamformee's
+# report HE TB PPDU. A BFRP is an 802.11ax Trigger-frame variant, so this is a
+# genuine hardware-scheduled, contention-free UL transmission.
+#
+#   AP  = devourer HE access point on a Kestrel adapter (RTL8832CU, 35bc:0101),
+#         tests/ul_trigger_ap.cpp with DEVOURER_SND=1 — advertises itself as an
+#         HE beamformer, registers the associated STA as a beamformee, and airs
+#         a periodic sounding (StartSounding).
+#   STA = a real kernel HE supplicant (RTL8852BU, 35bc:0108, rtw89_8852bu) that
+#         associates and, as an SU beamformee, answers the BFRP with an HE TB
+#         PPDU carrying its compressed-beamforming report.
+#   B210 = ground-truth witness: a strong OFDM burst (the AP's NDPA/BFRP) plus a
+#         co-located HE burst one SIFS later (the STA's TB PPDU report).
+#
+# PASS  = association AND (ap.summary ul_tb > 0  ||  B210 co-located-HE > baseline):
+#         the AP airs the sounding and the beamformee answers with a TB PPDU.
+# PARTIAL(airs) = associated + soundings sent + B210 strong bursts appear (the
+#         NDPA/BFRP airs) but no TB report — STA-side beamformee gap.
+# FAIL  = no association (iterate the HE IEs; STA dmesg shows the reason).
+#
+#   sudo tests/ul_sounding_e2e.sh [seconds] [channel]
+set -u
+cd "$(dirname "$0")/.."
+[ "$(id -u)" -eq 0 ] || { echo "FAIL: needs root"; exit 2; }
+
+SEC=${1:-40}
+CH=${2:-149}         # a quiet UNII-3 5 GHz channel (rtw89 needs `iw reg set US`)
+AP_ID="35bc:0101"    # RTL8832CU — devourer HE AP (beamformer)
+STA_ID="35bc:0108"   # RTL8852BU — rtw89 HE station (beamformee)
+WIT_ID="${WIT_ID:-2357:012d}"   # RTL8812BU (Archer T3U) on a bus OTHER than the
+                                 # AP's — a decode witness that isn't USB-starved
+                                 # by the AP (the 8812AU on the AP's bus hears 0).
+WIT_VID="0x${WIT_ID%%:*}"; WIT_PID="0x${WIT_ID##*:}"
+SSID="devourerAP"
+BIN="/tmp/ul_snd_ap"
+WPA="/tmp/ul_snd_wpa.conf"
+APLOG="/tmp/ul_snd_e2e_ap.log"
+STALOG="/tmp/ul_snd_e2e_sta.log"
+WITLOG="/tmp/ul_snd_e2e_wit.jsonl"
+B210LOG="/tmp/ul_snd_e2e_b210.txt"
+FREQ=$(( 5000 + 5*CH ))
+# sdr2wifi lives in the INVOKING user's home — NOT $HOME, which is /root under
+# sudo (so "$HOME/git/sdr2wifi" silently fails to exist and the B210 scan never
+# runs). Resolve via SUDO_USER. Override with SDR2WIFI=... if it lives elsewhere.
+SDR2WIFI="${SDR2WIFI:-/home/${SUDO_USER:-$USER}/git/sdr2wifi}"
+B210GAIN="${B210GAIN:-62}"
+
+lsusb -d "$AP_ID" >/dev/null 2>&1 || { echo "SKIP: AP $AP_ID (8832CU) not plugged"; exit 0; }
+lsusb -d "$STA_ID" >/dev/null 2>&1 || { echo "SKIP: STA $STA_ID (8852BU) not plugged"; exit 0; }
+
+sysdir_for() {
+  local vid=${1%%:*} pid=${1##*:} d
+  for d in /sys/bus/usb/devices/*; do
+    [ -f "$d/idVendor" ] || continue
+    [ "$(cat "$d/idVendor")" = "$vid" ] && [ "$(cat "$d/idProduct")" = "$pid" ] \
+      && { echo "$d"; return; }
+  done
+}
+netdev_for() { local d; d=$(sysdir_for "$1"); [ -n "$d" ] && ls "$d"/*:*/net/ 2>/dev/null | head -1; }
+unbind_kernel() {
+  local d iface drv; d=$(sysdir_for "$1"); [ -n "$d" ] || return 0
+  for iface in "$d":*; do
+    [ -e "$iface/driver" ] || continue
+    drv=$(basename "$(readlink "$iface/driver")")
+    echo "$(basename "$iface")" > "/sys/bus/usb/drivers/$drv/unbind" 2>/dev/null || true
+  done
+}
+
+STA_IF=""
+cleanup() {
+  pkill -9 -x ul_trigger_ap 2>/dev/null || true
+  pkill -9 -x wpa_supplicant 2>/dev/null || true
+  pkill -9 -x rxdemo 2>/dev/null || true
+  [ -n "$STA_IF" ] && { ip addr flush dev "$STA_IF" 2>/dev/null; iw dev "$STA_IF" disconnect 2>/dev/null; }
+  rm -f "$WPA"
+}
+trap cleanup EXIT INT TERM
+
+echo "== ul_sounding_e2e: AP 8832CU($AP_ID) sounds STA 8852BU($STA_ID) ch$CH ${FREQ}MHz, ${SEC}s =="
+
+# --- VBUS cold-cycle the AP dongle (the 8852C retains a wedged CH12 state
+# across soft re-init; only a real power-cycle gives a clean chip). Port 1 of
+# hub 3-2.3 is the AP devourer opens; the STA (35bc:0108) is elsewhere. ---
+AP_HUB="${AP_HUB:-3-2.3}"; AP_PORT="${AP_PORT:-1}"
+if [ "${VBUS_CYCLE:-1}" = 1 ] && command -v uhubctl >/dev/null; then
+  echo "-- VBUS cold-cycle AP hub $AP_HUB port $AP_PORT --"
+  uhubctl -l "$AP_HUB" -p "$AP_PORT" -a cycle -d 3 >/dev/null 2>&1 || echo "WARN: uhubctl cycle failed"
+  sleep 5
+fi
+
+# --- build the AP harness ---
+[ -f build/libdevourer.a ] || cmake --build build -j --target devourer >/dev/null 2>&1
+g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/ul_trigger_ap.cpp \
+    examples/common/env_config.cpp build/libdevourer.a \
+    $(pkg-config --cflags --libs libusb-1.0) -lpthread -o "$BIN" || { echo "FAIL: build"; exit 1; }
+
+# --- STA side: 8852BU under rtw89_8852bu (world regdomain blocks UNII-3 active
+# scan — set US so ch149-165 are usable for association) ---
+modprobe rtw89_8852bu 2>/dev/null || true
+iw reg set US 2>/dev/null || true
+unbind_kernel "$AP_ID"       # free the AP dongle for devourer
+sleep 2
+STA_IF=$(netdev_for "$STA_ID")
+[ -n "$STA_IF" ] || { echo "FAIL: 8852BU has no rtw89 netdev (STA)"; exit 1; }
+echo "STA netdev: $STA_IF"
+printf 'network={\n\tssid="%s"\n\tkey_mgmt=NONE\n\tscan_ssid=1\n}\n' "$SSID" > "$WPA"
+pkill -9 -x wpa_supplicant 2>/dev/null; iw dev "$STA_IF" disconnect 2>/dev/null; sleep 1
+
+# --- AP up in SOUNDING mode (DEVOURER_SND=1): beamformer IEs + StartSounding ---
+# Periodic sounding (SND_PERIOD>0): ONE H2C arms fw-autonomous repeated sounding
+# (SNDF2P_ADD). This is the correct sustained path — a per-sounding one-shot loop
+# wedges the CH12 queue after ~7 (the fw holds an H2C page per one-shot sounding
+# until its frame-exchange completes; with no report they never release).
+SND_PERIOD=${SND_PERIOD:-10}; SND_GAP=${SND_GAP:-0}
+# INJECT=1: run the AP in trigger-INJECTION mode instead of sounding — SendTrigger
+# host-builds a raw 802.11ax Basic Trigger (build_basic_trigger) and pushes it
+# through the mgmt TX queue (like a beacon/RTS), bypassing the fw sounding/F2P
+# scheduler that the client fw doesn't run. The witness decodes an aired trigger
+# as rx.trigger (FC=0x24). This is the path that CAN put a trigger on the air.
+if [ "${INJECT:-0}" = 1 ]; then
+  env DEVOURER_VID=0x35bc DEVOURER_PID=0x0101 DEVOURER_CHANNEL="$CH" \
+      DEVOURER_BCN_TU=25 DEVOURER_TX_WITH_RX=thread \
+      DEVOURER_TRIG_GAP_MS="${TRIG_GAP_MS:-50}" \
+      DEVOURER_LOG_LEVEL=info "$BIN" "$SEC" >/dev/null 2>"$APLOG" &
+else
+  env DEVOURER_VID=0x35bc DEVOURER_PID=0x0101 DEVOURER_CHANNEL="$CH" \
+      DEVOURER_BCN_TU=25 DEVOURER_TX_WITH_RX=thread DEVOURER_SND=1 \
+      DEVOURER_SND_PERIOD="$SND_PERIOD" DEVOURER_SND_GAP_MS="$SND_GAP" \
+      DEVOURER_LOG_LEVEL=info "$BIN" "$SEC" >/dev/null 2>"$APLOG" &
+fi
+# Wait up to 25 s for bring-up (fresh-rig FWDL + init_sounding is ~8 s; a fixed
+# short sleep raced it and made the whole script bail with "AP did not come up").
+for i in $(seq 1 25); do grep -q "HE AP up" "$APLOG" 2>/dev/null && break; sleep 1; done
+grep -q "HE AP up" "$APLOG" || { echo "FAIL: AP did not come up"; tail -8 "$APLOG"; exit 1; }
+grep -q "init_sounding" "$APLOG" && echo "AP: sounding engine armed"
+
+# --- decode witness: an RTL8812BU (Archer T3U) that decodes any aired BFRP
+# (FC=0x24) as rx.trigger — the unambiguous "the BFRP aired" signal. NOTE: on
+# this bench the 8812AU sits on the AP's own USB bus and reads 0 frames; whether
+# that is USB starvation vs another cause was not conclusively isolated, so this
+# uses a separate-bus adapter. WIT=0 disables it (e.g. to leave the B210's bus
+# uncontended). ---
+WIT_UP=0
+if [ "${WIT:-1}" = 1 ] && lsusb -d "$WIT_ID" >/dev/null 2>&1; then
+  unbind_kernel "$WIT_ID"
+  env DEVOURER_PID="${WIT_PID:-0x012d}" DEVOURER_VID="${WIT_VID:-0x2357}" \
+      DEVOURER_CHANNEL="$CH" DEVOURER_RX_DUMP_ALL=1 \
+      DEVOURER_EVENTS=stdout DEVOURER_LOG_LEVEL=warn build/rxdemo >"$WITLOG" 2>/dev/null &
+  WIT_UP=1
+  echo "decode witness ${WIT_VID:-0x2357}:${WIT_PID:-0x012d} on ch$CH (rx.trigger + all-frame count)"
+  sleep 4
+fi
+
+# --- B210 is the energy/preamble witness; the 2nd Kestrel monitor is disabled by
+# default (two same-ID 8852C devourer instances on one hub conflict on bring-up). ---
+WIT2LOG="/tmp/ul_snd_e2e_wit2.jsonl"; : > "$WIT2LOG"; WIT2_UP=0
+WIT2_PORT="${WIT2_PORT:-2.3.2}"
+if [ "${WIT2:-0}" = 1 ]; then
+  env DEVOURER_VID=0x35bc DEVOURER_PID=0x0101 DEVOURER_USB_BUS=3 \
+      DEVOURER_USB_PORT="$WIT2_PORT" DEVOURER_CHANNEL="$CH" \
+      DEVOURER_EVENTS=stdout DEVOURER_LOG_LEVEL=warn build/rxdemo >"$WIT2LOG" 2>/dev/null &
+  WIT2_UP=1
+  echo "co-located witness 8832CU (hub $AP_HUB port $WIT2_PORT) on ch$CH"
+  sleep 4
+fi
+
+# --- B210 BASELINE (AP beacon only, no association/sounding yet) ---
+B210BASE="/tmp/ul_snd_e2e_b210_base.txt"; : > "$B210BASE"; : > "$B210LOG"
+HAS_B210=0; uhd_find_devices 2>/dev/null | grep -qi B210 && HAS_B210=1
+if [ "$HAS_B210" = 1 ]; then
+  echo "-- B210 baseline (beacon-only) 6 s --"
+  python3 "$SDR2WIFI/iq_burst_scan.py" --freq "${FREQ}e6" --secs 6 --gain "$B210GAIN" \
+      2>/dev/null | grep -E "bursts>=2us" | tee "$B210BASE" || true
+fi
+
+# --- STA connects (as a beamformee) ---
+dmesg -C 2>/dev/null || true
+wpa_supplicant -i "$STA_IF" -c "$WPA" -B >/dev/null 2>&1
+echo "-- waiting for HE association --"
+LINK=""
+for i in $(seq 1 20); do
+  LINK=$(iw dev "$STA_IF" link 2>&1 | grep -oE 'Connected to [0-9a-f:]+') && { echo "   $LINK (after ${i}s)"; break; }
+  sleep 1
+done
+# Keepalive so the STA stays associated across the sounding window (the AP has an
+# ARP/ICMP responder; without traffic the supplicant re-associates every ~7s).
+if [ -n "$LINK" ]; then
+  ip addr flush dev "$STA_IF" 2>/dev/null
+  ip addr add 192.168.99.2/24 dev "$STA_IF" 2>/dev/null
+  ( for k in $(seq 1 60); do ping -c 1 -W 1 -I "$STA_IF" 192.168.99.1 >/dev/null 2>&1; sleep 0.4; done ) &
+fi
+# Wait for the AP to start sounding (association latched), then B210-scan the
+# sounding window. Not gated on the momentary LINK (the STA re-associates ~7s;
+# the sounding fires whenever it is associated).
+for i in $(seq 1 10); do grep -q '"ev":"ap.sounding"\|set_snd_para' "$APLOG" && break; sleep 1; done
+
+if [ "$HAS_B210" = 1 ]; then
+  echo "-- B210 sounding-window scan 10 s (compare strong/HE vs baseline) --"
+  python3 "$SDR2WIFI/iq_burst_scan.py" --freq "${FREQ}e6" --secs 10 --gain "$B210GAIN" \
+      2>/dev/null | grep -E "bursts>=2us" | tee "$B210LOG" || true
+fi
+
+sleep $((SEC - 30 > 4 ? SEC - 30 : 4))
+iw dev "$STA_IF" link > "$STALOG" 2>&1 || true
+sleep 4
+pkill -9 -x ul_trigger_ap 2>/dev/null || true
+sleep 1
+
+echo "--- AP summary ---"
+grep -F '"ev":"ap.assoc"' "$APLOG" | tail -1
+grep -F '"ev":"ap.bfee"' "$APLOG" | tail -1
+SUMM=$(grep -F '"ev":"ap.summary"' "$APLOG" | tail -1); echo "$SUMM"
+grep -F 'set_snd_para' "$APLOG" | tail -1
+grep -iE 'SER|halt|fw.err' "$APLOG" | tail -2
+WITALL=$(grep -cE '"ev":"rx' "$WITLOG" 2>/dev/null); WITALL=${WITALL:-0}
+WITTRIG=$(grep -cF '"ev":"rx.trigger"' "$WITLOG" 2>/dev/null); WITTRIG=${WITTRIG:-0}
+echo "--- decode witness $WIT_ID: total frames heard=$WITALL, aired BFRP/Triggers=$WITTRIG ---"
+[ "$WITALL" -eq 0 ] && echo "    (0 frames — witness deaf: wrong bus/channel or USB-starved by the AP)"
+[ "$WITTRIG" -gt 0 ] && grep -F '"ev":"rx.trigger"' "$WITLOG" | head -1
+# co-located Kestrel witness (the decisive airing detector)
+WIT2ALL=$(grep -cE '"ev":"rx' "$WIT2LOG" 2>/dev/null); WIT2ALL=${WIT2ALL:-0}
+WIT2TRIG=$(grep -cF '"ev":"rx.trigger"' "$WIT2LOG" 2>/dev/null); WIT2TRIG=${WIT2TRIG:-0}
+WIT2TB=$(grep -cE '"ppdu_type":10|ppdu_type=10' "$WIT2LOG" 2>/dev/null); WIT2TB=${WIT2TB:-0}
+echo "--- co-located 8832CU witness: total rx=$WIT2ALL, aired BFRP/Triggers=$WIT2TRIG, HE_TB(ppdu10)=$WIT2TB ---"
+[ "$WIT2TRIG" -gt 0 ] && grep -F '"ev":"rx.trigger"' "$WIT2LOG" | head -1
+echo "--- STA link ---"; grep -iE "Connected|freq|signal|tx bitrate|rx bitrate" "$STALOG" | head
+echo "--- STA assoc dmesg ---"; dmesg 2>/dev/null | grep -iE "rtw89|assoc|he |beamform|802.11ax" | tail -6
+
+# --- B210 baseline-vs-sounding delta. The AP arrives at ~-27 dBm at 1 m, which
+# sits BELOW the scanner's "strong>+20dB" threshold, so use the PREAMBLE
+# CLASSIFIER counts instead: OFDM L-STF (legacy — beacon + the BFRP trigger) and
+# VHT/HE RL-SIG (the HE NDP + the TB PPDU report). A rise in RL-SIG during
+# sounding is the NDP/TB signature; a rise in OFDM is the aired BFRP. ---
+parse_b210() { grep -oE "$2: [0-9]+" "$1" 2>/dev/null | grep -oE '[0-9]+$' | tail -1; }
+BASE_OFDM=$(parse_b210 "$B210BASE" 'OFDM L-STF'); BASE_OFDM=${BASE_OFDM:-0}
+SND_OFDM=$(parse_b210 "$B210LOG" 'OFDM L-STF'); SND_OFDM=${SND_OFDM:-0}
+BASE_HE=$(parse_b210 "$B210BASE" 'VHT/HE RL-SIG'); BASE_HE=${BASE_HE:-0}
+SND_HE=$(parse_b210 "$B210LOG" 'VHT/HE RL-SIG'); SND_HE=${SND_HE:-0}
+echo "--- B210 preamble classifier: OFDM L-STF base=$BASE_OFDM snd=$SND_OFDM | HE RL-SIG base=$BASE_HE snd=$SND_HE ---"
+
+# --- verdict ---
+ULTB=$(echo "$SUMM" | grep -oE '"ul_tb":[0-9]+' | grep -oE '[0-9]+'); ULTB=${ULTB:-0}
+SND=$(echo "$SUMM" | grep -oE '"soundings":[0-9]+' | grep -oE '[0-9]+'); SND=${SND:-0}
+TRIG=$(echo "$SUMM" | grep -oE '"triggers":[0-9]+' | grep -oE '[0-9]+'); TRIG=${TRIG:-0}
+ASSOCOK=0; grep -q '"associated":true' <<<"$SUMM" && ASSOCOK=1
+if [ "${INJECT:-0}" = 1 ]; then
+  # Injection mode: SendTrigger host-injects a Basic Trigger via the mgmt queue.
+  # The witness decoding rx.trigger with the commanded params proves it airs.
+  if [ "$WITTRIG" -gt 0 ] && [ "$ULTB" -gt 0 ]; then
+    echo "RESULT: PASS — host-injected Trigger AIRS ($TRIG sent, $WITTRIG decoded by"
+    echo "        the witness) AND the STA answered with $ULTB HE TB PPDU(s)."
+  elif [ "$WITTRIG" -gt 0 ]; then
+    echo "RESULT: TRIGGER-AIRS — the host-injected HE Basic Trigger AIRS: $TRIG sent,"
+    echo "        $WITTRIG decoded on-air by the witness with the commanded params"
+    echo "        (overturns 'no trigger airs'). But ul_tb=$ULTB — the STA did not"
+    echo "        answer with a TB PPDU (host-injected triggers lack fw SIFS-response"
+    echo "        arming; that half needs a fw-scheduled trigger the client fw won't air)."
+  elif [ "$TRIG" -gt 0 ]; then
+    echo "RESULT: PARTIAL — $TRIG triggers injected but witness decoded 0 (witness"
+    echo "        deaf/misplaced: frames=$WITALL) — can't confirm airing."
+  else
+    echo "RESULT: PARTIAL — associated but no triggers injected."
+  fi
+elif [ "$ULTB" -gt 0 ] || [ "$SND_HE" -gt "$((BASE_HE + 3))" ]; then
+  echo "RESULT: PASS — HE sounding closed: ul_tb=$ULTB (AP-decoded report), B210"
+  echo "        HE RL-SIG bursts $BASE_HE->$SND_HE (NDP + on-air TB PPDU). $SND soundings."
+elif [ "$SND" -gt 0 ] && { [ "$WITTRIG" -gt 0 ] || [ "$SND_OFDM" -gt "$((BASE_OFDM + 3))" ]; }; then
+  echo "RESULT: PARTIAL(airs) — $SND soundings; the NDPA/BFRP AIRS (witness BFRP="
+  echo "        $WITTRIG, B210 OFDM $BASE_OFDM->$SND_OFDM) but no TB report"
+  echo "        (ul_tb=$ULTB, HE RL-SIG $BASE_HE->$SND_HE): STA-side gap."
+elif [ "$SND" -gt 0 ]; then
+  echo "RESULT: PARTIAL(accepted) — $SND soundings fw-ACCEPTED (no SER) but no aired"
+  echo "        frames seen (witness_frames=$WITALL trig=$WITTRIG, B210 OFDM"
+  echo "        $BASE_OFDM->$SND_OFDM HE $BASE_HE->$SND_HE): fw accepts SET_SND_PARA"
+  echo "        but its client-fw scheduler doesn't air it (or witnesses still deaf)."
+elif [ "$ASSOCOK" = 1 ]; then
+  echo "RESULT: PARTIAL — HE association works, but no sounding issued."
+else
+  echo "RESULT: FAIL — no association (iterate HE IEs; see STA dmesg above)."
+fi

--- a/tests/ul_trigger_airs.sh
+++ b/tests/ul_trigger_airs.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# ul_trigger_airs.sh — tier-A validation for the 802.11ax scheduled-UL path:
+# does the RTL8852 firmware, driven by devourer's F2P command (SendTrigger),
+# actually AIR an HE Basic Trigger frame?
+#
+#   Injector : RTL8852BU (35bc:0108) under devourer `kestrelprobe trig` — brings
+#              up TX then fires a burst of Basic Triggers via the F2P H2C.
+#   Witness  : RTL8812AU (0bda:8812) under devourer rxdemo. A Trigger is an
+#              802.11 CONTROL frame aired in a legacy PPDU, so even this 11ac
+#              witness captures the bytes; rxdemo decodes them as `rx.trigger`
+#              (src/TriggerParse.h) and reports the trigger type / RU / MCS.
+#
+# PASS  = kestrelprobe reports sent>0 (H2C accepted) AND the witness logs >=1
+#         rx.trigger whose fields match the fired config (Basic, BW20, RU 61).
+# PARTIAL = H2C accepted but no rx.trigger — the fw likely ignores F2P_TEST in
+#           normal (non-MP) mode: fall to tests/ul_ofdma_e2e.sh (UL_FIXINFO) and
+#           sweep DEVOURER_TRIG_MODE. This is the documented runtime discovery.
+#
+# Optional: an SDR duty read (tests/sdr_duty.py) confirms on-air energy while the
+# burst runs (set SDR=1; needs the B210).
+#
+#   sudo tests/ul_trigger_airs.sh [channel] [trigger_count]
+set -u
+cd "$(dirname "$0")/.."
+[ "$(id -u)" -eq 0 ] || { echo "FAIL: needs root (USB claim + driver unbind)"; exit 2; }
+
+CH=${1:-36}
+COUNT=${2:-200}
+DUT_ID="35bc:0108"   # RTL8852BU — the F2P trigger source (devourer)
+RX_ID="0bda:8812"    # RTL8812AU — the monitor witness (devourer rxdemo)
+KP="build/kestrelprobe"
+RXDEMO="build/rxdemo"
+RXLOG="/tmp/ul_trigger_airs_rx.jsonl"
+TRIGLOG="/tmp/ul_trigger_airs_trig.jsonl"
+for b in "$KP" "$RXDEMO"; do
+  [ -x "$b" ] || { echo "FAIL: $b not built (cmake --build build)"; exit 2; }
+done
+
+plugged() { lsusb -d "$1" >/dev/null 2>&1; }
+for d in "$DUT_ID injector-8852BU" "$RX_ID witness-8812AU"; do
+  read -r id name <<<"$d"
+  plugged "$id" || { echo "SKIP: $name ($id) not plugged"; exit 0; }
+done
+
+# Resolve the USB interface sysfs node so we can unbind the auto-probing kernel
+# driver (rtw89 for the 8852BU, rtw88 for the 8812AU) — modprobe -r does not
+# survive a re-enumeration, an explicit unbind of THIS device does.
+sysdir_for() {
+  local vid=${1%%:*} pid=${1##*:} d
+  for d in /sys/bus/usb/devices/*; do
+    [ -f "$d/idVendor" ] || continue
+    [ "$(cat "$d/idVendor")" = "$vid" ] && [ "$(cat "$d/idProduct")" = "$pid" ] \
+      && { echo "$d"; return; }
+  done
+}
+unbind_kernel() {  # $1 = VID:PID — unbind any driver from its interface(s)
+  local d iface drv; d=$(sysdir_for "$1"); [ -n "$d" ] || return 0
+  for iface in "$d":*; do
+    [ -e "$iface/driver" ] || continue
+    drv=$(basename "$(readlink "$iface/driver")")
+    echo "$(basename "$iface")" > "/sys/bus/usb/drivers/$drv/unbind" 2>/dev/null || true
+  done
+}
+
+RXPID=""
+cleanup() {
+  [ -n "$RXPID" ] && kill "$RXPID" 2>/dev/null || true
+  pkill -x kestrelprobe 2>/dev/null || true
+  pkill -x rxdemo 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+echo "== ul_trigger_airs: ch$CH, $COUNT triggers, 8852BU -> 8812AU witness =="
+unbind_kernel "$DUT_ID"
+unbind_kernel "$RX_ID"
+sleep 1
+
+# --- witness first: rxdemo on the 8812AU, capturing rx.trigger ---
+DEVOURER_PID=0x8812 DEVOURER_VID=0x0bda DEVOURER_CHANNEL="$CH" \
+  DEVOURER_EVENTS=stdout DEVOURER_LOG_LEVEL=warn \
+  "$RXDEMO" >"$RXLOG" 2>/dev/null &
+RXPID=$!
+sleep 6   # let the witness bring up + settle on-channel
+
+if ! kill -0 "$RXPID" 2>/dev/null; then
+  echo "FAIL: witness rxdemo exited during bring-up (see $RXLOG)"; exit 1
+fi
+
+# --- optional SDR duty read while the burst airs ---
+SDR_BG=""
+if [ "${SDR:-0}" = "1" ]; then
+  PY="tests/.venv/bin/python"; [ -x "$PY" ] || PY=python3
+  ( "$PY" tests/sdr_duty.py --freq "$(( 5000 + 5*CH ))e6" --secs 6 \
+      >/tmp/ul_trigger_airs_sdr.txt 2>&1 || true ) &
+  SDR_BG=$!
+fi
+
+# --- fire the triggers on the 8852BU ---
+DEVOURER_CHANNEL="$CH" DEVOURER_TRIGGER_COUNT="$COUNT" \
+  DEVOURER_EVENTS=stdout DEVOURER_LOG_LEVEL=info \
+  "$KP" trig --pid 0x0108 >"$TRIGLOG" 2>>"$TRIGLOG"
+TRIG_RC=$?
+[ -n "$SDR_BG" ] && wait "$SDR_BG" 2>/dev/null || true
+sleep 2   # let the last aired triggers reach the witness
+
+# --- verdict ---
+SENT=$(grep -F '"ev":"kestrel.trig"' "$TRIGLOG" | grep -oE '"sent":[0-9]+' | grep -oE '[0-9]+' | tail -1)
+SENT=${SENT:-0}
+# grep -c prints "0" AND exits 1 on no match, so `|| echo 0` would double it —
+# count with wc -l instead so exactly one integer lands in RXTRIG.
+RXTRIG=$(grep -cF '"ev":"rx.trigger"' "$RXLOG" 2>/dev/null); RXTRIG=${RXTRIG:-0}
+
+echo "---"
+echo "kestrelprobe trig: rc=$TRIG_RC sent=$SENT (H2C accepted count)"
+echo "witness rx.trigger events: $RXTRIG"
+if [ "$RXTRIG" -gt 0 ]; then
+  echo "sample decoded trigger:"; grep -F '"ev":"rx.trigger"' "$RXLOG" | head -1
+fi
+[ "${SDR:-0}" = "1" ] && { echo "SDR duty:"; cat /tmp/ul_trigger_airs_sdr.txt 2>/dev/null | tail -3; }
+
+if [ "$SENT" -gt 0 ] && [ "$RXTRIG" -gt 0 ]; then
+  echo "RESULT: PASS — the fw airs Basic Triggers on the F2P command; witness decoded $RXTRIG."
+  exit 0
+elif [ "$SENT" -gt 0 ]; then
+  echo "RESULT: PARTIAL — H2C accepted but no aired trigger seen. The fw likely"
+  echo "        ignores F2P_TEST in normal mode. Next: sweep DEVOURER_TRIG_MODE=0..3,"
+  echo "        then tests/ul_ofdma_e2e.sh (UL_FIXINFO tf_periodic) as the production path."
+  exit 1
+else
+  echo "RESULT: FAIL — the F2P H2C was not accepted (bring-up or descriptor issue; see $TRIGLOG)."
+  exit 1
+fi

--- a/tests/ul_trigger_ap.cpp
+++ b/tests/ul_trigger_ap.cpp
@@ -1,0 +1,450 @@
+// ul_trigger_ap.cpp — tier-C end-to-end harness for 802.11ax scheduled UL.
+//
+// devourer runs as an HE (802.11ax) access point on a Kestrel adapter (default
+// the RTL8832CU / 8852C, 35bc:0101): it beacons with HT+VHT+HE Capabilities /
+// Operation IEs, answers probe/auth/(re)assoc, and serves the ARP/ICMP/DHCP
+// data plane (so an associated station stays up and generates UL traffic). On a
+// completed association it registers the station as a peer (RegisterPeerSta) and
+// then drives the firmware UL-OFDMA scheduler (ConfigureUlOfdma tf_periodic +
+// periodic SendTrigger) to grant that station UL transmit opportunities. An HE
+// station responds to a Basic Trigger with a TB PPDU at trigger+SIFS in
+// hardware — the AP's full-duplex RX logs frames from the station's MAC with
+// their PPDU type, so an HE TB PPDU (vs a normal contention UL frame) is
+// visible.
+//
+// The station side is a real kernel HE supplicant — the RTL8852BU under
+// rtw89_8852bu (the one HE-capable USB kernel driver on the bench). Orchestrated
+// by tests/ul_ofdma_e2e.sh.
+//
+// Build: g++ -std=c++20 -O2 -Isrc -Iexamples/common tests/ul_trigger_ap.cpp \
+//   examples/common/env_config.cpp build/libdevourer.a \
+//   $(pkg-config --cflags --libs libusb-1.0) -lpthread -o build/ul_trigger_ap
+// Run: sudo DEVOURER_VID=0x35bc DEVOURER_PID=0x0101 DEVOURER_CHANNEL=36 \
+//   DEVOURER_TX_WITH_RX=thread build/ul_trigger_ap [sec]
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+#include <unistd.h>
+#include <libusb.h>
+#include "RadiotapBuilder.h"
+#include "RxPacket.h"
+#include "SelectedChannel.h"
+#include "TriggerTwt.h"
+#include "TxMode.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "env_config.h"
+#include "logger.h"
+
+// Locally-administered unicast BSSID (a station cannot unicast-auth to a
+// multicast address — see ap_responder.cpp).
+static const uint8_t kBssid[6] = {0x02, 0x42, 0x75, 0x05, 0xd6, 0x00};
+static IRtlDevice* g_dev = nullptr;
+static std::vector<uint8_t> g_rt;
+static uint8_t g_chan = 36;
+static std::atomic<uint64_t> g_probe{0}, g_auth{0}, g_assoc{0}, g_sent{0}, g_data{0};
+static std::atomic<uint64_t> g_ul{0}, g_ul_tb{0}, g_trig{0}, g_snd{0};
+static std::atomic<bool> g_associated{false};
+// Sounding mode (DEVOURER_SND=1): drive the production NDPA/NDP/BFRP path
+// (StartSounding) instead of the F2P/UL_FIXINFO triggers, and advertise the AP
+// as an HE beamformer so the STA acts as a beamformee and answers the BFRP with
+// an HE TB PPDU report.
+static bool g_snd_mode = false;
+static uint8_t g_sta[6] = {0};
+static std::mutex g_q_mu;
+static std::vector<std::vector<uint8_t>> g_q;
+static const uint8_t kApIp[4] = {192, 168, 99, 1};
+static const uint8_t kLeaseIp[4] = {192, 168, 99, 2};
+// The single granted station: AID 1 / macid 1 / addr-cam index 1.
+static constexpr uint8_t kStaAid = 1, kStaMacid = 1, kStaCamIdx = 1;
+
+static uint16_t csum16(const uint8_t* d, int len) {
+  uint32_t s = 0; for (int i = 0; i + 1 < len; i += 2) s += (d[i] << 8) | d[i + 1];
+  if (len & 1) s += d[len - 1] << 8;
+  while (s >> 16) s = (s & 0xffff) + (s >> 16);
+  return ~s;
+}
+static std::vector<uint8_t> build_data(const uint8_t* sta, uint16_t eth,
+                                       const uint8_t* pl, int pllen) {
+  std::vector<uint8_t> m = {0x08, 0x02, 0x00, 0x00,
+      sta[0],sta[1],sta[2],sta[3],sta[4],sta[5],
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5], 0x00,0x00,
+      0xaa,0xaa,0x03,0x00,0x00,0x00, (uint8_t)(eth >> 8), (uint8_t)(eth & 0xff)};
+  m.insert(m.end(), pl, pl + pllen);
+  return m;
+}
+static std::vector<uint8_t> build_dhcp_reply(const uint8_t* sta, const uint8_t* xid,
+                                             uint8_t msgtype) {
+  std::vector<uint8_t> bootp(240, 0);
+  bootp[0] = 2; bootp[1] = 1; bootp[2] = 6;
+  std::memcpy(&bootp[4], xid, 4);
+  std::memcpy(&bootp[16], kLeaseIp, 4);
+  std::memcpy(&bootp[20], kApIp, 4);
+  std::memcpy(&bootp[28], sta, 6);
+  bootp[236] = 0x63; bootp[237] = 0x82; bootp[238] = 0x53; bootp[239] = 0x63;
+  std::vector<uint8_t> opt = {53,1,msgtype, 54,4,kApIp[0],kApIp[1],kApIp[2],kApIp[3],
+      51,4,0,0,0x0e,0x10, 1,4,255,255,255,0, 3,4,kApIp[0],kApIp[1],kApIp[2],kApIp[3],
+      255};
+  bootp.insert(bootp.end(), opt.begin(), opt.end());
+  int ul = 8 + (int)bootp.size();
+  std::vector<uint8_t> pl(20 + ul, 0);
+  pl[0] = 0x45; int tot = 20 + ul; pl[2] = tot >> 8; pl[3] = tot & 0xff;
+  pl[8] = 64; pl[9] = 17; std::memcpy(&pl[12], kApIp, 4);
+  pl[16]=pl[17]=pl[18]=pl[19]=0xff;
+  uint16_t ic = csum16(pl.data(), 20); pl[10] = ic >> 8; pl[11] = ic & 0xff;
+  pl[20] = 0; pl[21] = 67; pl[22] = 0; pl[23] = 68;
+  pl[24] = ul >> 8; pl[25] = ul & 0xff;
+  std::memcpy(&pl[28], bootp.data(), bootp.size());
+  return build_data(sta, 0x0800, pl.data(), (int)pl.size());
+}
+
+// ---- 802.11ax HE information elements for a 5 GHz 20 MHz HE AP ----
+// Minimal-but-valid HT/VHT/HE Capabilities + Operation so an HE station
+// negotiates HE. 1SS. Lengths are the element bodies (the 0xff extension
+// elements count the extension-ID byte in their length). Tweak here if a
+// station's supplicant rejects the association (iterate against dmesg / iw).
+static void append_he_ies(std::vector<uint8_t>& m) {
+  // HT Capabilities (tag 45, len 26): SMPS disabled, 20 MHz, MCS0-7 (1SS).
+  m.insert(m.end(), {0x2d, 0x1a,
+      0x0c, 0x00,                                     // HT cap info (SMPS disabled)
+      0x03,                                           // A-MPDU params
+      0xff, 0,0,0,0,0,0,0,0,0, 0,0, 0,0,0,0,          // supported MCS set (1SS)
+      0x00, 0x00,                                     // HT extended cap
+      0x00, 0x00, 0x00, 0x00,                         // TX beamforming
+      0x00});                                         // ASEL
+  // HT Operation (tag 61, len 22): primary channel, 20 MHz, basic MCS0-7.
+  m.insert(m.end(), {0x3d, 0x16,
+      g_chan, 0x00, 0x00, 0x00, 0x00, 0x00,           // primary + op info
+      0xff, 0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0});         // basic MCS set
+  // VHT Capabilities (tag 191, len 12): 1SS MCS0-9.
+  m.insert(m.end(), {0xbf, 0x0c,
+      0x00, 0x00, 0x00, 0x00,                         // VHT cap info
+      0xfe, 0xff, 0x00, 0x00, 0xfe, 0xff, 0x00, 0x00}); // RX/TX MCS maps (1SS)
+  // VHT Operation (tag 192, len 5): 20/40 MHz, basic MCS0-7 (1SS).
+  m.insert(m.end(), {0xc0, 0x05, 0x00, 0x00, 0x00, 0xfc, 0xff});
+  // HE Capabilities (ext tag 255 / ext 35, len 22): MAC(6)+PHY(11)+MCS/NSS(4).
+  // In sounding mode advertise the AP as an SU+MU beamformer with 1 sounding
+  // dimension (HE PHY caps: SU Beamformer B31=byte3 bit7, SU Beamformee B32 +
+  // MU Beamformer B33 = byte4 bits 0/1, Number Of Sounding Dimensions<=80
+  // B40-42 = byte5 bits 0-2) so the STA responds to our BFRP with a TB report.
+  const uint8_t phy3 = g_snd_mode ? 0x80 : 0x00;
+  const uint8_t phy4 = g_snd_mode ? 0x03 : 0x00;
+  const uint8_t phy5 = g_snd_mode ? 0x01 : 0x00;
+  m.insert(m.end(), {0xff, 0x16, 0x23,
+      0x00,0x00,0x00,0x00,0x00,0x00,                  // HE MAC cap
+      0x02,0x00,0x00,phy3,phy4,phy5,0x00,0x00,0x00,0x00,0x00, // HE PHY cap
+      0xfe,0xff, 0xfe,0xff});                          // HE-MCS/NSS <=80MHz (1SS 0-9)
+  // HE Operation (ext tag 255 / ext 36, len 7): params(3)+color(1)+basic MCS(2).
+  m.insert(m.end(), {0xff, 0x07, 0x24,
+      0x00, 0x00, 0x00,                               // HE op params
+      0x01,                                           // BSS color 1
+      0xfc, 0xff});                                   // basic HE-MCS (1SS 0-7)
+}
+
+// Supported Rates IE, band-correct: CCK+OFDM on 2.4 GHz, OFDM-only on 5 GHz.
+// CCK basic rates (1/2/5.5/11) do not exist on 5 GHz — advertising them makes a
+// 5 GHz station skip the BSS with "rate sets do not match" (no association).
+static void append_rates(std::vector<uint8_t>& m) {
+  if (g_chan <= 14)  // 2.4 GHz: 1*,2*,5.5*,11*,18,24,36,54
+    m.insert(m.end(), {0x01, 0x08, 0x82, 0x84, 0x8b, 0x96, 0x24, 0x30, 0x48, 0x6c});
+  else               // 5 GHz: 6*,9,12*,18,24*,36,48,54 (basic = high bit set)
+    m.insert(m.end(), {0x01, 0x08, 0x8c, 0x12, 0x98, 0x24, 0xb0, 0x48, 0x60, 0x6c});
+}
+
+// [SSID +] rates + DS + HE IE tail for probe/assoc responses.
+static void append_ies(std::vector<uint8_t>& m, bool with_ssid) {
+  if (with_ssid) { const char* s = "devourerAP";
+    m.insert(m.end(), {0x00, 0x0a}); m.insert(m.end(), s, s + 10); }
+  append_rates(m);
+  m.insert(m.end(), {0x03, 0x01, g_chan});
+  append_he_ies(m);
+}
+static void enqueue(std::vector<uint8_t> mpdu) {
+  std::vector<uint8_t> f; f.reserve(g_rt.size() + mpdu.size());
+  f.insert(f.end(), g_rt.begin(), g_rt.end());
+  f.insert(f.end(), mpdu.begin(), mpdu.end());
+  std::lock_guard<std::mutex> lk(g_q_mu);
+  if (g_q.size() < 128) g_q.push_back(std::move(f));
+}
+static std::vector<uint8_t> mgmt_hdr(uint8_t subtype_fc, const uint8_t* sta) {
+  return {subtype_fc, 0x00, 0x00, 0x00,
+          sta[0],sta[1],sta[2],sta[3],sta[4],sta[5],
+          kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],
+          kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5], 0x00, 0x00};
+}
+
+static void on_rx(const Packet& p) {
+  if (p.Data.size() < 24 || p.RxAtrib.crc_err) return;
+  const uint8_t fc0 = p.Data[0], fc1 = p.Data[1];
+  const uint8_t* a1 = p.Data.data() + 4;
+  const uint8_t* sta = p.Data.data() + 10;
+  bool to_us = std::memcmp(a1, kBssid, 6) == 0;
+  bool bcast = (a1[0] & 0x01) != 0;
+  bool retry = (fc1 & 0x08) != 0;
+
+  if (fc0 == 0x40) {                                 // probe-request
+    if (!bcast && !to_us) return;
+    g_probe.fetch_add(1);
+    auto m = mgmt_hdr(0x50, sta);
+    m.insert(m.end(), {0,0,0,0,0,0,0,0, 0x64,0x00, 0x01,0x00});
+    append_ies(m, true);
+    enqueue(std::move(m));
+  } else if (fc0 == 0xb0 && to_us) {                 // authentication
+    g_auth.fetch_add(1);
+    fprintf(stderr, "  AUTH from %02x:%02x:%02x:%02x:%02x:%02x retry=%d\n",
+            sta[0],sta[1],sta[2],sta[3],sta[4],sta[5], retry);
+    auto m = mgmt_hdr(0xb0, sta);
+    m.insert(m.end(), {0x00,0x00, 0x02,0x00, 0x00,0x00});
+    enqueue(std::move(m));
+  } else if ((fc0 == 0x00 || fc0 == 0x20) && to_us) {  // (re)assoc request
+    g_assoc.fetch_add(1);
+    fprintf(stderr, "  ASSOC from %02x:%02x:%02x:%02x:%02x:%02x retry=%d\n",
+            sta[0],sta[1],sta[2],sta[3],sta[4],sta[5], retry);
+    auto m = mgmt_hdr(0x10, sta);
+    // AID field: aid in bits 0-13, bits 14-15 set (802.11 convention) — LE, so
+    // low byte = aid[7:0], high byte = 0xc0 | aid[13:8]. Encoding it the other
+    // way round gives the STA a WRONG AID (e.g. 0xC1=193 instead of 1), so a
+    // BFRP addressed to kStaAid is ignored — no TB report.
+    m.insert(m.end(), {0x01,0x00, 0x00,0x00,
+                       (uint8_t)(kStaAid & 0xff),
+                       (uint8_t)(0xc0 | ((kStaAid >> 8) & 0x3f))});  // cap, status, AID
+    append_ies(m, false);
+    enqueue(std::move(m));
+    // Latch the station MAC + associated flag ONLY here (RX thread). The peer
+    // registration + all UL-OFDMA H2Cs are issued from the main thread — every
+    // H2C funnels through KestrelFw's non-thread-safe scratch/seq state, so
+    // firing them from the RX callback while the main thread also issues H2Cs
+    // corrupts the H2C queue (peer_reg silently failed that way).
+    if (!g_associated.exchange(true))
+      std::memcpy(g_sta, sta, 6);
+  } else if ((fc0 == 0x08 || fc0 == 0x88 || fc0 == 0xe8) && (fc1 & 0x01) && to_us) {
+    // Uplink data from the associated station. Count it + log its PPDU type:
+    // an HE TB PPDU (trigger-based) is the scheduled-UL response we're after.
+    if (g_associated && std::memcmp(sta, g_sta, 6) == 0) {
+      g_ul.fetch_add(1);
+      const uint8_t ppt = p.RxAtrib.ppdu_type;
+      // RxPacket.h ppdu_type: 2=OFDM 3=HT 5/6=VHT 7=HE_SU 8=HE_ERSU 9=HE_MU
+      // 10=HE_TB. HE_TB is the trigger-based UL response we're after.
+      bool tb = (ppt == 10);
+      if (tb) g_ul_tb.fetch_add(1);
+      static uint64_t logged = 0;
+      if (logged++ < 40 || tb)
+        fprintf(stderr, "{\"ev\":\"ul.rx\",\"ppdu_type\":%d,\"rate\":\"0x%x\","
+                        "\"len\":%zu,\"tb\":%s,\"tsfl\":%u}\n",
+                ppt, p.RxAtrib.data_rate, p.Data.size(), tb ? "true" : "false",
+                p.RxAtrib.tsfl);
+    }
+    // Keep the data plane alive (ARP/ICMP/DHCP) so the station stays associated
+    // and keeps generating UL traffic — the BSR the fw needs to grant a trigger.
+    int hlen = 24 + ((fc0 == 0x88 || fc0 == 0xe8) ? 2 : 0);
+    if ((int)p.Data.size() < hlen + 8) return;
+    const uint8_t* llc = p.Data.data() + hlen;
+    if (!(llc[0] == 0xaa && llc[1] == 0xaa && llc[2] == 0x03)) return;
+    uint16_t eth = (llc[6] << 8) | llc[7];
+    const uint8_t* pl = llc + 8;
+    int pllen = (int)p.Data.size() - (hlen + 8);
+    if (eth == 0x0806 && pllen >= 28) {
+      uint16_t oper = (pl[6] << 8) | pl[7];
+      const uint8_t* sha = pl + 8; const uint8_t* spa = pl + 14; const uint8_t* tpa = pl + 24;
+      if (oper == 1 && std::memcmp(tpa, kApIp, 4) == 0) {
+        uint8_t a[28] = {0,1, 8,0, 6,4, 0,2,
+            kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],
+            kApIp[0],kApIp[1],kApIp[2],kApIp[3],
+            sha[0],sha[1],sha[2],sha[3],sha[4],sha[5], spa[0],spa[1],spa[2],spa[3]};
+        enqueue(build_data(sta, 0x0806, a, 28)); g_data.fetch_add(1);
+      }
+    } else if (eth == 0x0800 && pllen >= 28) {
+      const uint8_t* ip = pl; int ihl = (ip[0] & 0x0f) * 4;
+      if (ip[9] == 1 && (int)pllen >= ihl + 8 && std::memcmp(ip + 16, kApIp, 4) == 0) {
+        const uint8_t* icmp = ip + ihl;
+        if (icmp[0] == 8) {
+          std::vector<uint8_t> r(pl, pl + pllen);
+          std::memcpy(r.data() + 12, kApIp, 4);
+          std::memcpy(r.data() + 16, ip + 12, 4);
+          r[10] = r[11] = 0;
+          uint16_t ic = csum16(r.data(), ihl); r[10] = ic >> 8; r[11] = ic & 0xff;
+          r[ihl] = 0; r[ihl + 2] = r[ihl + 3] = 0;
+          uint16_t cc = csum16(r.data() + ihl, pllen - ihl);
+          r[ihl + 2] = cc >> 8; r[ihl + 3] = cc & 0xff;
+          enqueue(build_data(sta, 0x0800, r.data(), pllen)); g_data.fetch_add(1);
+        }
+      } else if (ip[9] == 17 && (int)pllen >= ihl + 8 + 240) {
+        const uint8_t* udp = ip + ihl;
+        if (((udp[2] << 8) | udp[3]) == 67) {
+          const uint8_t* dh = udp + 8; const uint8_t* end = pl + pllen;
+          uint8_t mt = 0;
+          for (const uint8_t* o = dh + 240; o + 1 < end && *o != 0xff; ) {
+            if (*o == 0) { o++; continue; }
+            if (*o == 53 && o + 2 < end) mt = o[2];
+            o += 2 + o[1];
+          }
+          uint8_t reply = (mt == 1) ? 2 : (mt == 3) ? 5 : 0;
+          if (reply) { enqueue(build_dhcp_reply(sta, dh + 4, reply)); g_data.fetch_add(1); }
+        }
+      }
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  int sec = argc > 1 ? atoi(argv[1]) : 60;
+  if (const char* c = std::getenv("DEVOURER_CHANNEL")) g_chan = (uint8_t)atoi(c);
+  auto logger = std::make_shared<Logger>();
+  apply_logging_env(*logger);
+  libusb_context* ctx = nullptr; libusb_init(&ctx);
+  libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
+  uint16_t vid = 0x35bc, pid = 0x0101;   // default AP = RTL8832CU (8852C)
+  if (const char* v = std::getenv("DEVOURER_VID")) vid = (uint16_t)strtoul(v, 0, 0);
+  if (const char* p = std::getenv("DEVOURER_PID")) pid = (uint16_t)strtoul(p, 0, 0);
+  auto* h = libusb_open_device_with_vid_pid(ctx, vid, pid);
+  if (!h) { fprintf(stderr, "open %04x:%04x fail\n", vid, pid); return 1; }
+  std::shared_ptr<devourer::UsbDeviceLock> lk;
+  if (devourer::claim_interface_then_reset(h, devourer::find_wifi_interface(h), logger, true, lk) != 0) return 1;
+  WiFiDriver wifi(logger);
+  auto dev = wifi.CreateRtlDevice(h, ctx, lk, devourer_config_from_env());
+  g_dev = dev.get();
+  if (!g_dev) return 1;
+  if (!g_dev->GetAdapterCaps().trigger_ul_ok) {
+    fprintf(stderr, "AP adapter has no trigger-UL support (Kestrel-only)\n");
+    return 1;
+  }
+  // Sounding mode: the production NDPA/NDP/BFRP trigger path (advertises the AP
+  // as an HE beamformer + drives StartSounding). Must be set before the beacon
+  // IEs are built. Requires the sounding cap.
+  g_snd_mode = std::getenv("DEVOURER_SND") && atoi(std::getenv("DEVOURER_SND"));
+  if (g_snd_mode && !g_dev->GetAdapterCaps().sounding_ok) {
+    fprintf(stderr, "AP adapter has no HE sounding support\n");
+    return 1;
+  }
+  g_rt = devourer::build_stream_radiotap(devourer::parse_tx_mode_str("6M"));
+  g_dev->InitWrite(SelectedChannel{g_chan, 0, CHANNEL_WIDTH_20});
+
+  std::vector<uint8_t> bcn = {
+      0x00,0x00,0x0a,0x00,0x00,0x80,0x00,0x00,0x08,0x00,
+      0x80,0x00,0x00,0x00, 0xff,0xff,0xff,0xff,0xff,0xff,
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],
+      kBssid[0],kBssid[1],kBssid[2],kBssid[3],kBssid[4],kBssid[5],
+      0x00,0x00, 0,0,0,0,0,0,0,0, 0x64,0x00, 0x01,0x00};
+  { const char* s = "devourerAP"; bcn.insert(bcn.end(), {0x00,0x0a});
+    bcn.insert(bcn.end(), s, s + 10);
+    append_rates(bcn);
+    bcn.insert(bcn.end(), {0x03,0x01,g_chan});
+    append_he_ies(bcn); }
+  int bcn_tu = 100;
+  if (const char* iv = std::getenv("DEVOURER_BCN_TU")) bcn_tu = atoi(iv);
+  bool bok = g_dev->StartBeacon(bcn.data(), bcn.size(), bcn_tu);
+  std::thread rx([&]{ g_dev->StartRxLoop(on_rx); });
+  fprintf(stderr, "ul_trigger_ap: HE AP up on ch%d SSID devourerAP (beacon %s). "
+                  "%ds. Connect an HE station.\n", g_chan, bok ? "OK" : "FAIL", sec);
+
+  // Trigger cadence: DEVOURER_TRIG_GAP_MS between SendTrigger calls once a
+  // station is associated (0 = rely only on the UL_FIXINFO tf_periodic engine).
+  long trig_gap_ms = 50;
+  if (const char* e = std::getenv("DEVOURER_TRIG_GAP_MS")) trig_gap_ms = atol(e);
+  // Sounding cadence: DEVOURER_SND_PERIOD>0 (default 50) arms fw-autonomous
+  // PERIODIC sounding from a single H2C (SNDF2P_ADD) — the robust path, since a
+  // fast per-sounding H2C loop floods and wedges the CH12 H2C queue (rc=-7).
+  // SND_PERIOD=0 falls back to a slow one-shot re-issue at SND_GAP_MS.
+  long snd_period = 50;
+  if (const char* e = std::getenv("DEVOURER_SND_PERIOD")) snd_period = atol(e);
+  long snd_gap_ms = 200;
+  if (const char* e = std::getenv("DEVOURER_SND_GAP_MS")) snd_gap_ms = atol(e);
+  bool peer_registered = false, ul_fixinfo_done = false, bfee_registered = false;
+  bool snd_started = false;
+  auto next_trig = std::chrono::steady_clock::now();
+  auto next_snd = std::chrono::steady_clock::now();
+  uint8_t snd_dialog = 0;
+
+  auto end = std::chrono::steady_clock::now() + std::chrono::seconds(sec);
+  while (std::chrono::steady_clock::now() < end) {
+    { std::vector<std::vector<uint8_t>> batch;
+      { std::lock_guard<std::mutex> lk2(g_q_mu); batch.swap(g_q); }
+      for (auto& f : batch) if (g_dev->send_packet(f.data(), f.size())) g_sent.fetch_add(1); }
+
+    if (g_associated && g_snd_mode) {
+      // Sounding path: register the STA as a beamformee, then air the NDPA/NDP/
+      // BFRP sequence (StartSounding). The fw builds+airs the trigger and arms
+      // RX for the report HE TB PPDU (ppdu_type==10, counted as g_ul_tb below).
+      if (!bfee_registered) {
+        devourer::StaBfCaps bf;      // Nc-1=0 (1 col), Nr-1=1 (AP 2rx), Ng4, cb.
+        bf.nc = 0; bf.nr = 1; bf.ng = 0; bf.cb = 1; bf.csi_bw = 0;
+        bool ok = g_dev->RegisterBeamformee(g_sta, kStaMacid, kStaCamIdx, bf);
+        fprintf(stderr, "{\"ev\":\"ap.bfee\",\"macid\":%d,\"aid\":%d,"
+                        "\"reg\":%s}\n", kStaMacid, kStaAid, ok ? "true":"false");
+        bfee_registered = true;
+      }
+      if (snd_period > 0) {
+        // Periodic: one H2C arms fw-autonomous repeated sounding.
+        if (!snd_started) {
+          devourer::SoundingConfig sc = devourer::make_he_bfrp_sounding(
+              kBssid, kBssid, g_sta, kStaAid, kStaMacid, snd_dialog++,
+              (uint16_t)snd_period);
+          bool ok = g_dev->StartSounding(sc);
+          if (ok) g_snd.fetch_add(1);
+          fprintf(stderr, "{\"ev\":\"ap.sounding\",\"periodic\":true,\"period\":%ld,"
+                          "\"ok\":%s}\n", snd_period, ok ? "true" : "false");
+          snd_started = true;
+        }
+      } else if (snd_gap_ms > 0 && std::chrono::steady_clock::now() >= next_snd) {
+        // One-shot fallback at a deliberately slow cadence (>=100 ms) so the
+        // CH12 H2C queue drains between soundings.
+        devourer::SoundingConfig sc = devourer::make_he_bfrp_sounding(
+            kBssid, kBssid, g_sta, kStaAid, kStaMacid, snd_dialog++, 0);
+        if (g_dev->StartSounding(sc)) g_snd.fetch_add(1);
+        next_snd = std::chrono::steady_clock::now() +
+                   std::chrono::milliseconds(snd_gap_ms < 100 ? 100 : snd_gap_ms);
+      }
+    } else if (g_associated) {
+      // Register the associated station as a peer (main thread — serialized H2C).
+      if (!peer_registered) {
+        bool ok = g_dev->RegisterPeerSta(g_sta, kStaMacid, kStaCamIdx);
+        fprintf(stderr, "{\"ev\":\"ap.assoc\",\"sta\":\"%02x:%02x:%02x:%02x:%02x:%02x\","
+                        "\"macid\":%d,\"aid\":%d,\"peer_reg\":%s}\n",
+                g_sta[0],g_sta[1],g_sta[2],g_sta[3],g_sta[4],g_sta[5],
+                kStaMacid, kStaAid, ok ? "true" : "false");
+        peer_registered = true;
+      }
+      // Program the fw UL-OFDMA scheduler once (tf_periodic grants the STA).
+      if (!ul_fixinfo_done) {
+        devourer::UlOfdmaConfig ul;
+        ul.mode = 3; ul.interval_s = 1; ul.tf_type = 0; ul.ppdu_bw = 0;
+        ul.n_stas = 1; ul.stas[0].macid = kStaMacid; ul.stas[0].ru_pos = 61;
+        ul.stas[0].mcs = 0; ul.stas[0].ss = 1; ul.stas[0].tgt_rssi_dbm = -50;
+        bool uok = g_dev->ConfigureUlOfdma(ul);
+        fprintf(stderr, "{\"ev\":\"ap.ul_ofdma\",\"ok\":%s}\n", uok ? "true" : "false");
+        ul_fixinfo_done = true;
+      }
+      // Also fire explicit Basic Triggers granting the STA (belt + suspenders).
+      if (trig_gap_ms > 0 && std::chrono::steady_clock::now() >= next_trig) {
+        devourer::TriggerConfig cfg;
+        cfg.ul_bw = 0; cfg.n_users = 1;
+        cfg.users[0].aid12 = kStaAid; cfg.users[0].macid = kStaMacid;
+        cfg.users[0].ru_alloc = devourer::he_ru_alloc(242, 0);
+        cfg.users[0].ul_mcs = 0; cfg.users[0].ss = 1; cfg.users[0].tgt_rssi_dbm = -50;
+        if (g_dev->SendTrigger(cfg)) g_trig.fetch_add(1);
+        next_trig = std::chrono::steady_clock::now() +
+                    std::chrono::milliseconds(trig_gap_ms);
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  fprintf(stderr, "{\"ev\":\"ap.summary\",\"probe\":%llu,\"auth\":%llu,\"assoc\":%llu,"
+                  "\"associated\":%s,\"mode\":\"%s\",\"triggers\":%llu,\"soundings\":%llu,"
+                  "\"ul_rx\":%llu,\"ul_tb\":%llu,\"data\":%llu,\"sent\":%llu}\n",
+          (unsigned long long)g_probe.load(), (unsigned long long)g_auth.load(),
+          (unsigned long long)g_assoc.load(), g_associated ? "true" : "false",
+          g_snd_mode ? "sounding" : "trigger",
+          (unsigned long long)g_trig.load(), (unsigned long long)g_snd.load(),
+          (unsigned long long)g_ul.load(),
+          (unsigned long long)g_ul_tb.load(), (unsigned long long)g_data.load(),
+          (unsigned long long)g_sent.load());
+  _exit(0);
+}


### PR DESCRIPTION
Adds the 802.11ax uplink-scheduling surface to the Kestrel HAL (RTL8852BU/8832BU, RTL8852CU/8832CU): the firmware command encoders, sounding hardware init and per-STA beamformee registration, and a host-injected Basic Trigger path that puts a real HE Trigger on the air.

## Two transmit paths

**Firmware-scheduled** — F2P trigger, UL_FIXINFO, and the CL_SOUND sounding sequence (NDPA → NDP → BFRP), byte-exact against the vendor `mac_ax` encoders (v0 8852B / v1 8852C) and firmware-accepted (no SER). The shipped **client** firmware does not run the trigger-transmit scheduler: F2P is silently dropped, and the sounding command is accepted and *engaged* but not transmitted. Confirmed on-air — an independent monitor decoding 139k frames from the AP and station saw zero Trigger frames while the sounding command fired.

**Host-injected** (`SendTrigger`, default) — `build_basic_trigger()` assembles the raw HE Trigger bytes on the host and transmits them through the normal management path, bypassing the firmware scheduler. This airs a real, correctly-decodable HE Trigger: a monitor decoded the injected triggers with the exact commanded parameters (AP power, AID, RU, MCS, NSS). Group-addressed triggers are marked BMC in the TX descriptor so the firmware transmits them once instead of retrying an unacknowledged broadcast.

The host-injected trigger does not by itself elicit a hardware SIFS-timed TB PPDU response — a host-built frame does not arm the MAC receive window, and that half needs a firmware-scheduled trigger the client firmware does not air. The trigger-on-air path is the basis for an adaptive uplink (the per-user RU/MCS/target-RSSI grant is a closed-loop control channel); see `docs/he-trigger-ul.md`.

## API

`IRtlDevice` (default-false on pre-AX generations): `SendTrigger`, `ConfigureUlOfdma`, `ConfigureTwt`/`TwtBindSta`/`ConfigureTwtOfdma`, `StartSounding`/`RegisterBeamformee`, `RegisterPeerSta`; `AdapterCaps.{trigger_ul_ok, twt_ok, sounding_ok}`.

## Testing

Headless golden-byte encoder checks under `ctest` (`kestrel_sched`; 26/26 green). On-air: `tests/ul_sounding_e2e.sh` brings up a devourer HE software-AP on a Kestrel adapter, associates a real `rtw89` station, and drives the sounding command (default) or host-injection (`INJECT=1`), with a separate-bus monitor and a USRP B210 as witnesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)