### PR TITLE
kestrel: override GetTxStats so tx.stats reflects real submissions

### DIFF
--- a/src/kestrel/RtlKestrelDevice.h
+++ b/src/kestrel/RtlKestrelDevice.h
@@ -68,6 +68,7 @@ public:
   }
   void SetMonitorChannel(SelectedChannel channel) override;
   bool send_packet(const uint8_t *packet, size_t length) override;
+  devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
   SelectedChannel GetSelectedChannel() override { return _channel; }
 
   /* Static capability aggregate (resolved from chip identity; thread-safe,


### PR DESCRIPTION
## Problem

On Kestrel (RTL8852BU/8832CU), `txdemo` reports `tx.stats ... "submitted":0`
even when frames are actually being transmitted — the log stream shows
thousands of `bulk_send EP 5 OK 148 bytes` at the same time.

`RtlKestrelDevice` is the only `IRtlDevice` implementation that does **not**
override `GetTxStats()`, so it falls through to the default in `IRtlDevice.h`:

```cpp
virtual devourer::TxStats GetTxStats() { return {}; }   // -> submitted = 0
```

Meanwhile the real TX path increments the counters on the transport behind
`_device`:

```
RtlKestrelDevice::send_packet
  -> _device.bulk_send_sync_ep(ep, ...)
    -> UsbTransport::tx_sync   // _tx_submitted.fetch_add(1), logs "bulk_send EP.. OK"
```

So the counters are live on `_device`'s transport, but `GetTxStats()` reads
the empty default — the two are simply disconnected for Kestrel. Purely a
reporting bug: transmission itself is unaffected.

## Fix

Add the same one-line override that `RtlJaguar1/2/3Device` already carry:

```cpp
devourer::TxStats GetTxStats() override { return _device.GetTxStats(); }
```

## Verification

- Builds clean (`cmake --build build --target txdemo`).
- Over-air confirmation that the frames were always airing (independent of this
  cosmetic counter): a USRP B210 at 5180 MHz saw a 5.1x mean-power increase and
  ~3000 extra frames while `txdemo` ran `DEVOURER_TX_RATE=HE1SS_MCS0/20` on ch36,
  including HE MCS0 / L-SIG-LENGTH=94 / HE-SIG-A-CRC-4-OK PPDUs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)