### PR TITLE
Per-packet TX power on Jaguar3 + 8814A; Jaguar1 fast BB-swing lever

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,13 +385,27 @@ write-only, so their `GetTxPowerState` reports the software shadow
 (`hw_readback=false`). `txpower` (examples/txpower/) is the reference
 consumer; register-level validation: `tests/txpwr_offset_regcheck.sh`.
 
-**Per-packet TX power is Jaguar2-only**: the 8822B/8821C TX descriptor's
-`TXPWR_OFSET` field is a hardware LUT (0/-3/-7/-11/+3/+6 dB) applied per-frame
-at zero USB cost — `send_packet` quantizes a radiotap `DBM_TX_POWER` delta to
-it (`jaguar2::txpkt_pwr_step_for_db`), and
-`RtlJaguar2Device::SetTxPacketPowerStep` sets a session default. The 8812AU
-has no such field (its per-packet power *is* per-rate selection via radiotap);
-Jaguar3's `TXPWR_OFSET_TYPE` is measured inert.
+**Per-packet TX power** (a radiotap `DBM_TX_POWER` dB-delta per frame, zero
+USB cost once armed; see the `per_pkt_txpwr_*` caps): **Jaguar2** — the
+8822B/8821C descriptor `TXPWR_OFSET` hardware LUT (0/-3/-7/-11/+3/+6 dB),
+session default `SetTxPacketPowerStep`. **Jaguar3** — the descriptor
+`TXPWR_OFSET_TYPE` is a bank *selector*: types 2/3 pick two programmable
+7-bit-signed power-index offsets in BB `0x1e70[31:16]` (~1 dB/step,
+`DEVOURER_TXPKT_STEP_QDB` recalibrates), LRU-managed by
+`SetTxPacketPowerOffsetQdb` (`src/jaguar3/TxPktPwrBanks.h`) — the banks
+reset *disabled* at BB-table load, so the descriptor field alone is inert
+until programmed (types 0/1 = per-STA BB-RAM by descriptor MACID, left as
+the 0 dB baseline). On-air-validated on 8822CU + 8822EU, sticky across
+`SetMonitorChannel`/`FastRetune`; the E compresses deep cuts (≈−6 dB floor,
+same TSSI reshape as its offset slope). **8814A** — the same 3-bit LUT field
+at the 8822B position (dword5 [30:28]), `SetTxPacketPowerStep` on
+`RtlJaguarDevice`. **8812AU/8821AU** — no descriptor field exists (per-rate
+selection via radiotap is their only per-packet lever); the compensating
+fast lever is `FastSetTxPowerOffsetQdb` (BB-swing TxScale `0xc1c/0xe1c`:
+global per-burst, 1–4 writes, 0.5 dB steps, −12..+2 dB, folded through the
+8812A thermal tracker; on-air-validated on the 8812AU). Sweep harnesses:
+`tests/txpkt_pwr_ofset_onair.sh` (TX_PID/TX_VID select the DUT),
+`tests/txpkt_fastswing_onair.sh`, `tests/txpkt_hop_persist.sh`.
 
 Per-packet unequal error protection: `svctx` classifies stdin HEVC NALs by
 temporal layer and injects each at its ladder's rate

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -811,6 +811,18 @@ if(DEVOURER_JAGUAR2_8822B OR DEVOURER_JAGUAR2_8821C)
     add_test(NAME txpkt_pwr_quant COMMAND TxPktPwrSelftest)
 endif()
 
+# Headless guard for the Jaguar3 per-packet power-bank planner (the
+# TxPktPwrBanks.h LRU/encode policy) + the descriptor bit positions of
+# TXPWR_OFSET_TYPE (8822C, incl. the bit30 ANTSEL_EN_V1 hazard) and the 8814A
+# TX_POWER_OFFSET. The planner header is HAL-agnostic; the descriptor parts
+# self-gate on the DEVOURER_HAVE_JAGUAR1/3 defines the library exports.
+add_executable(TxPktBankSelftest
+    tests/txpkt_bank_selftest.cpp
+)
+target_link_libraries(TxPktBankSelftest PRIVATE devourer)
+target_include_directories(TxPktBankSelftest PRIVATE src)
+add_test(NAME txpkt_bank_policy COMMAND TxPktBankSelftest)
+
 # Headless guard for the USB TX-aggregation URB packing (src/TxAggPlan.h) —
 # block alignment, the never-a-bulk-multiple boundary shim, the OQT
 # descs-per-bulk guard, the frame/byte caps — plus the HalMAC descriptor agg

--- a/examples/common/caps_event.h
+++ b/examples/common/caps_event.h
@@ -70,6 +70,11 @@ inline void emit_adapter_caps(EventSink &sink, IRtlDevice *dev) {
       .f("ldpc_rx_flag", c.ldpc_rx_flag ? 1 : 0);
 
   ev.f("per_pkt_txpwr", c.per_packet_txpower ? 1 : 0)
+      .f("per_pkt_txpwr_steps", c.per_pkt_txpwr_steps)
+      .f("per_pkt_txpwr_step_qdb", c.per_pkt_txpwr_step_qdb)
+      .f("per_pkt_txpwr_min_qdb", c.per_pkt_txpwr_min_qdb)
+      .f("per_pkt_txpwr_max_qdb", c.per_pkt_txpwr_max_qdb)
+      .f("per_pkt_txpwr_measured", c.per_pkt_txpwr_measured ? 1 : 0)
       .f("narrowband", c.narrowband_ok ? 1 : 0)
       .f("fastretune", c.fastretune_ok ? 1 : 0)
       .f("he_er_su", c.he_er_su_ok ? 1 : 0)

--- a/examples/common/env_config.cpp
+++ b/examples/common/env_config.cpp
@@ -113,6 +113,10 @@ devourer::DeviceConfig devourer_config_from_env() {
   if (const char *e = env_str("DEVOURER_THERMAL_TRACK"))
     cfg.tuning.thermal_track = std::strcmp(e, "0") != 0;
   cfg.tuning.disable_cca = env_flag("DEVOURER_DIS_CCA");
+  /* Jaguar3 per-packet power-bank step size (qdB per 0x1e70 offset-index
+   * step; default 4 = 1 dB) — bench slope-calibration override. */
+  if (env_long("DEVOURER_TXPKT_STEP_QDB", &v) && v > 0)
+    cfg.tuning.txpkt_step_qdb = static_cast<int>(v);
   if (env_long("DEVOURER_RFE", &v))
     cfg.tuning.rfe_type = static_cast<uint8_t>(v);
   if (env_long("DEVOURER_NB_DAC", &v))

--- a/examples/tx/main.cpp
+++ b/examples/tx/main.cpp
@@ -36,6 +36,7 @@
 #include "HopSchedule.h"
 #include "RxPacket.h"
 #include "SweepSpec.h"
+#include "TxPower.h" /* txpkt_pwr_db_for_step — DEVOURER_TX_PKT_OFSET fan-out */
 #include "caps_event.h"
 #if defined(DEVOURER_HAVE_JAGUAR1)
 #include "jaguar1/RtlJaguarDevice.h"
@@ -560,14 +561,51 @@ int main(int argc, char **argv) {
     rtlDevice->SetTxPowerOffsetQdb(
         static_cast<int>(std::strtol(p, nullptr, 0)));
 
-  /* DEVOURER_TX_PKT_OFSET=N — (Jaguar2 8822B/8821C) default per-packet
-   * TXPWR_OFSET LUT step written into every TX descriptor: 0=none, 1=-3dB,
-   * 2=-7dB, 3=-11dB, 4=+3dB, 5=+6dB. The measurement driver for the descriptor
-   * per-packet power lever (tests/txpkt_pwr_ofset_onair.sh). */
-#if defined(DEVOURER_HAVE_JAGUAR2)
+  /* DEVOURER_TX_PKT_OFSET=N — default per-packet TX-power LUT step written
+   * into every TX descriptor: 0=none, 1=-3dB, 2=-7dB, 3=-11dB, 4=+3dB,
+   * 5=+6dB. One env var, three families: Jaguar2 8822B/8821C
+   * (descriptor TXPWR_OFSET, on-air-confirmed), Jaguar1 8814A (dword5
+   * [30:28], same LUT), and Jaguar3 8822C/8822E (the step's nominal dB is
+   * mapped onto a programmable 0x1e70 offset bank). The measurement driver
+   * for tests/txpkt_pwr_ofset_onair.sh. */
   if (const char *p = std::getenv("DEVOURER_TX_PKT_OFSET")) {
+    const uint8_t step = static_cast<uint8_t>(std::strtol(p, nullptr, 0));
+#if defined(DEVOURER_HAVE_JAGUAR2)
     if (jag2)
-      jag2->SetTxPacketPowerStep(static_cast<uint8_t>(std::strtol(p, nullptr, 0)));
+      jag2->SetTxPacketPowerStep(step);
+#endif
+#if defined(DEVOURER_HAVE_JAGUAR1)
+    if (jag)
+      jag->SetTxPacketPowerStep(step);
+#endif
+#if defined(DEVOURER_HAVE_JAGUAR3)
+    if (jag3)
+      jag3->SetTxPacketPowerOffsetQdb(4 *
+                                      devourer::txpkt_pwr_db_for_step(step));
+#endif
+    (void)step;
+  }
+
+  /* DEVOURER_TX_PKT_PWR_QDB=N — Jaguar3-only fine-grained per-packet power
+   * default in quarter-dB (the bank mechanism is continuous, unlike the LUT
+   * families). Overrides DEVOURER_TX_PKT_OFSET's mapped value when both are
+   * set. */
+#if defined(DEVOURER_HAVE_JAGUAR3)
+  if (const char *p = std::getenv("DEVOURER_TX_PKT_PWR_QDB")) {
+    if (jag3)
+      jag3->SetTxPacketPowerOffsetQdb(
+          static_cast<int>(std::strtol(p, nullptr, 0)));
+  }
+#endif
+
+  /* DEVOURER_TX_FAST_PWR_QDB=N — Jaguar1 fast global BB-swing power offset
+   * (FastSetTxPowerOffsetQdb): 0.5 dB steps, -12..+2 dB, 1-4 BB writes.
+   * Per-burst, NOT per-packet — the compensating lever for the 8812A/8821A,
+   * whose descriptors have no per-frame power field. */
+#if defined(DEVOURER_HAVE_JAGUAR1)
+  if (const char *p = std::getenv("DEVOURER_TX_FAST_PWR_QDB")) {
+    if (jag)
+      jag->FastSetTxPowerOffsetQdb(static_cast<int>(std::strtol(p, nullptr, 0)));
   }
 #endif
 

--- a/src/AdapterCaps.h
+++ b/src/AdapterCaps.h
@@ -139,7 +139,25 @@ struct AdapterCaps {
   bool ldpc_rx_flag = false;
 
   /* --- feature flags --- */
-  bool per_packet_txpower = false; /* Jaguar2 descriptor TXPWR_OFSET LUT only */
+  /* Per-packet TX power: the TX descriptor carries a per-frame
+   * power trim, driven by radiotap DBM_TX_POWER (dB delta vs the calibrated
+   * table) or a session default. Two hardware shapes:
+   *   - Jaguar2 (8822B/8821C) + 8814A: a fixed 6-rung LUT in the descriptor
+   *     ({0,-3,-7,-11,+3,+6} dB) — per_pkt_txpwr_steps = 6, step_qdb = 0.
+   *   - Jaguar3 (8822C/8822E): a 2-bit bank selector; the banks are
+   *     programmable 7-bit signed offsets (0x1e70) in per_pkt_txpwr_step_qdb
+   *     units (nominally 4 = 1 dB), 2 concurrent non-zero levels —
+   *     per_pkt_txpwr_steps = 0 (continuous), min/max give the travel.
+   * per_pkt_txpwr_measured stays false until the family's descriptor path
+   * has been proven to move on-air power (tests/txpkt_pwr_ofset_onair.sh) —
+   * the honest flag for the vendor-defined-but-unvalidated 8814A/Jaguar3
+   * fields. */
+  bool per_packet_txpower = false;
+  uint8_t per_pkt_txpwr_steps = 0;    /* 6 = LUT rungs; 0 = continuous qdb */
+  uint8_t per_pkt_txpwr_step_qdb = 0; /* Jaguar3 bank step (qdB); 0 for LUT */
+  int16_t per_pkt_txpwr_min_qdb = 0;  /* most negative per-packet trim */
+  int16_t per_pkt_txpwr_max_qdb = 0;  /* most positive per-packet trim */
+  bool per_pkt_txpwr_measured = false; /* on-air-confirmed (J2 today) */
   bool narrowband_ok = false;      /* 5/10 MHz re-clock (Jaguar2/Jaguar3) */
   uint8_t xtal_cap_max = 0;        /* crystal-cap trim range top (0 = no trim;
                                     * 0x3f on Jaguar1/2, 0x7f on Jaguar3) */

--- a/src/DeviceConfig.h
+++ b/src/DeviceConfig.h
@@ -202,6 +202,13 @@ struct DeviceConfig {
     /* env: DEVOURER_DIS_CCA — Jaguar3 EDCCA-disable at bring-up (before the
      * coex thread starts). Runtime equivalent: SetCcaMode. */
     bool disable_cca = false;
+    /* env: DEVOURER_TXPKT_STEP_QDB — Jaguar3 per-packet power-bank step size
+     * in quarter-dB: the dB weight of one 0x1e70 offset-index step
+     * (SetTxPacketPowerOffsetQdb / radiotap DBM_TX_POWER).
+     * Default 4 (= 1 dB), the vendor-stated step for the 22C class ("each
+     * tx_pwr_ofst step will be 1dB", phydm.h bb_ram block); override for
+     * bench slope calibration (tests/txpkt_pwr_ofset_onair.sh). */
+    int txpkt_step_qdb = 4;
     /* env: DEVOURER_RFE — Jaguar2 RFE type override (antenna/LNA switch
      * variant; unset = efuse, blank efuse falls back per vendor). */
     std::optional<uint8_t> rfe_type;

--- a/src/RadiotapPeek.h
+++ b/src/RadiotapPeek.h
@@ -7,6 +7,7 @@
  * flushes the pending URB) before handing the frame to the generation's
  * builder. Generation-neutral; the full parse stays in each HAL. */
 
+#include <climits> /* INT_MIN — "field absent" sentinel */
 #include <cstddef>
 #include <cstdint>
 
@@ -52,6 +53,27 @@ inline int radiotap_peek_channel(const uint8_t *packet, size_t length) {
     }
   }
   return 0;
+}
+
+/* Peek the radiotap DBM_TX_POWER field (signed per-packet power delta, dB).
+ * Returns INT_MIN when absent — the same "no per-packet power" sentinel the
+ * generations' send_packet parsers use. Lets a batch packer group frames by
+ * requested power, so a power-bank reprogram (Jaguar3) lands between URBs,
+ * never mid-URB. */
+inline int radiotap_peek_dbm_tx_power(const uint8_t *packet, size_t length) {
+  const uint16_t rlen = radiotap_hdr_len(packet, length);
+  if (rlen == 0)
+    return INT_MIN;
+  auto *hdr = reinterpret_cast<struct ieee80211_radiotap_header *>(
+      const_cast<uint8_t *>(packet));
+  struct ieee80211_radiotap_iterator it;
+  if (ieee80211_radiotap_iterator_init(&it, hdr, rlen, nullptr) != 0)
+    return INT_MIN;
+  while (ieee80211_radiotap_iterator_next(&it) == 0) {
+    if (it.this_arg_index == IEEE80211_RADIOTAP_DBM_TX_POWER)
+      return *reinterpret_cast<const int8_t *>(it.this_arg);
+  }
+  return INT_MIN;
 }
 
 } /* namespace devourer */

--- a/src/TxPower.h
+++ b/src/TxPower.h
@@ -70,6 +70,33 @@ struct TxPowerState {
  * lands in *steps_out when non-null. Returns 0 for unsupported caps. */
 int quantize_offset_qdb(int qdb, const TxPowerCaps &caps, int *steps_out);
 
+/* Per-packet TX-power LUT quantizer, shared by the families whose TX
+ * descriptor carries the 3-bit hardware TXPWR_OFSET LUT (Jaguar2 8822B/8821C
+ * at txdesc+0x14[30:28]; 8814A same position via its own descriptor macro).
+ * The field is discrete — {0, -3, -7, -11, +3, +6} dB — so an adaptive
+ * link's continuous request lands on the closest rung. Pure; unit-tested in
+ * tests/txpkt_pwr_selftest.cpp. */
+inline uint8_t txpkt_pwr_step_for_db(int db) {
+  static const struct { int db; uint8_t step; } lut[] = {
+      {0, 0}, {-3, 1}, {-7, 2}, {-11, 3}, {3, 4}, {6, 5}};
+  uint8_t best = 0;
+  int best_err = 1 << 30;
+  for (const auto &e : lut) {
+    int err = db > e.db ? db - e.db : e.db - db;
+    if (err < best_err) {
+      best_err = err;
+      best = e.step;
+    }
+  }
+  return best;
+}
+
+/* Inverse: the nominal dB of a LUT step (for readback / logging). */
+inline int txpkt_pwr_db_for_step(uint8_t step) {
+  static const int db[] = {0, -3, -7, -11, 3, 6};
+  return step < 6 ? db[step] : 0;
+}
+
 } // namespace devourer
 
 #endif /* DEVOURER_TX_POWER_H */

--- a/src/jaguar1/FrameParser.h
+++ b/src/jaguar1/FrameParser.h
@@ -93,6 +93,15 @@
 #define SET_TX_DESC_RTS_SHORT_8812(__pTxDesc, __Value) SET_BITS_TO_LE_4BYTE(__pTxDesc + 20, 12, 1, __Value)
 #define SET_TX_DESC_RTS_SC_8812(__pTxDesc, __Value) SET_BITS_TO_LE_4BYTE(__pTxDesc + 20, 13, 4, __Value)
 #define SET_TX_DESC_TX_ANT_8812(__pTxDesc, __Value) SET_BITS_TO_LE_4BYTE(__pTxDesc + 20, 24, 4, __Value)
+/* Per-packet TX-power offset — 8814A ONLY (rtl8814a_xmit.h TX_POWER_OFFSET,
+ * dword5 [30:28]). Same position/width as the 8822B's working TXPWR_OFSET
+ * hardware LUT (halmac guards the 3-bit macro with HALMAC_8814A_SUPPORT
+ * alongside 8822B/8821C), so the LUT semantics are expected to match:
+ * 0=none 1=-3 2=-7 3=-11 4=+3 5=+6 dB (devourer::txpkt_pwr_step_for_db).
+ * NEVER write on 8812/8821: their dword5 has no such field ([30:28]
+ * undefined; [27:24] is TX_ANT). Vendor-defined but vendor-unused — on-air
+ * status tracked in AdapterCaps. */
+#define SET_TX_DESC_TX_POWER_OFFSET_8814A(__pTxDesc, __Value) SET_BITS_TO_LE_4BYTE(__pTxDesc + 20, 28, 3, __Value)
 
 /* Dword 6 */
 #define SET_TX_DESC_SW_DEFINE_8812(__pTxDesc, __Value) SET_BITS_TO_LE_4BYTE(__pTxDesc + 24, 0, 12, __Value)

--- a/src/jaguar1/PowerTracking8812a.cpp
+++ b/src/jaguar1/PowerTracking8812a.cpp
@@ -68,6 +68,13 @@ void PowerTracking8812a::Init() {
       unsigned(_defaultOfdmIndex), unsigned(swing_idx),
       unsigned(_eepromManager->GetEepromThermalMeter()),
       unsigned(_txPowerTrackControl));
+
+  /* A fast user offset recorded before bring-up (FastSetTxPowerOffsetQdb)
+   * applies now: the tick path can't be relied on for it — it early-returns
+   * on blank-EFUSE units (_txPowerTrackControl false) and on zero thermal
+   * delta. */
+  if (_userOfsSteps != 0)
+    ApplySwingToBb();
 }
 
 void PowerTracking8812a::ClearState() {
@@ -169,11 +176,29 @@ void PowerTracking8812a::ApplySwingToBb() {
       idx_to_write = final_ofdm_swing_index;
     }
 
+    /* Fast user offset (FastSetTxPowerOffsetQdb): folded AFTER the thermal
+     * clamp so `_userOfsSteps == 0` is byte-identical to the pre-lever
+     * behaviour, bounded at kUserBoostLimit (+2 dB) upward / table floor
+     * (-12 dB) downward. */
+    if (_userOfsSteps != 0) {
+      idx_to_write += _userOfsSteps;
+      if (idx_to_write > kUserBoostLimit)
+        idx_to_write = kUserBoostLimit;
+      if (idx_to_write < 0)
+        idx_to_write = 0;
+    }
+
     uint32_t bb_addr =
         (p == 0) ? rA_TxScale_Jaguar : rB_TxScale_Jaguar;
     _device.phy_set_bb_reg(bb_addr, 0xFFE00000u,
                            kTxScalingTableJaguar[idx_to_write]);
   }
+}
+
+void PowerTracking8812a::SetUserOffsetSteps(int steps) {
+  _userOfsSteps = steps;
+  if (_initialised)
+    ApplySwingToBb(); /* immediate: 2 BB writes, thermal state untouched */
 }
 
 void PowerTracking8812a::TickThermalMeter(BandType band, uint8_t channel) {

--- a/src/jaguar1/PowerTracking8812a.h
+++ b/src/jaguar1/PowerTracking8812a.h
@@ -78,6 +78,17 @@ public:
    * tx_agc change (`odm_clear_txpowertracking_state`). */
   void ClearState();
 
+  /* Fast global TX-power offset in BB-swing steps (0.5 dB each) — the
+   * 8812A leg of RtlJaguarDevice::FastSetTxPowerOffsetQdb.
+   * Folded into ApplySwingToBb AFTER the thermal clamp, so it composes
+   * with (and survives) every thermal tick / channel-set instead of being
+   * overwritten by it. Applies immediately when the tracker is
+   * initialised. Positive travel is bounded at swing index 28 (+2.0 dB —
+   * the vendor thermal upper bound; digital swing above 0 dB eats DAC
+   * headroom and degrades EVM on high-PAPR OFDM). */
+  void SetUserOffsetSteps(int steps);
+  int UserOffsetSteps() const { return _userOfsSteps; }
+
 private:
   RtlAdapter _device;
   std::shared_ptr<EepromManager> _eepromManager;
@@ -91,6 +102,9 @@ private:
 
   bool _txPowerTrackControl = true;
   bool _initialised = false;
+  /* Fast user swing offset (SetUserOffsetSteps), folded post-thermal-clamp. */
+  int _userOfsSteps = 0;
+  static constexpr int kUserBoostLimit = 28; /* +2.0 dB — vendor thermal cap */
 
   uint8_t _defaultOfdmIndex = 24; /* 0 dB; reseeded by Init() */
 

--- a/src/jaguar1/RadioManagementModule.cpp
+++ b/src/jaguar1/RadioManagementModule.cpp
@@ -1,5 +1,6 @@
 #include "RadioManagementModule.h"
 #include "Hal8812PhyReg.h"
+#include "Hal8812a_TxPwrTrack.h" /* kTxScalingTableJaguar — fast swing lever */
 #include "InitTimer.h"
 #include "registry_priv.h"
 
@@ -75,6 +76,58 @@ void RadioManagementModule::InitPwrTrack() { _pwrTrk.Init(); }
 
 void RadioManagementModule::TickPwrTrack() {
   _pwrTrk.TickThermalMeter(current_band_type, _currentChannel);
+}
+
+int RadioManagementModule::FastSwingOffsetSteps(int steps, bool apply_now) {
+  /* Clamp to the usable swing travel relative to a 0 dB base: table floor
+   * -24 steps (-12 dB), vendor thermal cap +4 steps (+2 dB). */
+  if (steps < -24)
+    steps = -24;
+  if (steps > 4)
+    steps = 4;
+  _fast_swing_steps = steps;
+  if (_eepromManager->version_id.ICType == CHIP_8812) {
+    /* 8812A: fold into the thermal tracker so its per-channel-set tick
+     * composes with the offset instead of overwriting it. (Records-only
+     * pre-Init — the tracker applies once initialised.) */
+    _pwrTrk.SetUserOffsetSteps(steps);
+  } else if (apply_now) {
+    apply_fast_swing_direct();
+  }
+  return steps;
+}
+
+void RadioManagementModule::apply_fast_swing_direct() {
+  /* Direct BB-swing write for the chips without a power tracker (8821A 1T1R,
+   * 8814A 4T4R). Per active path: capture the pre-offset base index once
+   * (nearest kTxScalingTableJaguar match of the live [31:21] value; no match
+   * -> 24 = 0 dB), then write table[clamp(base + steps)]. If the live value
+   * is neither our last write nor matched by the cached base's code, an
+   * external writer (phy_SetBBSwingByBand_*) replaced the swing base — the
+   * base is re-captured from the live value so the offset never compounds. */
+  static const uint16_t regs[4] = {rA_TxScale_Jaguar, rB_TxScale_Jaguar,
+                                   0x181c, 0x1a1c};
+  const int npaths =
+      _eepromManager->numTotalRfPath > 4 ? 4 : _eepromManager->numTotalRfPath;
+  auto nearest_idx = [](uint32_t code) -> uint8_t {
+    for (int i = 0; i < kTxScaleTableSize; i++)
+      if (code == kTxScalingTableJaguar[i])
+        return static_cast<uint8_t>(i);
+    return 24; /* unknown code -> treat as 0 dB base */
+  };
+  for (int p = 0; p < npaths; p++) {
+    const uint32_t cur = phy_query_bb_reg(regs[p], 0xFFE00000u);
+    if (_swing_base_idx[p] == 0xFF || cur != _swing_last_written[p])
+      _swing_base_idx[p] = nearest_idx(cur);
+    int idx = static_cast<int>(_swing_base_idx[p]) + _fast_swing_steps;
+    if (idx < 0)
+      idx = 0;
+    if (idx > 28) /* +2.0 dB — vendor thermal cap (EVM/DAC headroom) */
+      idx = 28;
+    const uint32_t code = kTxScalingTableJaguar[idx];
+    _device.phy_set_bb_reg(regs[p], 0xFFE00000u, code);
+    _swing_last_written[p] = code;
+  }
 }
 
 ThermalStatus RadioManagementModule::ReadThermalStatus() {
@@ -591,6 +644,16 @@ void RadioManagementModule::phy_SwChnlAndSetBwMode8812() {
   if (!_fast_skip_heavy &&
       _eepromManager->version_id.ICType == CHIP_8812) {
     _pwrTrk.TickThermalMeter(current_band_type, _currentChannel);
+  }
+
+  /* Fast BB-swing offset (FastSwingOffsetSteps) is sticky across channel
+   * sets on the non-tracker chips too: a band switch rewrites the TxScale
+   * base (phy_SetBBSwingByBand_*), so re-apply — the direct-write leg
+   * detects the external write and re-captures its base. (On the 8812A the
+   * offset rides the pwrtrk tick above.) */
+  if (!_fast_skip_heavy && _fast_swing_steps != 0 &&
+      _eepromManager->version_id.ICType != CHIP_8812) {
+    apply_fast_swing_direct();
   }
 
   /* Kernel cross-validation oracle: when debug.dump_canary is set

--- a/src/jaguar1/RadioManagementModule.h
+++ b/src/jaguar1/RadioManagementModule.h
@@ -133,6 +133,15 @@ class RadioManagementModule {
 #if defined(DEVOURER_HAVE_8814)
   Iqk8814a _iqk8814;
 #endif
+  /* Fast BB-swing offset state (FastSwingOffsetSteps). The direct-write leg
+   * (8821A/8814A) tracks, per path, the pre-offset base swing index and the
+   * last table code IT wrote — a mismatch on the next apply means someone
+   * else rewrote the register (band-switch swing base), so the base is
+   * re-captured from the current value instead of compounding the offset. */
+  int _fast_swing_steps = 0;
+  uint8_t _swing_base_idx[4] = {0xFF, 0xFF, 0xFF, 0xFF}; /* 0xFF = uncaptured */
+  uint32_t _swing_last_written[4] = {0, 0, 0, 0};
+  void apply_fast_swing_direct();
 
 public:
   RadioManagementModule(RtlAdapter device,
@@ -226,6 +235,23 @@ public:
    * SetTxPowerOffsetSteps() value to the TXAGC registers mid-session (used by
    * the thermal-vs-gain ramp and SetTxPowerOffsetQdb). */
   void ApplyTxPower() { PHY_SetTxPowerLevel8812(_currentChannel); }
+
+  /* Fast global TX-power offset via the BB-swing TxScale digital scaler
+   * (0xc1c/0xe1c[31:21], + 0x181c/0x1a1c paths C/D on the 8814A) — the lean
+   * lever behind RtlJaguarDevice::FastSetTxPowerOffsetQdb:
+   * 1-4 register writes, rate-independent, ~0.5 dB per step, vs the 30-50+
+   * write per-rate TXAGC rewrite of ApplyTxPower. On the 8812A the offset is
+   * folded into the thermal power-tracking loop (PowerTracking8812a) so the
+   * per-channel-set tick composes with it instead of overwriting it; on
+   * 8821A/8814A (no tracker) it is written directly, re-applied after every
+   * channel-set, with the per-path pre-offset base re-captured whenever an
+   * external write is detected (the band-switch swing-base case). Returns
+   * the applied steps after clamping to [-24, +4] (-12..+2 dB — the positive
+   * bound is the vendor thermal cap; digital swing above 0 dB eats DAC
+   * headroom / EVM). apply_now=false records only (pre-bring-up: the value
+   * is folded by the first channel-set / pwrtrk tick instead of writing an
+   * unconfigured BB). */
+  int FastSwingOffsetSteps(int steps, bool apply_now = true);
 
 private:
   void rtw_hal_set_msr(uint8_t net_type);

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -11,10 +11,12 @@
 #include "SignalStop.h"
 #include "ToneMask.h"
 #include "TxAggPlan.h" /* USB TX aggregation URB packing */
+#include "TxPower.h"   /* txpkt_pwr_step_for_db — 8814A per-packet LUT */
 #include "TxReport.h"  /* CCX TX-status report decode + tx.report event */
 
 #include <algorithm>
 #include <chrono>
+#include <climits> /* INT_MIN — "no radiotap DBM_TX_POWER" sentinel */
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -833,6 +835,10 @@ size_t RtlJaguarDevice::build_tx_block(const uint8_t *packet, size_t length,
   bool rate_from_radiotap = false;
   /* Per-packet hop target from a radiotap CHANNEL field (0 = none present). */
   int radiotap_channel = 0;
+  /* Per-packet TX-power delta from a radiotap DBM_TX_POWER field (dB vs the
+   * calibrated table; 8814A only — quantized to its descriptor LUT).
+   * INT_MIN = not present -> the SetTxPacketPowerStep session default. */
+  int radiotap_pkt_pwr_db = INT_MIN;
   if (length < sizeof(struct ieee80211_radiotap_header)) {
     return 0;
   }
@@ -881,6 +887,13 @@ size_t RtlJaguarDevice::build_tx_block(const uint8_t *packet, size_t length,
        * the RATE/MCS/VHT fields). */
       radiotap_channel =
           devourer::freq_to_chan(get_unaligned_le16(iterator.this_arg));
+      break;
+
+    case IEEE80211_RADIOTAP_DBM_TX_POWER:
+      /* Signed dB delta for THIS frame — 8814A quantizes it to the dword5
+       * TX_POWER_OFFSET LUT below (the Jaguar2 per-packet convention);
+       * ignored on 8812/8821 (no descriptor field). */
+      radiotap_pkt_pwr_db = *reinterpret_cast<const int8_t *>(iterator.this_arg);
       break;
 
     case IEEE80211_RADIOTAP_MCS: {
@@ -1105,6 +1118,18 @@ size_t RtlJaguarDevice::build_tx_block(const uint8_t *packet, size_t length,
   }
 
   SET_TX_DESC_DATA_STBC_8812(usb_frame, stbc & 3);
+
+  /* Per-packet TX-power offset — 8814A only (dword5 [30:28] hardware LUT,
+   * see FrameParser.h). Radiotap DBM_TX_POWER wins per frame (quantized to
+   * the LUT), else the SetTxPacketPowerStep session default. 0 = baseline,
+   * byte-identical descriptor. Never written on 8812/8821 (no field there). */
+  if (is_8814a) {
+    uint8_t pkt_pwr_step = _tx_pkt_pwr_step.load(std::memory_order_relaxed);
+    if (radiotap_pkt_pwr_db != INT_MIN)
+      pkt_pwr_step = devourer::txpkt_pwr_step_for_db(radiotap_pkt_pwr_db);
+    if (pkt_pwr_step)
+      SET_TX_DESC_TX_POWER_OFFSET_8814A(usb_frame, pkt_pwr_step & 0x7);
+  }
 
   /* DEVOURER_TX_NDPA=1 — beamforming self-sounding probe: mark the injected
    * frame as an NDPA (TX-desc Dword3 [23:22]=1) so the MAC sounding engine
@@ -1464,6 +1489,39 @@ bool RtlJaguarDevice::ReApplyTxPower() {
   return true;
 }
 
+int RtlJaguarDevice::FastSetTxPowerOffsetQdb(int qdb) {
+  if (_cw_active) {
+    /* The CW/continuous-TX paths save+zero the TxScale words; a swing write
+     * mid-tone would corrupt the restore snapshot. */
+    _logger->warn("FastSetTxPowerOffsetQdb refused: CW tone active");
+    return 0;
+  }
+  /* Quantize to 0.5 dB (2 qdB) swing steps, ties away from zero; the radio
+   * module clamps to the [-24, +4] step travel and applies (1-4 BB writes).
+   * Pre-bring-up: record only — the bring-up channel-set folds it. */
+  const int steps = (qdb >= 0 ? qdb * 2 + 2 : qdb * 2 - 2) / 4;
+  const int applied_steps =
+      _radioManagement->FastSwingOffsetSteps(steps, _brought_up);
+  _logger->info("fast TX-power (BB-swing) offset: {} qdB requested -> {} qdB "
+                "applied ({} steps of 0.5 dB)",
+                qdb, applied_steps * 2, applied_steps);
+  return applied_steps * 2;
+}
+
+void RtlJaguarDevice::SetTxPacketPowerStep(uint8_t step) {
+  _tx_pkt_pwr_step = step & 0x7;
+  if (_eepromManager->version_id.ICType != CHIP_8814A) {
+    /* Recorded but inert: the 8812/8821 descriptor has no per-packet power
+     * field — the build path only writes it on the 8814A. */
+    _logger->warn("SetTxPacketPowerStep: 8814A-only (dword5 [30:28]); this "
+                  "chip's descriptor has no per-packet power field — inert");
+    return;
+  }
+  _logger->info("8814A: per-packet TX_POWER_OFFSET default step = {} "
+                "(0=none 1=-3 2=-7 3=-11 4=+3 5=+6 dB)",
+                step & 0x7);
+}
+
 devourer::TxCaps RtlJaguarDevice::GetTxCaps() {
   /* numTotalRfPath is the TX chain count the EFUSE RF-type resolves to (1 on
    * the 8811AU/8821AU 1T1R cuts, 2 on 8812AU, 4 on 8814AU). All Jaguar-1 AC
@@ -1521,6 +1579,18 @@ devourer::AdapterCaps RtlJaguarDevice::GetAdapterCaps() {
     c.narrowband_ok = true;
   }
   c.fastretune_ok = true; /* phy_SwChnl8812_fast (8812/8821) + full-path fallback */
+  /* Per-packet TX power: 8814A only — its dword5 [30:28] descriptor LUT (the
+   * 8822B TXPWR_OFSET position; vendor-defined, vendor-unused). measured
+   * stays false until tests/txpkt_pwr_ofset_onair.sh proves it moves on-air
+   * power. The 8812A/8821A descriptors have no per-frame power field —
+   * their fast lever is FastSetTxPowerOffsetQdb (BB-swing, global). */
+  if (_eepromManager->version_id.ICType == CHIP_8814A) {
+    c.per_packet_txpower = true;
+    c.per_pkt_txpwr_steps = 6;
+    c.per_pkt_txpwr_min_qdb = -44; /* -11 dB LUT floor */
+    c.per_pkt_txpwr_max_qdb = 24;  /* +6 dB LUT top */
+    c.per_pkt_txpwr_measured = false;
+  }
   c.hw_rx_timestamp = true;   /* FrameParser fills RxAtrib.tsfl on every frame */
   c.hw_beacon_txtsf = true;  /* StartBeacon: MAC inserts the egress TSF into
                               * beacons (bench: 8821AU + 8814AU body-TS steps

--- a/src/jaguar1/RtlJaguarDevice.h
+++ b/src/jaguar1/RtlJaguarDevice.h
@@ -58,6 +58,9 @@ class RtlJaguarDevice : public IRtlDevice {
   /* A-MPDU TX mode (SetAmpduMode). Read lock-free in the TX descriptor path
    * (same pattern as _tx_mode_default). */
   devourer::AmpduMode _ampdu;
+  /* Default per-packet TX-power LUT step — 8814A only (dword5 [30:28]);
+   * see SetTxPacketPowerStep. */
+  std::atomic<uint8_t> _tx_pkt_pwr_step{0};
 
   /* CW single-tone (StartCwTone/StopCwTone) saved state for a clean restore:
    * the pre-tone RF 0x00 and four BB dwords — RFE-pinmux words on 8812/8821
@@ -130,6 +133,24 @@ public:
   int SetTxPowerOffsetQdb(int qdb) override;
   void SetTxPowerIndexOverride(int idx) override;
   bool ReApplyTxPower() override;
+  /* Per-packet TX-power offset default — 8814A ONLY (its dword5 [30:28]
+   * descriptor LUT at the 8822B TXPWR_OFSET position: 0=none 1=-3 2=-7
+   * 3=-11 4=+3 5=+6 dB; see FrameParser.h). Stamped into every TX
+   * descriptor; a radiotap DBM_TX_POWER field overrides per packet (dB
+   * delta quantized to the LUT, devourer::txpkt_pwr_step_for_db). Warns and
+   * stays inert on 8812/8821 — their descriptor has no such field (rate
+   * selection is their only per-packet power lever). */
+  void SetTxPacketPowerStep(uint8_t step);
+  /* Fast global TX-power offset via the BB-swing digital scaler — the lean
+   * Jaguar1 power lever: 1-4 BB writes (~0.5 dB steps, -12..+2
+   * dB) vs the 30-50+ write TXAGC rewrite of SetTxPowerOffsetQdb. Per-burst,
+   * NOT per-packet (the 8812A/8821A descriptor has no power field — this is
+   * the closest those chips have). Composes with SetTxPowerOffsetQdb (a
+   * separate hardware stage: digital IQ scaling after the TXAGC index) and
+   * with the 8812A thermal tracker (folded post-clamp, survives its ticks).
+   * EVM caveat above 0 dB: positive digital swing eats DAC headroom, capped
+   * at +2 dB (the vendor thermal bound). Returns the applied qdB. */
+  int FastSetTxPowerOffsetQdb(int qdb);
   int SetXtalCap(int cap) override;
   int GetXtalCap() override { return _xtal_cap; }
   devourer::TxPowerState GetTxPowerState() override;

--- a/src/jaguar2/FrameParserJaguar2.h
+++ b/src/jaguar2/FrameParserJaguar2.h
@@ -7,6 +7,7 @@
 
 #include "basic_types.h"
 #include "TxDescBits.h"
+#include "TxPower.h"
 #include "RxPacket.h"
 
 /* Jaguar2 (RTL8822B) TX/RX descriptor layout. 8822B is a HalMAC 88xx chip, so
@@ -114,30 +115,12 @@ inline void cal_txdesc_chksum_8822b(uint8_t *txdesc) {
 
 /* Fill an 8822B data/monitor-inject TX descriptor (48 bytes, zeroed by caller)
  * and finalise its checksum. Mirrors the Jaguar3 inject field choices. */
-/* Quantize a requested per-packet power delta (dB) to the nearest hardware
- * TXPWR_OFSET LUT step. The field is discrete — {0, -3, -7, -11, +3, +6} dB —
- * so an adaptive link's continuous request lands on the closest rung. Pure;
- * unit-tested in tests/txpkt_pwr_selftest.cpp. */
-inline uint8_t txpkt_pwr_step_for_db(int db) {
-  static const struct { int db; uint8_t step; } lut[] = {
-      {0, 0}, {-3, 1}, {-7, 2}, {-11, 3}, {3, 4}, {6, 5}};
-  uint8_t best = 0;
-  int best_err = 1 << 30;
-  for (const auto &e : lut) {
-    int err = db > e.db ? db - e.db : e.db - db;
-    if (err < best_err) {
-      best_err = err;
-      best = e.step;
-    }
-  }
-  return best;
-}
-
-/* Inverse: the nominal dB of a LUT step (for readback / logging). */
-inline int txpkt_pwr_db_for_step(uint8_t step) {
-  static const int db[] = {0, -3, -7, -11, 3, 6};
-  return step < 6 ? db[step] : 0;
-}
+/* The per-packet TXPWR_OFSET LUT quantizer lives in src/TxPower.h
+ * (devourer::txpkt_pwr_step_for_db) — the 8814A shares the same 3-bit LUT, so
+ * the pure functions are generation-neutral. Forwarding aliases keep the
+ * original jaguar2:: spellings compiling. */
+using devourer::txpkt_pwr_step_for_db;
+using devourer::txpkt_pwr_db_for_step;
 
 inline void fill_data_tx_desc_8822b(uint8_t *d, uint16_t pkt_size,
                                     uint8_t rate_hw, uint8_t rate_id, uint8_t bw,

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -978,7 +978,13 @@ devourer::AdapterCaps RtlJaguar2Device::GetAdapterCaps() {
                            ? 0x20
                            : (_hal.efuse_logical_byte(0xB9) & 0x3f);
   c.fastretune_ok = true;
-  c.per_packet_txpower = true; /* TX descriptor TXPWR_OFSET LUT — Jaguar2 only */
+  /* TX descriptor TXPWR_OFSET LUT — on-air-confirmed: the RSSI sweep tracks
+   * the vendor 0/-3/-7/-11/+3/+6 dB rungs (tests/txpkt_pwr_ofset_onair.sh). */
+  c.per_packet_txpower = true;
+  c.per_pkt_txpwr_steps = 6;
+  c.per_pkt_txpwr_min_qdb = -44; /* -11 dB LUT floor */
+  c.per_pkt_txpwr_max_qdb = 24;  /* +6 dB LUT top */
+  c.per_pkt_txpwr_measured = true;
   /* LDPC RX: both variants decode HT+VHT LDPC (bench: encoding-matrix
    * devourer↔devourer cells at full delivery, 8822BU cross-checked reporting
    * ldpc=1) and report it per-frame from PHY-status byte7[5]

--- a/src/jaguar3/FrameParserJaguar3.h
+++ b/src/jaguar3/FrameParserJaguar3.h
@@ -47,6 +47,20 @@ constexpr size_t RXDESC_SIZE_8822C = 24; /* RX_DESC_SIZE_88XX */
 #define SET_TX_DESC_DATA_BW_8822C(d, v)    SET_BITS_TO_LE_4BYTE((d) + 0x14, 5, 2, v)
 #define SET_TX_DESC_DATA_LDPC_8822C(d, v)  SET_BITS_TO_LE_4BYTE((d) + 0x14, 7, 1, v)
 #define SET_TX_DESC_DATA_STBC_8822C(d, v)  SET_BITS_TO_LE_4BYTE((d) + 0x14, 8, 2, v)
+/* Per-packet TX-power offset BANK SELECTOR (halmac TXPWR_OFSET_TYPE,
+ * txdesc+0x14[29:28]). Unlike the 8822B's 3-bit dB LUT at the same offset,
+ * this 2-bit field selects which pre-programmed power-index offset the BB
+ * adds for this frame: 0/1 = per-STA BB-RAM tx_pwr_offset0/1[MACID] (0x1e84
+ * protocol), 2 = global 0x1e70[22:16] (en [23]), 3 = global 0x1e70[30:24]
+ * (en [31]) — vendor phydm.h bb_ram block. The banks reset to disabled at
+ * BB-table load (0x1E70 = 0x00001000), so the field is a no-op until
+ * RtlJaguar3Device programs them (src/jaguar3/TxPktPwrBanks.h). STRICTLY 2
+ * bits: 0x14[30] is ANTSEL_EN_V1 on this generation — writing a 3-bit
+ * 8822B-style value here would silently enable antenna-select (measured as
+ * a non-monotonic on-air wiggle). NB: types 0/1 are per-STA by the descriptor
+ * MACID (0x01 in devourer's inject path) — devourer's bank policy uses the
+ * global types 2/3 and keeps type 0 as the untouched 0 dB baseline. */
+#define SET_TX_DESC_TXPWR_OFSET_TYPE_8822C(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x14, 28, 2, v)
 #define SET_TX_DESC_DISQSELSEQ_8822C(d, v) SET_BITS_TO_LE_4BYTE((d) + 0x00, 31, 1, v)
 #define SET_TX_DESC_G_ID_8822C(d, v)       SET_BITS_TO_LE_4BYTE((d) + 0x08, 24, 6, v)
 /* Per-frame TX-status report request (halmac SPE_RPT): the fw answers this
@@ -118,6 +132,7 @@ inline void fill_data_tx_desc_8822c(uint8_t *d, uint16_t pkt_size,
                                     bool short_gi, bool ldpc, uint8_t stbc,
                                     bool bmc = false, bool ndpa = false,
                                     uint8_t data_sc = 0,
+                                    uint8_t pwr_ofset_type = 0,
                                     uint8_t pkt_offset = 0) {
   SET_TX_DESC_TXPKTSIZE_8822C(d, pkt_size);
   SET_TX_DESC_OFFSET_8822C(d, static_cast<uint32_t>(TXDESC_SIZE_8822C));
@@ -151,6 +166,10 @@ inline void fill_data_tx_desc_8822c(uint8_t *d, uint16_t pkt_size,
   SET_TX_DESC_DATA_SHORT_8822C(d, short_gi ? 1 : 0);
   SET_TX_DESC_DATA_LDPC_8822C(d, ldpc ? 1 : 0);
   SET_TX_DESC_DATA_STBC_8822C(d, stbc & 0x3);
+  /* Per-packet power-offset bank (0 = baseline, byte-identical to the prior
+   * descriptor). Inside the checksummed span (0x14) — before the checksum. */
+  if (pwr_ofset_type)
+    SET_TX_DESC_TXPWR_OFSET_TYPE_8822C(d, pwr_ofset_type & 0x3);
   SET_TX_DESC_EN_HWSEQ_8822C(d, 1);
   /* USB-agg boundary shim: pkt_offset × 8 bytes of pad between this descriptor
    * and its frame (halmac PKT_OFFSET, unit 8 B). 0 = none (byte-identical).

--- a/src/jaguar3/Halrf8822c.cpp
+++ b/src/jaguar3/Halrf8822c.cpp
@@ -119,7 +119,11 @@ void Halrf8822c::nctl() {
   }
 }
 
-/* _iqk_backup_mac_bb_8822c / _iqk_backup_rf_8822c */
+/* _iqk_backup_mac_bb_8822c / _iqk_backup_rf_8822c.
+ * NB: the list includes 0x1e70 FULL-DWORD — its [31:16] are the per-packet
+ * TX-power offset banks (TxPktPwrBanks.h). Save/restore is benign today
+ * because IQK runs at bring-up only (before banks are programmed); a future
+ * RUNTIME re-cal restoring a stale 0x1e70 must re-apply the banks after. */
 void Halrf8822c::backup_mac_bb(uint32_t *mac, uint32_t *bb) {
   static const uint16_t macreg[MAC_REG_NUM_8822C] = {0x520, 0x1c, 0x70};
   static const uint16_t bbreg[BB_REG_NUM_8822C] = {

--- a/src/jaguar3/Halrf8822e.cpp
+++ b/src/jaguar3/Halrf8822e.cpp
@@ -13,7 +13,12 @@ namespace {
 /* RF direct-write window bases (path A / path B) — identical to 8822c. */
 constexpr uint16_t RF_WIN[2] = {0x3c00, 0x4c00};
 
-/* IQK MAC/BB/RF register backup tables (halrf_iqk_8822e.c _phy_iq_calibrate). */
+/* IQK MAC/BB/RF register backup tables (halrf_iqk_8822e.c _phy_iq_calibrate).
+ * NB: kBackupBbReg includes 0x1e70 FULL-DWORD — its [31:16] are the
+ * per-packet TX-power offset banks (TxPktPwrBanks.h). Save/restore is benign
+ * today because IQK/TXGAPK run at bring-up only (before banks are
+ * programmed); a future RUNTIME re-cal restoring a stale 0x1e70 must
+ * re-apply the banks after. */
 constexpr uint16_t kBackupMacReg[4] = {0x520, 0x1c, 0xec, 0x70};
 constexpr uint16_t kBackupBbReg[21] = {
     0x0820, 0x0824, 0x1c38, 0x1c68, 0x1d60, 0x180c, 0x410c, 0x1c3c, 0x1a14,

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -1,6 +1,7 @@
 #include "RtlJaguar3Device.h"
 
 #include <algorithm>
+#include <climits> /* INT_MIN — "no radiotap DBM_TX_POWER" sentinel */
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -850,6 +851,15 @@ void RtlJaguar3Device::InitWrite(SelectedChannel channel) {
    * TX-power state (flat override / offset) only sticks when applied after
    * them. The coex thread's ~2 s ticks do not rewrite the refs. */
   apply_tx_power_current(/*full=*/true);
+  /* Per-packet power banks: the BB init table reset 0x1e70 (0x00001000, all
+   * banks disabled) and may have cleared the per-STA RAM — re-sync the
+   * hardware to the planner state (a pre-bring-up SetTxPacketPowerOffsetQdb
+   * or a re-init with banks in use). Pre-coex-thread, so no _reg_mu needed. */
+  _txpkt_ram_cleared = false;
+  if (_txpkt_banks.active())
+    apply_txpkt_banks_locked();
+  else
+    _txpkt_img.store(0, std::memory_order_relaxed);
   apply_dpdt_route_8822e(); /* 8822E DPDT/eFEM pin-mux (post-coex) */
   apply_replay_wseq(); /* DEVOURER_REPLAY_WSEQ golden-init replay (debug) */
   if (_cfg.debug.bb_dump) {
@@ -1146,6 +1156,11 @@ void RtlJaguar3Device::SetMonitorChannel(SelectedChannel channel) {
    * re-assert the disable if it was armed. */
   if (_brought_up && _cca_disabled)
     apply_cca_mode_locked(true);
+  /* Per-packet power banks are sticky too (the lever contract): the channel
+   * set doesn't touch 0x1e70[31:16] today, but a cheap RMW re-assert keeps
+   * the contract robust against future channel-path changes. */
+  if (_brought_up && _txpkt_banks.active())
+    apply_txpkt_banks_locked();
 }
 
 void RtlJaguar3Device::FastRetune(uint8_t channel, bool cache_rf) {
@@ -1317,6 +1332,86 @@ bool RtlJaguar3Device::ReApplyTxPower() {
   return true;
 }
 
+/* --- Per-packet TX-power banks (see TxPktPwrBanks.h) --- */
+
+int RtlJaguar3Device::txpkt_idx_for_qdb(int qdb) const {
+  /* Round to the nearest bank step (ties away from zero), like
+   * quantize_offset_qdb. Step from cfg (default 4 qdB = 1 dB — the vendor's
+   * "each tx_pwr_ofst step will be 1dB" for the 22C class; the on-air slope
+   * run pins it per variant). */
+  const int step = _cfg.tuning.txpkt_step_qdb > 0 ? _cfg.tuning.txpkt_step_qdb : 4;
+  const int num = qdb >= 0 ? qdb * 2 + step : qdb * 2 - step;
+  return num / (2 * step);
+}
+
+void RtlJaguar3Device::apply_txpkt_banks_locked() {
+  if (!_txpkt_ram_cleared) {
+    /* One-time defensive clear of the macid-1 per-STA BB-RAM offsets (types
+     * 0/1): descriptor MACID is 0x01, and stale RAM content (a prior driver /
+     * killed session) would silently offset every type-0 "baseline" frame.
+     * Vendor 0x1e84 write protocol (phydm_wt_ram_pwr / phydm_rst_ram_pwr):
+     * all offset+en+hwigi fields zero, macid[29:24], write_en(30); then a
+     * read_en(31) pulse latches; then release. */
+    _device.rtw_write<uint32_t>(0x1e84, ((1u & 0x3f) << 24) | (1u << 30));
+    _device.rtw_write<uint32_t>(0x1e84, 0x80000000u);
+    _device.rtw_write<uint32_t>(0x1e84, 0x00000000u);
+    _txpkt_ram_cleared = true;
+  }
+  /* Both global banks live in one dword: 0x1e70[23:16] = en|idx (type 2),
+   * [31:24] = en|idx (type 3). Offsets are 7-bit two's-complement power-index
+   * steps. Plain BB RMW — the 0x1c90[15] gate applies to TXAGC-table writes
+   * only (vendor programs 0x1e70 with a bare odm_set_bb_reg). */
+  const uint16_t img = _txpkt_banks.reg16();
+  _device.phy_set_bb_reg(0x1e70, 0xFFFF0000u, img);
+  _txpkt_img.store(img, std::memory_order_relaxed);
+}
+
+uint8_t RtlJaguar3Device::txpkt_type_for_idx(int idx) {
+  idx = jaguar3::TxPktPwrBankPlanner::clamp_idx(idx);
+  if (idx == 0)
+    return 0;
+  /* Lock-free hit check against the committed 0x1e70 image (one relaxed
+   * load): the common case for a UEP stream cycling 1-2 offset levels. */
+  const uint16_t img = _txpkt_img.load(std::memory_order_relaxed);
+  const uint8_t want =
+      static_cast<uint8_t>(0x80 | (static_cast<uint8_t>(idx) & 0x7f));
+  if ((img & 0xff) == want)
+    return 2;
+  if ((img >> 8) == want)
+    return 3;
+  /* Miss: allocate/evict a bank and program it. Serialized on _reg_mu against
+   * the coex tick and channel retunes; unconditional re-apply also heals a
+   * stale mirror (e.g. a pre-bring-up recorded default). */
+  std::lock_guard<std::mutex> lk(_reg_mu);
+  const auto plan = _txpkt_banks.request(idx);
+  apply_txpkt_banks_locked();
+  return plan.type;
+}
+
+int RtlJaguar3Device::SetTxPacketPowerOffsetQdb(int qdb) {
+  const int step = _cfg.tuning.txpkt_step_qdb > 0 ? _cfg.tuning.txpkt_step_qdb : 4;
+  const int idx =
+      jaguar3::TxPktPwrBankPlanner::clamp_idx(txpkt_idx_for_qdb(qdb));
+  uint8_t type = 0;
+  {
+    std::lock_guard<std::mutex> lk(_reg_mu);
+    if (idx != 0) {
+      const auto plan = _txpkt_banks.request(idx);
+      type = plan.type;
+      if (_brought_up)
+        apply_txpkt_banks_locked();
+    }
+  }
+  _txpkt_dflt_idx.store(idx, std::memory_order_relaxed);
+  _txpkt_dflt_type.store(type, std::memory_order_relaxed);
+  const int applied = idx * step;
+  _logger->info("per-packet TX-power default: {} qdB requested -> {} qdB "
+                "(bank idx {}, type {}){}",
+                qdb, applied, idx, type,
+                _brought_up ? "" : " (recorded; applies at bring-up)");
+  return applied;
+}
+
 devourer::TxCaps RtlJaguar3Device::GetTxCaps() {
   return devourer::tx_caps_for_chains(2); /* 8822C/8822E are 2T2R */
 }
@@ -1346,6 +1441,27 @@ devourer::AdapterCaps RtlJaguar3Device::GetAdapterCaps() {
   c.tx_chains = 2; /* 8822C/8822E are 2T2R */
   c.rx_chains = 2;
   c.per_chain_rssi = true;
+  /* Per-packet TX power: the TXPWR_OFSET_TYPE bank selector + programmable
+   * 0x1e70 offset banks (SetTxPacketPowerOffsetQdb / radiotap DBM_TX_POWER;
+   * TxPktPwrBanks.h). Continuous in step_qdb units, ±63/-64 index travel, 2
+   * concurrent non-zero levels. On-air-measured on BOTH variants
+   * (tests/txpkt_pwr_ofset_onair.sh, ch36 MCS3, chip-RSSI ground): 8822CU
+   * 5/5 LUT-mapped steps + 2/2 radiotap cells sign-correct (+6 nominal ->
+   * +4..+6 raw, -11 -> -13..-14); 8822EU 5/5 + 2/2 (+6 -> +8 raw; deep cuts
+   * compress: -7 and -11 both land ~-6 raw — its TSSI/kfree transfer, same
+   * caveat as its SetTxPowerOffsetQdb slope). Banks survive
+   * SetMonitorChannel + FastRetune (tests/txpkt_hop_persist.sh: +6 dB held
+   * across 36<->40 hops). */
+  {
+    const int step =
+        _cfg.tuning.txpkt_step_qdb > 0 ? _cfg.tuning.txpkt_step_qdb : 4;
+    c.per_packet_txpower = true;
+    c.per_pkt_txpwr_steps = 0; /* continuous (bank-programmable) */
+    c.per_pkt_txpwr_step_qdb = static_cast<uint8_t>(step);
+    c.per_pkt_txpwr_min_qdb = static_cast<int16_t>(-64 * step);
+    c.per_pkt_txpwr_max_qdb = static_cast<int16_t>(63 * step);
+    c.per_pkt_txpwr_measured = true;
+  }
   c.bw_mask = devourer::bw_mask_for_generation(c.generation);
   c.fastretune_ok = true;
   c.narrowband_ok = true; /* 5/10 MHz baseband re-clock — Jaguar3 only */
@@ -1503,9 +1619,13 @@ size_t RtlJaguar3Device::send_packets(const TxPacketView *pkts, size_t count) {
     /* Collect the contiguous run for ONE URB: well-formed frames staying on
      * one channel. A frame whose radiotap CHANNEL differs ends the run — the
      * pending URB airs on the old channel, and the retune happens inside
-     * build_tx_block when that frame leads the next URB. */
+     * build_tx_block when that frame leads the next URB. Same rule for a
+     * differing radiotap DBM_TX_POWER: a first-seen power value can reprogram
+     * an offset bank (0x1e70), which must land between URBs — an already-
+     * packed frame would otherwise air at the new bank value. */
     std::vector<size_t> lens;
     int run_chan = 0; /* 0 = no per-packet CHANNEL seen yet (current channel) */
+    int run_pwr = INT_MIN; /* INT_MIN = session-default power */
     for (size_t i = done; i < count && lens.size() < lim.max_frames; ++i) {
       const uint16_t rlen =
           devourer::radiotap_hdr_len(pkts[i].data, pkts[i].len);
@@ -1516,11 +1636,16 @@ size_t RtlJaguar3Device::send_packets(const TxPacketView *pkts, size_t count) {
       }
       const int want =
           devourer::radiotap_peek_channel(pkts[i].data, pkts[i].len);
-      if (lens.empty())
+      const int want_pwr =
+          devourer::radiotap_peek_dbm_tx_power(pkts[i].data, pkts[i].len);
+      if (lens.empty()) {
         run_chan = want;
-      else if (want > 0 &&
-               want != (run_chan > 0 ? run_chan : _channel.Channel))
+        run_pwr = want_pwr;
+      } else if ((want > 0 &&
+                  want != (run_chan > 0 ? run_chan : _channel.Channel)) ||
+                 want_pwr != run_pwr) {
         break;
+      }
       lens.push_back(pkts[i].len - rlen);
     }
     if (lens.empty())
@@ -1595,6 +1720,10 @@ size_t RtlJaguar3Device::build_tx_block(const uint8_t *packet, size_t length,
   bool rate_from_radiotap = false; /* did the frame's radiotap carry a rate? */
   /* Per-packet hop target from a radiotap CHANNEL field (0 = none present). */
   int radiotap_channel = 0;
+  /* Per-packet TX-power delta from a radiotap DBM_TX_POWER field (dB vs the
+   * calibrated table, the Jaguar2 convention). INT_MIN = not present -> the
+   * SetTxPacketPowerOffsetQdb session default applies. */
+  int radiotap_pkt_pwr_db = INT_MIN;
 
   auto *rtap_hdr = reinterpret_cast<struct ieee80211_radiotap_header *>(
       const_cast<uint8_t *>(packet));
@@ -1616,6 +1745,11 @@ size_t RtlJaguar3Device::build_tx_block(const uint8_t *packet, size_t length,
        * the RATE/MCS/VHT fields). Same contract as the Jaguar1 path. */
       radiotap_channel =
           devourer::freq_to_chan(get_unaligned_le16(it.this_arg));
+      break;
+    case IEEE80211_RADIOTAP_DBM_TX_POWER:
+      /* Signed dB delta for THIS frame, resolved to a power-offset bank
+       * below (txpkt_type_for_idx). Mirrors the Jaguar2 per-packet path. */
+      radiotap_pkt_pwr_db = *reinterpret_cast<const int8_t *>(it.this_arg);
       break;
     case IEEE80211_RADIOTAP_MCS: {
       /* One shared reading of the HT MCS known/flag/index bytes (bw/sgi/mcs +
@@ -1737,9 +1871,16 @@ size_t RtlJaguar3Device::build_tx_block(const uint8_t *packet, size_t length,
    * STBC frame the chip can't do. */
   if (stbc && !GetTxCaps().stbc_ok)
     stbc = 0;
+  /* Per-packet TX-power bank selector: radiotap DBM_TX_POWER wins per frame
+   * (resolved to a bank, programming 0x1e70 on a first-seen value), else the
+   * SetTxPacketPowerOffsetQdb session default (pre-resolved, lock-free). */
+  uint8_t pwr_type = _txpkt_dflt_type.load(std::memory_order_relaxed);
+  if (radiotap_pkt_pwr_db != INT_MIN)
+    pwr_type = txpkt_type_for_idx(txpkt_idx_for_qdb(radiotap_pkt_pwr_db * 4));
   jaguar3::fill_data_tx_desc_8822c(
       out, static_cast<uint16_t>(frame_len), MRateToHwRate(fixed_rate), rate_id,
-      bw_desc, sgi != 0, ldpc != 0, stbc, bmc, ndpa, data_sc, pkt_offset);
+      bw_desc, sgi != 0, ldpc != 0, stbc, bmc, ndpa, data_sc, pwr_type,
+      pkt_offset);
   if (_cfg.tx.report) {
     /* DEVOURER_TX_REPORT: SPE_RPT asks the fw for a per-frame CCX TX report;
      * the report echoes SW_DEFINE's low byte, so stamp a rotating tag for

--- a/src/jaguar3/RtlJaguar3Device.h
+++ b/src/jaguar3/RtlJaguar3Device.h
@@ -17,6 +17,7 @@
 #include "LaCapture.h"
 #include "RadioManagementJaguar3.h"
 #include "PhydmRuntimeJaguar3.h"
+#include "TxPktPwrBanks.h"
 
 /* RtlJaguar3Device is the orchestrator for the Realtek "Jaguar3" 802.11ac family
  * — RTL8822CU, RTL8812EU, RTL8822EU. It is the Jaguar3 sibling of
@@ -113,6 +114,20 @@ public:
   int SetTxPowerOffsetQdb(int qdb) override;
   void SetTxPowerIndexOverride(int idx) override;
   bool ReApplyTxPower() override;
+  /* Per-packet TX-power offset — session default. Programs a
+   * hardware offset BANK (global 0x1e70 reg0/reg1, see TxPktPwrBanks.h) and
+   * stamps its 2-bit selector into every TX descriptor's TXPWR_OFSET_TYPE, so
+   * the per-frame power trim costs zero USB transfers once a bank holds the
+   * value. A radiotap DBM_TX_POWER field overrides per packet (dB delta vs
+   * the calibrated table, the Jaguar2 convention); up to two distinct
+   * non-zero offsets are held in banks concurrently — a third evicts the
+   * least-recently-used one (one masked 0x1e70 write). Offsets quantize to
+   * cfg.tuning.txpkt_step_qdb (default 4 qdB = 1 dB — the vendor-stated bank
+   * step; bench-pinned by tests/txpkt_pwr_ofset_onair.sh). Returns the
+   * applied qdB after quantize/clamp. 0 clears the default (type-0 baseline).
+   * Composes additively with SetTxPowerOffsetQdb (which moves the TXAGC
+   * references themselves). */
+  int SetTxPacketPowerOffsetQdb(int qdb);
   int SetXtalCap(int cap) override;
   int GetXtalCap() override { return _xtal_cap; }
   devourer::TxPowerState GetTxPowerState() override;
@@ -234,6 +249,26 @@ private:
   /* Rotating SW_DEFINE tag stamped when tx.report is on — the CCX report
    * echoes its low byte, correlating reports to frames (src/TxReport.h). */
   std::atomic<uint16_t> _tx_rpt_tag{0};
+  /* Per-packet TX-power banks (SetTxPacketPowerOffsetQdb / radiotap
+   * DBM_TX_POWER). _txpkt_banks is the allocation policy,
+   * mutated under _reg_mu; _txpkt_img mirrors its committed 0x1e70[31:16]
+   * image so the TX hot path resolves an already-programmed offset to its
+   * bank type from ONE relaxed atomic load (a miss takes _reg_mu and
+   * reprograms). _txpkt_dflt_* is the session default stamped on frames
+   * without a radiotap DBM_TX_POWER field. */
+  jaguar3::TxPktPwrBankPlanner _txpkt_banks;
+  std::atomic<uint16_t> _txpkt_img{0};
+  std::atomic<int> _txpkt_dflt_idx{0};
+  std::atomic<uint8_t> _txpkt_dflt_type{0};
+  bool _txpkt_ram_cleared = false; /* one-time macid-1 BB-RAM clear done */
+  /* Resolve a power-index offset to a descriptor type: lock-free on a bank
+   * hit / zero; takes _reg_mu and programs 0x1e70 on a miss. */
+  uint8_t txpkt_type_for_idx(int idx);
+  /* Program 0x1e70[31:16] from the planner image + the one-time defensive
+   * macid-1 RAM clear. Caller holds _reg_mu (or pre-coex bring-up). */
+  void apply_txpkt_banks_locked();
+  /* Requested-dB -> bank power-index steps (cfg.tuning.txpkt_step_qdb). */
+  int txpkt_idx_for_qdb(int qdb) const;
   /* A-MPDU TX mode (SetAmpduMode). Read lock-free in the TX descriptor path
    * (same pattern as the TX-mode default); a control write during TX is the
    * caller's to sequence and at worst tears one frame's mode benignly. */

--- a/src/jaguar3/TxPktPwrBanks.h
+++ b/src/jaguar3/TxPktPwrBanks.h
@@ -1,0 +1,95 @@
+#ifndef DEVOURER_JAGUAR3_TXPKT_PWR_BANKS_H
+#define DEVOURER_JAGUAR3_TXPKT_PWR_BANKS_H
+
+#include <cstdint>
+
+/* Per-packet TX-power offset banks — the Jaguar3 (8822C/8812F/8822E) hardware
+ * behind the TX-descriptor TXPWR_OFSET_TYPE field (txdesc+0x14[29:28]).
+ *
+ * The 2-bit type selects one of four power-index offset sources the BB adds
+ * on top of the frame's rate-selected TXAGC (vendor phydm.h "bb_ram" block):
+ *
+ *   type 0 / 1 -> per-STA BB-RAM tx_pwr_offset0/1[macid] (0x1e84 write
+ *                 protocol, readback 0x2de8) — macid = descriptor MACID.
+ *   type 2     -> global reg0: 0x1e70[22:16], enable 0x1e70[23]
+ *   type 3     -> global reg1: 0x1e70[30:24], enable 0x1e70[31]
+ *
+ * Offsets are 7-bit two's-complement (-64..+63) in TX-power-index steps
+ * (vendor: "each tx_pwr_ofst step will be 1dB" on the 22C class — the on-air
+ * slope is bench-pinned via cfg.tuning.txpkt_step_qdb). Both chips' BB init
+ * tables write 0x1E70 = 0x00001000, i.e. all banks disabled — which is why
+ * the descriptor field measured inert before the banks were programmed.
+ *
+ * devourer's policy: type 0 is the permanent 0 dB baseline (the per-STA RAM
+ * for macid 1 is cleared once, defensively, at feature enable and never
+ * programmed — so every pre-existing descriptor, which carries 0 in the
+ * field, keeps today's power). The two GLOBAL banks (types 2/3) carry the
+ * active offsets: both live in one dword, so programming both is a single
+ * masked 0x1e70[31:16] write. This planner is the pure allocation policy —
+ * no I/O, unit-tested in tests/txpkt_bank_selftest.cpp. */
+
+namespace jaguar3 {
+
+class TxPktPwrBankPlanner {
+public:
+  struct Plan {
+    uint8_t type;    /* TXPWR_OFSET_TYPE to put in the descriptor (0/2/3) */
+    bool program;    /* true -> write reg16 into 0x1e70[31:16] first */
+    uint16_t reg16;  /* the [31:16] image after this request */
+  };
+
+  /* Clamp a power-index offset request to the 7-bit two's-complement range. */
+  static int clamp_idx(int idx) {
+    return idx < -64 ? -64 : (idx > 63 ? 63 : idx);
+  }
+
+  /* Map a requested offset (power-index steps) onto a bank. 0 -> type 0
+   * (baseline, never a write). A value already held by an enabled bank hits
+   * it (no write, refreshes recency). Otherwise program a free bank, or
+   * evict the least-recently-used one. */
+  Plan request(int idx) {
+    idx = clamp_idx(idx);
+    if (idx == 0)
+      return {0, false, reg16()};
+    for (int b = 0; b < 2; ++b) {
+      if (_b[b].en && _b[b].idx == idx) {
+        _b[b].stamp = ++_tick;
+        return {static_cast<uint8_t>(2 + b), false, reg16()};
+      }
+    }
+    int victim = !_b[0].en ? 0 : (!_b[1].en ? 1 : (_b[0].stamp <= _b[1].stamp ? 0 : 1));
+    _b[victim].en = true;
+    _b[victim].idx = static_cast<int8_t>(idx);
+    _b[victim].stamp = ++_tick;
+    return {static_cast<uint8_t>(2 + victim), true, reg16()};
+  }
+
+  /* The 0x1e70[31:16] image for the current bank state:
+   * bank2 (type 2) -> bits [23:16] = en<<7 | idx&0x7f (register [23] | [22:16])
+   * bank3 (type 3) -> bits [31:24] = en<<7 | idx&0x7f (register [31] | [30:24]) */
+  uint16_t reg16() const {
+    auto byte = [](const Bank &b) -> uint16_t {
+      return b.en ? static_cast<uint16_t>(0x80 | (static_cast<uint8_t>(b.idx) & 0x7f))
+                  : 0;
+    };
+    return static_cast<uint16_t>(byte(_b[1]) << 8) | byte(_b[0]);
+  }
+
+  bool active() const { return _b[0].en || _b[1].en; }
+
+  /* Forget both banks (bring-up reset: the BB init table rewrote 0x1e70). */
+  void reset() { _b[0] = {}; _b[1] = {}; _tick = 0; }
+
+private:
+  struct Bank {
+    bool en = false;
+    int8_t idx = 0;
+    uint32_t stamp = 0;
+  };
+  Bank _b[2]; /* [0] = type 2, [1] = type 3 */
+  uint32_t _tick = 0;
+};
+
+} /* namespace jaguar3 */
+
+#endif /* DEVOURER_JAGUAR3_TXPKT_PWR_BANKS_H */

--- a/tests/txagg_selftest.cpp
+++ b/tests/txagg_selftest.cpp
@@ -219,7 +219,8 @@ static void test_desc_8822c() {
   std::memset(blk, 0, sizeof(blk));
   jaguar3::fill_data_tx_desc_8822c(blk, 1500, 7, 9, 0, false, false, 0,
                                    /*bmc=*/false, /*ndpa=*/false,
-                                   /*data_sc=*/0, /*pkt_offset=*/1);
+                                   /*data_sc=*/0, /*pwr_ofset_type=*/0,
+                                   /*pkt_offset=*/1);
   CHECK((blk[0x07] & 0x1f) == 1, "8822c: pkt_offset field=%u want 1",
         blk[0x07] & 0x1f);
   const uint16_t ck_pad0 = static_cast<uint16_t>(blk[0x1C] | (blk[0x1D] << 8));

--- a/tests/txpkt_bank_selftest.cpp
+++ b/tests/txpkt_bank_selftest.cpp
@@ -1,0 +1,160 @@
+/* Headless guard for the Jaguar3 per-packet TX-power bank planner
+ * (jaguar3::TxPktPwrBankPlanner) and the descriptor-byte layout
+ * of the per-packet power fields on Jaguar3 (TXPWR_OFSET_TYPE, 0x14[29:28])
+ * and the 8814A (TX_POWER_OFFSET, 0x14[30:28]). A policy or bit-position
+ * regression fails ctest instead of surfacing as wrong on-air power. */
+#include <cstdio>
+#include <cstring>
+
+#include "jaguar3/TxPktPwrBanks.h"
+#if defined(DEVOURER_HAVE_JAGUAR3)
+#include "jaguar3/FrameParserJaguar3.h"
+#endif
+#if defined(DEVOURER_HAVE_JAGUAR1)
+#include "basic_types.h" /* jaguar1/FrameParser.h expects the LE macros pre-included */
+#include "jaguar1/FrameParser.h"
+#endif
+
+static int g_fail = 0;
+#define CHECK(cond, ...)                                                       \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      ++g_fail;                                                                \
+      std::printf("FAIL: " __VA_ARGS__);                                       \
+      std::printf("\n");                                                       \
+    }                                                                          \
+  } while (0)
+
+static void test_planner_policy() {
+  using jaguar3::TxPktPwrBankPlanner;
+  TxPktPwrBankPlanner pl;
+
+  /* Zero -> type 0, never a write, banks untouched. */
+  auto p0 = pl.request(0);
+  CHECK(p0.type == 0 && !p0.program, "request(0) -> type %u program %d",
+        p0.type, p0.program);
+  CHECK(pl.reg16() == 0 && !pl.active(), "empty planner not idle");
+
+  /* First non-zero value programs bank 2 ([23:16] half: en bit7 + s7 idx). */
+  auto p1 = pl.request(4);
+  CHECK(p1.type == 2 && p1.program, "first value -> type %u program %d",
+        p1.type, p1.program);
+  CHECK((p1.reg16 & 0xff) == (0x80 | 4), "bank2 byte 0x%02x want 0x84",
+        p1.reg16 & 0xff);
+  CHECK((p1.reg16 >> 8) == 0, "bank3 byte polluted: 0x%02x", p1.reg16 >> 8);
+
+  /* Repeat -> same type, no reprogram. */
+  auto p2 = pl.request(4);
+  CHECK(p2.type == 2 && !p2.program, "repeat reprogrammed (type %u prog %d)",
+        p2.type, p2.program);
+
+  /* Second distinct value -> bank 3; negative encodes s7 two's-complement. */
+  auto p3 = pl.request(-4);
+  CHECK(p3.type == 3 && p3.program, "second value -> type %u program %d",
+        p3.type, p3.program);
+  CHECK((p3.reg16 >> 8) == (0x80 | 0x7c), "bank3 byte 0x%02x want 0xfc (-4 s7)",
+        p3.reg16 >> 8);
+  CHECK((p3.reg16 & 0xff) == (0x80 | 4), "bank2 byte lost on bank3 program");
+
+  /* Third distinct value evicts the LRU bank — bank2 (value 4) was touched
+   * less recently than bank3 (-4). */
+  auto p4 = pl.request(12);
+  CHECK(p4.type == 2 && p4.program, "third value -> type %u program %d",
+        p4.type, p4.program);
+  CHECK((p4.reg16 & 0xff) == (0x80 | 12), "evicted bank2 byte 0x%02x",
+        p4.reg16 & 0xff);
+  CHECK((p4.reg16 >> 8) == (0x80 | 0x7c), "bank3 byte lost on eviction");
+
+  /* Touch bank2 (12), then a fourth value must evict bank3 this time. */
+  (void)pl.request(12);
+  auto p5 = pl.request(-20);
+  CHECK(p5.type == 3 && p5.program, "fourth value -> type %u", p5.type);
+  CHECK((p5.reg16 >> 8) == (0x80 | ((-20) & 0x7f)),
+        "bank3 byte 0x%02x want 0x%02x", p5.reg16 >> 8, 0x80 | ((-20) & 0x7f));
+
+  /* Clamp: the 7-bit two's-complement travel is [-64, +63]. */
+  CHECK(TxPktPwrBankPlanner::clamp_idx(200) == 63, "clamp +");
+  CHECK(TxPktPwrBankPlanner::clamp_idx(-200) == -64, "clamp -");
+  auto p6 = pl.request(63);
+  CHECK((p6.reg16 & 0xff) == (0x80 | 63) || (p6.reg16 >> 8) == (0x80 | 63),
+        "max idx not programmed");
+
+  /* reset() forgets both banks. */
+  pl.reset();
+  CHECK(pl.reg16() == 0 && !pl.active(), "reset left state");
+}
+
+#if defined(DEVOURER_HAVE_JAGUAR3)
+static void test_desc_8822c_type_bits() {
+  /* TXPWR_OFSET_TYPE lives at dword5 (byte 0x14) bits [29:28] = byte 0x17
+   * bits [5:4]. Bit 30 (byte 0x17 bit 6) is ANTSEL_EN_V1 on this generation
+   * and must NEVER be set by the 2-bit macro — an earlier sweep wrote a
+   * 3-bit 8822B-style value and silently enabled antenna-select. */
+  uint8_t d[48];
+  for (uint8_t type = 0; type < 4; type++) {
+    std::memset(d, 0, sizeof(d));
+    jaguar3::fill_data_tx_desc_8822c(d, 1500, 7, 9, 0, false, false, 0,
+                                     /*bmc=*/false, /*ndpa=*/false,
+                                     /*data_sc=*/0, /*pwr_ofset_type=*/type);
+    CHECK(((d[0x17] >> 4) & 0x3) == type, "type %u not at 0x14[29:28]", type);
+    CHECK((d[0x17] & 0x40) == 0, "type %u leaked into bit30 (ANTSEL_EN_V1)",
+          type);
+  }
+
+  /* type=0 output must be byte-identical to a fill without the argument —
+   * the "feature unused" path keeps today's descriptors unchanged. */
+  uint8_t a[48], b[48];
+  std::memset(a, 0, sizeof(a));
+  std::memset(b, 0, sizeof(b));
+  jaguar3::fill_data_tx_desc_8822c(a, 1500, 7, 9, 0, false, false, 0);
+  jaguar3::fill_data_tx_desc_8822c(b, 1500, 7, 9, 0, false, false, 0,
+                                   /*bmc=*/false, /*ndpa=*/false,
+                                   /*data_sc=*/0, /*pwr_ofset_type=*/0);
+  CHECK(std::memcmp(a, b, sizeof(a)) == 0, "type=0 fill not byte-identical");
+
+  /* The type is inside the checksummed span: flipping it must change the
+   * checksum the fill computed (i.e. it was set BEFORE the checksum). */
+  std::memset(a, 0, sizeof(a));
+  std::memset(b, 0, sizeof(b));
+  jaguar3::fill_data_tx_desc_8822c(a, 1500, 7, 9, 0, false, false, 0,
+                                   false, false, 0, /*pwr_ofset_type=*/0);
+  jaguar3::fill_data_tx_desc_8822c(b, 1500, 7, 9, 0, false, false, 0,
+                                   false, false, 0, /*pwr_ofset_type=*/3);
+  const uint16_t ck_a = static_cast<uint16_t>(a[0x1C] | (a[0x1D] << 8));
+  const uint16_t ck_b = static_cast<uint16_t>(b[0x1C] | (b[0x1D] << 8));
+  CHECK(ck_a != ck_b, "checksum ignores TXPWR_OFSET_TYPE (set after chksum?)");
+}
+#endif /* DEVOURER_HAVE_JAGUAR3 */
+
+#if defined(DEVOURER_HAVE_JAGUAR1)
+static void test_desc_8814a_offset_bits() {
+  /* SET_TX_DESC_TX_POWER_OFFSET_8814A = dword5 (byte 0x14) [30:28] = byte
+   * 0x17 bits [6:4] — the 8822B TXPWR_OFSET position (vendor
+   * rtl8814a_xmit.h:207). */
+  uint8_t d[40];
+  std::memset(d, 0, sizeof(d));
+  SET_TX_DESC_TX_POWER_OFFSET_8814A(d, 5);
+  CHECK(((d[0x17] >> 4) & 0x7) == 5, "8814A step 5 not at 0x14[30:28]");
+  CHECK(d[0x14] == 0 && d[0x15] == 0 && d[0x16] == 0,
+        "8814A write leaked outside byte 0x17");
+  /* Within the Jaguar1 32-byte checksummed span (dword5 < 32B) — position
+   * check only; rtl8812a_cal_txdesc_chksum runs after all dword writes in
+   * build_tx_block. */
+}
+#endif /* DEVOURER_HAVE_JAGUAR1 */
+
+int main() {
+  test_planner_policy();
+#if defined(DEVOURER_HAVE_JAGUAR3)
+  test_desc_8822c_type_bits();
+#endif
+#if defined(DEVOURER_HAVE_JAGUAR1)
+  test_desc_8814a_offset_bits();
+#endif
+  if (g_fail) {
+    std::printf("%d failure(s)\n", g_fail);
+    return 1;
+  }
+  std::printf("txpkt bank/descriptor selftest: all OK\n");
+  return 0;
+}

--- a/tests/txpkt_fastswing_onair.sh
+++ b/tests/txpkt_fastswing_onair.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# MEASURE the Jaguar1 fast BB-swing TX-power lever on-air
+# (RtlJaguarDevice::FastSetTxPowerOffsetQdb): does the TxScale digital scaler
+# (0xc1c/0xe1c[31:21], table steps of 0.5 dB) move radiated power by the
+# requested amount? This is the 8812A/8821A compensating lever — global,
+# per-burst, NOT per-packet (their descriptor has no per-frame power field);
+# the 8814A also has it (4 paths) on top of its descriptor LUT.
+#
+# TX = the DUT at a FIXED rate/power, one DEVOURER_TX_FAST_PWR_QDB per cell;
+# ground = a second devourer part reporting per-frame RSSI. Cells sweep
+# {0, +2, -2, -4, -8} dB (qdb 0/+8/-8/-16/-32); the +2 ceiling is the vendor
+# thermal cap the lever clamps to.
+#
+# Usage: sudo -v && tests/txpkt_fastswing_onair.sh [ground_pid]
+#   TX_PID/TX_VID          DUT identity (default 8812AU 0bda:8812)
+#   GROUND_PID/GROUND_VID  RSSI sensor identity (default 8822BU 2357:012d)
+#   CH                     channel (default 36)
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="${FASTSWING_OUT:-/tmp/devourer-txpkt-fastswing}"
+CH="${CH:-36}"
+TX_PID="${TX_PID:-0x8812}" TX_VID="${TX_VID:-0x0bda}"
+GROUND_PID="${1:-0x012d}" GROUND_VID="${GROUND_VID:-0x2357}"
+# qdb cells paired with their nominal dB (for the assertion).
+QDBS="0 8 -8 -16 -32"
+declare -A DB=( [0]=0 [8]=2 [-8]=-2 [-16]=-4 [-32]=-8 )
+mkdir -p "$OUT"
+
+cleanup() { pkill -x txdemo 2>/dev/null||true; pkill -x rxdemo 2>/dev/null||true; true; }
+trap cleanup EXIT INT TERM
+plugged() { lsusb -d "$(printf '%04x:%04x' "$2" "$1")" >/dev/null 2>&1; }
+plugged "$TX_PID" "$TX_VID" || { echo "SKIP: TX DUT $TX_VID:$TX_PID not plugged"; exit 0; }
+plugged "$GROUND_PID" "$GROUND_VID" || { echo "SKIP: ground $GROUND_PID not plugged"; exit 0; }
+
+echo "== building =="
+cmake --build "$ROOT/build" -j --target txdemo rxdemo >/dev/null || exit 1
+
+echo "== ground RX ($GROUND_PID) on ch$CH =="
+: >"$OUT/ground.log"
+sudo -n env DEVOURER_PID="$GROUND_PID" DEVOURER_VID="$GROUND_VID" \
+    DEVOURER_CHANNEL="$CH" DEVOURER_STREAM_OUT=1 \
+    stdbuf -oL timeout 300 "$ROOT/build/rxdemo" 2>"$OUT/ground.err" \
+    | while IFS= read -r l; do printf '%s %s\n' "$(date +%s.%N)" "$l"; done \
+    >>"$OUT/ground.log" &
+GJ=$!
+sleep 12
+
+: >"$OUT/cells.txt"
+for qdb in $QDBS; do
+    t0="$(date +%s.%N)"
+    # Fixed rate MCS3, fixed base power, only the fast swing offset varies.
+    sudo -n env DEVOURER_PID="$TX_PID" DEVOURER_VID="$TX_VID" DEVOURER_CHANNEL="$CH" \
+        DEVOURER_TX_RATE=MCS3 DEVOURER_TX_PWR=40 DEVOURER_TX_FAST_PWR_QDB="$qdb" \
+        DEVOURER_TX_GAP_US=1500 \
+        timeout 12 "$ROOT/build/txdemo" >/dev/null 2>&1 || true
+    t1="$(date +%s.%N)"
+    echo "q$qdb ${DB[$qdb]} $t0 $t1" >>"$OUT/cells.txt"
+    sleep 2
+done
+sudo -n pkill -x rxdemo 2>/dev/null; wait "$GJ" 2>/dev/null
+
+python3 - "$OUT/ground.log" "$OUT/cells.txt" <<'PYEOF'
+import re, statistics, sys
+frames = []
+rx = re.compile(r'^([0-9.]+) .*"ev":"rx\.frame".*"rssi":\[(-?\d+),')
+for line in open(sys.argv[1], errors="replace"):
+    m = rx.match(line)
+    if m:
+        frames.append((float(m.group(1)), int(m.group(2))))
+def med(t0, t1):
+    win = [r for (t, r) in frames if t0 + 6 <= t <= t1 - 1]
+    return (int(statistics.median(win)), len(win)) if len(win) >= 15 else (None, len(win))
+
+cells = []
+for line in open(sys.argv[2]):
+    label, db, t0, t1 = line.split(); db, t0, t1 = int(db), float(t0), float(t1)
+    rssi, n = med(t0, t1)
+    if rssi is None:
+        print(f"{label} ({db:+d} dB): too few frames ({n})"); continue
+    cells.append((db, rssi))
+    print(f"<fastswing> nominal_db={db:+d} rssi_med={rssi} frames={n}")
+
+base = next((r for (d, r) in cells if d == 0), None)
+if base is None or len(cells) < 4:
+    print("RESULT-FASTSWING inconclusive (no 0 dB baseline)"); sys.exit(1)
+print(f"\nfast-swing baseline (0 dB) rssi = {base}")
+moved = correct = total = 0
+for db, rssi in cells:
+    if db == 0:
+        continue
+    total += 1
+    d = rssi - base
+    moved += abs(d) >= 1
+    correct += (db > 0 and d > 0) or (db < 0 and d < 0)
+    print(f"  {db:+3d} dB: rssi {base}->{rssi} = {d:+d} raw")
+if moved == 0:
+    print("RESULT-FASTSWING INERT — BB-swing writes did not move on-air power")
+    sys.exit(1)
+if correct >= total - 1:
+    print(f"RESULT-FASTSWING WORKS — {correct}/{total} cells correct direction")
+    sys.exit(0)
+print(f"RESULT-FASTSWING PARTIAL — {correct}/{total} correct sign"); sys.exit(1)
+PYEOF

--- a/tests/txpkt_hop_persist.sh
+++ b/tests/txpkt_hop_persist.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# PERSISTENCE check for the Jaguar3 per-packet power banks: the
+# lever contract says power knobs stick across channel switches. One txdemo
+# session hops 36<->40 via FastRetune while a +6 dB per-packet default is
+# active; a second identical session runs at 0 dB. The ground (fixed ch36)
+# only decodes the ch36 dwells — if a retune dropped the 0x1e70 banks, the
+# offset session's ch36 median would collapse to the baseline instead of
+# holding ~+6 dB above the 0 dB session.
+#
+# Usage: sudo -v && tests/txpkt_hop_persist.sh [ground_pid]
+#   TX_PID/TX_VID (default 8812CU 0bda:c812), GROUND_* (default 8822BU).
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="${TXPKT_OUT:-/tmp/devourer-txpkt-hop-persist}"
+TX_PID="${TX_PID:-0xc812}" TX_VID="${TX_VID:-0x0bda}"
+GROUND_PID="${1:-0x012d}" GROUND_VID="${GROUND_VID:-0x2357}"
+mkdir -p "$OUT"
+
+cleanup() { pkill -x txdemo 2>/dev/null||true; pkill -x rxdemo 2>/dev/null||true; true; }
+trap cleanup EXIT INT TERM
+plugged() { lsusb -d "$(printf '%04x:%04x' "$2" "$1")" >/dev/null 2>&1; }
+plugged "$TX_PID" "$TX_VID" || { echo "SKIP: TX DUT $TX_VID:$TX_PID not plugged"; exit 0; }
+plugged "$GROUND_PID" "$GROUND_VID" || { echo "SKIP: ground $GROUND_PID not plugged"; exit 0; }
+
+cmake --build "$ROOT/build" -j --target txdemo rxdemo >/dev/null || exit 1
+
+echo "== ground RX ($GROUND_PID) fixed on ch36 =="
+: >"$OUT/ground.log"
+sudo -n env DEVOURER_PID="$GROUND_PID" DEVOURER_VID="$GROUND_VID" \
+    DEVOURER_CHANNEL=36 DEVOURER_STREAM_OUT=1 \
+    stdbuf -oL timeout 120 "$ROOT/build/rxdemo" 2>"$OUT/ground.err" \
+    | while IFS= read -r l; do printf '%s %s\n' "$(date +%s.%N)" "$l"; done \
+    >>"$OUT/ground.log" &
+GJ=$!
+sleep 10
+
+: >"$OUT/cells.txt"
+for qdb in 24 0; do
+    t0="$(date +%s.%N)"
+    # 36<->40 FastRetune hops, ~200 frames per dwell, per-packet default $qdb.
+    sudo -n env DEVOURER_PID="$TX_PID" DEVOURER_VID="$TX_VID" DEVOURER_CHANNEL=36 \
+        DEVOURER_TX_RATE=MCS3 DEVOURER_TX_PWR=40 DEVOURER_TX_PKT_PWR_QDB="$qdb" \
+        DEVOURER_HOP_CHANNELS=36,40 DEVOURER_HOP_DWELL_FRAMES=200 DEVOURER_HOP_FAST=1 \
+        DEVOURER_TX_GAP_US=1500 \
+        timeout 20 "$ROOT/build/txdemo" >/dev/null 2>&1 || true
+    t1="$(date +%s.%N)"
+    echo "$qdb $t0 $t1" >>"$OUT/cells.txt"
+    sleep 2
+done
+sudo -n pkill -x rxdemo 2>/dev/null; wait "$GJ" 2>/dev/null
+
+python3 - "$OUT/ground.log" "$OUT/cells.txt" <<'PYEOF'
+import re, statistics, sys
+frames = []
+rx = re.compile(r'^([0-9.]+) .*"ev":"rx\.frame".*"rssi":\[(-?\d+),')
+for line in open(sys.argv[1], errors="replace"):
+    m = rx.match(line)
+    if m:
+        frames.append((float(m.group(1)), int(m.group(2))))
+med = {}
+for line in open(sys.argv[2]):
+    qdb, t0, t1 = line.split(); qdb, t0, t1 = int(qdb), float(t0), float(t1)
+    win = [r for (t, r) in frames if t0 + 4 <= t <= t1 - 1]
+    if len(win) < 15:
+        print(f"qdb={qdb}: too few ch36 frames ({len(win)})"); sys.exit(1)
+    med[qdb] = int(statistics.median(win))
+    print(f"<hop-persist> qdb={qdb:+d} ch36_rssi_med={med[qdb]} frames={len(win)}")
+d = med[24] - med[0]
+print(f"\n+6 dB session vs 0 dB session across FastRetune hops: {d:+d} raw")
+if d >= 3:
+    print("RESULT-PERSIST WORKS — banks survive FastRetune (offset held on-air)")
+    sys.exit(0)
+print("RESULT-PERSIST FAIL — offset lost across retunes")
+sys.exit(1)
+PYEOF

--- a/tests/txpkt_pwr_ofset_onair.sh
+++ b/tests/txpkt_pwr_ofset_onair.sh
@@ -1,23 +1,37 @@
 #!/usr/bin/env bash
-# MEASURE the Jaguar2 per-packet TX-descriptor power lever (TXPWR_OFSET). Does
-# setting the 3-bit descriptor field actually move on-air power standalone (no
-# phydm dynamic-txpwr enable), and by the vendor LUT (0=none, 1=-3, 2=-7, 3=-11,
-# 4=+3, 5=+6 dB)? Measure-first, before wiring the radiotap per-packet path.
+# MEASURE the per-packet TX-descriptor power lever on-air. Does
+# the DUT's per-frame power mechanism actually move radiated power, and by the
+# nominal dB the sweep requests? Family mechanisms behind the ONE env knob
+# (DEVOURER_TX_PKT_OFSET, examples/tx fan-out):
+#   Jaguar2 8822B/8821C — descriptor TXPWR_OFSET 3-bit hardware LUT
+#     (0=none 1=-3 2=-7 3=-11 4=+3 5=+6 dB). The original, on-air-confirmed.
+#   Jaguar1 8814A       — dword5 [30:28] descriptor field, same LUT expected.
+#   Jaguar3 8822C/8822E — TXPWR_OFSET_TYPE bank selector; the step's nominal
+#     dB is programmed into a 0x1e70 offset bank (TxPktPwrBanks.h) — slope
+#     calibratable via DEVOURER_TXPKT_STEP_QDB (passed through when set).
 #
-# TX = 8822BU (the descriptor field is Jaguar2) at a FIXED rate/power, stepping
-# DEVOURER_TX_PKT_OFSET; ground = a second devourer part reporting per-frame
-# RSSI (the same chip-RSSI sensor the TX-power slope work uses, since the B210
-# front end limits on near-field frames). If the field works, ground RSSI
-# tracks the LUT: step 4 (+3) up ~3 dB, step 5 (+6) up ~6 dB, step 1/2/3
-# (-3/-7/-11) down, all vs step 0.
+# TX = the DUT at a FIXED rate/power, stepping DEVOURER_TX_PKT_OFSET; ground =
+# a second devourer part reporting per-frame RSSI (the same chip-RSSI sensor
+# the TX-power slope work uses, since the B210 front end limits on near-field
+# frames). If the lever works, ground RSSI tracks the nominal dB per step.
 #
 # Usage: sudo -v && tests/txpkt_pwr_ofset_onair.sh [ground_pid]
+#   TX_PID/TX_VID          DUT identity (default 8822BU T3U 2357:012d)
+#   TX_BUS/TX_PORT         USB topology pin when VID:PID is ambiguous (8814A)
+#   GROUND_PID/GROUND_VID  RSSI sensor identity (default 8812CU 0bda:c812)
+#   CH                     channel (default 36; 8822E DUTs are 5 GHz-only TX)
 set -u
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 OUT="${TXPKT_OUT:-/tmp/devourer-txpkt-ofset}"
 CH="${CH:-36}"
-TX_PID=0x012d TX_VID=0x2357          # 8822BU (T3U) — has TXPWR_OFSET
+TX_PID="${TX_PID:-0x012d}" TX_VID="${TX_VID:-0x2357}"
+TX_BUS="${TX_BUS:-}" TX_PORT="${TX_PORT:-}"
 GROUND_PID="${1:-0xc812}" GROUND_VID="${GROUND_VID:-0x0bda}"
+# Extra env for the TX cells (topology pin + J3 slope override when set).
+TX_EXTRA=()
+[ -n "$TX_BUS" ] && TX_EXTRA+=("DEVOURER_USB_BUS=$TX_BUS")
+[ -n "$TX_PORT" ] && TX_EXTRA+=("DEVOURER_USB_PORT=$TX_PORT")
+[ -n "${DEVOURER_TXPKT_STEP_QDB:-}" ] && TX_EXTRA+=("DEVOURER_TXPKT_STEP_QDB=$DEVOURER_TXPKT_STEP_QDB")
 # LUT steps to sweep, paired with their nominal dB (for the assertion).
 STEPS="0 4 5 1 2 3"
 declare -A DB=( [0]=0 [4]=3 [5]=6 [1]=-3 [2]=-7 [3]=-11 )
@@ -26,7 +40,7 @@ mkdir -p "$OUT"
 cleanup() { pkill -x txdemo 2>/dev/null||true; pkill -x rxdemo 2>/dev/null||true; true; }
 trap cleanup EXIT INT TERM
 plugged() { lsusb -d "$(printf '%04x:%04x' "$2" "$1")" >/dev/null 2>&1; }
-plugged "$TX_PID" "$TX_VID" || { echo "SKIP: 8822BU (TX) not plugged"; exit 0; }
+plugged "$TX_PID" "$TX_VID" || { echo "SKIP: TX DUT $TX_VID:$TX_PID not plugged"; exit 0; }
 plugged "$GROUND_PID" "$GROUND_VID" || { echo "SKIP: ground $GROUND_PID not plugged"; exit 0; }
 
 echo "== building =="
@@ -48,7 +62,7 @@ for step in $STEPS; do
     # Fixed rate MCS3, fixed base power, only the per-packet offset varies.
     sudo -n env DEVOURER_PID="$TX_PID" DEVOURER_VID="$TX_VID" DEVOURER_CHANNEL="$CH" \
         DEVOURER_TX_RATE=MCS3 DEVOURER_TX_PWR=40 DEVOURER_TX_PKT_OFSET="$step" \
-        DEVOURER_TX_GAP_US=1500 \
+        DEVOURER_TX_GAP_US=1500 "${TX_EXTRA[@]}" \
         timeout 12 "$ROOT/build/txdemo" >/dev/null 2>&1 || true
     t1="$(date +%s.%N)"
     echo "$step ${DB[$step]} $t0 $t1" >>"$OUT/cells.txt"
@@ -72,7 +86,7 @@ for pair in "0:0" "6:6" "-11:-11"; do
     t0="$(date +%s.%N)"
     sudo -n env DEVOURER_PID="$TX_PID" DEVOURER_VID="$TX_VID" DEVOURER_CHANNEL="$CH" \
         DEVOURER_TX_RATE=MCS3 DEVOURER_TX_PWR=40 DEVOURER_TX_PKT_PWR_DB="$db" \
-        DEVOURER_TX_GAP_US=1500 \
+        DEVOURER_TX_GAP_US=1500 "${TX_EXTRA[@]}" \
         timeout 12 "$ROOT/build/txdemo" >/dev/null 2>&1 || true
     t1="$(date +%s.%N)"
     echo "r$db $db $t0 $t1" >>"$OUT/cells.txt"

--- a/tests/txpkt_pwr_selftest.cpp
+++ b/tests/txpkt_pwr_selftest.cpp
@@ -44,6 +44,15 @@ int main() {
     std::printf("FAIL: db_for_step(2) != -7\n");
   }
 
+  /* The quantizer is hoisted to src/TxPower.h (shared with the 8814A path);
+   * the jaguar2:: spellings above are forwarding aliases. Guard the direct
+   * devourer:: symbols too. */
+  if (devourer::txpkt_pwr_step_for_db(-7) != 2 ||
+      devourer::txpkt_pwr_db_for_step(5) != 6) {
+    ++g_fail;
+    std::printf("FAIL: devourer:: hoisted quantizer diverges\n");
+  }
+
   if (g_fail) {
     std::printf("%d failure(s)\n", g_fail);
     return 1;


### PR DESCRIPTION
## What

Per-packet / fast TX-power control for the two families that lacked it:

**Jaguar3 (8822C/8822E)** — the TX-descriptor `TXPWR_OFSET_TYPE` field is a bank *selector*, not an 8822B-style dB LUT: types 2/3 select two programmable 7-bit-signed power-index offsets in BB `0x1e70[31:16]` (enable bits 23/31); types 0/1 select per-STA BB-RAM offsets by descriptor MACID. Both chips' BB init tables reset `0x1e70` to banks-disabled, so the descriptor field alone is inert until programmed. devourer now:
- programs the global banks via an LRU planner (`src/jaguar3/TxPktPwrBanks.h`, one masked BB write per new value)
- stamps the 2-bit type per frame — radiotap `DBM_TX_POWER` wins, session default via `SetTxPacketPowerOffsetQdb`
- re-applies across `InitWrite` / `SetMonitorChannel` (`FastRetune` never touches `0x1e70`)
- splits USB-agg URB runs on differing per-packet power so a bank reprogram never lands mid-URB
- the 2-bit setter macro structurally cannot touch `0x14[30]` = `ANTSEL_EN_V1` (a 3-bit 8822B-style write there silently enables antenna-select)

**8814A** — wires the vendor-defined `SET_TX_DESC_TX_POWER_OFFSET_8814A` (dword5 `[30:28]`, the 8822B `TXPWR_OFSET` position; halmac guards the same 3-bit macro) as the Jaguar2 LUT, via `SetTxPacketPowerStep` + radiotap. Caps report `per_pkt_txpwr_measured=false` until its on-air sweep runs (`TX_PID=0x8813 tests/txpkt_pwr_ofset_onair.sh`).

**8812A/8821A** — no descriptor power field exists (confirmed against the vendor descriptor layout); the compensating lever is `FastSetTxPowerOffsetQdb`: BB-swing TxScale `0xc1c/0xe1c[31:21]` digital scaling, 0.5 dB steps, −12..+2 dB, 1–4 register writes vs the 30–50+ write TXAGC rewrite. Folded through the 8812A thermal tracker post-clamp so tracker ticks compose instead of clobbering; direct-write leg with external-writer base recapture on 8821A/8814A.

Shared: LUT quantizer hoisted to `src/TxPower.h` (jaguar2 aliases kept, byte-identical path); `AdapterCaps` gains `per_pkt_txpwr_{steps,step_qdb,min_qdb,max_qdb,measured}`; `DEVOURER_TX_PKT_OFSET` fans out to all three families, plus `DEVOURER_TX_PKT_PWR_QDB` / `DEVOURER_TX_FAST_PWR_QDB` / `DEVOURER_TXPKT_STEP_QDB`.

## Validation

On-air, two-adapter chip-RSSI ground (ch36, MCS3, fixed base power), windowed medians:

| Chip | Result |
|---|---|
| 8822CU | 5/5 LUT steps track + 2/2 radiotap per-packet cells (+6 → +4/+6, −11 → −13/−14 raw) |
| 8822EU | 5/5 + 2/2; deep cuts compress to ≈−6 dB (its TSSI transfer, same as its offset slope) |
| Persistence | +6 dB held across 36↔40 `FastRetune` hops (`tests/txpkt_hop_persist.sh`) |
| 8812AU | BB-swing 3/4 cells correct, monotonic (`tests/txpkt_fastswing_onair.sh`) |
| 8821AU | BB-swing 4/4 exact (+2/−2/−4/−8 → +2/−2/−4/−8 raw) |
| 8822BU | Jaguar2 regression 4/5 + 2/2 (the +3 cell sat at the ground's AGC ceiling) |
| 8814A | descriptor field wired; on-air sweep pending a plugged unit |

Headless: new `txpkt_bank_policy` ctest (planner LRU/s7-encode/clamps, descriptor bit positions incl. the bit30 hazard, type-0 byte-identical descriptors, checksum coverage); full suite 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)