### PR TITLE
Kernel channel-switch baseline: measured matrix + go/no-go for standard-driver FHSS (exp 1/5)

### DIFF
--- a/docs/kernel-channel-switch-baseline.md
+++ b/docs/kernel-channel-switch-baseline.md
@@ -1,0 +1,303 @@
+# Kernel-driver channel-switch baseline
+
+Like-for-like latency and behavior of every channel-switch primitive the
+standard Linux/Realtek kernel drivers expose on devourer-supported silicon —
+the baseline the firmware-assisted-FHSS investigation measures itself
+against. Companion harness: `tests/kchansw_bench.py` (orchestrator),
+`tests/kchansw_trace.py` (ftrace session), `tests/kchansw_inject.py`
+(tagged-frame injector), `tests/kchansw_analyze.py` (offline analysis +
+gate verdicts). Devourer's own numbers for the same operation:
+[fhss.md](fhss.md) — FastRetune 0.55–2.5 ms per generation.
+
+## Method
+
+One timeline, three instruments:
+
+- **Kernel side**: ftrace with `trace_clock=mono` (== `CLOCK_MONOTONIC` ==
+  the harness's `time.monotonic_ns()`), the cfg80211 `rdev_*` and mac80211
+  `drv_*`/queue trace events, and `kchansw/` kprobe pairs on the driver's
+  internal switch functions. Host-command latency = the `rdev_*`
+  entry→return pair, i.e. the nl80211 request as the driver experiences it
+  (the `iw` exec overhead is excluded by construction). A `trace_marker`
+  write brackets every switch for segmentation.
+- **On-air oracle** (mandatory — an API success without destination-channel
+  RF evidence is a *failed* measurement): two devourer `rxdemo` receivers
+  pinned to the source and destination channels
+  (`DEVOURER_STREAM_OUT=1`, SA-gated via `DEVOURER_RX_AGG_SA`), stdout
+  stamped per line at read time. Per-frame placement does not use the noisy
+  pipe stamps: each oracle's MAC-latched µs RX timestamp (`tsfl`) is mapped
+  to host time by a robust linear fit (Theil-Sen + inlier least-squares;
+  observed residual σ 70–320 µs, slope error < 30 ppm), so frame times are
+  chip-clock-precise. **Dead air** per switch = first frame decoded on the
+  destination channel minus last frame decoded on the source channel.
+- **Traffic**: a 2 kHz AF_PACKET injector on the DUT's monitor interface;
+  every frame carries a payload counter + send timestamp (decodable from
+  the oracle's `rx.frame` body hex, immune to kernel sequence-number
+  rewrites) — the loss/duplication ledger. For CSA the AP's own beacons are
+  the stream; for the scan row the DUT's probe requests are.
+
+Instrumentation overhead, measured by an instrumented/bare A/B of the same
+20 switches: +2.5 ms on a ~114 ms operation (~2 %).
+
+Gates (issue criteria, applied to on-air dead-time p99 per config):
+**< 5 ms** advance as an FHSS primitive; **5–20 ms** slow slot-hopping
+only; **> 20 ms** control row.
+
+## Capability matrix
+
+DUT silicon: RTL8822BU (TP-Link Archer T3U, `2357:012d`). Kernel
+6.18.33-1-lts, regdom US. Every row verified live on this rig (evidence in
+parentheses).
+
+| Primitive | rtw88_8822bu (in-tree, mac80211) | rtl88x2bu vendor (cfg80211) | rtw89_8852bu (in-tree, RTL8852BU) |
+|---|---|---|---|
+| Monitor set-channel | functional (measured below) | functional (measured below) | functional (measured below) |
+| AP + CSA | measured below (wpa_supplicant AP mode) | not attempted — no `channel_switch` cfg80211 op in the fork | measured below (chanctx driver) |
+| Remain-on-channel | mac80211 software ROC (driver has no `remain_on_channel` op — module symtab) | `.remain_on_channel` op functional (measured below, trace-only) | hardware ROC (`rtw89_ops_remain_on_channel` in symtab) |
+| Single-freq active scan | measured below (`drv_hw_scan` fw-offload) | not measured | not measured |
+| TDLS channel switch | **unsupported** — no `tdls_channel_switch` op in symtab, zero TDLS mentions in `iw phy` | code present, compile-gated `CONFIG_TDLS=y` → `rtw_hal_ch_sw_oper_offload` → **H2C 0x1C** `H2C_CHNL_SWITCH_OPER_OFFLOAD`; runtime-gated `rtw_wifi_spec=1`; end-to-end **blocked-hardware-absent** (needs two associated STAs + AP; no helper AP on rig this session) | no `tdls_channel_switch` op |
+| MCC / FCS | **not implemented** (no chanctx ops; "interface combinations are not supported") | machinery live (measured below): MCC build auto-creates the second vif, STA associates, `mcc/` proc knobs accept `mcc_enable=1`, policy table exposed (100 ms interval, 20/80 duration splits); engine idle until *both* vifs are linked on different channels — driving that is exp-3 (#271) | MCC exists (chanctx) but is P2P-driven — documented-only |
+| `set_txpower` | **rejected** `EOPNOTSUPP` (no userspace TX-power control) | not probed | not probed |
+
+Vendor-build facts: the OpenHD `rtl88x2bu` fork builds `88x2bu_ohd.ko` on
+6.18 after one compat fix (cfg80211 `tdls_mgmt` gained `int link_id` ≥ 6.0
+— the TDLS code had never been compiled on the 6.x branch) and on the
+measurement VM's 5.15 after a second (`timer_container_of` is ≥ 6.16;
+older kernels spell it `from_timer`); the TDLS and MCC firmware-offload
+families cannot coexist in one binary, and the MCC make variant renames
+the module `8812bu.ko`.
+
+**The vendor driver must be measured in a VM.** With the TDLS-variant
+module loaded (no `CONFIG_CONCURRENT_MODE`), `iw dev <if> interface add
+<x> type monitor` — adding *any* second vif — deadlocks the kernel inside
+the driver's add-interface path with RTNL held: ssh dies, `dmesg` blocks,
+nothing panics, only a power cycle recovers. This livelock took the whole
+host down twice before a step-by-step probe (VM-contained, reproduced on
+demand) isolated it to that single operation — the kprobes and the switch
+churn are innocent. `tests/kchansw_vm.sh` therefore runs the vendor phase
+inside the pinned-kernel VM (Ubuntu 22.04 / 5.15) with the DUT
+USB-passed-through (still pinned to its USB2 port — passthrough URBs ride
+the host controller) and the oracles left on the host; a repeat wedge
+costs a `virsh reset`. The bench maps the VM's CLOCK_MONOTONIC onto the
+host timeline with a min-RTT-midpoint ssh probe (±0.15 ms, drift-checked
+before and after each config); dead-air numbers never cross that bridge —
+both oracles are host-side.
+
+## Results — rtw88_8822bu (in-tree, kernel 6.18.33)
+
+DUT on its USB2-HS link (see Endurance for why that matters). Warm-ups
+excluded; every row below carries on-air RF evidence; zero failed switches
+in all set-channel configs.
+
+### Ordinary set-channel (monitor interface)
+
+| config | n | dead air med | p90 | p99 | max | host-cmd med | driver med | gate |
+|---|---|---|---|---|---|---|---|---|
+| 36↔40, 20 MHz | 2000 | **52.0 ms** | 57.7 | 60.6 | 86.6 | 84.0 ms | 42.7 ms | control |
+| 1↔6, 20 MHz | 300 | **6.1 ms** | 11.8 | 16.6 | 22.7 | 84.4 ms | 42.2 ms | **slow-slot-only** |
+| 36↔44, HT40+ | 300 | 55.4 ms | 56.2 | 57.7 | 60.4 | 83.6 ms | 42.2 ms | control |
+| 36↔6 cross-band (control) | 50 | 57.6 ms | 60.9 | 64.3 | 66.6 | 83.7 ms | 42.2 ms | control |
+
+The structure is striking: the driver-internal call (`rtw_set_channel`
+kprobe pair) costs a band-independent ~42 ms and the nl80211 round trip
+~84 ms — but the RADIO's actual dark time is 6 ms intra-2.4 GHz versus
+52 ms whenever 5 GHz is involved on either end (cross-band is *not*
+bimodal: leaving **or** entering 5 GHz pays the full price, so the cost sits
+in the 5 GHz RF-path programming, not in a generic "band switch"). On
+2.4 GHz the radio is already airing frames ~78 ms before the nl80211 call
+returns. Host-command latency alone (the number an API-only benchmark
+would report) overstates the 2.4 GHz RF transition by 14× and understates
+nothing on 5 GHz — the on-air oracle is not optional.
+
+The monitor set-channel path involves **no firmware H2C**
+(`rtw_fw_send_h2c_command` count = 0 per switch) and does **not** stop
+mac80211 TX queues — frames submitted during the switch are simply lost
+(gap ledger: ~89 lost frames per 5 GHz switch at 2 kHz ≈ 45 ms of blind
+TX, independently cross-checking the oracle's dead-air figure).
+
+### Remain-on-channel (software ROC — no driver op)
+
+Trace-only timing (single-vif driver: no parallel monitor vif possible, so
+no on-air evidence; `need_rf` waived for this primitive):
+
+| metric | 36→ROC(40) n=1000 | 40→ROC(36) n=300 |
+|---|---|---|
+| request → ready-on-channel | 45.9 ms med / 54.5 p99 | 46.7 / 54.9 |
+| granted dwell (20 ms asked) | 22.1 ms med | 22.0 ms |
+| TX queues stopped (total blackout) | 116.4 ms med / 127.6 p99 | 117.1 / 128.1 |
+
+ROC *does* stop queues (unlike set-channel), and the ~46 ms grant latency
+matches the one-way 5 GHz retune cost seen above. A 20 ms off-channel
+errand costs ~116 ms of link blackout round-trip.
+
+### Single-frequency active scan (`drv_hw_scan` firmware offload)
+
+The closest in-tree cousin of firmware-assisted hopping — and the slowest
+path measured: request → first probe request decoded on the target channel
+**2.23 s median** (n=295, RF-evidenced), host-cmd 2.15 s, queues stopped
+226 ms per scan. The firmware scan machinery is built for background
+discovery, not agile retuning. Control row.
+
+### AP/CSA — policy-rejected (no latency row possible)
+
+hostapd brings a beaconing AP up on the rtw88 DUT without complaint (open
+BSS, ch 36 and ch 1 both verified on-air: the source-channel oracle decodes
+the beacon stream), but every `chan_switch` is refused **before any
+nl80211 call**: hostapd logs `CSA is not supported` (the wiphy never
+advertises the AP-CSA driver flag) and wpa_supplicant's AP-mode
+`CHAN_SWITCH` fails the same way. Zero `rdev_channel_switch` events reach
+cfg80211 across all attempts; the destination-channel oracle hears
+nothing. Classification: **policy-rejected at the driver-capability
+level** — CSA on this driver cannot even be benchmarked, let alone used.
+
+### Cold first switch
+
+Each in-run wedge recovery is a driver-cold bring-up (module reload or
+deeper) immediately followed by an instrumented switch, so the endurance
+data doubles as the cold sample: post-recovery first switches show the
+same ~52 ms dead-air profile as steady-state — the expensive part of a
+cold start is the firmware download + bring-up (seconds), not the first
+retune afterwards.
+
+### Endurance and the USB-link dependence
+
+The issue's endurance criterion (no cumulative wedge across 1,000
+switches) fails outright on the T3U's native USB3/SuperSpeed link and
+passes completely on USB2:
+
+- **USB3 (Bus 10 root port)**: sustained 2 kHz monitor injection + switch
+  churn wedged the DUT repeatedly — first as EPROTO register-write
+  failures escalating to full USB disconnect, then as a *silent-TX* state
+  (sends accepted, nothing airs, dmesg clean) with a ~15–30 k-frame
+  cadence, and terminally as a uPD720201 host-controller hang (xhci
+  re-probe -110) that required a PCI bus reset + D3hot→D0 bounce + rescan
+  plus a 12 s per-port power-off. The recovery ladder in
+  `kchansw_bench.py` (re-probe → module reload → authorized/VBUS cycle →
+  bus/controller revive) automates all four rungs.
+- **USB2 (same adapter, companion bus after the hard reset)**: 2000 + 300
+  + 300 + 50 + 1010 + 310 switches with **zero wedges**.
+
+For comparison, devourer's own TX path sustains this duty for hours on the
+same silicon over USB3. An injection-heavy kernel-driver deployment on
+this hardware should pin the adapter to USB2 or expect the wedge ladder.
+
+Instrument note: a low-rate B210 partial-band energy capture during the
+5 GHz run confirms the macroscopic on/off cycling (37 dB contrast, zero
+overflows) but near-field adjacent-channel splatter fragments the silent
+periods, so the energy view cannot resolve the decode-vs-energy edge bias
+below ~10 ms; the decode oracle remains the primary instrument
+(`tests/kchansw_b210_gap.py`).
+
+## Results — rtl88x2bu vendor driver (VM, kernel 5.15, `rtw_wifi_spec=1`)
+
+Same silicon, same channels, same oracles as Phase A — different driver.
+
+### Ordinary set-channel (monitor interface)
+
+| config | n | dead air med | p90 | p99 | max | host-cmd med | gate |
+|---|---|---|---|---|---|---|---|
+| 36↔40, 20 MHz | 998/1000 | **1.08 ms** | 1.68 | 4.42 | 32.9 | 66.3 ms | **advance** |
+
+The headline of the whole experiment: the vendor driver's internal switch
+path (`rtw_set_chbw_cmd` → `rtw_hal_set_chnl_bw` →
+`phy_SwChnlAndSetBwMode8822B`) goes dark for a median **1.08 ms** on the
+same 36↔40 5 GHz hop that costs the in-tree rtw88 driver 52 ms — a 48×
+difference, and *under* the < 5 ms FHSS gate at p99. The ~66 ms nl80211
+round trip is pure bookkeeping: the radio is already airing on the
+destination channel ~65 ms before the `iw` call returns. The gap ledger
+cross-checks (731 lost frames over 998 switches at 2 kHz ≈ 0.37 ms mean
+blind time), and both oracle fits are chip-clock tight (σ 40/280 µs,
+< 20 ppm). Two switches failed the RF-evidence gate; max observed dead
+air 32.9 ms.
+
+This is direct evidence that the RTL8822BU hardware/firmware retune is
+FHSS-capable through a kernel driver, and that rtw88's 52 ms lives in
+that driver's software sequence (RF-K/calibration replay on the 5 GHz
+path), not in the silicon.
+
+### Remain-on-channel (driver `.remain_on_channel` op, trace-only)
+
+No second vif is possible on this build (see the deadlock note), so no
+injector — trace spans only (n=300, VM clock, spans shift-invariant):
+grant (rdev entry → `cfg80211_ready_on_channel`) median **0.2 ms** /
+p90 0.4 / p99 99.6; granted dwell median 62 ms for 20 ms requested; full
+request→expired cycle median 67 ms. The instant grant is consistent with
+the ~1 ms RF switch; the dwell over-run and the p99 tail (~100 ms, an
+internal command-queue beat) make it a scheduler curiosity rather than a
+hopping primitive.
+
+### TDLS / MCC offload paths
+
+TDLS channel-switch offload stays **blocked-hardware-absent** end-to-end
+(needs two associated STAs under an AP), but the target is now fully
+named from source + build evidence: `rtw_hal_ch_sw_oper_offload`
+(`hal/hal_com.c`) composes **H2C 0x1C `CHNL_SWITCH_OPER_OFFLOAD`**, built
+and runtime-armed in the measured module. The MCC attempt got further
+than expected (capability matrix): everything up to `mcc_enable=1` works;
+the firmware engine (H2C family 0x10 `MCC_LOCATION`/`FCS_RSVDPAGE`, 0x11
+`FCS_INFO`, 0x18 `MCC_CTRL`, 0x19 `TIME_SETTING`) idles until both vifs
+are linked on different channels.
+
+## Results — rtw89_8852bu (in-tree, RTL8852BU, kernel 6.18.33)
+
+Quick pass (×200 per primitive, host venue — the in-tree driver showed no
+host-side instability in ~700 switches):
+
+| primitive | n | dead air med | p90 | p99 | max | host-cmd med | gate |
+|---|---|---|---|---|---|---|---|
+| set-channel 36↔40 | 200/200 | 31.5 ms | 33.8 | 36.3 | 39.0 | 66.3 ms | control |
+| CSA 36↔40 (AP, count=1) | 116/200 | 102.9 ms | 203.8 | 205.8 | 205.8 | 66.4 ms | control |
+| ROC 36→40 (hardware) | 200/200 | trace-only | | | | 52.6 ms | — |
+
+- **CSA actually works on rtw89** — hostapd accepts `chan_switch`, the
+  full `rdev_channel_switch` → `ch_switch_notify` chain fires (~70 ms),
+  and the beacon stream provably moves channel. rtw88's "CSA is not
+  supported" is that driver's missing capability flag, not a Realtek-USB
+  constraint. The dead air is TBTT-quantized: median ≈ one 100 ms beacon
+  interval, p90+ ≈ two (a missed TBTT), and 84/200 attempts left no
+  destination-channel RF evidence in the dwell window — usable for slow
+  planned migration, useless for hopping.
+- Monitor set-channel is a uniform ~31 ms dark (tighter distribution than
+  rtw88's 52 ms, still 6× the FHSS gate) with zero per-switch H2C — the
+  channel programming is register-direct here too.
+- Hardware ROC grants in 52.7 ms med (p99 57) and dwells 74.5 ms for the
+  20 ms asked — the off-channel errand is cheaper and much more
+  deterministic than rtw88's software ROC (46 ms grant, 116 ms blackout)
+  but still far from agile.
+
+## Go/no-go
+
+Gate verdicts across every measured row:
+
+| driver / primitive | on-air p99 | verdict |
+|---|---|---|
+| **vendor rtl88x2bu set-channel (5 GHz)** | **4.4 ms** | **advance** |
+| rtw88 set-channel 2.4 GHz | 16.6 ms | slow-slot-only |
+| rtw88 set-channel 5 GHz / 40 MHz / cross-band | 58–64 ms | control |
+| rtw89 set-channel 5 GHz | 36.3 ms | control |
+| rtw88 scan / ROC, rtw89 CSA / ROC | ≥ 57 ms | control |
+| rtw88 CSA | — | policy-rejected |
+
+**Go.** The experiment's core question — can a standard-driver path
+approach FHSS-grade switching? — has a measured *yes*: the RTL8822BU
+retunes in ~1 ms when the driver's software sequence stays out of the
+way. The nominations for the follow-on experiments:
+
+- **Exp-2 (#270, TDLS-style offload)**: target
+  `rtw_hal_ch_sw_oper_offload` → **H2C 0x1C
+  `CHNL_SWITCH_OPER_OFFLOAD`** (vendor `hal/hal_com.c`,
+  `include/hal_com_h2c.h`). Compiled, loaded and runtime-armed
+  (`rtw_wifi_spec=1`) in the exact module that measured 1.08 ms — the
+  offload hands the same fast internal switch to the firmware with a
+  channel list and timing, removing even the 66 ms host round trip.
+  Devourer's own FastRetune on this chip is 2.5 ms; the kernel-measured
+  1.08 ms says there is roughly a millisecond of headroom worth chasing.
+- **Exp-3 (#271, MCC/FCS)**: target the **H2C 0x10/0x11/0x18/0x19
+  family** (`MCC_LOCATION`/`FCS_RSVDPAGE`, `FCS_INFO`, `MCC_CTRL`,
+  `TIME_SETTING`). Everything up to `mcc_enable=1` is verified live;
+  the remaining step — both vifs linked on different channels so the
+  firmware schedule engages — is precisely that experiment's setup.
+- The in-tree drivers are the control arm: nothing they expose (rtw88 or
+  rtw89, any primitive) comes within 6× of the gate, and rtw88's 2.4 GHz
+  6 ms median is the only slow-slot candidate — band-asymmetric and
+  unhoppable on 5 GHz, so not a link design anyone should build on.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -86,7 +86,7 @@ Emitters: L = library, RX/TX/... = demo. Optional fields in [brackets];
 | ev | emitter | fields |
 |---|---|---|
 | `rx.pkt` | RX | n, len (first 10 + every 100th frame) |
-| `rx.frame` | RX (`DEVOURER_STREAM_OUT`), duplex | rate, len, crc, icv, rssi[2], evm[2], snr[2], seq, tsfl, bw, stbc, ldpc, sgi, paggr, ppdu, fc1 (FC flags byte; bit3 = 802.11 RETRY), body hex; `tx_tsf` (sender's hardware egress TSF) on beacons/probe-responses only |
+| `rx.frame` | RX (`DEVOURER_STREAM_OUT`), duplex | rate, len, crc, icv, rssi[2], evm[2], snr[2], seq, tsfl, bw, stbc, ldpc, sgi, paggr, ppdu, fc1 (FC flags byte; bit3 = 802.11 RETRY), sa hex, body hex; `tx_tsf` (sender's hardware egress TSF) on beacons/probe-responses only. SA gate: canonical-SA with `DEVOURER_RX_AGG_SA` unset; when set, that filter ("canon"/mac/"any") selects the stream instead |
 | `rx.body` | RX (`DEVOURER_DUMP_BODY`) | rate, rssi[2], evm[2], snr[2], crc, len, body hex |
 | `rx.corrupt` | RX (`DEVOURER_RX_DUMP_ALL`) | len, crc, icv, rate, bw, stbc, ldpc, sgi, rssi[2], evm[2], snr[2] |
 | `rx.txhit` | RX, TX | hits, total_rx, len, seq, paggr, ppdu, rate, bw, stbc, ldpc, ppdu_type — canonical-SA (57:42:75:05:d6:00) matcher; rate/ldpc prove what encoding was decoded (8814A reports ldpc=0 always — no HW indicator); ppdu_type is the AX RXD format nibble (7=HE_SU, 8=HE_ERSU; 255 on pre-AX chips) |

--- a/examples/rx/main.cpp
+++ b/examples/rx/main.cpp
@@ -466,6 +466,15 @@ static const bool g_agg_sa_parsed = []() {
   }
   return false;
 }();
+/* DEVOURER_RX_AGG_SA also re-gates the per-frame rx.frame stream in
+ * packetProcessor: env unset keeps the historic canonical-SA-only stream;
+ * "canon"/mac narrows it to that SA; "any" widens it to every frame. A
+ * separate presence flag because "any" parses to no filter (above) yet must
+ * widen the stream gate, while unset must not. */
+static const bool g_agg_sa_env = []() {
+  const char *e = std::getenv("DEVOURER_RX_AGG_SA");
+  return e != nullptr && *e != '\0';
+}();
 static bool agg_sa_match(const Packet &packet) {
   if (!g_agg_sa_filter)
     return true;
@@ -660,7 +669,27 @@ static void packetProcessor(const Packet &packet) {
    * one adapter while txdemo runs against another on the same
    * channel, each hit confirms an injected frame made it over the air. */
   if (packet.Data.size() >= 16) {
-    if (std::memcmp(packet.Data.data() + 10, kTxSa, 6) == 0) {
+    const bool sa_canon =
+        std::memcmp(packet.Data.data() + 10, kTxSa, 6) == 0;
+    /* DEVOURER_STREAM_OUT=1: print every stream-SA frame's body (uncapped)
+     * for the stream RX driver (tools/precoder/stream_rx.py) to decode. Tag
+     * is distinct so the regular dump_body capture stays uncluttered. The
+     * stream's SA gate follows DEVOURER_RX_AGG_SA when set — an oracle
+     * watching a foreign transmitter (e.g. a kernel-driver DUT's own MAC)
+     * selects it there — and stays canonical-SA-only when unset. */
+    static const bool stream_out =
+        std::getenv("DEVOURER_STREAM_OUT") != nullptr;
+    const bool stream_sa = g_agg_sa_env ? agg_sa_match(packet) : sa_canon;
+    /* DEVOURER_RX_KEEP_CORRUPTED=1: surface the body even when the chip
+     * flagged CRC/ICV error. Default is to filter them out for the byte-
+     * stream consumer (stream_rx.py), since a body with a wrong tail is
+     * the byte-mode parser's worst-case input. The flag is the entry
+     * point for the corruption_analysis.py tool — by-design opt-in so
+     * accidental enablement doesn't cause IP-stack misery. */
+    static const bool keep_corrupted =
+        std::getenv("DEVOURER_RX_KEEP_CORRUPTED") != nullptr;
+    const bool corrupted = packet.RxAtrib.crc_err || packet.RxAtrib.icv_err;
+    if (sa_canon) {
       static int hits = 0;
       ++hits;
       if (hits <= 10 || hits % 100 == 0) {
@@ -726,20 +755,6 @@ static void packetProcessor(const Packet &packet) {
        * 6M OFDM and that its shaped PSDU bytes round-tripped intact — the
        * two-adapter, no-SDR verification. First few hits only. */
       static const bool dump_body = std::getenv("DEVOURER_DUMP_BODY") != nullptr;
-      /* DEVOURER_STREAM_OUT=1: like DEVOURER_DUMP_BODY but uncapped — print
-       * every canonical-SA frame's body for the stream RX driver
-       * (tools/precoder/stream_rx.py) to decode. Tag is distinct so the
-       * regular dump_body capture stays uncluttered. */
-      static const bool stream_out = std::getenv("DEVOURER_STREAM_OUT") != nullptr;
-      /* DEVOURER_RX_KEEP_CORRUPTED=1: surface the body even when the chip
-       * flagged CRC/ICV error. Default is to filter them out for the byte-
-       * stream consumer (stream_rx.py), since a body with a wrong tail is
-       * the byte-mode parser's worst-case input. The flag is the entry
-       * point for the corruption_analysis.py tool — by-design opt-in so
-       * accidental enablement doesn't cause IP-stack misery. */
-      static const bool keep_corrupted =
-          std::getenv("DEVOURER_RX_KEEP_CORRUPTED") != nullptr;
-      const bool corrupted = packet.RxAtrib.crc_err || packet.RxAtrib.icv_err;
       /* DEVOURER_RX_ALLPATHS=1: emit all four RX chains (A,B,C,D) of per-stream
        * RSSI / SNR / EVM on a distinct `rx.path` event. Opt-in and separate so
        * the canonical two-path `rx.frame`/`rx.body` events stay untouched.
@@ -762,60 +777,6 @@ static void packetProcessor(const Packet &packet) {
             .arr("snr", snr, 4)
             .arr("evm", evm, 4);
       }
-      if (stream_out && (!corrupted || keep_corrupted)) {
-        /* Per-stream phy soft metrics (RSSI / EVM / SNR for paths A,B; on
-         * 8814AU paths C,D would also be non-zero but we surface only A,B
-         * here to stay aligned with rx.body's fields). These are
-         * link-quality measurements at the PHY before decoding — same
-         * source as the Tier-2 diagnostics — so a consumer like
-         * corruption_analysis.py can correlate BER with link quality on a
-         * per-frame basis instead of relying on aggregated statistics. */
-        /* seq + tsfl: chip-side sequence number (12-bit u16) and TSF low
-         * (full 32-bit u32). Consumers can dedup by seq and measure
-         * one-way latency by diffing TSF against the host clock. Optional
-         * fields — pre-#84 regex consumers tolerate them via the same
-         * pass-through pattern. */
-        /* Decoded PHY descriptor fields (bw/stbc/ldpc/sgi) alongside the rate
-         * index: these let an SDR-as-TX completeness harness assert that the
-         * frame devourer received carries the bandwidth / STBC / FEC / guard
-         * interval the transmitter encoded. Valid on 8812/8821; on 8814AU the
-         * RX descriptor doesn't expose these at this offset (FrameParser.cpp),
-         * so they read as the chip's defaults there. */
-        const int rssi[2] = {packet.RxAtrib.rssi[0], packet.RxAtrib.rssi[1]};
-        const int evm[2] = {packet.RxAtrib.evm[0], packet.RxAtrib.evm[1]};
-        const int snr[2] = {packet.RxAtrib.snr[0], packet.RxAtrib.snr[1]};
-        const size_t body_len =
-            packet.Data.size() > 24 ? packet.Data.size() - 24 : 0;
-        auto ev = devourer::Ev(*g_ev, "rx.frame");
-        ev.f("rate", packet.RxAtrib.data_rate)
-            .f("len", packet.Data.size())
-            .f("crc", packet.RxAtrib.crc_err ? 1 : 0)
-            .f("icv", packet.RxAtrib.icv_err ? 1 : 0)
-            .arr("rssi", rssi, 2)
-            .arr("evm", evm, 2)
-            .arr("snr", snr, 2)
-            .f("seq", packet.RxAtrib.seq_num)
-            .f("tsfl", packet.RxAtrib.tsfl)
-            .f("bw", packet.RxAtrib.bw)
-            .f("stbc", packet.RxAtrib.stbc)
-            .f("ldpc", packet.RxAtrib.ldpc)
-            .f("sgi", packet.RxAtrib.sgi)
-            /* A-MPDU RX markers (src/RxPacket.h): paggr = inside an
-             * aggregate; ppdu = the halmac 2-bit received-PPDU counter
-             * (frames sharing a value shared one PPDU). */
-            .f("paggr", packet.RxAtrib.paggr ? 1 : 0)
-            .f("ppdu", packet.RxAtrib.ppdu_cnt)
-            /* FC flags byte (frame byte 1): bit3 = the 802.11 RETRY flag —
-             * distinguishes hardware retransmissions (e.g. an A-MPDU
-             * re-aired for want of a BlockAck) from first airings. */
-            .f("fc1", packet.Data.size() > 1 ? packet.Data[1] : 0);
-        /* tx_tsf: the sender's hardware TX-egress TSF (beacons / probe responses
-         * only). Pair with tsfl — the local hardware RX timestamp above — for
-         * one-way hardware time sync with no host-clock jitter on either end. */
-        if (auto tx = packet.TxEgressTsf())
-          ev.f("tx_tsf", (unsigned long long)*tx);
-        ev.hex("body", packet.Data.data() + 24, body_len);
-      }
       if (dump_body && hits <= 5) {
         /* Tier-2 health diagnostics alongside the byte mirror: rate (0x04 =
          * 6M OFDM), per-stream RSSI/EVM/SNR (link quality — content-blind),
@@ -835,6 +796,63 @@ static void packetProcessor(const Packet &packet) {
             .f("len", packet.Data.size())
             .hex("body", packet.Data.data() + 24, body_len);
       }
+    }
+    if (stream_out && stream_sa && (!corrupted || keep_corrupted)) {
+      /* Per-stream phy soft metrics (RSSI / EVM / SNR for paths A,B; on
+       * 8814AU paths C,D would also be non-zero but we surface only A,B
+       * here to stay aligned with rx.body's fields). These are
+       * link-quality measurements at the PHY before decoding — same
+       * source as the Tier-2 diagnostics — so a consumer like
+       * corruption_analysis.py can correlate BER with link quality on a
+       * per-frame basis instead of relying on aggregated statistics. */
+      /* seq + tsfl: chip-side sequence number (12-bit u16) and TSF low
+       * (full 32-bit u32). Consumers can dedup by seq and measure
+       * one-way latency by diffing TSF against the host clock. Optional
+       * fields — pre-#84 regex consumers tolerate them via the same
+       * pass-through pattern. */
+      /* Decoded PHY descriptor fields (bw/stbc/ldpc/sgi) alongside the rate
+       * index: these let an SDR-as-TX completeness harness assert that the
+       * frame devourer received carries the bandwidth / STBC / FEC / guard
+       * interval the transmitter encoded. Valid on 8812/8821; on 8814AU the
+       * RX descriptor doesn't expose these at this offset (FrameParser.cpp),
+       * so they read as the chip's defaults there. */
+      const int rssi[2] = {packet.RxAtrib.rssi[0], packet.RxAtrib.rssi[1]};
+      const int evm[2] = {packet.RxAtrib.evm[0], packet.RxAtrib.evm[1]};
+      const int snr[2] = {packet.RxAtrib.snr[0], packet.RxAtrib.snr[1]};
+      const size_t body_len =
+          packet.Data.size() > 24 ? packet.Data.size() - 24 : 0;
+      auto ev = devourer::Ev(*g_ev, "rx.frame");
+      ev.f("rate", packet.RxAtrib.data_rate)
+          .f("len", packet.Data.size())
+          .f("crc", packet.RxAtrib.crc_err ? 1 : 0)
+          .f("icv", packet.RxAtrib.icv_err ? 1 : 0)
+          .arr("rssi", rssi, 2)
+          .arr("evm", evm, 2)
+          .arr("snr", snr, 2)
+          .f("seq", packet.RxAtrib.seq_num)
+          .f("tsfl", packet.RxAtrib.tsfl)
+          .f("bw", packet.RxAtrib.bw)
+          .f("stbc", packet.RxAtrib.stbc)
+          .f("ldpc", packet.RxAtrib.ldpc)
+          .f("sgi", packet.RxAtrib.sgi)
+          /* A-MPDU RX markers (src/RxPacket.h): paggr = inside an
+           * aggregate; ppdu = the halmac 2-bit received-PPDU counter
+           * (frames sharing a value shared one PPDU). */
+          .f("paggr", packet.RxAtrib.paggr ? 1 : 0)
+          .f("ppdu", packet.RxAtrib.ppdu_cnt)
+          /* FC flags byte (frame byte 1): bit3 = the 802.11 RETRY flag —
+           * distinguishes hardware retransmissions (e.g. an A-MPDU
+           * re-aired for want of a BlockAck) from first airings. */
+          .f("fc1", packet.Data.size() > 1 ? packet.Data[1] : 0);
+      /* sa: the transmitter address the stream gate matched on — lets a
+       * multi-source consumer attribute frames when the gate is "any". */
+      ev.hex("sa", packet.Data.data() + 10, 6);
+      /* tx_tsf: the sender's hardware TX-egress TSF (beacons / probe responses
+       * only). Pair with tsfl — the local hardware RX timestamp above — for
+       * one-way hardware time sync with no host-clock jitter on either end. */
+      if (auto tx = packet.TxEgressTsf())
+        ev.f("tx_tsf", (unsigned long long)*tx);
+      ev.hex("body", packet.Data.data() + 24, body_len);
     }
   }
 }

--- a/tests/kchansw_analyze.py
+++ b/tests/kchansw_analyze.py
@@ -528,6 +528,19 @@ def analyze_run(run_dir):
             meta = json.load(f)
         trace = parse_trace(os.path.join(d, "trace.txt"))
         inject = load_jsonl(os.path.join(d, "inject.jsonl"))
+        # VM-hosted DUT (phase-b-vm): trace/control/inject carry the VM's
+        # CLOCK_MONOTONIC; meta records the measured VM→host offset so the
+        # oracle (host-clock) windows line up. VM-internal spans (host-cmd,
+        # driver, h2c) are differences and thus shift-invariant.
+        shift = int(meta.get("vm_clock_shift_ns", 0))
+        if shift:
+            for ev in trace:
+                ev["ts_ns"] += shift
+                if ev.get("marker"):
+                    ev["marker"]["mono_ns"] += shift
+            for rec in inject:
+                if "mono_ns" in rec:
+                    rec["mono_ns"] += shift
         wedge_is = [r["i"] for r in load_jsonl(os.path.join(d, "control.jsonl"))
                     if r.get("ev") == "kchansw.wedge"]
         frames_by_ch = {}

--- a/tests/kchansw_analyze.py
+++ b/tests/kchansw_analyze.py
@@ -1,0 +1,704 @@
+#!/usr/bin/env python3
+"""Offline analyzer for kernel channel-switch bench runs (issue: standard-
+driver FHSS baseline). No root, no hardware — pure parsing + numpy.
+
+Input: a run directory produced by tests/kchansw_bench.py, one subdirectory
+per config, each holding:
+
+    meta.json        config descriptor (prim, channels, oracle roles,
+                     probe_name→role map, fingerprint mode)
+    control.jsonl    kchansw.req / kchansw.done records (host mono_ns)
+    trace.txt        ftrace text (trace_clock=mono) incl. KCHANSW markers
+    oracle_a.jsonl   {"host_mono_ns":..,"raw":"<rxdemo JSONL>"} per line
+    oracle_b.jsonl   same for the second oracle
+    inject.jsonl     inj.tx records (P1-style configs)
+
+Timeline: one clock everywhere (CLOCK_MONOTONIC). ftrace timestamps are
+directly comparable to mono_ns; oracle frames get sub-ms placement via a
+robust per-oracle linear fit host_mono_ns ≈ a + b·tsfl (tsfl = the chip's
+MAC-latched µs RX timestamp, unwrapped mod 2^32), so stdout-pipe jitter on
+the reader stamps averages out instead of polluting per-frame times.
+
+Outputs (into the run dir): switches.csv.gz (per-switch records across all
+configs), summary.json (distributions + fit diagnostics + gate verdicts),
+summary.md (tables in the docs/performance-tuning.md style).
+
+Gate rule (headline = on-air dead time p99 per config):
+    < 5 ms  → advance ; 5–20 ms → slow-slot-only ; > 20 ms → control
+
+`--self-test` fabricates a synthetic run with known truth (dead time, fit
+slope, losses) and asserts the pipeline recovers it — run it before spending
+any hardware time, and in CI-less environments after edits.
+"""
+
+import argparse
+import csv
+import gzip
+import io
+import json
+import math
+import os
+import re
+import struct
+import sys
+
+import numpy as np
+
+MAGIC_HEX = "4b435357"  # 'KCSW'
+
+GATE_ADVANCE_NS = 5e6
+GATE_SLOW_NS = 20e6
+
+# ---------------------------------------------------------------------------
+# Parsing.
+# ---------------------------------------------------------------------------
+
+# `  comm-pid [cpu] flags 12345.678901: event_name: details`
+_TRACE_RE = re.compile(
+    r"^\s*(?P<comm>.+?)-(?P<pid>\d+)\s+\[(?P<cpu>\d+)\]\s+\S+\s+"
+    r"(?P<ts>\d+\.\d+):\s+(?P<name>[\w.]+):\s?(?P<detail>.*)$")
+
+_MARKER_RE = re.compile(
+    r"KCHANSW i=(?P<i>\d+) prim=(?P<prim>\S+) cfg=(?P<cfg>\S+) "
+    r"from=(?P<from>\S+) to=(?P<to>\S+) mono=(?P<mono>\d+)")
+
+
+def parse_trace(path):
+    """Yield dicts {ts_ns, pid, name, detail} plus markers {..., marker:{}}."""
+    events = []
+    with open(path, "r", errors="replace") as f:
+        for line in f:
+            m = _TRACE_RE.match(line)
+            if not m:
+                continue
+            ev = {
+                "ts_ns": int(round(float(m.group("ts")) * 1e9)),
+                "pid": int(m.group("pid")),
+                "name": m.group("name"),
+                "detail": m.group("detail"),
+            }
+            if ev["name"] == "tracing_mark_write":
+                mm = _MARKER_RE.search(ev["detail"])
+                if mm:
+                    ev["marker"] = {
+                        "i": int(mm.group("i")),
+                        "prim": mm.group("prim"),
+                        "cfg": mm.group("cfg"),
+                        "from": mm.group("from"),
+                        "to": mm.group("to"),
+                        "mono_ns": int(mm.group("mono")),
+                    }
+            events.append(ev)
+    return events
+
+
+def load_jsonl(path):
+    out = []
+    if not os.path.exists(path):
+        return out
+    with open(path, "r", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line or not line.startswith("{"):
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return out
+
+
+def oracle_frames(path):
+    """Parse a stamped oracle log into frame records:
+    {host_mono_ns, tsfl_us, len, crc, seq, ctr, send_ns, nonce} — ctr/send_ns
+    only when the KCSW fingerprint is present in the body."""
+    frames = []
+    for rec in load_jsonl(path):
+        raw = rec.get("raw")
+        host = rec.get("host_mono_ns")
+        if raw is None or host is None:
+            continue
+        try:
+            ev = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if ev.get("ev") != "rx.frame":
+            continue
+        fr = {
+            "host_mono_ns": int(host),
+            "tsfl_us": int(ev.get("tsfl", 0)),
+            "len": int(ev.get("len", 0)),
+            "crc": int(ev.get("crc", 0)),
+            "seq": int(ev.get("seq", 0)),
+            "ctr": None,
+            "send_ns": None,
+            "nonce": None,
+            "body": ev.get("body", ""),
+        }
+        body = fr["body"]
+        if isinstance(body, str) and body.lower().startswith(MAGIC_HEX):
+            try:
+                blob = bytes.fromhex(body[:40])
+                _, nonce, ctr, send_ns = struct.unpack("<4sIIQ", blob)
+                fr["nonce"], fr["ctr"], fr["send_ns"] = nonce, ctr, send_ns
+            except (ValueError, struct.error):
+                pass
+        frames.append(fr)
+    return frames
+
+
+# ---------------------------------------------------------------------------
+# tsfl → host-mono fit.
+# ---------------------------------------------------------------------------
+
+def unwrap_tsfl(frames):
+    """Unwrap the 32-bit µs tsfl in host-stamp order (adds 2^32 per wrap)."""
+    off = 0
+    prev = None
+    for fr in sorted(frames, key=lambda f: f["host_mono_ns"]):
+        t = fr["tsfl_us"]
+        if prev is not None and t < prev - (1 << 31):
+            off += 1 << 32
+        prev = t
+        fr["tsfl_unwrapped_us"] = t + off
+    return frames
+
+
+def fit_tsfl(frames, max_pairs=800):
+    """Robust linear fit host_mono_ns ≈ a + b*tsfl_unwrapped_us.
+
+    Theil-Sen slope on a decimated subset, then least-squares on inliers
+    (|residual| < 3*1.4826*MAD, floored at 50 µs). Returns dict with a, b,
+    residual std (ns), inlier fraction — or ok=False when too thin."""
+    pts = [(f["tsfl_unwrapped_us"], f["host_mono_ns"]) for f in frames]
+    if len(pts) < 20:
+        return {"ok": False, "n": len(pts), "reason": "too-few-frames"}
+    x = np.array([p[0] for p in pts], dtype=np.float64)
+    y = np.array([p[1] for p in pts], dtype=np.float64)
+    if len(x) > max_pairs:
+        idx = np.linspace(0, len(x) - 1, max_pairs).astype(int)
+        xs, ys = x[idx], y[idx]
+    else:
+        xs, ys = x, y
+    dx = xs[None, :] - xs[:, None]
+    dy = ys[None, :] - ys[:, None]
+    mask = np.triu(np.abs(dx) > 1e3, k=1)  # pairs ≥1 ms apart in tsfl
+    if not mask.any():
+        return {"ok": False, "n": len(pts), "reason": "no-spread"}
+    b = float(np.median(dy[mask] / dx[mask]))
+    a = float(np.median(y - b * x))
+    resid = y - (a + b * x)
+    mad = float(np.median(np.abs(resid - np.median(resid))))
+    thr = max(3 * 1.4826 * mad, 50e3)  # ≥50 µs floor
+    inl = np.abs(resid - np.median(resid)) < thr
+    if inl.sum() >= 20:
+        A = np.vstack([x[inl], np.ones(inl.sum())]).T
+        sol, *_ = np.linalg.lstsq(A, y[inl], rcond=None)
+        b, a = float(sol[0]), float(sol[1])
+        resid = y - (a + b * x)
+    r_std = float(np.std(resid[inl])) if inl.sum() else float("inf")
+    slope_err_ppm = (b / 1e3 - 1.0) * 1e6  # vs nominal 1000 ns/µs
+    # Gate on MAPPING stability, not stamp noise: per-frame fitted times come
+    # from tsfl (exact µs), so reader-stamp jitter only widens the residual —
+    # it does not propagate into fitted placements. A broken tsfl stream
+    # (wraps, stalls) shows up as huge residuals or an insane slope.
+    return {
+        "ok": r_std <= 2e6 and abs(slope_err_ppm) < 1000,
+        "n": len(pts), "a": a, "b": b,
+        "residual_std_ns": r_std,
+        "slope_err_ppm": slope_err_ppm,
+        "inlier_frac": float(inl.mean()),
+    }
+
+
+def fitted_ns(fit, fr):
+    return fit["a"] + fit["b"] * fr["tsfl_unwrapped_us"]
+
+
+# ---------------------------------------------------------------------------
+# Per-switch extraction.
+# ---------------------------------------------------------------------------
+
+CSV_COLS = [
+    "cfg", "prim", "i", "warmup", "from_ch", "to_ch", "direction",
+    "t_req_ns", "rdev_entry_ns", "rdev_ret_ns", "drv_entry_ns", "drv_ret_ns",
+    "chip_entry_ns", "chip_ret_ns", "h2c_n", "h2c_first_ns", "h2c_last_ns",
+    "qstop_ns", "qwake_ns", "ready_ns", "expired_ns", "notify_ns",
+    "last_src_air_ns", "first_dst_air_ns", "first_back_air_ns", "dead_ns",
+    "src_last_ctr", "dst_first_ctr", "gap_frames", "dup", "inj_errs",
+    "ok", "fail_reason",
+]
+
+
+def _first(events, name, after=None, pid=None):
+    for ev in events:
+        if ev["name"] != name:
+            continue
+        if after is not None and ev["ts_ns"] < after:
+            continue
+        if pid is not None and ev["pid"] != pid:
+            continue
+        return ev
+    return None
+
+
+def _last(events, name, before=None):
+    out = None
+    for ev in events:
+        if ev["name"] != name:
+            continue
+        if before is not None and ev["ts_ns"] >= before:
+            continue
+        out = ev
+    return out
+
+
+def extract_switches(meta, trace, frames_by_ch, fits_by_ch, inject):
+    """Per-switch records for one config. frames_by_ch maps channel →
+    (frames sorted by fitted host time, fit)."""
+    rdev_entry_name = meta.get("rdev_entry", "rdev_set_monitor_channel")
+    probe_map = meta.get("probe_map", {})
+    drv_p = probe_map.get("drv")
+    chip_p = probe_map.get("chip")
+    h2c_p = probe_map.get("h2c")
+
+    markers = [ev for ev in trace if ev.get("marker")
+               and ev["marker"]["cfg"] == meta["cfg"]]
+    markers.sort(key=lambda ev: ev["ts_ns"])
+    inj_times = [(r["mono_ns"], r.get("errno", 0)) for r in inject
+                 if r.get("ev") == "inj.tx"]
+    inj_times.sort()
+
+    rows = []
+    for k, mk in enumerate(markers):
+        w0 = mk["ts_ns"]
+        w1 = markers[k + 1]["ts_ns"] if k + 1 < len(markers) else w0 + int(2e9)
+        win = [ev for ev in trace if w0 <= ev["ts_ns"] < w1]
+        mkm = mk["marker"]
+        row = {c: "" for c in CSV_COLS}
+        row.update({
+            "cfg": meta["cfg"], "prim": mkm["prim"], "i": mkm["i"],
+            "warmup": 1 if mkm["i"] < meta.get("warmup", 0) else 0,
+            "from_ch": mkm["from"], "to_ch": mkm["to"],
+            "direction": f"{mkm['from']}>{mkm['to']}",
+            "t_req_ns": mkm["mono_ns"],
+            "ok": 1, "fail_reason": "",
+        })
+
+        entry = _first(win, rdev_entry_name)
+        if entry:
+            row["rdev_entry_ns"] = entry["ts_ns"]
+            for ret_name in ("rdev_return_int", "rdev_return_void"):
+                ret = _first(win, ret_name, after=entry["ts_ns"],
+                             pid=entry["pid"])
+                if ret:
+                    row["rdev_ret_ns"] = ret["ts_ns"]
+                    break
+        for role, col_e, col_r in ((drv_p, "drv_entry_ns", "drv_ret_ns"),
+                                   (chip_p, "chip_entry_ns", "chip_ret_ns")):
+            if not role:
+                continue
+            e = _first(win, role)
+            if e:
+                row[col_e] = e["ts_ns"]
+                r = _first(win, role + "_ret", after=e["ts_ns"])
+                if r:
+                    row[col_r] = r["ts_ns"]
+        if h2c_p:
+            h2cs = [ev for ev in win if ev["name"] == h2c_p]
+            h2c_rets = [ev for ev in win if ev["name"] == h2c_p + "_ret"]
+            row["h2c_n"] = len(h2cs)
+            if h2cs:
+                row["h2c_first_ns"] = h2cs[0]["ts_ns"]
+            if h2c_rets:
+                row["h2c_last_ns"] = h2c_rets[-1]["ts_ns"]
+        qs = _first(win, "stop_queue")
+        qw = _last(win, "wake_queue")
+        if qs:
+            row["qstop_ns"] = qs["ts_ns"]
+        if qw:
+            row["qwake_ns"] = qw["ts_ns"]
+        for name, col in (("cfg80211_ready_on_channel", "ready_ns"),
+                          ("cfg80211_ready_on_channel_expired", "expired_ns"),
+                          ("cfg80211_ch_switch_notify", "notify_ns")):
+            ev = _first(win, name)
+            if ev:
+                row[col] = ev["ts_ns"]
+
+        # --- on-air evidence -------------------------------------------------
+        src = frames_by_ch.get(str(mkm["from"]))
+        dst = frames_by_ch.get(str(mkm["to"]))
+        first_dst = None
+        if dst is not None:
+            dfr, dfit = dst
+            for fr in dfr:
+                t = fitted_ns(dfit, fr)
+                if w0 <= t < w1:
+                    first_dst = (t, fr)
+                    break
+        last_src = None
+        if src is not None and first_dst is not None:
+            sfr, sfit = src
+            for fr in sfr:
+                t = fitted_ns(sfit, fr)
+                if t >= first_dst[0]:
+                    break
+                if w0 - int(50e6) <= t:  # allow frames just before the marker
+                    last_src = (t, fr)
+        if first_dst:
+            row["first_dst_air_ns"] = int(first_dst[0])
+            if first_dst[1]["ctr"] is not None:
+                row["dst_first_ctr"] = first_dst[1]["ctr"]
+        if last_src:
+            row["last_src_air_ns"] = int(last_src[0])
+            if last_src[1]["ctr"] is not None:
+                row["src_last_ctr"] = last_src[1]["ctr"]
+        if first_dst and last_src:
+            row["dead_ns"] = int(first_dst[0] - last_src[0])
+            if (row["src_last_ctr"] != "" and row["dst_first_ctr"] != ""
+                    and row["dst_first_ctr"] > row["src_last_ctr"]):
+                row["gap_frames"] = row["dst_first_ctr"] - row["src_last_ctr"] - 1
+        elif meta.get("need_rf", True):
+            row["ok"] = 0
+            row["fail_reason"] = "no_rf_evidence"
+
+        # ROC return-to-base: first source-channel frame after expiry.
+        if row["expired_ns"] != "" and src is not None:
+            sfr, sfit = src
+            for fr in sfr:
+                t = fitted_ns(sfit, fr)
+                if t > row["expired_ns"]:
+                    row["first_back_air_ns"] = int(t)
+                    break
+
+        # Duplicates: same counter twice on the dst oracle inside the window.
+        if dst is not None:
+            seen, dups = set(), 0
+            dfr, dfit = dst
+            for fr in dfr:
+                t = fitted_ns(dfit, fr)
+                if not (w0 <= t < w1) or fr["ctr"] is None:
+                    continue
+                if fr["ctr"] in seen:
+                    dups += 1
+                seen.add(fr["ctr"])
+            row["dup"] = dups
+        if inj_times:
+            row["inj_errs"] = sum(1 for t, e in inj_times
+                                  if w0 <= t < w1 and e != 0)
+        rows.append(row)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Stats + gates + reports.
+# ---------------------------------------------------------------------------
+
+def _dist(vals):
+    if not vals:
+        return None
+    a = np.array(vals, dtype=np.float64)
+    return {
+        "n": len(vals),
+        "median_ms": float(np.median(a)) / 1e6,
+        "p90_ms": float(np.percentile(a, 90)) / 1e6,
+        "p99_ms": float(np.percentile(a, 99)) / 1e6,
+        "max_ms": float(np.max(a)) / 1e6,
+    }
+
+
+def gate(p99_ns):
+    if p99_ns is None:
+        return "no-data"
+    if p99_ns < GATE_ADVANCE_NS:
+        return "advance"
+    if p99_ns <= GATE_SLOW_NS:
+        return "slow-slot-only"
+    return "control"
+
+
+def summarize(rows):
+    """Distributions per (cfg): host-cmd, driver, chip, h2c span, queue span,
+    dead time, total; plus failure/loss accounting and the gate verdict."""
+    cfgs = {}
+    for row in rows:
+        if row["warmup"]:
+            continue
+        cfgs.setdefault(row["cfg"], []).append(row)
+    out = {}
+    for cfg, rws in cfgs.items():
+        ok = [r for r in rws if r["ok"] == 1]
+
+        def span(c1, c2):
+            return [r[c2] - r[c1] for r in ok
+                    if r[c1] != "" and r[c2] != "" and r[c2] >= r[c1]]
+
+        dead = [r["dead_ns"] for r in ok if r["dead_ns"] != ""]
+        total = [r["first_dst_air_ns"] - r["t_req_ns"] for r in ok
+                 if r["first_dst_air_ns"] != ""]
+        d = _dist(dead)
+        out[cfg] = {
+            "switches": len(rws),
+            "ok": len(ok),
+            "failures": {
+                r["fail_reason"]: sum(1 for x in rws
+                                      if x["fail_reason"] == r["fail_reason"])
+                for r in rws if r["fail_reason"]
+            },
+            "host_cmd": _dist(span("rdev_entry_ns", "rdev_ret_ns")),
+            "driver": _dist(span("drv_entry_ns", "drv_ret_ns")),
+            "chip": _dist(span("chip_entry_ns", "chip_ret_ns")),
+            "h2c_span": _dist(span("h2c_first_ns", "h2c_last_ns")),
+            "queue_stopped": _dist(span("qstop_ns", "qwake_ns")),
+            "dead_air": d,
+            "total_req_to_air": _dist(total),
+            "gap_frames_total": sum(r["gap_frames"] for r in ok
+                                    if r["gap_frames"] != ""),
+            "dup_total": sum(r["dup"] for r in ok if r["dup"] != ""),
+            "inj_errs_total": sum(r["inj_errs"] for r in ok
+                                  if r["inj_errs"] != ""),
+            "gate": gate(d["p99_ms"] * 1e6 if d else None),
+        }
+    return out
+
+
+def render_md(summary, fits):
+    buf = io.StringIO()
+    buf.write("| config | n | dead-air med | p90 | p99 | max | host-cmd med "
+              "| driver med | queue med | gap | fail | gate |\n")
+    buf.write("|---|---|---|---|---|---|---|---|---|---|---|---|\n")
+
+    def ms(d, k="median_ms"):
+        return f"{d[k]:.2f} ms" if d else "—"
+
+    for cfg in sorted(summary):
+        s = summary[cfg]
+        fails = sum(s["failures"].values()) if s["failures"] else 0
+        buf.write(
+            f"| {cfg} | {s['ok']}/{s['switches']} | {ms(s['dead_air'])} | "
+            f"{ms(s['dead_air'], 'p90_ms')} | {ms(s['dead_air'], 'p99_ms')} | "
+            f"{ms(s['dead_air'], 'max_ms')} | {ms(s['host_cmd'])} | "
+            f"{ms(s['driver'])} | {ms(s['queue_stopped'])} | "
+            f"{s['gap_frames_total']} | {fails} | **{s['gate']}** |\n")
+    buf.write("\nOracle clock fits (host_mono ≈ a + b·tsfl):\n\n")
+    for name, fit in fits.items():
+        if not fit:
+            continue
+        if fit.get("ok"):
+            buf.write(f"- {name}: residual σ {fit['residual_std_ns']/1e3:.0f} µs, "
+                      f"slope err {fit['slope_err_ppm']:.0f} ppm, "
+                      f"n={fit['n']}, inliers {fit['inlier_frac']*100:.0f}%\n")
+        else:
+            buf.write(f"- {name}: FIT BAD ({fit.get('reason', 'residual gate')}, "
+                      f"n={fit.get('n')})\n")
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Run-dir walker.
+# ---------------------------------------------------------------------------
+
+def analyze_run(run_dir):
+    all_rows = []
+    fits = {}
+    for cfg_dir in sorted(os.listdir(run_dir)):
+        d = os.path.join(run_dir, cfg_dir)
+        meta_path = os.path.join(d, "meta.json")
+        if not os.path.isdir(d) or not os.path.exists(meta_path):
+            continue
+        with open(meta_path) as f:
+            meta = json.load(f)
+        trace = parse_trace(os.path.join(d, "trace.txt"))
+        inject = load_jsonl(os.path.join(d, "inject.jsonl"))
+        frames_by_ch = {}
+        for role in ("a", "b"):
+            ch = str(meta.get(f"oracle_{role}_ch", ""))
+            path = os.path.join(d, f"oracle_{role}.jsonl")
+            if not ch or not os.path.exists(path):
+                continue
+            frames = unwrap_tsfl(oracle_frames(path))
+            # Fingerprint filter: KCSW counter or (CSA/scan) plain SA stream.
+            if meta.get("fingerprint", "kcsw") == "kcsw":
+                frames = [fr for fr in frames if fr["ctr"] is not None]
+            fit = fit_tsfl(frames)
+            fits[f"{meta['cfg']}/oracle_{role}(ch{ch})"] = fit
+            if fit.get("ok"):
+                frames.sort(key=lambda fr: fitted_ns(fit, fr))
+                frames_by_ch[ch] = (frames, fit)
+        rows = extract_switches(meta, trace, frames_by_ch, fits, inject)
+        # fit_bad configs keep trace columns but lose oracle-derived ones.
+        all_rows.extend(rows)
+    return all_rows, fits
+
+
+def write_outputs(run_dir, rows, fits):
+    csv_path = os.path.join(run_dir, "switches.csv.gz")
+    with gzip.open(csv_path, "wt", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=CSV_COLS)
+        w.writeheader()
+        for row in rows:
+            w.writerow(row)
+    summary = summarize(rows)
+    with open(os.path.join(run_dir, "summary.json"), "w") as f:
+        json.dump({"configs": summary, "fits": fits}, f, indent=2)
+    md = render_md(summary, fits)
+    with open(os.path.join(run_dir, "summary.md"), "w") as f:
+        f.write(md)
+    return summary, md
+
+
+# ---------------------------------------------------------------------------
+# Self-test: synthetic run with known truth.
+# ---------------------------------------------------------------------------
+
+def _selftest(tmp):
+    """Fabricate a 30-switch P1-like config: dead time 25 ms (→ gate
+    `control`), 2 kHz injector, tsfl slope exactly 1000 ns/µs + offset,
+    ±120 µs stamp jitter, 3 warmups, one no-RF-evidence failure."""
+    rng = np.random.default_rng(7)
+    cfg = os.path.join(tmp, "a36-40")
+    os.makedirs(cfg, exist_ok=True)
+    n_sw, warmup, dead_ns = 30, 3, int(25e6)
+    period = int(5e5)  # 2 kHz
+    t0 = int(100e9)
+    dwell = int(150e6)
+
+    meta = {"cfg": "a36-40", "prim": "set_channel", "from": 36, "to": 40,
+            "warmup": warmup, "oracle_a_ch": 36, "oracle_b_ch": 40,
+            "rdev_entry": "rdev_set_monitor_channel",
+            "probe_map": {"drv": "kc_drv_set_channel",
+                          "chip": "kc_chip_set_channel", "h2c": "kc_h2c"},
+            "fingerprint": "kcsw", "need_rf": True}
+    with open(os.path.join(cfg, "meta.json"), "w") as f:
+        json.dump(meta, f)
+
+    # Oracle clocks: tsfl_us = (host_ns - off)/1000 with distinct offsets.
+    offs = {36: int(11e9), 40: int(23e9)}
+
+    def mk_frame(ch, host_ns, ctr):
+        tsfl = ((host_ns - offs[ch]) // 1000) % (1 << 32)
+        body = struct.pack("<4sIIQ", b"KCSW", 42, ctr, host_ns).hex()
+        raw = json.dumps({"ev": "rx.frame", "len": 96, "crc": 0, "seq": ctr & 0xFFF,
+                          "tsfl": int(tsfl), "body": body})
+        stamp = int(host_ns + rng.integers(3e5, 12e5))  # pipe latency+jitter
+        return {"host_mono_ns": stamp, "raw": raw}
+
+    oa, ob, trace_lines, control, inject = [], [], [], [], []
+    ctr = 0
+    # The no-RF failure must be the LAST switch: any earlier one gets
+    # "rescued" by the next switch's pre-dwell stream on the same channel
+    # (showing up as a huge dead time, not missing evidence — which is
+    # itself the realistic signature of a wedged-then-recovered switch).
+    fail_i = n_sw - 1
+
+    def tl(ts_ns, name, detail=""):
+        trace_lines.append(f" bench-1000  [001] ..... "
+                           f"{ts_ns/1e9:.6f}: {name}: {detail}")
+
+    t = t0
+    for i in range(n_sw):
+        frm, to = (36, 40) if i % 2 == 0 else (40, 36)
+        # pre-switch stream on `frm` for one dwell.
+        for _ in range(dwell // period):
+            ctr += 1
+            inject.append({"ev": "inj.tx", "n": ctr, "mono_ns": t, "errno": 0})
+            (oa if frm == 36 else ob).append(mk_frame(frm, t, ctr))
+            t += period
+        req = t
+        tl(req + 40_000, "tracing_mark_write",
+           f"KCHANSW i={i} prim=set_channel cfg=a36-40 from={frm} to={to} "
+           f"mono={req}")
+        control.append({"ev": "kchansw.req", "i": i, "mono_ns": req})
+        tl(req + int(2.2e6), "rdev_set_monitor_channel", "phy0")
+        tl(req + int(2.5e6), "kc_drv_set_channel", "(rtw_set_channel)")
+        tl(req + int(3.0e6), "kc_h2c", "(h2c)")
+        tl(req + int(3.2e6), "kc_h2c_ret", "(h2c)")
+        tl(req + int(9.0e6), "kc_chip_set_channel", "(chip)")
+        tl(req + int(19.0e6), "kc_chip_set_channel_ret", "(chip)")
+        tl(req + int(20.0e6), "kc_drv_set_channel_ret", "(rtw_set_channel)")
+        tl(req + int(21.0e6), "rdev_return_int", "ret=0")
+        tl(req + int(1.0e6), "stop_queue", "queue=0")
+        tl(req + int(23.0e6), "wake_queue", "queue=0")
+        # dead air: frames sent during it are lost.
+        lost = dead_ns // period
+        ctr += lost
+        t += dead_ns
+        # post-switch stream on `to` (skipped for the injected failure case).
+        if i != fail_i:
+            for _ in range(dwell // period):
+                ctr += 1
+                inject.append({"ev": "inj.tx", "n": ctr, "mono_ns": t,
+                               "errno": 0})
+                (oa if to == 36 else ob).append(mk_frame(to, t, ctr))
+                t += period
+        else:
+            t += dwell
+
+    for path, recs in (("oracle_a.jsonl", oa), ("oracle_b.jsonl", ob),
+                       ("control.jsonl", control), ("inject.jsonl", inject)):
+        with open(os.path.join(cfg, path), "w") as f:
+            for r in recs:
+                f.write(json.dumps(r) + "\n")
+    with open(os.path.join(cfg, "trace.txt"), "w") as f:
+        f.write("\n".join(trace_lines) + "\n")
+
+    rows, fits = analyze_run(tmp)
+    summary, _ = write_outputs(tmp, rows, fits)
+    s = summary["a36-40"]
+
+    def approx(v, want, tol):
+        return v is not None and abs(v - want) <= tol
+
+    checks = [
+        ("switch rows", len(rows) == n_sw),
+        ("one no-RF failure", s["failures"].get("no_rf_evidence", 0) == 1
+         and s["ok"] == n_sw - warmup - 1),
+        # dead-air median: truth 25 ms; quantization = one injector period.
+        ("dead-air median ≈ 25 ms",
+         approx(s["dead_air"]["median_ms"], 25.0, 1.5)),
+        ("gate = control", s["gate"] == "control"),
+        ("host-cmd ≈ 18.8 ms",
+         approx(s["host_cmd"]["median_ms"], 18.8, 0.5)),
+        ("driver ≈ 17.5 ms", approx(s["driver"]["median_ms"], 17.5, 0.5)),
+        ("queue-stopped ≈ 22 ms",
+         approx(s["queue_stopped"]["median_ms"], 22.0, 0.5)),
+        ("gap accounting", s["gap_frames_total"] ==
+         (n_sw - warmup - 1) * (dead_ns // period)),
+        ("both fits ok", all(f.get("ok") for f in fits.values())),
+        ("fit slope ppm sane", all(abs(f["slope_err_ppm"]) < 200
+                                   for f in fits.values() if f.get("ok"))),
+    ]
+    failed = [name for name, ok in checks if not ok]
+    for name, ok in checks:
+        print(f"  [{'ok' if ok else 'FAIL'}] {name}")
+    if failed:
+        print(json.dumps(s, indent=2))
+        return 1
+    print("kchansw_analyze --self-test: all checks passed")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("run_dir", nargs="?", help="bench run directory")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        import tempfile
+        with tempfile.TemporaryDirectory(prefix="kchansw-selftest-") as tmp:
+            return _selftest(tmp)
+    if not args.run_dir:
+        ap.print_help()
+        return 1
+    rows, fits = analyze_run(args.run_dir)
+    if not rows:
+        sys.stderr.write("no per-switch rows extracted — is this a run dir?\n")
+        return 1
+    summary, md = write_outputs(args.run_dir, rows, fits)
+    print(md)
+    print(f"[{len(rows)} switches → {os.path.join(args.run_dir, 'switches.csv.gz')}]")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/kchansw_analyze.py
+++ b/tests/kchansw_analyze.py
@@ -445,6 +445,10 @@ def summarize(rows):
         total = [r["first_dst_air_ns"] - r["t_req_ns"] for r in ok
                  if r["first_dst_air_ns"] != ""]
         d = _dist(dead)
+        # ROC-specific: request→grant, granted dwell, expiry→back-on-base RF.
+        roc_grant = span("rdev_entry_ns", "ready_ns")
+        roc_dwell = span("ready_ns", "expired_ns")
+        roc_return = span("expired_ns", "first_back_air_ns")
         out[cfg] = {
             "switches": len(rws),
             "ok": len(ok),
@@ -463,6 +467,9 @@ def summarize(rows):
             "queue_stopped": _dist(span("qstop_ns", "qwake_ns")),
             "dead_air": d,
             "total_req_to_air": _dist(total),
+            "roc_grant": _dist(roc_grant),
+            "roc_dwell": _dist(roc_dwell),
+            "roc_return": _dist(roc_return),
             "gap_frames_total": sum(r["gap_frames"] for r in ok
                                     if r["gap_frames"] != ""),
             "dup_total": sum(r["dup"] for r in ok if r["dup"] != ""),

--- a/tests/kchansw_analyze.py
+++ b/tests/kchansw_analyze.py
@@ -66,6 +66,8 @@ _MARKER_RE = re.compile(
 def parse_trace(path):
     """Yield dicts {ts_ns, pid, name, detail} plus markers {..., marker:{}}."""
     events = []
+    if not os.path.exists(path):  # uninstrumented config (smoke A/B bare leg)
+        return events
     with open(path, "r", errors="replace") as f:
         for line in f:
             m = _TRACE_RE.match(line)
@@ -226,7 +228,7 @@ CSV_COLS = [
     "qstop_ns", "qwake_ns", "ready_ns", "expired_ns", "notify_ns",
     "last_src_air_ns", "first_dst_air_ns", "first_back_air_ns", "dead_ns",
     "src_last_ctr", "dst_first_ctr", "gap_frames", "dup", "inj_errs",
-    "ok", "fail_reason",
+    "ok", "fail_reason", "post_recovery",
 ]
 
 
@@ -253,9 +255,13 @@ def _last(events, name, before=None):
     return out
 
 
-def extract_switches(meta, trace, frames_by_ch, fits_by_ch, inject):
+def extract_switches(meta, trace, frames_by_ch, fits_by_ch, inject,
+                     wedge_is=()):
     """Per-switch records for one config. frames_by_ch maps channel →
-    (frames sorted by fitted host time, fit)."""
+    (frames sorted by fitted host time, fit). wedge_is: switch indices at
+    which a wedge/recovery happened — rows from the first onwards are
+    flagged post_recovery."""
+    first_wedge = min(wedge_is) if wedge_is else None
     rdev_entry_name = meta.get("rdev_entry", "rdev_set_monitor_channel")
     probe_map = meta.get("probe_map", {})
     drv_p = probe_map.get("drv")
@@ -283,6 +289,8 @@ def extract_switches(meta, trace, frames_by_ch, fits_by_ch, inject):
             "direction": f"{mkm['from']}>{mkm['to']}",
             "t_req_ns": mkm["mono_ns"],
             "ok": 1, "fail_reason": "",
+            "post_recovery": 1 if (first_wedge is not None
+                                   and mkm["i"] >= first_wedge) else 0,
         })
 
         entry = _first(win, rdev_entry_name)
@@ -440,6 +448,9 @@ def summarize(rows):
         out[cfg] = {
             "switches": len(rws),
             "ok": len(ok),
+            "wedges": sum(1 for r in rws if r.get("post_recovery"))
+                      and len({r["i"] for r in rws if r.get("post_recovery")})
+                      or 0,
             "failures": {
                 r["fail_reason"]: sum(1 for x in rws
                                       if x["fail_reason"] == r["fail_reason"])
@@ -510,6 +521,8 @@ def analyze_run(run_dir):
             meta = json.load(f)
         trace = parse_trace(os.path.join(d, "trace.txt"))
         inject = load_jsonl(os.path.join(d, "inject.jsonl"))
+        wedge_is = [r["i"] for r in load_jsonl(os.path.join(d, "control.jsonl"))
+                    if r.get("ev") == "kchansw.wedge"]
         frames_by_ch = {}
         for role in ("a", "b"):
             ch = str(meta.get(f"oracle_{role}_ch", ""))
@@ -525,7 +538,8 @@ def analyze_run(run_dir):
             if fit.get("ok"):
                 frames.sort(key=lambda fr: fitted_ns(fit, fr))
                 frames_by_ch[ch] = (frames, fit)
-        rows = extract_switches(meta, trace, frames_by_ch, fits, inject)
+        rows = extract_switches(meta, trace, frames_by_ch, fits, inject,
+                                wedge_is)
         # fit_bad configs keep trace columns but lose oracle-derived ones.
         all_rows.extend(rows)
     return all_rows, fits

--- a/tests/kchansw_b210_gap.py
+++ b/tests/kchansw_b210_gap.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""B210 energy-gap probe for the kernel channel-switch bench.
+
+Answers the decode-oracle bias question: the rxdemo oracles time a switch by
+FIRST DECODED FRAME; RF energy lands earlier (AGC settle, preamble sync,
+partial frames). This probe watches ONE of the two hop channels with the
+B210 while the bench's alternating switch loop runs, computes per-window
+in-band power, extracts the OFF-gap duration distribution (channel silent
+while the DUT dwells on the other channel + both transitions), and reports
+it for comparison against the same cycle's decode-derived OFF gaps from
+kchansw_analyze — no cross-clock alignment needed, distributions compare
+directly on independent clocks.
+
+Partial-band trick: sampling 4-8 MS/s inside a 20 MHz OFDM signal captures
+a proportional slice of its power — plenty for on/off detection — while
+staying well inside the python-streaming rate the B210 sustains without
+overflows (full 56 MS/s needs a compiled consumer; see repo SDR lore).
+
+Usage:  tests/.venv/bin/python tests/kchansw_b210_gap.py \
+            --freq 5200e6 --rate 8e6 --secs 20 --out /tmp/b210_gap.json
+"""
+
+import argparse
+import json
+import sys
+
+import numpy as np
+
+
+def capture(freq, rate, secs, gain):
+    import uhd
+    usrp = uhd.usrp.MultiUSRP("type=b200")
+    usrp.set_rx_rate(rate)
+    usrp.set_rx_freq(uhd.libpyuhd.types.tune_request(freq))
+    usrp.set_rx_gain(gain)
+    st_args = uhd.usrp.StreamArgs("fc32", "sc16")
+    st_args.channels = [0]
+    rx = usrp.get_rx_stream(st_args)
+    md = uhd.types.RXMetadata()
+    n_total = int(rate * secs)
+    buf = np.empty(n_total, dtype=np.complex64)
+    chunk = np.empty(rx.get_max_num_samps() * 16, dtype=np.complex64)
+    cmd = uhd.types.StreamCMD(uhd.types.StreamMode.start_cont)
+    cmd.stream_now = True
+    rx.issue_stream_cmd(cmd)
+    got = 0
+    overflows = 0
+    while got < n_total:
+        n = rx.recv(chunk, md, 1.0)
+        if md.error_code == uhd.types.RXMetadataErrorCode.overflow:
+            overflows += 1
+            continue
+        if md.error_code != uhd.types.RXMetadataErrorCode.none:
+            sys.stderr.write(f"rx error: {md.error_code}\n")
+            break
+        take = min(n, n_total - got)
+        buf[got:got + take] = chunk[:take]
+        got += take
+    rx.issue_stream_cmd(uhd.types.StreamCMD(uhd.types.StreamMode.stop_cont))
+    return buf[:got], overflows
+
+
+def gaps_from_power(buf, rate, win_s=0.5e-3):
+    """Per-window power → on/off threshold → OFF-gap durations (ms)."""
+    win = int(rate * win_s)
+    n = len(buf) // win
+    p = (np.abs(buf[:n * win].reshape(n, win)) ** 2).mean(axis=1)
+    pdb = 10 * np.log10(p + 1e-12)
+    # Threshold halfway between the two modes (quiet floor vs on-air).
+    lo, hi = np.percentile(pdb, 10), np.percentile(pdb, 90)
+    thr = (lo + hi) / 2
+    on = pdb > thr
+    # OFF-run lengths, ignoring the truncated first/last runs.
+    gaps = []
+    run = 0
+    started = False
+    for v in on:
+        if v:
+            if started and run:
+                gaps.append(run * win_s * 1e3)
+            run = 0
+            started = True
+        else:
+            run += 1
+    return np.array(gaps), float(thr), float(hi - lo)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--freq", type=float, default=5200e6)
+    ap.add_argument("--rate", type=float, default=8e6)
+    ap.add_argument("--secs", type=float, default=20.0)
+    ap.add_argument("--gain", type=float, default=45.0)
+    ap.add_argument("--min-gap-ms", type=float, default=5.0,
+                    help="ignore shorter OFF runs (inter-frame spacing)")
+    ap.add_argument("--max-gap-ms", type=float, default=2000.0,
+                    help="ignore longer OFF runs (bench idle, recovery)")
+    ap.add_argument("--out", default="/tmp/b210_gap.json")
+    args = ap.parse_args()
+
+    buf, overflows = capture(args.freq, args.rate, args.secs, args.gain)
+    gaps, thr, contrast_db = gaps_from_power(buf, args.rate)
+    sel = gaps[(gaps >= args.min_gap_ms) & (gaps <= args.max_gap_ms)]
+    result = {
+        "freq_mhz": args.freq / 1e6, "rate_msps": args.rate / 1e6,
+        "secs_captured": len(buf) / args.rate, "overflows": overflows,
+        "threshold_dbfs": thr, "contrast_db": contrast_db,
+        "gaps_all": len(gaps), "gaps_selected": len(sel),
+        "gap_ms": {
+            "median": float(np.median(sel)) if len(sel) else None,
+            "p10": float(np.percentile(sel, 10)) if len(sel) else None,
+            "p90": float(np.percentile(sel, 90)) if len(sel) else None,
+            "min": float(sel.min()) if len(sel) else None,
+            "max": float(sel.max()) if len(sel) else None,
+        },
+    }
+    with open(args.out, "w") as f:
+        json.dump(result, f, indent=2)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kchansw_bench.py
+++ b/tests/kchansw_bench.py
@@ -77,8 +77,15 @@ DRIVER_SETS = {
 }
 
 
+_LOG_FILE = None
+
+
 def log(msg: str) -> None:
-    sys.stderr.write(f"[kchansw {time.strftime('%H:%M:%S')}] {msg}\n")
+    line = f"[kchansw {time.strftime('%H:%M:%S')}] {msg}\n"
+    sys.stderr.write(line)
+    if _LOG_FILE:
+        _LOG_FILE.write(line)
+        _LOG_FILE.flush()
 
 
 def ch_to_freq(ch: int) -> int:
@@ -252,25 +259,28 @@ def spawn_injector(iface, out_dir, hz, size=96, append=False) -> Child:
 
 
 class WpaAp:
-    """wpa_supplicant AP-mode (mode=2) on the DUT — the no-hostapd CSA path."""
+    """hostapd AP on the DUT. (wpa_supplicant AP-mode was tried first and
+    its CHAN_SWITCH returns FAIL before any nl80211 call reaches cfg80211 —
+    zero rdev_channel_switch events in the trace — so hostapd is the CSA
+    path; that refusal is itself a capability-matrix row.)"""
 
     def __init__(self, iface, freq, out_dir, beacon_int=100):
         self.iface = iface
-        self.ctrl = os.path.join(out_dir, "wpa")
-        conf = os.path.join(out_dir, "wpa_ap.conf")
+        self.ctrl = os.path.join(out_dir, "hostapd")
+        conf = os.path.join(out_dir, "hostapd.conf")
+        ch = (freq - 5000) // 5 if freq >= 5000 else (freq - 2407) // 5
         with open(conf, "w") as f:
-            f.write(f"ctrl_interface=DIR={self.ctrl}\n"
-                    "country=US\n"
-                    "network={\n"
-                    '    ssid="kchansw-bench"\n'
-                    "    mode=2\n"
-                    f"    frequency={freq}\n"
-                    "    key_mgmt=NONE\n"
-                    f"    beacon_int={beacon_int}\n"
-                    "}\n")
+            f.write(f"interface={iface}\n"
+                    f"ctrl_interface={self.ctrl}\n"
+                    "driver=nl80211\n"
+                    "ssid=kchansw-bench\n"
+                    f"hw_mode={'a' if freq >= 5000 else 'g'}\n"
+                    f"channel={ch}\n"
+                    f"beacon_int={beacon_int}\n"
+                    "country_code=US\n"
+                    "auth_algs=1\n")
         set_managed_idle(iface)
-        self.child = Child("wpa", ["wpa_supplicant", "-Dnl80211",
-                                   "-i", iface, "-c", conf],
+        self.child = Child("hostapd", ["hostapd", conf],
                            os.path.join(out_dir, "wpa.log"), stamp=False,
                            stderr_path=os.path.join(out_dir, "wpa.stderr"))
 
@@ -286,9 +296,8 @@ class WpaAp:
         return False
 
     def chan_switch(self, count, freq):
-        return run(["wpa_cli", "-p", os.path.join(self.ctrl),
-                    "-i", self.iface, "chan_switch", str(count), str(freq)],
-                   timeout=8)
+        return run(["hostapd_cli", "-p", self.ctrl, "-i", self.iface,
+                    "chan_switch", str(count), str(freq)], timeout=8)
 
     def stop(self):
         self.child.stop()
@@ -349,6 +358,8 @@ class Session:
             if r.returncode != 0:
                 raise SystemExit(f"modprobe {mod}: {r.stderr.strip()}")
         regress.attach_to_host_kernel(self.dut)
+        dut_iface(self.dut)
+        time.sleep(2.5)          # let udev finish the wlan0→wlxMAC rename
         iface = dut_iface(self.dut)
         unmanage(iface)
         run(["rfkill", "unblock", "wifi"], timeout=6)
@@ -631,11 +642,13 @@ def run_csa(s: Session, cfg: Cfg, iface: str):
             log(f"{cfg.name}: wpa_supplicant AP failed to start — "
                 f"CSA row = blocked (see wpa.log)")
             return
-        if not oracle_rate_gate(oa, min_lines=10, timeout=15):
+        if not oracle_rate_gate(oa, min_frames=10, timeout=15):
             log(f"{cfg.name}: oracle_a hears no beacons yet — continuing")
         with kchansw_trace.TraceSession(d, kprobes=s.driver["probes"]) as ts:
             total = cfg.warmup + cfg.switches
             cur = cfg.from_ch
+            consec_fail = 0
+            any_ok = False
             for i in range(total):
                 to = cfg.to_ch if cur == cfg.from_ch else cfg.from_ch
                 t_req = time.monotonic_ns()
@@ -663,6 +676,26 @@ def run_csa(s: Session, cfg: Cfg, iface: str):
                 if not moved:
                     log(f"{cfg.name} i={i}: CSA did not complete "
                         f"({(r.stdout + r.stderr).strip()[:80]})")
+                    consec_fail += 1
+                    if consec_fail >= 3 and not any_ok:
+                        # The driver refuses CSA outright (observed on
+                        # rtw88: hostapd "CSA is not supported" — the wiphy
+                        # never advertises AP_CSA, nothing reaches
+                        # cfg80211). Record the classification and stop
+                        # burning 5 s per attempt.
+                        ctl.write(json.dumps({
+                            "ev": "kchansw.capability", "prim": "csa",
+                            "status": "policy-rejected",
+                            "detail": "AP up + beaconing, but chan_switch "
+                                      "refused pre-nl80211 (no AP_CSA drv "
+                                      "flag); 0 rdev_channel_switch events",
+                        }) + "\n")
+                        log(f"{cfg.name}: CSA refused by stack — recording "
+                            f"capability row, aborting config")
+                        break
+                else:
+                    consec_fail = 0
+                    any_ok = True
                 cur = to if moved else cur
                 time.sleep(0.3)
                 if i % 50 == 49:
@@ -949,6 +982,293 @@ def run_mcc_attempt(s: Session, iface: str, helper_pid: str):
 
 
 # ---------------------------------------------------------------------------
+# Phase B in the VM. Kprobing the vendor module on the host deadlocked the
+# host kernel outright (ssh dead, dmesg blocked, power cycle to recover) —
+# twice — so the DUT + trace session live inside the pinned-kernel VM
+# (tests/kchansw_vm.sh prepare) and the oracles stay on the host. The
+# VM-side files carry VM CLOCK_MONOTONIC; a min-RTT midpoint estimator
+# measures the VM→host offset and the analyzer shifts them into the host
+# timeline (VM-internal spans are differences, i.e. shift-invariant).
+# ---------------------------------------------------------------------------
+
+class VmDut:
+    SSH_OPTS = ["-o", "StrictHostKeyChecking=no",
+                "-o", "UserKnownHostsFile=/dev/null",
+                "-o", "LogLevel=ERROR", "-o", "ConnectTimeout=8"]
+    # The bench runs under sudo; offer the invoking user's key.
+    _sudo_user = os.environ.get("SUDO_USER")
+    if _sudo_user:
+        for _k in ("id_ed25519", "id_rsa"):
+            _key = os.path.expanduser(f"~{_sudo_user}/.ssh/{_k}")
+            if os.path.exists(_key):
+                SSH_OPTS += ["-i", _key]
+                break
+
+    def __init__(self, dest: str):
+        self.dest = dest
+
+    def ssh(self, cmd: str, timeout=30):
+        return run(["ssh", *self.SSH_OPTS, self.dest, cmd], timeout=timeout)
+
+    def popen(self, cmd: str, **kw):
+        return subprocess.Popen(["ssh", *self.SSH_OPTS, self.dest, cmd],
+                                **kw)
+
+    def clock_shift_ns(self, rounds=25):
+        """host_mono ≈ vm_mono + shift, from the min-RTT midpoint sample."""
+        p = self.popen(
+            "python3 -u -c 'import sys,time\n"
+            "for _ in sys.stdin: print(time.monotonic_ns(), flush=True)'",
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True,
+            bufsize=1)
+        best = None
+        try:
+            for _ in range(rounds):
+                t0 = time.monotonic_ns()
+                p.stdin.write("x\n")
+                p.stdin.flush()
+                line = p.stdout.readline()
+                t1 = time.monotonic_ns()
+                if not line.strip():
+                    raise RuntimeError("clock_shift_ns: ssh pipe died "
+                                       "(VM wedged?)")
+                vm_ns = int(line.strip())
+                rtt = t1 - t0
+                if best is None or rtt < best[1]:
+                    best = ((t0 + t1) // 2 - vm_ns, rtt)
+        finally:
+            p.kill()
+        if best is None:
+            raise RuntimeError("clock_shift_ns: no samples")
+        return best
+
+    def iface(self) -> str:
+        r = self.ssh("ls /sys/class/net | grep -v -e lo -e '^en' | head -1")
+        name = r.stdout.strip()
+        if r.returncode != 0 or not name:
+            raise SystemExit("phase-b-vm: no wlan netdev in the VM — "
+                             "run tests/kchansw_vm.sh prepare first")
+        return name
+
+
+def run_vm_config(s: Session, vm: VmDut, cfg: Cfg, vm_iface: str):
+    d = s.cfg_dir(cfg)
+    oa = spawn_oracle("a", s.oracle_a_dut, cfg.from_ch, "canon", d)
+    ob = spawn_oracle("b", s.oracle_b_dut, cfg.to_ch, "canon", d)
+    shift0, rtt0 = vm.clock_shift_ns()
+    log(f"{cfg.name}: vm clock shift {shift0 / 1e6:.3f} ms "
+        f"(min-RTT {rtt0 / 1e6:.2f} ms)")
+    vm_out = f"/tmp/kchansw-vm/{cfg.name}"
+    vm.ssh(f"sudo rm -rf {vm_out}")
+    prim = "set-channel" if cfg.prim == "set_channel" else "roc"
+    p = vm.popen(
+        f"sudo python3 /opt/kchansw/kchansw_vm_dut.py {prim} "
+        f"--cfg {cfg.name} --iface {vm_iface} --from-ch {cfg.from_ch} "
+        f"--to-ch {cfg.to_ch} --switches {cfg.switches} "
+        f"--warmup {cfg.warmup} --dwell-ms {cfg.dwell_ms} "
+        f"--roc-ms {cfg.roc_ms} --hz {cfg.inject_hz:.0f} "
+        f"--roc-monitor-vif 0 --out {vm_out}",
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True,
+        bufsize=1)
+    threading.Thread(
+        target=lambda: [log(f"[vm] {ln.rstrip()}") for ln in p.stderr],
+        daemon=True).start()
+    if prim == "set-channel":
+        oracle_rate_gate(oa)  # runs inside the vm_dut settle window
+    budget = (cfg.warmup + cfg.switches) * (cfg.dwell_ms / 1e3 + 0.8) + 180
+    try:
+        rc = p.wait(timeout=budget)
+    except subprocess.TimeoutExpired:
+        log(f"{cfg.name}: vm_dut overran {budget:.0f}s — killing "
+            f"(VM wedged? `virsh reset` and re-prepare)")
+        p.kill()
+        rc = -9
+    shift1 = None
+    try:
+        shift1, _ = vm.clock_shift_ns()
+        if abs(shift1 - shift0) > 5_000_000:
+            log(f"{cfg.name}: VM clock drifted "
+                f"{(shift1 - shift0) / 1e6:.2f} ms over the config")
+    except (RuntimeError, subprocess.TimeoutExpired, OSError):
+        log(f"{cfg.name}: post-run clock probe failed (VM dead?)")
+    pull = subprocess.run(
+        ["ssh", *vm.SSH_OPTS, vm.dest, f"sudo tar -C {vm_out} -c ."],
+        capture_output=True)
+    if pull.returncode == 0 and pull.stdout:
+        subprocess.run(["tar", "-C", d, "-x"], input=pull.stdout,
+                       capture_output=True)
+    else:
+        log(f"{cfg.name}: artifact pull FAILED "
+            f"({pull.stderr.decode()[:100]})")
+    extra = {"vm": True, "vm_ssh_rtt_ns": rtt0, "vm_dut_rc": rc,
+             "vm_clock_shift_ns": ((shift0 + shift1) // 2
+                                   if shift1 is not None else shift0),
+             "vm_clock_shift_start_ns": shift0,
+             "vm_clock_shift_end_ns": shift1}
+    res_path = os.path.join(d, "vmdut_result.json")
+    if cfg.prim == "roc" and os.path.exists(res_path):
+        with open(res_path) as f:
+            have_mon = json.load(f).get("roc_monitor_vif", False)
+        cfg.need_rf = have_mon
+        extra["monitor_vif"] = have_mon
+        extra["roc_ms"] = cfg.roc_ms
+    s.write_meta(cfg, d, cfg.from_ch, cfg.to_ch, extra)
+    oa.stop()
+    ob.stop()
+    log(f"{cfg.name}: done (vm rc={rc})")
+    return rc == 0
+
+
+def run_mcc_attempt_vm(s: Session, vm: VmDut, vm_iface: str,
+                       helper_pid: str):
+    """The host run_mcc_attempt with the DUT leg driven over ssh. The
+    helper AP (8821AU + hostapd) stays on the host; association is over
+    the air, the /proc mcc knobs live in the VM."""
+    d = str(s.out_root / "mcc")
+    os.makedirs(d, exist_ok=True)
+    result = {"prim": "mcc", "status": "attempted", "venue": "vm",
+              "steps": []}
+
+    def finish():
+        with open(os.path.join(d, "mcc_result.json"), "w") as f:
+            json.dump(result, f, indent=2)
+
+    def step(name, ok, detail=""):
+        result["steps"].append({"step": name, "ok": ok, "detail": detail})
+        log(f"mcc: {name}: {'ok' if ok else 'FAILED'} {detail}")
+        finish()  # persist per step — a VM kernel wedge loses nothing
+        return ok
+
+    _real_ssh = vm.ssh
+
+    def _safe_ssh(cmd, timeout=30):
+        # A wedged VM leaves ssh hanging; convert that into a failed step
+        # instead of an unhandled TimeoutExpired.
+        try:
+            return _real_ssh(cmd, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            return subprocess.CompletedProcess([], 124, "",
+                                               "ssh timeout (VM wedged?)")
+    vm.ssh = _safe_ssh
+
+    try:
+        helper = find_dut(helper_pid)
+    except SystemExit:
+        result["status"] = "blocked-hardware-absent"
+        step("helper adapter", False, f"{helper_pid} not plugged")
+        finish()
+        return
+    run(["modprobe", "rtw88_8821au"], timeout=30)
+    regress.attach_to_host_kernel(helper)
+    try:
+        dut_iface(helper)
+        time.sleep(2.5)          # let udev finish the wlan0→wlxMAC rename
+        h_iface = dut_iface(helper)
+    except RuntimeError as e:
+        step("helper iface", False, str(e))
+        result["status"] = "blocked-helper-bringup"
+        finish()
+        return
+    unmanage(h_iface)
+    ap = WpaAp(h_iface, ch_to_freq(36), d)
+    ok = step("helper AP beaconing on 36", ap.wait_beaconing())
+    if ok:
+        # Open BSS — iw's own open-system connect avoids needing
+        # wpa_supplicant inside the VM.
+        vm.ssh(f"sudo ip link set {vm_iface} down; "
+               f"sudo iw dev {vm_iface} set type managed; "
+               f"sudo ip link set {vm_iface} up; "
+               f"sudo iw dev {vm_iface} connect kchansw-bench")
+        assoc = False
+        end = time.monotonic() + 30
+        while time.monotonic() < end:
+            r = vm.ssh(f"iw dev {vm_iface} link")
+            if "Connected to" in r.stdout:
+                assoc = True
+                break
+            time.sleep(1)
+        ok = step("DUT STA associated to helper", assoc)
+    if ok:
+        # CONCURRENT_MODE builds auto-create the second vif at insmod.
+        r = vm.ssh(f"ls /sys/class/net | grep -v -e lo -e '^en' "
+                   f"| grep -v '^{vm_iface}$' | head -1")
+        second = r.stdout.strip()
+        if not second:
+            r = vm.ssh(f"sudo iw dev {vm_iface} interface add kcap0 "
+                       f"type managed")
+            second = "kcap0" if r.returncode == 0 else ""
+        ok = step("second vif", bool(second), second or
+                  r.stderr.strip()[:100])
+    if ok:
+        r = vm.ssh(f"ls /proc/net/*/{vm_iface}/mcc/mcc_* 2>/dev/null")
+        knobs = r.stdout.split()
+        ok = step("mcc proc knobs present", bool(knobs), str(knobs[:3]))
+        if ok:
+            base = os.path.dirname(knobs[0])
+            r = vm.ssh(f"echo 1 | sudo tee {base}/mcc_enable")
+            step("mcc_enable=1", r.returncode == 0, r.stderr.strip()[:80])
+            for k in ("mcc_info", "mcc_policy_table"):
+                r = vm.ssh(f"sudo cat {base}/{k} 2>/dev/null")
+                if r.stdout:
+                    result[k] = r.stdout[:4000]
+    if not ok:
+        result["status"] = "blocked-see-steps"
+    finish()
+    vm.ssh(f"sudo pkill wpa_supplicant; sudo iw dev kcap0 del 2>/dev/null; "
+           f"true")
+    ap.stop()
+    s.dmesg_dump(d)
+
+
+def cmd_phase_b_vm(s: Session, a):
+    if not a.vm_ssh:
+        raise SystemExit("phase-b-vm: --vm-ssh user@ip required "
+                         "(tests/kchansw_vm.sh status shows the IP)")
+    vm = VmDut(a.vm_ssh)
+    r = vm.ssh("lsmod | grep -qE '^(88x2bu_ohd|8812bu)' && uname -r")
+    if r.returncode != 0:
+        raise SystemExit("phase-b-vm: vendor module not loaded in the VM — "
+                         "run tests/kchansw_vm.sh prepare first")
+    with open(s.out_root / "vm_manifest.json", "w") as f:
+        json.dump({"vm_uname": r.stdout.strip(),
+                   "vm_ssh": a.vm_ssh,
+                   "vm_modinfo": vm.ssh(
+                       "modinfo /opt/kchansw/rtl88x2bu/88x2bu_ohd.ko "
+                       "| head -8").stdout}, f, indent=2)
+    write_manifest(s)
+    vm_iface = vm.iface()
+    log(f"phase-b-vm: VM kernel {r.stdout.strip()}, DUT iface {vm_iface}")
+    configs = [
+        Cfg("b-set-36-40", "set_channel", 36, 40, a.switches),
+        Cfg("b-roc-36-40", "roc", 36, 40, a.switches_aux,
+            rdev_entry="rdev_remain_on_channel"),
+    ]
+    for cfg in configs:
+        if a.primitive not in ("all",) and a.primitive not in cfg.name \
+                and a.primitive != cfg.prim:
+            continue
+        if not run_vm_config(s, vm, cfg, vm_iface):
+            log(f"{cfg.name}: vm run reported failure — continuing")
+        if not iface_alive_vm(vm, vm_iface):
+            log("phase-b-vm: VM DUT iface dead — stopping")
+            return
+    if a.primitive in ("all", "mcc"):
+        log("phase-b-vm: rebuilding VARIANT=mcc in VM for the MCC attempt")
+        r = subprocess.run(["tests/kchansw_vm.sh", "mcc"], cwd=str(REPO),
+                           capture_output=True, text=True, timeout=900)
+        if r.returncode != 0:
+            log(f"mcc variant build/load failed: {r.stdout[-200:]} "
+                f"{r.stderr[-200:]}")
+            return
+        run_mcc_attempt_vm(s, vm, vm.iface(), a.helper_pid)
+
+
+def iface_alive_vm(vm: VmDut, iface: str) -> bool:
+    r = vm.ssh(f"iw dev {iface} info")
+    return r.returncode == 0 and "Interface" in r.stdout
+
+
+# ---------------------------------------------------------------------------
 # Manifest, inventory, smoke.
 # ---------------------------------------------------------------------------
 
@@ -1094,7 +1414,9 @@ def run_phase(s: Session, configs, only: str):
             elif cfg.prim == "scan":
                 run_scan(s, cfg, iface)
         except Exception as e:
+            import traceback
             log(f"{cfg.name}: EXCEPTION {e!r} — continuing with next config")
+            log(traceback.format_exc())
     log(f"phase done → analyze with: tests/.venv/bin/python "
         f"tests/kchansw_analyze.py {s.out_root}")
 
@@ -1139,7 +1461,9 @@ def cmd_phase_c(s: Session, a):
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("cmd", choices=["inventory", "smoke", "phase-a", "cold",
-                                    "phase-b", "phase-c"])
+                                    "phase-b", "phase-b-vm", "phase-c"])
+    ap.add_argument("--vm-ssh", default="",
+                    help="user@ip of the prepared VM (phase-b-vm)")
     ap.add_argument("--primitive", default="all",
                     help="filter configs by primitive/name substring")
     ap.add_argument("--dut-pid", default="2357:012d")
@@ -1167,11 +1491,13 @@ def main() -> int:
                    f"{args.cmd}"
 
     regress._install_cleanup_handlers()
-    driver_key = {"phase-b": "vendor", "phase-c": "rtw89"}.get(args.cmd,
-                                                               "rtw88")
+    driver_key = {"phase-b": "vendor", "phase-b-vm": "vendor",
+                  "phase-c": "rtw89"}.get(args.cmd, "rtw88")
     if args.cmd == "phase-c":
         args.dut_pid = "35bc:0108"
     s = Session(args, driver_key)
+    global _LOG_FILE
+    _LOG_FILE = open(s.out_root / "bench.log", "a")
     log(f"out dir: {s.out_root}  driver: {driver_key}  DUT: {s.dut.vidpid} "
         f"({s.dut.chipset})")
 
@@ -1187,6 +1513,14 @@ def main() -> int:
         set_monitor(iface, 36)
         run_cold(s, args.cold_trials)
     elif args.cmd == "phase-b":
+        # Kprobing the vendor module on the host deadlocked the host kernel
+        # (power cycle to recover) — twice. Use phase-b-vm.
+        if os.environ.get("KCHANSW_HOST_VENDOR_OK") != "1":
+            sys.stderr.write(
+                "phase-b (host insmod) hangs the whole machine — use "
+                "phase-b-vm (tests/kchansw_vm.sh prepare). Set "
+                "KCHANSW_HOST_VENDOR_OK=1 to override.\n")
+            return 2
         # Module must already be inserted by kchansw_vendor_build.sh.
         if run(["sh", "-c", "lsmod | grep -q '^88x2bu_ohd'"]).returncode != 0:
             sys.stderr.write("phase-b: vendor module 88x2bu_ohd not loaded — "
@@ -1201,6 +1535,8 @@ def main() -> int:
         if args.primitive in ("all", "mcc"):
             iface = dut_iface(s.dut)
             run_mcc_attempt(s, iface, args.helper_pid)
+    elif args.cmd == "phase-b-vm":
+        cmd_phase_b_vm(s, args)
     elif args.cmd == "phase-c":
         cmd_phase_c(s, args)
     # Hand the artifacts to the invoking user so the (non-root) analyzer can

--- a/tests/kchansw_bench.py
+++ b/tests/kchansw_bench.py
@@ -167,11 +167,12 @@ class Child:
     """Popen wrapper: stdout consumed by a stamping reader thread."""
 
     def __init__(self, name, argv, out_path, env=None, stamp=True,
-                 stderr_path=None):
+                 stderr_path=None, append=False):
         self.name = name
         self.lines = 0
+        self.frame_lines = 0  # oracle rx.frame decode counter
         self._stamp = stamp
-        self._out = open(out_path, "w")
+        self._out = open(out_path, "a" if append else "w")
         self._err = open(stderr_path, "w") if stderr_path else subprocess.DEVNULL
         self.proc = subprocess.Popen(
             argv, stdout=subprocess.PIPE, stderr=self._err,
@@ -194,6 +195,8 @@ class Child:
             else:
                 self._out.write(line + "\n")
             self.lines += 1
+            if '"ev":"rx.frame"' in line:
+                self.frame_lines += 1
         self._out.flush()
 
     def alive(self) -> bool:
@@ -233,11 +236,12 @@ def spawn_oracle(role, dut, channel, agg_sa, out_dir) -> Child:
     return c
 
 
-def spawn_injector(iface, out_dir, hz, size=96) -> Child:
+def spawn_injector(iface, out_dir, hz, size=96, append=False) -> Child:
     return Child("inject", [sys.executable, str(INJECT), "--iface", iface,
                             "--hz", str(hz), "--size", str(size)],
                  os.path.join(out_dir, "inject.jsonl"), stamp=False,
-                 stderr_path=os.path.join(out_dir, "inject.stderr"))
+                 stderr_path=os.path.join(out_dir, "inject.stderr"),
+                 append=append)
 
 
 class WpaAp:
@@ -371,17 +375,47 @@ class Session:
         return open(os.path.join(d, "control.jsonl"), "w")
 
 
-def oracle_rate_gate(oracle: Child, min_lines=50, timeout=20.0) -> bool:
-    """Liveness: the oracle must be decoding (stamped lines flowing)."""
-    start_lines = oracle.lines
+def oracle_rate_gate(oracle: Child, min_frames=50, timeout=20.0) -> bool:
+    """Liveness: the oracle must be DECODING (rx.frame lines, not just init
+    chatter — the smoke run showed the loose any-line gate passing on a
+    channel the oracle could barely hear)."""
+    start = oracle.frame_lines
     end = time.monotonic() + timeout
     while time.monotonic() < end:
-        if oracle.lines - start_lines >= min_lines:
+        if oracle.frame_lines - start >= min_frames:
             return True
         if not oracle.alive():
             return False
         time.sleep(0.5)
-    return oracle.lines - start_lines >= min_lines
+    return oracle.frame_lines - start >= min_frames
+
+
+def recover_dut(s: "Session", ch: int, ht: str = "", start: str = "rebind"):
+    """Recovery ladder after a DUT wedge/USB drop (the smoke run lost the
+    netdev to a full USB disconnect after ~25 switch cycles): re-probe →
+    module reload → authorized/VBUS power-cycle. Returns (iface, rung) or
+    (None, 'exhausted'). The chip usually re-enumerates by itself; the
+    rungs differ in how much driver state they rebuild."""
+    mod = s.driver["module"]
+    ladder = ("rebind", "module-reload", "power-cycle")
+    for action in ladder[ladder.index(start):]:
+        try:
+            if action == "module-reload" and s.driver_key != "vendor":
+                run(["modprobe", "-r", mod], timeout=30)
+                run(["modprobe", mod], timeout=60)
+            elif action == "power-cycle":
+                regress.usb_port_power_cycle(s.dut, settle_s=3.0)
+                if s.driver_key != "vendor":
+                    run(["modprobe", mod], timeout=60)
+            regress.attach_to_host_kernel(s.dut)
+            iface = dut_iface(s.dut, timeout=20)
+            unmanage(iface)
+            set_monitor(iface, ch, ht)
+            log(f"recover_dut: '{action}' worked → {iface}")
+            return iface, action
+        except Exception as e:  # noqa: BLE001 — every rung may legitimately fail
+            log(f"recover_dut: {action} failed: {e}")
+    return None, "exhausted"
 
 
 # ---------------------------------------------------------------------------
@@ -407,6 +441,7 @@ def run_set_channel(s: Session, cfg: Cfg, iface: str, uninstrumented=False):
         if trace_ctx:
             trace_ctx.__enter__()
         total = cfg.warmup + cfg.switches
+        last_prog = -1
         for i in range(total):
             frm, to = ((cfg.from_ch, cfg.to_ch) if i % 2 == 0
                        else (cfg.to_ch, cfg.from_ch))
@@ -430,15 +465,52 @@ def run_set_channel(s: Session, cfg: Cfg, iface: str, uninstrumented=False):
             if r.returncode != 0:
                 log(f"{cfg.name} i={i}: iw rc={r.returncode} "
                     f"{r.stderr.strip()[:80]}")
+                if "No such device" in r.stderr or "(-19)" in r.stderr:
+                    # USB drop mid-config (seen in smoke): recover, respawn
+                    # the injector (its socket died with the old ifindex),
+                    # and mark everything after as post-recovery.
+                    ctl.write(json.dumps({"ev": "kchansw.wedge", "i": i,
+                                          "mono_ns": time.monotonic_ns(),
+                                          "kind": "usb-drop"}) + "\n")
+                    inj.stop()
+                    iface2, rung = recover_dut(s, to, cfg.ht)
+                    ctl.write(json.dumps({"ev": "kchansw.recovered", "i": i,
+                                          "rung": rung,
+                                          "ok": iface2 is not None}) + "\n")
+                    if iface2 is None:
+                        log(f"{cfg.name}: recovery exhausted — aborting")
+                        break
+                    iface = iface2
+                    inj = spawn_injector(iface, d, cfg.inject_hz, append=True)
             time.sleep(cfg.dwell_ms / 1e3)
-            if i % 50 == 49:
+            if i % 25 == 24:
                 ctl.flush()
                 if not (inj.alive() and oa.alive() and ob.alive()):
                     log(f"{cfg.name}: child died (inj={inj.alive()} "
                         f"oa={oa.alive()} ob={ob.alive()}) — aborting config")
                     break
-                if iface_channel(iface) is None:
-                    log(f"{cfg.name}: iw info unresponsive — possible wedge")
+                prog = oa.frame_lines + ob.frame_lines
+                if prog == last_prog:
+                    # Injector alive and erroring 0, yet neither oracle
+                    # decodes anything new: the silent-TX wedge (probed on
+                    # this rig — dmesg stays clean; module reload clears it).
+                    log(f"{cfg.name} i={i}: silent-TX stall — recovering")
+                    ctl.write(json.dumps({"ev": "kchansw.wedge", "i": i,
+                                          "mono_ns": time.monotonic_ns(),
+                                          "kind": "silent-tx"}) + "\n")
+                    inj.stop()
+                    cur_ch = to
+                    iface2, rung = recover_dut(s, cur_ch, cfg.ht,
+                                               start="module-reload")
+                    ctl.write(json.dumps({"ev": "kchansw.recovered", "i": i,
+                                          "rung": rung,
+                                          "ok": iface2 is not None}) + "\n")
+                    if iface2 is None:
+                        log(f"{cfg.name}: recovery exhausted — aborting")
+                        break
+                    iface = iface2
+                    inj = spawn_injector(iface, d, cfg.inject_hz, append=True)
+                last_prog = oa.frame_lines + ob.frame_lines
     finally:
         if trace_ctx:
             trace_ctx.__exit__(None, None, None)
@@ -453,7 +525,7 @@ def run_set_channel(s: Session, cfg: Cfg, iface: str, uninstrumented=False):
         ctl.close()
         s.dmesg_dump(d)
     log(f"{cfg.name}: done ({cfg.warmup}+{cfg.switches} switches)")
-    return per_switch_wall
+    return per_switch_wall, iface
 
 
 def run_csa(s: Session, cfg: Cfg, iface: str):
@@ -870,10 +942,10 @@ def cmd_smoke(s: Session):
     write_manifest(s)
     cfg_i = Cfg(name="smoke-instrumented", prim="set_channel",
                 from_ch=36, to_ch=40, switches=20, warmup=2)
-    w_inst = run_set_channel(s, cfg_i, iface)
+    w_inst, iface = run_set_channel(s, cfg_i, iface)
     cfg_u = Cfg(name="smoke-bare", prim="set_channel",
                 from_ch=36, to_ch=40, switches=20, warmup=2)
-    w_bare = run_set_channel(s, cfg_u, iface, uninstrumented=True)
+    w_bare, iface = run_set_channel(s, cfg_u, iface, uninstrumented=True)
     import statistics
     med_i = statistics.median(w_inst) / 1e6 if w_inst else 0
     med_b = statistics.median(w_bare) / 1e6 if w_bare else 0
@@ -888,7 +960,9 @@ def cmd_smoke(s: Session):
 
 def phase_a_configs(a) -> list:
     return [
-        Cfg("a-set-36-40", "set_channel", 36, 40, a.switches),
+        # Headline endurance config: directions alternate, so ×2 yields the
+        # issue's ≥1000 switches in EACH direction.
+        Cfg("a-set-36-40", "set_channel", 36, 40, 2 * a.switches),
         Cfg("a-set-1-6", "set_channel", 1, 6, a.switches_aux),
         Cfg("a-set-ht40-36-44", "set_channel", 36, 44, a.switches_aux,
             ht="HT40+"),
@@ -917,7 +991,7 @@ def run_phase(s: Session, configs, only: str):
             f"×{cfg.switches}) ===")
         try:
             if cfg.prim == "set_channel":
-                run_set_channel(s, cfg, iface)
+                _, iface = run_set_channel(s, cfg, iface)
             elif cfg.prim == "csa":
                 run_csa(s, cfg, iface)
                 set_managed_idle(iface)
@@ -975,7 +1049,9 @@ def main() -> int:
     ap.add_argument("--primitive", default="all",
                     help="filter configs by primitive/name substring")
     ap.add_argument("--dut-pid", default="2357:012d")
-    ap.add_argument("--oracle-a-pid", default="0bda:8812")
+    ap.add_argument("--oracle-a-pid", default="2357:0120",
+                help="8821AU: on this rig the 8812AU position "
+                     "decodes <10%% of near-field injector frames")
     ap.add_argument("--oracle-b-pid", default="0bda:c812")
     ap.add_argument("--helper-pid", default="2357:0120",
                     help="helper AP adapter for the MCC attempt (8821AU)")
@@ -1033,6 +1109,12 @@ def main() -> int:
             run_mcc_attempt(s, iface, args.helper_pid)
     elif args.cmd == "phase-c":
         cmd_phase_c(s, args)
+    # Hand the artifacts to the invoking user so the (non-root) analyzer can
+    # write summaries next to them.
+    sudo_user = os.environ.get("SUDO_USER")
+    if sudo_user:
+        subprocess.run(["chown", "-R", f"{sudo_user}:", str(s.out_root)],
+                       capture_output=True)
     return 0
 
 

--- a/tests/kchansw_bench.py
+++ b/tests/kchansw_bench.py
@@ -1,0 +1,1040 @@
+#!/usr/bin/env python3
+"""Kernel channel-switch primitive bench — the hardware orchestrator.
+
+Measures every channel-switch primitive a standard Linux/Realtek kernel
+driver exposes (monitor set-channel, AP/CSA, remain-on-channel, single-freq
+active scan, TDLS capability, vendor MCC/FCS attempt) with:
+
+  - ftrace instrumentation (tests/kchansw_trace.py): cfg80211/mac80211 events
+    + kchansw/ kprobes on driver internals, trace_clock=mono;
+  - an on-air oracle: two devourer rxdemo receivers pinned to the source and
+    destination channels (DEVOURER_STREAM_OUT=1 + DEVOURER_RX_AGG_SA), their
+    stdout stamped per line with time.monotonic_ns() by reader threads;
+  - a continuous tagged-frame injector (tests/kchansw_inject.py) on the DUT
+    monitor interface for RF-evidence timestamps.
+
+Per config it writes <out>/<cfg>/{meta.json, control.jsonl, trace.txt,
+oracle_a.jsonl, oracle_b.jsonl, inject.jsonl, wpa.log, dmesg.log}; offline
+analysis is tests/kchansw_analyze.py. A switch whose API succeeded but shows
+no destination-channel RF evidence is a FAILED measurement by design.
+
+Subcommands:
+  inventory   capability matrix (~2 min, no long runs)
+  smoke       20 instrumented switches + 20 uninstrumented (overhead A/B)
+  phase-a     in-tree rtw88 DUT full matrix   [--primitive ...]
+  cold        ~10 driver-cold first-switch trials
+  phase-b     vendor 88x2bu DUT (module must already be loaded — see
+              tests/kchansw_vendor_build.sh)
+  phase-c     in-tree rtw89 8852BU quick pass (lifts/restores the kestrel
+              blacklist itself, VBUS-cycles the DUT after)
+
+Run as root. Reuses tests/regress.py's adapter machinery (sysfs bind/unbind,
+VBUS map, process hygiene) by import — regress.py is __main__-guarded.
+"""
+
+import argparse
+import dataclasses
+import glob
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import regress  # noqa: E402  (module-level is constants + defs only)
+import kchansw_trace  # noqa: E402
+
+REPO = Path(__file__).resolve().parent.parent
+RXDEMO = REPO / "build" / "rxdemo"
+INJECT = Path(__file__).resolve().parent / "kchansw_inject.py"
+BLACKLIST_KESTREL = "/etc/modprobe.d/zz-temp-blacklist-kestrel.conf"
+BLACKLIST_HOLD = BLACKLIST_KESTREL + ".kchansw-hold"
+
+# Roles beyond regress.SUPPORTED_DUTS (informational names only).
+EXTRA_IDS = {
+    "35bc:0108": "RTL8852BU (TP-Link TX20U Nano, rtw89)",
+    "0cf3:9271": "AR9271 (ath9k_htc helper AP)",
+}
+
+DRIVER_SETS = {
+    "rtw88": {"module": "rtw88_8822bu",
+              "probes": kchansw_trace.RTW88_PROBES,
+              "probe_map": {"drv": "kc_drv_set_channel",
+                            "chip": "kc_chip_set_channel", "h2c": "kc_h2c"}},
+    "vendor": {"module": "88x2bu",
+               "probes": kchansw_trace.VENDOR_PROBES,
+               "probe_map": {"drv": "kc_drv_set_channel",
+                             "chip": "kc_chip_set_channel", "h2c": "kc_h2c"}},
+    "rtw89": {"module": "rtw89_8852bu",
+              "probes": kchansw_trace.RTW89_PROBES,
+              "probe_map": {"drv": "kc_drv_set_channel",
+                            "chip": "kc_chip_set_channel", "h2c": "kc_h2c"}},
+}
+
+
+def log(msg: str) -> None:
+    sys.stderr.write(f"[kchansw {time.strftime('%H:%M:%S')}] {msg}\n")
+
+
+def ch_to_freq(ch: int) -> int:
+    return 2407 + 5 * ch if ch <= 14 else 5000 + 5 * ch
+
+
+def run(cmd, timeout=15, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True,
+                          timeout=timeout, **kw)
+
+
+# ---------------------------------------------------------------------------
+# Adapter roles.
+# ---------------------------------------------------------------------------
+
+def find_dut(vidpid: str) -> regress.Dut:
+    vid, pid = vidpid.lower().split(":")
+    for d in glob.glob("/sys/bus/usb/devices/*"):
+        try:
+            with open(f"{d}/idVendor") as f:
+                if f.read().strip() != vid:
+                    continue
+            with open(f"{d}/idProduct") as f:
+                if f.read().strip() != pid:
+                    continue
+        except (OSError, IsADirectoryError):
+            continue
+        name = regress.SUPPORTED_DUTS.get(vidpid, EXTRA_IDS.get(vidpid, "?"))
+        return regress.Dut(sysfs_id=os.path.basename(d), vid=vid, pid=pid,
+                           chipset=name)
+    raise SystemExit(f"adapter {vidpid} not found on USB — plug it or fix "
+                     f"--*-pid")
+
+
+def dut_iface(dut: regress.Dut, timeout=25.0) -> str:
+    return regress.KernelHost.local().wait_for_wlan_iface(dut, timeout)
+
+
+def iface_phy(iface: str) -> str:
+    return os.path.basename(os.readlink(f"/sys/class/net/{iface}/phy80211"))
+
+
+def iface_mac(iface: str) -> str:
+    with open(f"/sys/class/net/{iface}/address") as f:
+        return f.read().strip()
+
+
+def set_monitor(iface: str, ch: int, ht: str = "") -> None:
+    for cmd in ([["ip", "link", "set", iface, "down"],
+                 ["iw", "dev", iface, "set", "type", "monitor"],
+                 ["ip", "link", "set", iface, "up"]]):
+        r = run(cmd)
+        if r.returncode != 0:
+            raise RuntimeError(f"{' '.join(cmd)}: {r.stderr.strip()}")
+    args = ["iw", "dev", iface, "set", "channel", str(ch)] + ([ht] if ht else [])
+    r = run(args)
+    if r.returncode != 0:
+        raise RuntimeError(f"{' '.join(args)}: {r.stderr.strip()}")
+
+
+def set_managed_idle(iface: str) -> None:
+    run(["ip", "link", "set", iface, "down"])
+    r = run(["iw", "dev", iface, "set", "type", "managed"])
+    if r.returncode != 0:
+        raise RuntimeError(f"set managed: {r.stderr.strip()}")
+    run(["ip", "link", "set", iface, "up"])
+
+
+def iface_channel(iface: str):
+    r = run(["iw", "dev", iface, "info"], timeout=4)
+    m = re.search(r"channel (\d+)", r.stdout)
+    return int(m.group(1)) if m else None
+
+
+def unmanage(iface: str) -> None:
+    """Keep NetworkManager (if any) off the bench interface."""
+    if shutil.which("nmcli"):
+        run(["nmcli", "dev", "set", iface, "managed", "no"], timeout=6)
+
+
+# ---------------------------------------------------------------------------
+# Long-lived child processes (oracles / injector / wpa) with stamped readers.
+# ---------------------------------------------------------------------------
+
+class Child:
+    """Popen wrapper: stdout consumed by a stamping reader thread."""
+
+    def __init__(self, name, argv, out_path, env=None, stamp=True,
+                 stderr_path=None):
+        self.name = name
+        self.lines = 0
+        self._stamp = stamp
+        self._out = open(out_path, "w")
+        self._err = open(stderr_path, "w") if stderr_path else subprocess.DEVNULL
+        self.proc = subprocess.Popen(
+            argv, stdout=subprocess.PIPE, stderr=self._err,
+            env=env, text=True, bufsize=1,
+            preexec_fn=regress._child_preexec)
+        regress._register_local_proc(self.proc)
+        self._thread = threading.Thread(target=self._pump, daemon=True)
+        self._thread.start()
+
+    def _pump(self):
+        for line in self.proc.stdout:
+            t = time.monotonic_ns()
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            if self._stamp:
+                self._out.write(json.dumps(
+                    {"host_mono_ns": t, "raw": line},
+                    separators=(",", ":")) + "\n")
+            else:
+                self._out.write(line + "\n")
+            self.lines += 1
+        self._out.flush()
+
+    def alive(self) -> bool:
+        return self.proc.poll() is None
+
+    def stop(self, timeout=5.0):
+        if self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+        self._thread.join(timeout=3.0)
+        regress._unregister_local_proc(self.proc)
+        try:
+            self._out.close()
+        except OSError:
+            pass
+        if self._err is not subprocess.DEVNULL:
+            self._err.close()
+
+
+def spawn_oracle(role, dut, channel, agg_sa, out_dir) -> Child:
+    regress.detach_from_host_kernel(dut)
+    env = dict(os.environ)
+    env.update({
+        "DEVOURER_VID": f"0x{dut.vid}", "DEVOURER_PID": f"0x{dut.pid}",
+        "DEVOURER_CHANNEL": str(channel),
+        "DEVOURER_EVENTS": "stdout", "DEVOURER_LOG_LEVEL": "warn",
+        "DEVOURER_STREAM_OUT": "1", "DEVOURER_RX_AGG_SA": agg_sa,
+    })
+    c = Child(f"oracle_{role}", [str(RXDEMO)],
+              os.path.join(out_dir, f"oracle_{role}.jsonl"), env=env,
+              stamp=True, stderr_path=os.path.join(out_dir,
+                                                   f"oracle_{role}.stderr"))
+    log(f"oracle_{role}: rxdemo on {dut.vidpid} ch{channel} sa={agg_sa}")
+    return c
+
+
+def spawn_injector(iface, out_dir, hz, size=96) -> Child:
+    return Child("inject", [sys.executable, str(INJECT), "--iface", iface,
+                            "--hz", str(hz), "--size", str(size)],
+                 os.path.join(out_dir, "inject.jsonl"), stamp=False,
+                 stderr_path=os.path.join(out_dir, "inject.stderr"))
+
+
+class WpaAp:
+    """wpa_supplicant AP-mode (mode=2) on the DUT — the no-hostapd CSA path."""
+
+    def __init__(self, iface, freq, out_dir, beacon_int=100):
+        self.iface = iface
+        self.ctrl = os.path.join(out_dir, "wpa")
+        conf = os.path.join(out_dir, "wpa_ap.conf")
+        with open(conf, "w") as f:
+            f.write(f"ctrl_interface=DIR={self.ctrl}\n"
+                    "country=US\n"
+                    "network={\n"
+                    '    ssid="kchansw-bench"\n'
+                    "    mode=2\n"
+                    f"    frequency={freq}\n"
+                    "    key_mgmt=NONE\n"
+                    f"    beacon_int={beacon_int}\n"
+                    "}\n")
+        set_managed_idle(iface)
+        self.child = Child("wpa", ["wpa_supplicant", "-Dnl80211",
+                                   "-i", iface, "-c", conf],
+                           os.path.join(out_dir, "wpa.log"), stamp=False,
+                           stderr_path=os.path.join(out_dir, "wpa.stderr"))
+
+    def wait_beaconing(self, timeout=25.0) -> bool:
+        end = time.monotonic() + timeout
+        while time.monotonic() < end:
+            r = run(["iw", "dev", self.iface, "info"], timeout=4)
+            if "type AP" in r.stdout and "channel" in r.stdout:
+                return True
+            if not self.child.alive():
+                return False
+            time.sleep(0.5)
+        return False
+
+    def chan_switch(self, count, freq):
+        return run(["wpa_cli", "-p", os.path.join(self.ctrl),
+                    "-i", self.iface, "chan_switch", str(count), str(freq)],
+                   timeout=8)
+
+    def stop(self):
+        self.child.stop()
+
+
+# ---------------------------------------------------------------------------
+# Config + common runner scaffold.
+# ---------------------------------------------------------------------------
+
+@dataclasses.dataclass
+class Cfg:
+    name: str
+    prim: str            # set_channel | csa | roc | scan
+    from_ch: int
+    to_ch: int
+    switches: int
+    warmup: int = 10
+    dwell_ms: int = 150
+    ht: str = ""         # "HT40+" etc. applied to both endpoints
+    csa_count: int = 1
+    beacon_int: int = 100
+    roc_ms: int = 20
+    inject_hz: float = 2000.0
+    need_rf: bool = True
+    fingerprint: str = "kcsw"
+    rdev_entry: str = "rdev_set_monitor_channel"
+
+
+class Session:
+    """Everything shared across one bench invocation."""
+
+    def __init__(self, args, driver_key):
+        self.args = args
+        self.driver = DRIVER_SETS[driver_key]
+        self.driver_key = driver_key
+        self.out_root = Path(args.out)
+        self.out_root.mkdir(parents=True, exist_ok=True)
+        self.dut = find_dut(args.dut_pid)
+        self.oracle_a_dut = find_dut(args.oracle_a_pid)
+        self.oracle_b_dut = find_dut(args.oracle_b_pid)
+        self.dmesg_since = time.strftime("%Y-%m-%d %H:%M:%S")
+
+    # -- DUT bring-up --------------------------------------------------------
+
+    def dut_up(self) -> str:
+        mod = self.driver["module"]
+        if self.driver_key != "vendor":
+            r = run(["modprobe", mod], timeout=30)
+            if r.returncode != 0:
+                raise SystemExit(f"modprobe {mod}: {r.stderr.strip()}")
+        regress.attach_to_host_kernel(self.dut)
+        iface = dut_iface(self.dut)
+        unmanage(iface)
+        run(["rfkill", "unblock", "wifi"], timeout=6)
+        return iface
+
+    # -- per-config scaffold -------------------------------------------------
+
+    def cfg_dir(self, cfg: Cfg) -> str:
+        d = self.out_root / cfg.name
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+
+    def write_meta(self, cfg: Cfg, d: str, oa_ch, ob_ch, extra=None):
+        meta = {
+            "cfg": cfg.name, "prim": cfg.prim, "from": cfg.from_ch,
+            "to": cfg.to_ch, "warmup": cfg.warmup,
+            "oracle_a_ch": oa_ch, "oracle_b_ch": ob_ch,
+            "rdev_entry": cfg.rdev_entry,
+            "probe_map": self.driver["probe_map"],
+            "fingerprint": cfg.fingerprint, "need_rf": cfg.need_rf,
+            "driver": self.driver_key, "module": self.driver["module"],
+        }
+        meta.update(extra or {})
+        with open(os.path.join(d, "meta.json"), "w") as f:
+            json.dump(meta, f, indent=1)
+
+    def dmesg_dump(self, d: str):
+        r = run(["journalctl", "-k", "--since", self.dmesg_since,
+                 "--no-pager"], timeout=20)
+        with open(os.path.join(d, "dmesg.log"), "w") as f:
+            f.write(r.stdout)
+        bad = [ln for ln in r.stdout.splitlines()
+               if re.search(r"WARNING|BUG:|Oops|Call Trace|xhci.*(die|halt)",
+                            ln)]
+        if bad:
+            log(f"!! dmesg flagged {len(bad)} suspicious lines (see dmesg.log)")
+        return bad
+
+    def control_writer(self, d: str):
+        return open(os.path.join(d, "control.jsonl"), "w")
+
+
+def oracle_rate_gate(oracle: Child, min_lines=50, timeout=20.0) -> bool:
+    """Liveness: the oracle must be decoding (stamped lines flowing)."""
+    start_lines = oracle.lines
+    end = time.monotonic() + timeout
+    while time.monotonic() < end:
+        if oracle.lines - start_lines >= min_lines:
+            return True
+        if not oracle.alive():
+            return False
+        time.sleep(0.5)
+    return oracle.lines - start_lines >= min_lines
+
+
+# ---------------------------------------------------------------------------
+# Primitive runners.
+# ---------------------------------------------------------------------------
+
+def run_set_channel(s: Session, cfg: Cfg, iface: str, uninstrumented=False):
+    d = s.cfg_dir(cfg)
+    s.write_meta(cfg, d, cfg.from_ch, cfg.to_ch)
+    oa = spawn_oracle("a", s.oracle_a_dut, cfg.from_ch, "canon", d)
+    ob = spawn_oracle("b", s.oracle_b_dut, cfg.to_ch, "canon", d)
+    set_monitor(iface, cfg.from_ch, cfg.ht)
+    inj = spawn_injector(iface, d, cfg.inject_hz)
+    ok = oracle_rate_gate(oa)
+    if not ok:
+        log(f"{cfg.name}: oracle_a not decoding the injector stream — "
+            f"placement/saturation? continuing, rows may fail no_rf")
+    ctl = s.control_writer(d)
+    trace_ctx = (kchansw_trace.TraceSession(d, kprobes=s.driver["probes"])
+                 if not uninstrumented else None)
+    per_switch_wall = []
+    try:
+        if trace_ctx:
+            trace_ctx.__enter__()
+        total = cfg.warmup + cfg.switches
+        for i in range(total):
+            frm, to = ((cfg.from_ch, cfg.to_ch) if i % 2 == 0
+                       else (cfg.to_ch, cfg.from_ch))
+            t_req = time.monotonic_ns()
+            if trace_ctx:
+                trace_ctx.marker(f"KCHANSW i={i} prim={cfg.prim} "
+                                 f"cfg={cfg.name} from={frm} to={to} "
+                                 f"mono={t_req}")
+            ctl.write(json.dumps({"ev": "kchansw.req", "i": i,
+                                  "from": frm, "to": to,
+                                  "mono_ns": t_req}) + "\n")
+            argv = ["iw", "dev", iface, "set", "channel", str(to)]
+            if cfg.ht:
+                argv.append(cfg.ht)
+            r = run(argv, timeout=10)
+            t_done = time.monotonic_ns()
+            per_switch_wall.append(t_done - t_req)
+            ctl.write(json.dumps({"ev": "kchansw.done", "i": i,
+                                  "mono_ns": t_done, "rc": r.returncode,
+                                  "err": r.stderr.strip()[:120]}) + "\n")
+            if r.returncode != 0:
+                log(f"{cfg.name} i={i}: iw rc={r.returncode} "
+                    f"{r.stderr.strip()[:80]}")
+            time.sleep(cfg.dwell_ms / 1e3)
+            if i % 50 == 49:
+                ctl.flush()
+                if not (inj.alive() and oa.alive() and ob.alive()):
+                    log(f"{cfg.name}: child died (inj={inj.alive()} "
+                        f"oa={oa.alive()} ob={ob.alive()}) — aborting config")
+                    break
+                if iface_channel(iface) is None:
+                    log(f"{cfg.name}: iw info unresponsive — possible wedge")
+    finally:
+        if trace_ctx:
+            trace_ctx.__exit__(None, None, None)
+            with open(os.path.join(d, "trace_inventory.json"), "w") as f:
+                json.dump(trace_ctx.inventory, f, indent=1)
+        alive = {"inj": inj.alive(), "oa": oa.alive(), "ob": ob.alive(),
+                 "iface_ch": iface_channel(iface)}
+        inj.stop()
+        oa.stop()
+        ob.stop()
+        ctl.write(json.dumps({"ev": "kchansw.aliveness", **alive}) + "\n")
+        ctl.close()
+        s.dmesg_dump(d)
+    log(f"{cfg.name}: done ({cfg.warmup}+{cfg.switches} switches)")
+    return per_switch_wall
+
+
+def run_csa(s: Session, cfg: Cfg, iface: str):
+    d = s.cfg_dir(cfg)
+    mac = iface_mac(iface)
+    s.write_meta(cfg, d, cfg.from_ch, cfg.to_ch,
+                 {"bssid": mac, "csa_count": cfg.csa_count,
+                  "beacon_int": cfg.beacon_int})
+    oa = spawn_oracle("a", s.oracle_a_dut, cfg.from_ch, mac, d)
+    ob = spawn_oracle("b", s.oracle_b_dut, cfg.to_ch, mac, d)
+    ap = WpaAp(iface, ch_to_freq(cfg.from_ch), d, cfg.beacon_int)
+    ctl = s.control_writer(d)
+    try:
+        if not ap.wait_beaconing():
+            ctl.write(json.dumps({"ev": "kchansw.capability",
+                                  "prim": "csa",
+                                  "status": "ap-start-failed"}) + "\n")
+            log(f"{cfg.name}: wpa_supplicant AP failed to start — "
+                f"CSA row = blocked (see wpa.log)")
+            return
+        if not oracle_rate_gate(oa, min_lines=10, timeout=15):
+            log(f"{cfg.name}: oracle_a hears no beacons yet — continuing")
+        with kchansw_trace.TraceSession(d, kprobes=s.driver["probes"]) as ts:
+            total = cfg.warmup + cfg.switches
+            cur = cfg.from_ch
+            for i in range(total):
+                to = cfg.to_ch if cur == cfg.from_ch else cfg.from_ch
+                t_req = time.monotonic_ns()
+                ts.marker(f"KCHANSW i={i} prim=csa cfg={cfg.name} "
+                          f"from={cur} to={to} mono={t_req}")
+                ctl.write(json.dumps({"ev": "kchansw.req", "i": i,
+                                      "from": cur, "to": to,
+                                      "mono_ns": t_req}) + "\n")
+                r = ap.chan_switch(cfg.csa_count, ch_to_freq(to))
+                rc = r.returncode if "OK" in r.stdout else 1
+                # completion: driver reports the new channel
+                deadline = time.monotonic() + 5.0
+                moved = False
+                while time.monotonic() < deadline:
+                    if iface_channel(iface) == to:
+                        moved = True
+                        break
+                    time.sleep(0.02)
+                t_done = time.monotonic_ns()
+                ctl.write(json.dumps({"ev": "kchansw.done", "i": i,
+                                      "mono_ns": t_done, "rc": rc,
+                                      "moved": moved,
+                                      "err": (r.stdout + r.stderr).strip()[:120]
+                                      }) + "\n")
+                if not moved:
+                    log(f"{cfg.name} i={i}: CSA did not complete "
+                        f"({(r.stdout + r.stderr).strip()[:80]})")
+                cur = to if moved else cur
+                time.sleep(0.3)
+                if i % 50 == 49:
+                    ctl.flush()
+                    if not ap.child.alive():
+                        log(f"{cfg.name}: wpa_supplicant died — aborting")
+                        break
+            with open(os.path.join(d, "trace_inventory.json"), "w") as f:
+                json.dump(ts.inventory, f, indent=1)
+    finally:
+        ap.stop()
+        oa.stop()
+        ob.stop()
+        ctl.close()
+        s.dmesg_dump(d)
+    log(f"{cfg.name}: done")
+
+
+def run_roc(s: Session, cfg: Cfg, iface: str):
+    d = s.cfg_dir(cfg)
+    # Enabler: a second monitor vif pins the base channel and carries the
+    # injector, so ROC departure/return both leave RF evidence. If the
+    # driver's iface combinations refuse it, fall back to trace-only timing.
+    mon = "kcmon0"
+    have_mon = False
+    set_managed_idle(iface)
+    r = run(["iw", "dev", iface, "interface", "add", mon, "type", "monitor"])
+    if r.returncode == 0:
+        try:
+            run(["ip", "link", "set", mon, "up"])
+            r2 = run(["iw", "dev", mon, "set", "channel", str(cfg.from_ch)])
+            have_mon = r2.returncode == 0
+        except Exception:
+            have_mon = False
+    cfg.need_rf = have_mon
+    s.write_meta(cfg, d, cfg.from_ch, cfg.to_ch,
+                 {"monitor_vif": have_mon, "roc_ms": cfg.roc_ms})
+    oa = spawn_oracle("a", s.oracle_a_dut, cfg.from_ch, "canon", d)
+    ob = spawn_oracle("b", s.oracle_b_dut, cfg.to_ch, "canon", d)
+    inj = spawn_injector(mon, d, cfg.inject_hz) if have_mon else None
+    if inj:
+        oracle_rate_gate(oa)
+    ctl = s.control_writer(d)
+    try:
+        with kchansw_trace.TraceSession(d, kprobes=s.driver["probes"]) as ts:
+            total = cfg.warmup + cfg.switches
+            for i in range(total):
+                t_req = time.monotonic_ns()
+                ts.marker(f"KCHANSW i={i} prim=roc cfg={cfg.name} "
+                          f"from={cfg.from_ch} to={cfg.to_ch} mono={t_req}")
+                ctl.write(json.dumps({"ev": "kchansw.req", "i": i,
+                                      "mono_ns": t_req}) + "\n")
+                r = run(["iw", "dev", iface, "offchannel",
+                         str(ch_to_freq(cfg.to_ch)), str(cfg.roc_ms)],
+                        timeout=10)
+                t_done = time.monotonic_ns()
+                ctl.write(json.dumps({"ev": "kchansw.done", "i": i,
+                                      "mono_ns": t_done, "rc": r.returncode,
+                                      "err": r.stderr.strip()[:120]}) + "\n")
+                if r.returncode != 0 and i == 0:
+                    log(f"{cfg.name}: offchannel rejected: "
+                        f"{r.stderr.strip()[:100]} — aborting config")
+                    break
+                time.sleep((cfg.roc_ms + 120) / 1e3)
+                if i % 50 == 49:
+                    ctl.flush()
+            with open(os.path.join(d, "trace_inventory.json"), "w") as f:
+                json.dump(ts.inventory, f, indent=1)
+    finally:
+        if inj:
+            inj.stop()
+        oa.stop()
+        ob.stop()
+        ctl.close()
+        run(["iw", "dev", mon, "del"])
+        s.dmesg_dump(d)
+    log(f"{cfg.name}: done (monitor_vif={have_mon})")
+
+
+def run_scan(s: Session, cfg: Cfg, iface: str):
+    d = s.cfg_dir(cfg)
+    set_managed_idle(iface)
+    mac = iface_mac(iface)
+    s.write_meta(cfg, d, cfg.from_ch, cfg.to_ch, {"scan_sa": mac})
+    # Only the destination oracle matters (probe requests on the target
+    # frequency); a base-channel "last frame" doesn't exist for an idle STA.
+    oa = spawn_oracle("a", s.oracle_a_dut, cfg.from_ch, mac, d)
+    ob = spawn_oracle("b", s.oracle_b_dut, cfg.to_ch, mac, d)
+    ctl = s.control_writer(d)
+    try:
+        with kchansw_trace.TraceSession(d, kprobes=s.driver["probes"]) as ts:
+            total = cfg.warmup + cfg.switches
+            for i in range(total):
+                t_req = time.monotonic_ns()
+                ts.marker(f"KCHANSW i={i} prim=scan cfg={cfg.name} "
+                          f"from={cfg.from_ch} to={cfg.to_ch} mono={t_req}")
+                ctl.write(json.dumps({"ev": "kchansw.req", "i": i,
+                                      "mono_ns": t_req}) + "\n")
+                r = run(["iw", "dev", iface, "scan", "trigger", "freq",
+                         str(ch_to_freq(cfg.to_ch))], timeout=10)
+                t_done = time.monotonic_ns()
+                ctl.write(json.dumps({"ev": "kchansw.done", "i": i,
+                                      "mono_ns": t_done, "rc": r.returncode,
+                                      "err": r.stderr.strip()[:120]}) + "\n")
+                if r.returncode != 0 and i == 0 and "Operation not supported" \
+                        in r.stderr:
+                    log(f"{cfg.name}: scan trigger unsupported — aborting")
+                    break
+                time.sleep(0.4)  # single-freq scan completes well within
+                if i % 50 == 49:
+                    ctl.flush()
+            with open(os.path.join(d, "trace_inventory.json"), "w") as f:
+                json.dump(ts.inventory, f, indent=1)
+    finally:
+        oa.stop()
+        ob.stop()
+        ctl.close()
+        s.dmesg_dump(d)
+    log(f"{cfg.name}: done")
+
+
+def probe_tdls(s: Session, iface: str, out_root: Path):
+    """Capability row only: what the stack/driver claim about TDLS ch-sw."""
+    phy = iface_phy(iface)
+    r = run(["iw", "phy", phy, "info"], timeout=10)
+    caps = {
+        "tdls_supported": "tdls" in r.stdout.lower(),
+        "tdls_channel_switch_ext": "TDLS_CHANNEL_SWITCH" in r.stdout
+                                   or "tdls channel switch" in r.stdout.lower(),
+        "phy_info_excerpt": [ln.strip() for ln in r.stdout.splitlines()
+                             if "tdls" in ln.lower()],
+        "peer_prereqs": "blocked-hardware-absent (no helper AP on rig; "
+                        "TDLS needs two associated STAs)",
+    }
+    with open(out_root / "tdls_capability.json", "w") as f:
+        json.dump(caps, f, indent=2)
+    log(f"TDLS capability: supported={caps['tdls_supported']} "
+        f"ch-switch={caps['tdls_channel_switch_ext']}")
+
+
+def run_cold(s: Session, trials: int):
+    mod = s.driver["module"]
+    d = str(s.out_root / "cold")
+    os.makedirs(d, exist_ok=True)
+    cfg = Cfg(name="cold", prim="set_channel", from_ch=36, to_ch=40,
+              switches=1, warmup=0)
+    s.write_meta(cfg, d, 36, 40, {"trials": trials})
+    oa = spawn_oracle("a", s.oracle_a_dut, 36, "canon", d)
+    ob = spawn_oracle("b", s.oracle_b_dut, 40, "canon", d)
+    ctl = s.control_writer(d)
+    inj = None
+    try:
+        with kchansw_trace.TraceSession(d, kprobes=s.driver["probes"]) as ts:
+            for i in range(trials):
+                log(f"cold trial {i}: power-cycle + module reload")
+                if inj:
+                    inj.stop()
+                    inj = None
+                regress.usb_port_power_cycle(s.dut, settle_s=3.0)
+                run(["modprobe", "-r", mod], timeout=30)
+                t_load = time.monotonic_ns()
+                run(["modprobe", mod], timeout=60)
+                regress.attach_to_host_kernel(s.dut)
+                try:
+                    iface = dut_iface(s.dut, timeout=30)
+                except RuntimeError as e:
+                    ctl.write(json.dumps({"ev": "kchansw.done", "i": i,
+                                          "rc": 1, "err": str(e)[:120]}) + "\n")
+                    continue
+                unmanage(iface)
+                set_monitor(iface, 36)
+                inj = spawn_injector(iface, d, 2000)
+                time.sleep(1.0)  # stream on 36 so last-src exists
+                t_req = time.monotonic_ns()
+                ts.marker(f"KCHANSW i={i} prim=set_channel cfg=cold "
+                          f"from=36 to=40 mono={t_req}")
+                ctl.write(json.dumps({"ev": "kchansw.req", "i": i,
+                                      "mono_ns": t_req,
+                                      "t_load_ns": t_load}) + "\n")
+                r = run(["iw", "dev", iface, "set", "channel", "40"])
+                ctl.write(json.dumps({"ev": "kchansw.done", "i": i,
+                                      "mono_ns": time.monotonic_ns(),
+                                      "rc": r.returncode}) + "\n")
+                time.sleep(1.0)  # stream on 40 so first-dst exists
+            with open(os.path.join(d, "trace_inventory.json"), "w") as f:
+                json.dump(ts.inventory, f, indent=1)
+    finally:
+        if inj:
+            inj.stop()
+        oa.stop()
+        ob.stop()
+        ctl.close()
+        s.dmesg_dump(d)
+    log("cold: done")
+
+
+# ---------------------------------------------------------------------------
+# MCC attempt (phase-b, time-boxed, honest failure rows).
+# ---------------------------------------------------------------------------
+
+def run_mcc_attempt(s: Session, iface: str, helper_pid: str):
+    d = str(s.out_root / "mcc")
+    os.makedirs(d, exist_ok=True)
+    result = {"prim": "mcc", "status": "attempted", "steps": []}
+
+    def step(name, ok, detail=""):
+        result["steps"].append({"step": name, "ok": ok, "detail": detail})
+        log(f"mcc: {name}: {'ok' if ok else 'FAILED'} {detail}")
+        return ok
+
+    try:
+        helper = find_dut(helper_pid)
+    except SystemExit:
+        result["status"] = "blocked-hardware-absent"
+        step("helper adapter", False, f"{helper_pid} not plugged")
+        with open(os.path.join(d, "mcc_result.json"), "w") as f:
+            json.dump(result, f, indent=2)
+        return
+    # Helper AP on ch36 via rtw88 + wpa_supplicant (the 8821AU is 5G-capable).
+    run(["modprobe", "rtw88_8821au"], timeout=30)
+    regress.attach_to_host_kernel(helper)
+    try:
+        h_iface = dut_iface(helper)
+    except RuntimeError as e:
+        step("helper iface", False, str(e))
+        result["status"] = "blocked-helper-bringup"
+        with open(os.path.join(d, "mcc_result.json"), "w") as f:
+            json.dump(result, f, indent=2)
+        return
+    unmanage(h_iface)
+    ap = WpaAp(h_iface, ch_to_freq(36), d)
+    ok = step("helper AP beaconing on 36", ap.wait_beaconing())
+    sta_conf = os.path.join(d, "wpa_sta.conf")
+    sta = None
+    if ok:
+        with open(sta_conf, "w") as f:
+            f.write(f"ctrl_interface=DIR={d}/wpa_sta\ncountry=US\n"
+                    "network={\n    ssid=\"kchansw-bench\"\n"
+                    "    key_mgmt=NONE\n}\n")
+        set_managed_idle(iface)
+        sta = Child("wpa_sta", ["wpa_supplicant", "-Dnl80211", "-i", iface,
+                                "-c", sta_conf],
+                    os.path.join(d, "wpa_sta.log"), stamp=False)
+        end = time.monotonic() + 30
+        assoc = False
+        while time.monotonic() < end:
+            r = run(["iw", "dev", iface, "link"], timeout=4)
+            if "Connected to" in r.stdout:
+                assoc = True
+                break
+            time.sleep(1)
+        ok = step("DUT STA associated to helper", assoc)
+    if ok:
+        # Second vif for the concurrent leg.
+        r = run(["iw", "dev", iface, "interface", "add", "kcap0",
+                 "type", "managed"])
+        ok = step("second vif add", r.returncode == 0, r.stderr.strip()[:100])
+    if ok:
+        # Vendor proc knobs (only exist on the vendor driver).
+        knobs = glob.glob(f"/proc/net/*/{iface}/mcc_*")
+        ok = step("mcc proc knobs present", bool(knobs), str(knobs[:3]))
+        if ok:
+            base = os.path.dirname(knobs[0])
+            try:
+                with open(os.path.join(base, "mcc_enable"), "w") as f:
+                    f.write("1")
+                step("mcc_enable=1", True)
+                for k in ("mcc_info", "mcc_policy_table"):
+                    p = os.path.join(base, k)
+                    if os.path.exists(p):
+                        with open(p) as f:
+                            result[k] = f.read()[:4000]
+            except OSError as e:
+                step("mcc_enable", False, str(e))
+    if not ok:
+        result["status"] = "blocked-see-steps"
+    with open(os.path.join(d, "mcc_result.json"), "w") as f:
+        json.dump(result, f, indent=2)
+    if sta:
+        sta.stop()
+    ap.stop()
+    run(["iw", "dev", "kcap0", "del"])
+    s.dmesg_dump(d)
+
+
+# ---------------------------------------------------------------------------
+# Manifest, inventory, smoke.
+# ---------------------------------------------------------------------------
+
+def write_manifest(s: Session):
+    def sh(cmd):
+        try:
+            return run(cmd, timeout=15).stdout.strip()
+        except Exception as e:
+            return f"error: {e}"
+
+    mod = s.driver["module"]
+    man = {
+        "date_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "uname": sh(["uname", "-a"]),
+        "reg": sh(["iw", "reg", "get"]),
+        "lsusb": sh(["lsusb"]),
+        "lsusb_t": sh(["lsusb", "-t"]),
+        "driver": s.driver_key,
+        "module": mod,
+        "modinfo_srcversion": sh(["modinfo", "-F", "srcversion", mod]),
+        "modinfo_filename": sh(["modinfo", "-F", "filename", mod]),
+        "devourer_sha": sh(["git", "-C", str(REPO), "rev-parse", "HEAD"]),
+        "roles": {
+            "dut": dataclasses.asdict(s.dut),
+            "oracle_a": dataclasses.asdict(s.oracle_a_dut),
+            "oracle_b": dataclasses.asdict(s.oracle_b_dut),
+        },
+        "fw_version_dmesg": "\n".join(
+            ln for ln in sh(["journalctl", "-k", "--no-pager", "-n", "2000"])
+            .splitlines() if re.search(r"[Ff]irmware.*(rtw|version)", ln))[-2000:],
+        "vbus_map": os.environ.get("REGRESS_VBUS_MAP", ""),
+    }
+    with open(s.out_root / "manifest.json", "w") as f:
+        json.dump(man, f, indent=2)
+
+
+def cmd_inventory(s: Session):
+    inv = {
+        "tools": {t: bool(shutil.which(t)) for t in
+                  ("iw", "wpa_supplicant", "wpa_cli", "hostapd", "uhubctl",
+                   "tcpdump", "journalctl")},
+        "modules": {},
+        "trace_events": kchansw_trace.discover_events(),
+        "kprobe_symbols": {},
+    }
+    for key, spec in DRIVER_SETS.items():
+        mod = spec["module"]
+        r = run(["modinfo", "-F", "filename", mod], timeout=10)
+        inv["modules"][mod] = r.stdout.strip() if r.returncode == 0 else "absent"
+    iface = None
+    try:
+        iface = s.dut_up()
+        phy = iface_phy(iface)
+        r = run(["iw", "phy", phy, "info"], timeout=10)
+        (s.out_root / "iw_phy_info.txt").write_text(r.stdout)
+        inv["iface"] = iface
+        inv["iface_modes"] = re.findall(r"\* (\w[\w/-]*)", r.stdout.split(
+            "Supported interface modes:")[1].split("Band")[0]) \
+            if "Supported interface modes:" in r.stdout else []
+        combos = ""
+        if "valid interface combinations:" in r.stdout:
+            combos = r.stdout.split("valid interface combinations:")[1][:600]
+        inv["iface_combinations"] = combos
+        inv["kprobe_symbols"] = kchansw_trace.kallsyms_present(
+            sorted({sym for _, sym, _ in s.driver["probes"]}))
+    except Exception as e:
+        inv["dut_error"] = str(e)
+    (s.out_root / "inventory.json").write_text(json.dumps(inv, indent=2))
+    print(json.dumps(inv, indent=2))
+    write_manifest(s)
+    log(f"inventory → {s.out_root}/inventory.json")
+
+
+def cmd_smoke(s: Session):
+    iface = s.dut_up()
+    write_manifest(s)
+    cfg_i = Cfg(name="smoke-instrumented", prim="set_channel",
+                from_ch=36, to_ch=40, switches=20, warmup=2)
+    w_inst = run_set_channel(s, cfg_i, iface)
+    cfg_u = Cfg(name="smoke-bare", prim="set_channel",
+                from_ch=36, to_ch=40, switches=20, warmup=2)
+    w_bare = run_set_channel(s, cfg_u, iface, uninstrumented=True)
+    import statistics
+    med_i = statistics.median(w_inst) / 1e6 if w_inst else 0
+    med_b = statistics.median(w_bare) / 1e6 if w_bare else 0
+    log(f"smoke: per-switch iw wall median instrumented={med_i:.2f} ms "
+        f"bare={med_b:.2f} ms delta={med_i - med_b:+.2f} ms")
+    log(f"now run: tests/.venv/bin/python tests/kchansw_analyze.py {s.out_root}")
+
+
+# ---------------------------------------------------------------------------
+# Phases.
+# ---------------------------------------------------------------------------
+
+def phase_a_configs(a) -> list:
+    return [
+        Cfg("a-set-36-40", "set_channel", 36, 40, a.switches),
+        Cfg("a-set-1-6", "set_channel", 1, 6, a.switches_aux),
+        Cfg("a-set-ht40-36-44", "set_channel", 36, 44, a.switches_aux,
+            ht="HT40+"),
+        Cfg("a-set-xband-36-6", "set_channel", 36, 6, a.switches_crossband),
+        Cfg("a-scan-40", "scan", 36, 40, a.switches_aux, need_rf=False,
+            fingerprint="sa", rdev_entry="rdev_scan"),
+        Cfg("a-csa-36-40", "csa", 36, 40, a.switches, fingerprint="sa",
+            rdev_entry="rdev_channel_switch"),
+        Cfg("a-csa-1-6", "csa", 1, 6, 100, fingerprint="sa",
+            rdev_entry="rdev_channel_switch"),
+        Cfg("a-roc-36-40", "roc", 36, 40, a.switches,
+            rdev_entry="rdev_remain_on_channel"),
+        Cfg("a-roc-40-36", "roc", 40, 36, a.switches_aux,
+            rdev_entry="rdev_remain_on_channel"),
+    ]
+
+
+def run_phase(s: Session, configs, only: str):
+    iface = s.dut_up()
+    write_manifest(s)
+    probe_tdls(s, iface, s.out_root)
+    for cfg in configs:
+        if only != "all" and only not in cfg.prim and only not in cfg.name:
+            continue
+        log(f"=== {cfg.name} ({cfg.prim} {cfg.from_ch}↔{cfg.to_ch} "
+            f"×{cfg.switches}) ===")
+        try:
+            if cfg.prim == "set_channel":
+                run_set_channel(s, cfg, iface)
+            elif cfg.prim == "csa":
+                run_csa(s, cfg, iface)
+                set_managed_idle(iface)
+            elif cfg.prim == "roc":
+                run_roc(s, cfg, iface)
+            elif cfg.prim == "scan":
+                run_scan(s, cfg, iface)
+        except Exception as e:
+            log(f"{cfg.name}: EXCEPTION {e!r} — continuing with next config")
+    log(f"phase done → analyze with: tests/.venv/bin/python "
+        f"tests/kchansw_analyze.py {s.out_root}")
+
+
+def phase_c_guard(fn):
+    """Lift the kestrel rtw89 blacklist for the run; restore byte-identical."""
+    def wrapper(s: Session, *a, **kw):
+        held = False
+        if os.path.exists(BLACKLIST_KESTREL):
+            os.rename(BLACKLIST_KESTREL, BLACKLIST_HOLD)
+            held = True
+            log(f"lifted {BLACKLIST_KESTREL} (held aside)")
+        try:
+            return fn(s, *a, **kw)
+        finally:
+            if held:
+                os.rename(BLACKLIST_HOLD, BLACKLIST_KESTREL)
+                log(f"restored {BLACKLIST_KESTREL}")
+            for mod in ("rtw89_8852bu", "rtw89_8852b", "rtw89_usb"):
+                run(["modprobe", "-r", mod], timeout=30)
+            regress.usb_port_power_cycle(s.dut, settle_s=3.0)
+            log("phase-c: rtw89 modules removed, DUT power-cycled")
+    return wrapper
+
+
+@phase_c_guard
+def cmd_phase_c(s: Session, a):
+    configs = [
+        Cfg("c-set-36-40", "set_channel", 36, 40, a.switches_aux),
+        Cfg("c-csa-36-40", "csa", 36, 40, a.switches_crossband * 4,
+            fingerprint="sa", rdev_entry="rdev_channel_switch"),
+        Cfg("c-roc-36-40", "roc", 36, 40, a.switches_aux,
+            rdev_entry="rdev_remain_on_channel"),
+    ]
+    run_phase(s, configs, a.primitive)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("cmd", choices=["inventory", "smoke", "phase-a", "cold",
+                                    "phase-b", "phase-c"])
+    ap.add_argument("--primitive", default="all",
+                    help="filter configs by primitive/name substring")
+    ap.add_argument("--dut-pid", default="2357:012d")
+    ap.add_argument("--oracle-a-pid", default="0bda:8812")
+    ap.add_argument("--oracle-b-pid", default="0bda:c812")
+    ap.add_argument("--helper-pid", default="2357:0120",
+                    help="helper AP adapter for the MCC attempt (8821AU)")
+    ap.add_argument("--switches", type=int, default=1000)
+    ap.add_argument("--switches-aux", type=int, default=300)
+    ap.add_argument("--switches-crossband", type=int, default=50)
+    ap.add_argument("--cold-trials", type=int, default=10)
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+
+    if os.geteuid() != 0:
+        sys.stderr.write("kchansw_bench: needs root (sysfs/tracefs/iw)\n")
+        return 2
+    if not RXDEMO.is_file():
+        sys.stderr.write(f"missing {RXDEMO} — build first\n")
+        return 2
+    if not args.out:
+        args.out = f"/tmp/devourer-kchansw-{time.strftime('%Y%m%d-%H%M%S')}-" \
+                   f"{args.cmd}"
+
+    regress._install_cleanup_handlers()
+    driver_key = {"phase-b": "vendor", "phase-c": "rtw89"}.get(args.cmd,
+                                                               "rtw88")
+    if args.cmd == "phase-c":
+        args.dut_pid = "35bc:0108"
+    s = Session(args, driver_key)
+    log(f"out dir: {s.out_root}  driver: {driver_key}  DUT: {s.dut.vidpid} "
+        f"({s.dut.chipset})")
+
+    if args.cmd == "inventory":
+        cmd_inventory(s)
+    elif args.cmd == "smoke":
+        cmd_smoke(s)
+    elif args.cmd == "phase-a":
+        run_phase(s, phase_a_configs(args), args.primitive)
+    elif args.cmd == "cold":
+        iface = s.dut_up()
+        write_manifest(s)
+        set_monitor(iface, 36)
+        run_cold(s, args.cold_trials)
+    elif args.cmd == "phase-b":
+        # Module must already be inserted by kchansw_vendor_build.sh.
+        if run(["sh", "-c", "lsmod | grep -q '^88x2bu'"]).returncode != 0:
+            sys.stderr.write("phase-b: vendor module 88x2bu not loaded — run "
+                             "tests/kchansw_vendor_build.sh first\n")
+            return 2
+        configs = [
+            Cfg("b-set-36-40", "set_channel", 36, 40, args.switches),
+            Cfg("b-roc-36-40", "roc", 36, 40, args.switches_aux,
+                rdev_entry="rdev_remain_on_channel"),
+        ]
+        run_phase(s, configs, args.primitive)
+        if args.primitive in ("all", "mcc"):
+            iface = dut_iface(s.dut)
+            run_mcc_attempt(s, iface, args.helper_pid)
+    elif args.cmd == "phase-c":
+        cmd_phase_c(s, args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/kchansw_bench.py
+++ b/tests/kchansw_bench.py
@@ -66,7 +66,7 @@ DRIVER_SETS = {
               "probes": kchansw_trace.RTW88_PROBES,
               "probe_map": {"drv": "kc_drv_set_channel",
                             "chip": "kc_chip_set_channel", "h2c": "kc_h2c"}},
-    "vendor": {"module": "88x2bu",
+    "vendor": {"module": "88x2bu_ohd",
                "probes": kchansw_trace.VENDOR_PROBES,
                "probe_map": {"drv": "kc_drv_set_channel",
                              "chip": "kc_chip_set_channel", "h2c": "kc_h2c"}},
@@ -1094,9 +1094,9 @@ def main() -> int:
         run_cold(s, args.cold_trials)
     elif args.cmd == "phase-b":
         # Module must already be inserted by kchansw_vendor_build.sh.
-        if run(["sh", "-c", "lsmod | grep -q '^88x2bu'"]).returncode != 0:
-            sys.stderr.write("phase-b: vendor module 88x2bu not loaded — run "
-                             "tests/kchansw_vendor_build.sh first\n")
+        if run(["sh", "-c", "lsmod | grep -q '^88x2bu_ohd'"]).returncode != 0:
+            sys.stderr.write("phase-b: vendor module 88x2bu_ohd not loaded — "
+                             "run tests/kchansw_vendor_build.sh load first\n")
             return 2
         configs = [
             Cfg("b-set-36-40", "set_channel", 36, 40, args.switches),

--- a/tests/kchansw_bench.py
+++ b/tests/kchansw_bench.py
@@ -153,6 +153,13 @@ def iface_channel(iface: str):
     return int(m.group(1)) if m else None
 
 
+def iface_alive(iface: str) -> bool:
+    """The netdev still answers nl80211 (a managed-idle iface legitimately
+    reports no channel — don't confuse that with a wedge)."""
+    r = run(["iw", "dev", iface, "info"], timeout=4)
+    return r.returncode == 0 and "Interface" in r.stdout
+
+
 def unmanage(iface: str) -> None:
     """Keep NetworkManager (if any) off the bench interface."""
     if shutil.which("nmcli"):
@@ -320,6 +327,15 @@ class Session:
         self.out_root = Path(args.out)
         self.out_root.mkdir(parents=True, exist_ok=True)
         self.dut = find_dut(args.dut_pid)
+        self.dut_vidpid = args.dut_pid
+        # Controller BDF for the deepest recovery rung (bus_recover).
+        try:
+            bus = self.dut.sysfs_id.split("-")[0]
+            self.dut_ctrl_bdf = re.search(
+                r"(\d{4}:[0-9a-f]{2}:[0-9a-f]{2}\.\d)",
+                os.path.realpath(f"/sys/bus/usb/devices/usb{bus}")).group(1)
+        except (OSError, AttributeError):
+            self.dut_ctrl_bdf = ""
         self.oracle_a_dut = find_dut(args.oracle_a_pid)
         self.oracle_b_dut = find_dut(args.oracle_b_pid)
         self.dmesg_since = time.strftime("%Y-%m-%d %H:%M:%S")
@@ -390,21 +406,90 @@ def oracle_rate_gate(oracle: Child, min_frames=50, timeout=20.0) -> bool:
     return oracle.frame_lines - start >= min_frames
 
 
+def _port_disable_path(sysfs_id: str) -> str:
+    """sysfs per-port power node for a device id: '10-2' (root port) →
+    usb10/10-0:1.0/usb10-port2/disable; '3-2.3.4.3' (nested hub) →
+    3-2.3.4/3-2.3.4:1.0/3-2.3.4-port3/disable."""
+    bus, _, chain = sysfs_id.partition("-")
+    if "." not in chain:
+        return (f"/sys/bus/usb/devices/usb{bus}/{bus}-0:1.0/"
+                f"usb{bus}-port{chain}/disable")
+    parent, _, port = chain.rpartition(".")
+    pdev = f"{bus}-{parent}"
+    return (f"/sys/bus/usb/devices/{pdev}/{pdev}:1.0/"
+            f"{pdev}-port{port}/disable")
+
+
+def bus_recover(s: "Session") -> bool:
+    """Deepest rung: the device fell off the bus or its xHCI hung.
+    (Observed live: rtw88 churn wedged a T3U so hard its uPD720201 host
+    controller failed re-probe with -110, and only a PCI bus reset +
+    D3hot→D0 bounce + rescan, then a long per-port power-off, brought the
+    chip back — on the USB2 companion bus.) Try: 12 s per-port power-off at
+    the last-known port; if the controller's buses are gone, PCI-revive the
+    controller first."""
+    bdf = s.dut_ctrl_bdf
+    bus = s.dut.sysfs_id.split("-")[0]
+    if bdf and not os.path.isdir(f"/sys/bus/usb/devices/usb{bus}"):
+        log(f"bus_recover: usb{bus} gone — PCI reviving {bdf}")
+        for cmd in ([f"echo 1 > /sys/bus/pci/devices/{bdf}/reset"],
+                    [f"setpci -s {bdf} CAP_PM+4.b=03"],
+                    [f"setpci -s {bdf} CAP_PM+4.b=00"],
+                    [f"echo 1 > /sys/bus/pci/devices/{bdf}/remove"],
+                    ["echo 1 > /sys/bus/pci/rescan"]):
+            subprocess.run(["sh", "-c", cmd[0]], capture_output=True)
+            time.sleep(2)
+        time.sleep(6)
+    p = _port_disable_path(s.dut.sysfs_id)
+    if os.path.exists(p):
+        try:
+            with open(p, "w") as f:
+                f.write("1")
+            time.sleep(12)
+            with open(p, "w") as f:
+                f.write("0")
+            time.sleep(8)
+        except OSError as e:
+            log(f"bus_recover: port cycle {p}: {e}")
+    # The device may return on a different bus (SS↔HS companion switch) —
+    # rediscover by VID:PID before any sysfs writes.
+    end = time.monotonic() + 25
+    while time.monotonic() < end:
+        try:
+            s.dut = find_dut(s.dut_vidpid)
+            return True
+        except SystemExit:
+            time.sleep(2)
+    return False
+
+
 def recover_dut(s: "Session", ch: int, ht: str = "", start: str = "rebind"):
-    """Recovery ladder after a DUT wedge/USB drop (the smoke run lost the
-    netdev to a full USB disconnect after ~25 switch cycles): re-probe →
-    module reload → authorized/VBUS power-cycle. Returns (iface, rung) or
-    (None, 'exhausted'). The chip usually re-enumerates by itself; the
-    rungs differ in how much driver state they rebuild."""
+    """Recovery ladder after a DUT wedge/USB drop (all four rungs proven
+    necessary live on this rig): re-probe → module reload →
+    authorized/VBUS power-cycle → bus/controller revive. Returns
+    (iface, rung) or (None, 'exhausted'). Every rung rediscovers the
+    device by VID:PID first — wedge recoveries can move it across buses."""
     mod = s.driver["module"]
-    ladder = ("rebind", "module-reload", "power-cycle")
+    ladder = ("rebind", "module-reload", "power-cycle", "bus-recover")
     for action in ladder[ladder.index(start):]:
         try:
+            try:
+                s.dut = find_dut(s.dut_vidpid)
+            except SystemExit:
+                if action != "bus-recover":
+                    log(f"recover_dut: {action}: device off the bus — "
+                        f"escalating")
+                    continue
             if action == "module-reload" and s.driver_key != "vendor":
                 run(["modprobe", "-r", mod], timeout=30)
                 run(["modprobe", mod], timeout=60)
             elif action == "power-cycle":
                 regress.usb_port_power_cycle(s.dut, settle_s=3.0)
+                if s.driver_key != "vendor":
+                    run(["modprobe", mod], timeout=60)
+            elif action == "bus-recover":
+                if not bus_recover(s):
+                    continue
                 if s.driver_key != "vendor":
                     run(["modprobe", mod], timeout=60)
             regress.attach_to_host_kernel(s.dut)
@@ -989,6 +1074,15 @@ def run_phase(s: Session, configs, only: str):
             continue
         log(f"=== {cfg.name} ({cfg.prim} {cfg.from_ch}↔{cfg.to_ch} "
             f"×{cfg.switches}) ===")
+        # A config can end with the DUT wedged (heavy-TX runs do, every
+        # 100-200 switches) — verify and recover before the next bring-up.
+        if not iface_alive(iface):
+            log("inter-config: DUT unresponsive — recovering")
+            iface2, rung = recover_dut(s, cfg.from_ch, start="module-reload")
+            if iface2 is None:
+                log("inter-config recovery exhausted — stopping phase")
+                break
+            iface = iface2
         try:
             if cfg.prim == "set_channel":
                 _, iface = run_set_channel(s, cfg, iface)

--- a/tests/kchansw_inject.py
+++ b/tests/kchansw_inject.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""High-rate tagged-frame injector for the kernel channel-switch bench.
+
+Feeds the on-air oracle of tests/kchansw_bench.py: a continuous stream of
+canonical-SA probe requests on a kernel-driver monitor interface, each frame
+carrying a payload trailer
+
+    'KCSW' magic | u32 run-nonce | u32 rolling counter | u64 send mono_ns
+
+so the devourer RX oracle can attribute every decoded frame to a send instant
+and a position in the stream from the rx.frame `body` hex alone — robust
+against the kernel rewriting the 802.11 sequence-control field. The 802.11 SC
+is still set from the counter as the cheap secondary check, and the fixed
+`--size` PSDU length is the tertiary fingerprint.
+
+Per-frame JSONL on stdout (one object per line, first field `ev`):
+
+    {"ev":"inj.tx","n":123,"mono_ns":456789,"errno":0}
+
+A nonzero errno is itself queue-behavior data: mac80211 stops TX queues
+around a channel switch and AF_PACKET send() surfaces that as an error or a
+block, depending on ring state.
+
+Unlike tests/inject_beacon.py (scapy sendp per frame), the frame here is
+prebuilt once and per-frame fields are patched into a bytearray — a blocking
+AF_PACKET send() then paces at multi-kHz without scapy overhead.
+"""
+
+import argparse
+import json
+import os
+import socket
+import struct
+import sys
+import time
+
+CANONICAL_SA = "57:42:75:05:d6:00"
+MAGIC = b"KCSW"
+# Trailer layout right after the 24-byte 802.11 mgmt header.
+TRAILER_FMT = "<4sIIQ"
+TRAILER_LEN = struct.calcsize(TRAILER_FMT)  # 20
+
+# Radiotap: header(8) + Rate u8 @8 + pad @9 + TX-flags u16 @10 = 12 bytes.
+# present = Rate (bit 2) | TX_FLAGS (bit 15); TX flags 0x0008 = NOACK.
+_RT_PRESENT = (1 << 2) | (1 << 15)
+
+
+def build_frame(sa: str, rate_500k: int, psdu_len: int, nonce: int) -> tuple[bytearray, int]:
+    """Prebuild radiotap + 802.11 PSDU. Returns (buf, trailer_offset)."""
+    rt = struct.pack("<BBHI", 0, 0, 12, _RT_PRESENT) + bytes([rate_500k, 0]) + struct.pack("<H", 0x0008)
+    sa_b = bytes(int(x, 16) for x in sa.split(":"))
+    hdr = (
+        bytes([0x40, 0x00])          # FC: mgmt / probe request
+        + bytes([0x00, 0x00])        # duration
+        + b"\xff" * 6                # DA broadcast
+        + sa_b                       # SA — the oracle's stream-gate key
+        + sa_b                       # BSSID
+        + bytes([0x00, 0x00])        # SC (patched per frame)
+    )
+    trailer = struct.pack(TRAILER_FMT, MAGIC, nonce & 0xFFFFFFFF, 0, 0)
+    body_pad = max(0, psdu_len - len(hdr) - len(trailer))
+    buf = bytearray(rt + hdr + trailer + b"\x00" * body_pad)
+    return buf, len(rt) + len(hdr)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--iface", required=True, help="monitor-mode wlan iface")
+    ap.add_argument("--hz", type=float, default=2000.0,
+                    help="target frame rate (default 2000 → 0.5 ms dead-time "
+                         "resolution at the oracle)")
+    ap.add_argument("--size", type=int, default=96,
+                    help="802.11 PSDU length in bytes — the oracle's length "
+                         "fingerprint (default 96)")
+    ap.add_argument("--duration", type=float, default=0.0,
+                    help="seconds to run; 0 = until SIGTERM/SIGINT")
+    ap.add_argument("--rate", type=int, default=12,
+                    help="radiotap legacy rate in 500 kbps units "
+                         "(default 12 = 6M OFDM — decodable on both bands)")
+    ap.add_argument("--sa", default=CANONICAL_SA,
+                    help=f"source address (default canonical {CANONICAL_SA})")
+    ap.add_argument("--nonce", type=lambda v: int(v, 0), default=os.getpid(),
+                    help="u32 run nonce embedded per frame (default: pid)")
+    args = ap.parse_args()
+
+    buf, t_off = build_frame(args.sa, args.rate, args.size, args.nonce)
+    sc_off = t_off - 2  # SC is the last header field before the trailer
+
+    s = socket.socket(socket.AF_PACKET, socket.SOCK_RAW)
+    s.bind((args.iface, 0))
+
+    out = sys.stdout
+    period_ns = int(1e9 / args.hz) if args.hz > 0 else 0
+    end_ns = time.monotonic_ns() + int(args.duration * 1e9) if args.duration > 0 else None
+    n = 0
+    next_ns = time.monotonic_ns()
+    try:
+        while True:
+            now = time.monotonic_ns()
+            if end_ns is not None and now >= end_ns:
+                break
+            if period_ns:
+                if now < next_ns:
+                    time.sleep((next_ns - now) / 1e9)
+                    now = time.monotonic_ns()
+                # Deadline pacing without drift; if we fell behind more than
+                # 20 periods (a stopped TX queue), resync rather than burst.
+                next_ns += period_ns
+                if now - next_ns > 20 * period_ns:
+                    next_ns = now + period_ns
+            n += 1
+            struct.pack_into("<H", buf, sc_off, (n & 0xFFF) << 4)
+            struct.pack_into(TRAILER_FMT, buf, t_off, MAGIC, args.nonce & 0xFFFFFFFF,
+                             n & 0xFFFFFFFF, now & 0xFFFFFFFFFFFFFFFF)
+            err = 0
+            try:
+                s.send(buf)
+            except OSError as e:
+                err = e.errno or -1
+            out.write(json.dumps({"ev": "inj.tx", "n": n, "mono_ns": now,
+                                  "errno": err}, separators=(",", ":")) + "\n")
+            if n % 64 == 0:
+                out.flush()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        out.flush()
+        s.close()
+    sys.stderr.write(f"kchansw_inject: sent {n} frames on {args.iface}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/kchansw_setup.sh
+++ b/tests/kchansw_setup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# kchansw_setup.sh — preflight + venv prep + launch for the kernel
+# channel-switch bench. Thin wrapper so a session is one command:
+#
+#   sudo tests/kchansw_setup.sh inventory
+#   sudo tests/kchansw_setup.sh smoke
+#   sudo tests/kchansw_setup.sh phase-a [bench args...]
+#
+# Uses the tests/ uv venv (system-site-packages, per tests/pyproject.toml);
+# creates it if missing. The bench itself is tests/kchansw_bench.py.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+[ "$(id -u)" -eq 0 ] || { echo "FAIL: needs root (re-run with sudo)"; exit 2; }
+[ $# -ge 1 ] || { echo "usage: $0 {inventory|smoke|phase-a|cold|phase-b|phase-c} [args]"; exit 2; }
+
+VENV=tests/.venv
+if [ ! -x "$VENV/bin/python" ]; then
+  echo "== creating tests venv (uv, system-site-packages for uhd) =="
+  SUDO_UV="$(command -v uv || true)"
+  [ -n "$SUDO_UV" ] || { echo "FAIL: uv not on root PATH"; exit 2; }
+  "$SUDO_UV" venv "$VENV" --system-site-packages
+  "$SUDO_UV" pip install -p "$VENV/bin/python" -e tests >/dev/null
+fi
+
+for tool in iw ip modprobe journalctl wpa_supplicant wpa_cli; do
+  command -v "$tool" >/dev/null || { echo "FAIL: missing tool: $tool"; exit 2; }
+done
+[ -x build/rxdemo ] || { echo "FAIL: build/rxdemo missing — cmake --build build -j"; exit 2; }
+[ -d /sys/kernel/tracing ] || { echo "FAIL: tracefs not mounted"; exit 2; }
+
+exec "$VENV/bin/python" tests/kchansw_bench.py "$@"

--- a/tests/kchansw_trace.py
+++ b/tests/kchansw_trace.py
@@ -115,6 +115,17 @@ def _write(path: str, val: str) -> None:
         f.write(val)
 
 
+def _append(path: str, line: str) -> None:
+    """Append one line to a tracefs control file. Python's text-mode "a"
+    lseeks to EOF at open, which tracefs rejects with EINVAL — use a raw
+    O_APPEND fd like the shell's >> does."""
+    fd = os.open(path, os.O_WRONLY | os.O_APPEND)
+    try:
+        os.write(fd, line.encode())
+    finally:
+        os.close(fd)
+
+
 def kallsyms_present(symbols: list) -> dict:
     """Which of `symbols` exist in /proc/kallsyms (exact-match, text syms)."""
     want = set(symbols)
@@ -155,8 +166,7 @@ def force_clean() -> None:
             stale.append(name)
     for name in stale:
         try:
-            with open(kev, "a") as f:
-                f.write(f"-:{name}\n")
+            _append(kev, f"-:{name}\n")
         except OSError as e:
             sys.stderr.write(f"kchansw_trace: force_clean -:{name}: {e}\n")
 
@@ -235,12 +245,22 @@ class TraceSession:
                 _write(path, "0")
             except OSError:
                 pass
-        for name in self._registered_probes:
+        if self._registered_probes:
+            # Disarm the group before removal — removing a still-enabled
+            # kretprobe returns EBUSY.
             try:
-                with open(_p("kprobe_events"), "a") as f:
-                    f.write(f"-:{name}\n")
-            except OSError as e:
-                sys.stderr.write(f"kchansw_trace: remove {name}: {e}\n")
+                _write(_p("events", "kchansw", "enable"), "0")
+            except OSError:
+                pass
+        for name in self._registered_probes:
+            for attempt in (0.0, 0.2, 0.5):
+                time.sleep(attempt)
+                try:
+                    _append(_p("kprobe_events"), f"-:{name}\n")
+                    break
+                except OSError as e:
+                    if attempt == 0.5:
+                        sys.stderr.write(f"kchansw_trace: remove {name}: {e}\n")
         for key, path in (("clock", "trace_clock"),
                           ("buffer_size_kb", "buffer_size_kb"),
                           ("tracing_on", "tracing_on")):
@@ -272,12 +292,10 @@ class TraceSession:
                 self.inventory["kprobes"][name] = f"symbol-absent: {sym}"
                 continue
             try:
-                with open(_p("kprobe_events"), "a") as f:
-                    f.write(f"p:kchansw/{name} {sym}\n")
+                _append(_p("kprobe_events"), f"p:kchansw/{name} {sym}\n")
                 self._registered_probes.append(f"kchansw/{name}")
                 if want_ret:
-                    with open(_p("kprobe_events"), "a") as f:
-                        f.write(f"r:kchansw/{name}_ret {sym}\n")
+                    _append(_p("kprobe_events"), f"r:kchansw/{name}_ret {sym}\n")
                     self._registered_probes.append(f"kchansw/{name}_ret")
                 self.inventory["kprobes"][name] = "ok"
             except OSError as e:

--- a/tests/kchansw_trace.py
+++ b/tests/kchansw_trace.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""tracefs session for the kernel channel-switch bench (no trace-cmd needed).
+
+Owns everything under /sys/kernel/tracing for a bench run:
+
+  - selects the `mono` trace clock so ftrace timestamps share a timeline with
+    python time.monotonic_ns() and the bench's stamped oracle/injector JSONL;
+  - enables a curated set of cfg80211/mac80211 trace events (runtime-discovered
+    — absent names become capability-inventory rows, not errors);
+  - registers kretprobe/kprobe pairs on driver symbols under the private
+    `kchansw/` group (symbols checked in /proc/kallsyms first; a missing
+    symbol degrades to an inventory row);
+  - streams trace_pipe to <out_dir>/trace.txt from a reader thread (consuming
+    the pipe keeps the ring empty, so no overflow accounting);
+  - exposes trace_marker writes for per-switch segmentation markers;
+  - restores every knob it touched (clock, buffer size, events, probes) via
+    context-manager exit + atexit + signal hooks, and `force_clean()` heals
+    the leftovers of a crashed previous run.
+
+Standalone: `sudo python3 tests/kchansw_trace.py --inventory` prints the
+event/symbol availability map as JSON and exits (no state left behind).
+"""
+
+import argparse
+import atexit
+import json
+import os
+import select
+import signal
+import sys
+import threading
+import time
+
+TRACEFS = "/sys/kernel/tracing"
+
+# Curated event want-list. Names are checked against the live tracefs event
+# tree; whatever is absent lands in the inventory as event-absent and the
+# analyzer treats its columns as nullable.
+WANT_EVENTS = [
+    # cfg80211: the nl80211-request edge (host-command latency = entry→return).
+    "cfg80211/rdev_set_monitor_channel",
+    "cfg80211/rdev_channel_switch",
+    "cfg80211/rdev_remain_on_channel",
+    "cfg80211/rdev_cancel_remain_on_channel",
+    "cfg80211/rdev_mgmt_tx",
+    "cfg80211/rdev_scan",
+    "cfg80211/rdev_return_int",
+    "cfg80211/rdev_return_void",
+    "cfg80211/cfg80211_ready_on_channel",
+    "cfg80211/cfg80211_ready_on_channel_expired",
+    "cfg80211/cfg80211_ch_switch_notify",
+    "cfg80211/cfg80211_ch_switch_started_notify",
+    "cfg80211/cfg80211_scan_done",
+    # mac80211: driver-ops edge + queue behavior around the switch.
+    "mac80211/drv_config",
+    "mac80211/drv_return_void",
+    "mac80211/drv_return_int",
+    "mac80211/drv_remain_on_channel",
+    "mac80211/drv_cancel_remain_on_channel",
+    "mac80211/drv_hw_scan",
+    "mac80211/drv_sw_scan_start",
+    "mac80211/drv_sw_scan_complete",
+    "mac80211/drv_flush",
+    "mac80211/drv_start_ap",
+    "mac80211/drv_stop_ap",
+    "mac80211/drv_add_chanctx",
+    "mac80211/drv_remove_chanctx",
+    "mac80211/drv_change_chanctx",
+    "mac80211/drv_assign_vif_chanctx",
+    "mac80211/drv_unassign_vif_chanctx",
+    "mac80211/drv_switch_vif_chanctx",
+    "mac80211/drv_tdls_channel_switch",
+    "mac80211/stop_queue",
+    "mac80211/wake_queue",
+]
+
+# Driver kprobe candidates per phase. (probe_name, symbol, with_retprobe).
+# Names carry a kc_ prefix because trace lines print only the event name,
+# not the kchansw/ group — the prefix keeps them unambiguous to the parser.
+# The bench writes each config's probe_name→role mapping into meta.json so
+# the analyzer stays driver-agnostic ("drv"/"chip"/"h2c" roles).
+RTW88_PROBES = [
+    ("kc_ops_config", "rtw_ops_config", True),
+    ("kc_drv_set_channel", "rtw_set_channel", True),
+    ("kc_chip_set_channel", "rtw8822b_set_channel", True),
+    ("kc_h2c", "rtw_fw_send_h2c_command", True),
+]
+VENDOR_PROBES = [
+    ("kc_drv_set_channel", "rtw_set_chbw_cmd", True),
+    ("kc_hal_set_chnl_bw", "rtw_hal_set_chnl_bw", True),
+    ("kc_chip_set_channel", "phy_SwChnlAndSetBwMode8822B", True),
+    ("kc_h2c", "rtw_hal_fill_h2c_cmd", True),
+    ("kc_tdls_ch_sw_offload", "rtw_hal_ch_sw_oper_offload", True),
+]
+RTW89_PROBES = [
+    ("kc_drv_set_channel", "rtw89_set_channel", True),
+    ("kc_chip_set_channel", "rtw89_chip_set_channel", True),
+    ("kc_roc_start", "rtw89_roc_start", True),
+    ("kc_roc_end", "rtw89_roc_end", True),
+    ("kc_h2c", "rtw89_h2c_tx", True),
+]
+
+
+def _p(*parts: str) -> str:
+    return os.path.join(TRACEFS, *parts)
+
+
+def _read(path: str) -> str:
+    with open(path, "r") as f:
+        return f.read()
+
+
+def _write(path: str, val: str) -> None:
+    with open(path, "w") as f:
+        f.write(val)
+
+
+def kallsyms_present(symbols: list) -> dict:
+    """Which of `symbols` exist in /proc/kallsyms (exact-match, text syms)."""
+    want = set(symbols)
+    found = set()
+    with open("/proc/kallsyms", "r") as f:
+        for line in f:
+            parts = line.split()
+            if len(parts) >= 3:
+                name = parts[2].split("\t")[0]
+                if name in want:
+                    found.add(name)
+    return {s: (s in found) for s in symbols}
+
+
+def discover_events(want=WANT_EVENTS) -> dict:
+    """Map each want-list event to present/absent in the live event tree."""
+    out = {}
+    for ev in want:
+        out[ev] = os.path.isdir(_p("events", *ev.split("/")))
+    return out
+
+
+def force_clean() -> None:
+    """Remove any stale kchansw/ probes and disable their group. Idempotent;
+    safe to call when no prior state exists."""
+    kev = _p("kprobe_events")
+    if not os.path.exists(kev):
+        return
+    try:
+        _write(_p("events", "kchansw", "enable"), "0")
+    except OSError:
+        pass
+    stale = []
+    for line in _read(kev).splitlines():
+        # Lines look like: p:kchansw/set_channel rtw_set_channel
+        if ":kchansw/" in line:
+            name = line.split()[0].split(":", 1)[1]
+            stale.append(name)
+    for name in stale:
+        try:
+            with open(kev, "a") as f:
+                f.write(f"-:{name}\n")
+        except OSError as e:
+            sys.stderr.write(f"kchansw_trace: force_clean -:{name}: {e}\n")
+
+
+class TraceSession:
+    """Context manager owning one instrumented tracing window."""
+
+    def __init__(self, out_dir: str, kprobes=None, want_events=WANT_EVENTS,
+                 buffer_kb: int = 8192):
+        self.out_dir = out_dir
+        self.kprobes = list(kprobes or [])
+        self.want_events = list(want_events)
+        self.buffer_kb = buffer_kb
+        self.inventory = {"events": {}, "kprobes": {}}
+        self._saved = {}
+        self._enabled_events = []
+        self._registered_probes = []
+        self._marker_f = None
+        self._pipe_fd = None
+        self._reader = None
+        self._stop = threading.Event()
+        self._trace_path = os.path.join(out_dir, "trace.txt")
+        self._active = False
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def __enter__(self) -> "TraceSession":
+        os.makedirs(self.out_dir, exist_ok=True)
+        force_clean()
+        self._saved["clock"] = self._current_clock()
+        self._saved["buffer_size_kb"] = _read(_p("buffer_size_kb")).strip()
+        self._saved["tracing_on"] = _read(_p("tracing_on")).strip()
+        _write(_p("tracing_on"), "0")
+        _write(_p("trace_clock"), "mono")
+        _write(_p("buffer_size_kb"), str(self.buffer_kb))
+        _write(_p("trace"), "")  # clear ring
+        self.inventory["events"] = discover_events(self.want_events)
+        for ev, present in self.inventory["events"].items():
+            if not present:
+                continue
+            path = _p("events", *ev.split("/"), "enable")
+            try:
+                _write(path, "1")
+                self._enabled_events.append(path)
+            except OSError as e:
+                self.inventory["events"][ev] = f"enable-failed: {e}"
+        self._register_kprobes()
+        self._marker_f = open(_p("trace_marker"), "w")
+        self._pipe_fd = os.open(_p("trace_pipe"), os.O_RDONLY | os.O_NONBLOCK)
+        self._reader = threading.Thread(target=self._pump, daemon=True)
+        self._reader.start()
+        _write(_p("tracing_on"), "1")
+        self._active = True
+        atexit.register(self._teardown)
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self._teardown()
+
+    def _teardown(self) -> None:
+        if not self._active:
+            return
+        self._active = False
+        # Give the last events time to reach the ring, then let the pump
+        # drain what's left before switching tracing off.
+        time.sleep(0.5)
+        self._stop.set()
+        if self._reader:
+            self._reader.join(timeout=5.0)
+        try:
+            _write(_p("tracing_on"), "0")
+        except OSError:
+            pass
+        for path in self._enabled_events:
+            try:
+                _write(path, "0")
+            except OSError:
+                pass
+        for name in self._registered_probes:
+            try:
+                with open(_p("kprobe_events"), "a") as f:
+                    f.write(f"-:{name}\n")
+            except OSError as e:
+                sys.stderr.write(f"kchansw_trace: remove {name}: {e}\n")
+        for key, path in (("clock", "trace_clock"),
+                          ("buffer_size_kb", "buffer_size_kb"),
+                          ("tracing_on", "tracing_on")):
+            try:
+                _write(_p(path), self._saved[key])
+            except OSError:
+                pass
+        if self._marker_f:
+            self._marker_f.close()
+            self._marker_f = None
+        if self._pipe_fd is not None:
+            os.close(self._pipe_fd)
+            self._pipe_fd = None
+
+    # -- internals -----------------------------------------------------------
+
+    @staticmethod
+    def _current_clock() -> str:
+        # trace_clock reads like: "[local] global counter uptime ... mono ..."
+        for tok in _read(_p("trace_clock")).split():
+            if tok.startswith("[") and tok.endswith("]"):
+                return tok[1:-1]
+        return "local"
+
+    def _register_kprobes(self) -> None:
+        syms = kallsyms_present([s for _, s, _ in self.kprobes])
+        for name, sym, want_ret in self.kprobes:
+            if not syms.get(sym):
+                self.inventory["kprobes"][name] = f"symbol-absent: {sym}"
+                continue
+            try:
+                with open(_p("kprobe_events"), "a") as f:
+                    f.write(f"p:kchansw/{name} {sym}\n")
+                self._registered_probes.append(f"kchansw/{name}")
+                if want_ret:
+                    with open(_p("kprobe_events"), "a") as f:
+                        f.write(f"r:kchansw/{name}_ret {sym}\n")
+                    self._registered_probes.append(f"kchansw/{name}_ret")
+                self.inventory["kprobes"][name] = "ok"
+            except OSError as e:
+                self.inventory["kprobes"][name] = f"register-failed: {e}"
+        if self._registered_probes:
+            _write(_p("events", "kchansw", "enable"), "1")
+
+    def _pump(self) -> None:
+        with open(self._trace_path, "wb") as out:
+            while True:
+                r, _, _ = select.select([self._pipe_fd], [], [], 0.2)
+                if r:
+                    try:
+                        chunk = os.read(self._pipe_fd, 1 << 16)
+                    except BlockingIOError:
+                        chunk = b""
+                    if chunk:
+                        out.write(chunk)
+                        continue
+                if self._stop.is_set():
+                    # Final drain: anything that raced the stop flag.
+                    while True:
+                        r, _, _ = select.select([self._pipe_fd], [], [], 0.1)
+                        if not r:
+                            break
+                        try:
+                            chunk = os.read(self._pipe_fd, 1 << 16)
+                        except BlockingIOError:
+                            break
+                        if not chunk:
+                            break
+                        out.write(chunk)
+                    out.flush()
+                    return
+
+    # -- API -----------------------------------------------------------------
+
+    def marker(self, text: str) -> None:
+        """Write a segmentation marker; shows in the trace as
+        tracing_mark_write: <text>."""
+        self._marker_f.write(text + "\n")
+        self._marker_f.flush()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--inventory", action="store_true",
+                    help="print event/symbol availability as JSON and exit")
+    ap.add_argument("--force-clean", action="store_true",
+                    help="remove stale kchansw/ probes from a crashed run")
+    args = ap.parse_args()
+    if os.geteuid() != 0:
+        sys.stderr.write("kchansw_trace: needs root (tracefs)\n")
+        return 2
+    if args.force_clean:
+        force_clean()
+        print("kchansw_trace: cleaned")
+        return 0
+    if args.inventory:
+        all_syms = {s for probes in (RTW88_PROBES, VENDOR_PROBES, RTW89_PROBES)
+                    for _, s, _ in probes}
+        print(json.dumps({
+            "events": discover_events(),
+            "symbols": kallsyms_present(sorted(all_syms)),
+        }, indent=2))
+        return 0
+    ap.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(143))
+    sys.exit(main())

--- a/tests/kchansw_vendor_build.sh
+++ b/tests/kchansw_vendor_build.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# kchansw_vendor_build.sh — build reference/rtl88x2bu with the firmware-offload
+# paths compiled IN (CONFIG_TDLS=y → TDLS ch-sw offload H2C 0x1C;
+# CONFIG_MCC_MODE=y → the MCC/FCS H2C family 0x10/0x11/0x18/0x19), then
+# insmod it on the host for the kchansw phase-b measurements and restore the
+# in-tree rtw88 binding afterwards.
+#
+# The module is never installed — insmod from the submodule build dir only.
+# TDLS channel-switch is runtime-gated on rtw_wifi_spec=1 (core/rtw_tdls.c),
+# so the load passes that module param.
+#
+# Usage (root):
+#   tests/kchansw_vendor_build.sh build      # compile only (unattended-safe)
+#   tests/kchansw_vendor_build.sh load       # unbind rtw88, insmod, show iface
+#   tests/kchansw_vendor_build.sh restore    # rmmod, rebind rtw88
+#   tests/kchansw_vendor_build.sh status
+#
+# Env:
+#   MCC_CONCURRENT=1   add -DCONFIG_CONCURRENT_MODE (two-vif MCC attempt;
+#                      a bigger departure from the tested config — build it
+#                      only when the plain build is green)
+#   DUT_VIDPID=2357:012d   the adapter the vendor module should own
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+MODE="${1:-build}"
+DUT_VIDPID="${DUT_VIDPID:-2357:012d}"
+VID="${DUT_VIDPID%%:*}"
+PID="${DUT_VIDPID##*:}"
+DRVDIR="reference/rtl88x2bu"
+KO="$DRVDIR/88x2bu.ko"
+INTREE_MOD="rtw88_8822bu"
+
+need_root() { [ "$(id -u)" -eq 0 ] || { echo "FAIL: needs root"; exit 2; }; }
+
+find_devdir() {
+  local d
+  for d in /sys/bus/usb/devices/*; do
+    [ -f "$d/idVendor" ] || continue
+    [ "$(cat "$d/idVendor")" = "$VID" ] && \
+    [ "$(cat "$d/idProduct")" = "$PID" ] && { echo "$d"; return 0; }
+  done
+  return 1
+}
+
+iface_for_devdir() {
+  local n
+  for n in /sys/class/net/*; do
+    [ -e "$n/device" ] || continue
+    case "$(readlink -f "$n/device")" in
+      "$(readlink -f "$1")"*) basename "$n"; return 0 ;;
+    esac
+  done
+  return 1
+}
+
+do_build() {
+  [ -f "$DRVDIR/Makefile" ] || {
+    echo "FAIL: $DRVDIR missing — git submodule update --init"; exit 1; }
+  local extra=()
+  if [ "${MCC_CONCURRENT:-0}" = "1" ]; then
+    extra+=("USER_EXTRA_CFLAGS=-DCONFIG_CONCURRENT_MODE")
+    echo "== building with CONFIG_TDLS=y CONFIG_MCC_MODE=y +CONCURRENT_MODE =="
+  else
+    echo "== building with CONFIG_TDLS=y CONFIG_MCC_MODE=y =="
+  fi
+  make -C "$DRVDIR" clean >/dev/null 2>&1 || true
+  if ! make -C "$DRVDIR" CONFIG_TDLS=y CONFIG_MCC_MODE=y "${extra[@]}" \
+       -j"$(nproc)" 2>"$DRVDIR/build.err"; then
+    echo "FAIL: vendor build broke — last errors:"
+    tail -30 "$DRVDIR/build.err" | sed 's/^/    /'
+    exit 1
+  fi
+  echo "PASS: built $KO ($(du -h "$KO" | cut -f1)) for $(uname -r)"
+  # Prove the offload symbols actually made it in.
+  local syms
+  syms="$(nm "$KO" 2>/dev/null | grep -cE \
+    'rtw_hal_ch_sw_oper_offload|rtw_hal_mcc_change_scan_flag' || true)"
+  echo "  offload symbols present: $syms/2 (ch_sw_oper_offload + hal_mcc)"
+}
+
+do_load() {
+  need_root
+  [ -f "$KO" ] || { echo "FAIL: $KO not built — run '$0 build' first"; exit 1; }
+  local devdir iface drv
+  devdir="$(find_devdir)" || { echo "FAIL: $DUT_VIDPID not on the bus"; exit 1; }
+  # Unbind + unload the in-tree driver so a mid-run re-enumeration cannot
+  # race the vendor module for the device (CLAUDE.md auto-probe trap).
+  for ifdir in "$devdir":*; do
+    [ -L "$ifdir/driver" ] || continue
+    drv="$(readlink -f "$ifdir/driver")"
+    echo "  unbinding $(basename "$ifdir") from $(basename "$drv")"
+    echo "$(basename "$ifdir")" > "$drv/unbind" || true
+  done
+  modprobe -r "$INTREE_MOD" 2>/dev/null || true
+  insmod "$KO" rtw_wifi_spec=1 || { echo "FAIL: insmod (dmesg tail:)";
+    dmesg | tail -12 | sed 's/^/    /'; exit 1; }
+  local wlan="" i
+  for i in $(seq 1 20); do
+    wlan="$(iface_for_devdir "$devdir" || true)"
+    [ -n "$wlan" ] && break
+    sleep 0.5
+  done
+  [ -n "$wlan" ] || { echo "FAIL: no netdev appeared (dmesg tail:)";
+    dmesg | tail -12 | sed 's/^/    /'; exit 1; }
+  echo "PASS: 88x2bu loaded (rtw_wifi_spec=1), netdev $wlan"
+  echo "next: sudo tests/kchansw_bench.py phase-b"
+}
+
+do_restore() {
+  need_root
+  rmmod 88x2bu 2>/dev/null && echo "  rmmod 88x2bu" || true
+  modprobe "$INTREE_MOD" 2>/dev/null || true
+  local devdir
+  if devdir="$(find_devdir)"; then
+    echo "$(basename "$devdir"):1.0" > /sys/bus/usb/drivers_probe 2>/dev/null \
+      || true
+    echo "  reprobed $(basename "$devdir") → in-tree driver"
+  fi
+  echo "restore done; dmesg tail:"
+  dmesg | tail -5 | sed 's/^/    /'
+}
+
+do_status() {
+  lsmod | grep -E '^88x2bu|^rtw88_8822bu' || echo "  neither module loaded"
+  local devdir
+  if devdir="$(find_devdir)"; then
+    local drv="none"
+    [ -L "$devdir:1.0/driver" ] && drv="$(basename "$(readlink -f "$devdir:1.0/driver")")"
+    echo "  $DUT_VIDPID at $(basename "$devdir"), driver: $drv"
+  else
+    echo "  $DUT_VIDPID not on the bus"
+  fi
+}
+
+case "$MODE" in
+  build)   do_build ;;
+  load)    do_load ;;
+  restore) do_restore ;;
+  status)  do_status ;;
+  *) echo "usage: $0 {build|load|restore|status}"; exit 2 ;;
+esac

--- a/tests/kchansw_vendor_build.sh
+++ b/tests/kchansw_vendor_build.sh
@@ -1,24 +1,28 @@
 #!/usr/bin/env bash
-# kchansw_vendor_build.sh — build reference/rtl88x2bu with the firmware-offload
-# paths compiled IN (CONFIG_TDLS=y → TDLS ch-sw offload H2C 0x1C;
-# CONFIG_MCC_MODE=y → the MCC/FCS H2C family 0x10/0x11/0x18/0x19), then
-# insmod it on the host for the kchansw phase-b measurements and restore the
-# in-tree rtw88 binding afterwards.
+# kchansw_vendor_build.sh — build reference/rtl88x2bu with a firmware-offload
+# path compiled IN, insmod it on the host for the kchansw phase-b
+# measurements, and restore the in-tree rtw88 binding afterwards.
+#
+# The two offload paths are MUTUALLY EXCLUSIVE builds — include/drv_conf.h
+# hard-errors on TDLS+MCC together, and MCC additionally requires
+# CONCURRENT_MODE on and BT_COEXIST off:
+#
+#   VARIANT=tdls (default)  CONFIG_TDLS=y → TDLS ch-sw offload H2C 0x1C
+#                           (autoconf.h auto-enables CONFIG_TDLS_CH_SW,
+#                           runtime-gated on rtw_wifi_spec=1)
+#   VARIANT=mcc             CONFIG_MCC_MODE=y CONFIG_BT_COEXIST=n
+#                           + -DCONFIG_CONCURRENT_MODE → MCC/FCS H2C family
+#                           0x10/0x11/0x18/0x19 + two-vif support
 #
 # The module is never installed — insmod from the submodule build dir only.
-# TDLS channel-switch is runtime-gated on rtw_wifi_spec=1 (core/rtw_tdls.c),
-# so the load passes that module param.
 #
 # Usage (root):
-#   tests/kchansw_vendor_build.sh build      # compile only (unattended-safe)
+#   [VARIANT=tdls|mcc] tests/kchansw_vendor_build.sh build   # unattended-safe
 #   tests/kchansw_vendor_build.sh load       # unbind rtw88, insmod, show iface
 #   tests/kchansw_vendor_build.sh restore    # rmmod, rebind rtw88
 #   tests/kchansw_vendor_build.sh status
 #
 # Env:
-#   MCC_CONCURRENT=1   add -DCONFIG_CONCURRENT_MODE (two-vif MCC attempt;
-#                      a bigger departure from the tested config — build it
-#                      only when the plain build is green)
 #   DUT_VIDPID=2357:012d   the adapter the vendor module should own
 
 set -euo pipefail
@@ -58,26 +62,32 @@ iface_for_devdir() {
 do_build() {
   [ -f "$DRVDIR/Makefile" ] || {
     echo "FAIL: $DRVDIR missing — git submodule update --init"; exit 1; }
-  local extra=()
-  if [ "${MCC_CONCURRENT:-0}" = "1" ]; then
-    extra+=("USER_EXTRA_CFLAGS=-DCONFIG_CONCURRENT_MODE")
-    echo "== building with CONFIG_TDLS=y CONFIG_MCC_MODE=y +CONCURRENT_MODE =="
-  else
-    echo "== building with CONFIG_TDLS=y CONFIG_MCC_MODE=y =="
-  fi
+  local variant="${VARIANT:-tdls}" flags=() want_sym
+  case "$variant" in
+    tdls)
+      flags=(CONFIG_TDLS=y)
+      want_sym=rtw_hal_ch_sw_oper_offload ;;
+    mcc)
+      flags=(CONFIG_MCC_MODE=y CONFIG_BT_COEXIST=n
+             "USER_EXTRA_CFLAGS=-DCONFIG_CONCURRENT_MODE")
+      want_sym=rtw_hal_mcc_change_scan_flag ;;
+    *) echo "FAIL: VARIANT must be tdls or mcc"; exit 2 ;;
+  esac
+  echo "== building VARIANT=$variant: ${flags[*]} =="
   make -C "$DRVDIR" clean >/dev/null 2>&1 || true
-  if ! make -C "$DRVDIR" CONFIG_TDLS=y CONFIG_MCC_MODE=y "${extra[@]}" \
-       -j"$(nproc)" 2>"$DRVDIR/build.err"; then
-    echo "FAIL: vendor build broke — last errors:"
-    tail -30 "$DRVDIR/build.err" | sed 's/^/    /'
+  if ! make -C "$DRVDIR" "${flags[@]}" -j"$(nproc)" 2>"$DRVDIR/build.err"; then
+    echo "FAIL: vendor build broke — errors:"
+    grep -E 'error:' "$DRVDIR/build.err" | sort -u | head -15 | sed 's/^/    /'
+    tail -8 "$DRVDIR/build.err" | sed 's/^/    /'
     exit 1
   fi
-  echo "PASS: built $KO ($(du -h "$KO" | cut -f1)) for $(uname -r)"
-  # Prove the offload symbols actually made it in.
-  local syms
-  syms="$(nm "$KO" 2>/dev/null | grep -cE \
-    'rtw_hal_ch_sw_oper_offload|rtw_hal_mcc_change_scan_flag' || true)"
-  echo "  offload symbols present: $syms/2 (ch_sw_oper_offload + hal_mcc)"
+  echo "PASS: built $KO ($(du -h "$KO" | cut -f1)) for $(uname -r), VARIANT=$variant"
+  # Prove the offload symbol actually made it in.
+  if nm "$KO" 2>/dev/null | grep -q "$want_sym"; then
+    echo "  offload symbol present: $want_sym"
+  else
+    echo "  WARNING: $want_sym not in $KO symbol table"
+  fi
 }
 
 do_load() {

--- a/tests/kchansw_vendor_build.sh
+++ b/tests/kchansw_vendor_build.sh
@@ -33,7 +33,7 @@ DUT_VIDPID="${DUT_VIDPID:-2357:012d}"
 VID="${DUT_VIDPID%%:*}"
 PID="${DUT_VIDPID##*:}"
 DRVDIR="reference/rtl88x2bu"
-KO="$DRVDIR/88x2bu.ko"
+KO="$DRVDIR/88x2bu_ohd.ko"  # the OpenHD fork renames the module
 INTREE_MOD="rtw88_8822bu"
 
 need_root() { [ "$(id -u)" -eq 0 ] || { echo "FAIL: needs root"; exit 2; }; }
@@ -120,7 +120,7 @@ do_load() {
 
 do_restore() {
   need_root
-  rmmod 88x2bu 2>/dev/null && echo "  rmmod 88x2bu" || true
+  rmmod 88x2bu_ohd 2>/dev/null && echo "  rmmod 88x2bu" || true
   modprobe "$INTREE_MOD" 2>/dev/null || true
   local devdir
   if devdir="$(find_devdir)"; then
@@ -133,7 +133,7 @@ do_restore() {
 }
 
 do_status() {
-  lsmod | grep -E '^88x2bu|^rtw88_8822bu' || echo "  neither module loaded"
+  lsmod | grep -E '^88x2bu_ohd|^rtw88_8822bu' || echo "  neither module loaded"
   local devdir
   if devdir="$(find_devdir)"; then
     local drv="none"

--- a/tests/kchansw_vm.sh
+++ b/tests/kchansw_vm.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# kchansw_vm.sh — run the kchansw phase-b vendor-driver measurements inside
+# the pinned-kernel devourer-testrig VM.
+#
+# Why a VM here: insmod-ing the vendor 88x2bu module on the host and
+# kprobing its internal switch path deadlocked the host kernel outright
+# (ssh dead, dmesg blocked — power cycle to recover) — twice. In the VM the
+# same wedge costs a `virsh reset`.
+#
+# The DUT is passed through by vid:pid; the on-air oracles stay on the
+# host, so dead-air timing keeps its host-clock precision. The host bench
+# (`kchansw_bench.py phase-b-vm`) measures the VM→host CLOCK_MONOTONIC
+# offset and stamps it into each config's meta.json.
+#
+# Usage (root):
+#   tests/kchansw_vm.sh prepare   # start VM, push sources, build ko (tdls),
+#                                 # move DUT to its USB2 port, attach, load
+#   tests/kchansw_vm.sh mcc       # rebuild VARIANT=mcc inside VM + reload
+#   tests/kchansw_vm.sh restore   # rmmod in VM, detach DUT, shut VM down
+#   tests/kchansw_vm.sh status
+#
+# Env: VM_NAME (devourer-testrig), VM_USER (invoking user), DUT_VIDPID
+# (2357:012d), USB3_PORT_DISABLE (usb10-port2 — empty to skip the USB2 pin).
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+MODE="${1:-status}"
+VM_NAME="${VM_NAME:-devourer-testrig}"
+VM_USER="${VM_USER:-${SUDO_USER:-$USER}}"
+DUT_VIDPID="${DUT_VIDPID:-2357:012d}"
+VID="${DUT_VIDPID%%:*}"
+PID="${DUT_VIDPID##*:}"
+# The T3U wedges its USB3/SuperSpeed link under switch churn (measured in
+# phase A); pinning it to the USB2 companion port is load-bearing.
+USB3_PORT_DISABLE="${USB3_PORT_DISABLE:-/sys/bus/usb/devices/usb10/10-0:1.0/usb10-port2/disable}"
+VM_DIR=/opt/kchansw
+HOSTDEV_XML=/tmp/kchansw-hostdev.xml
+
+need_root() { [ "$(id -u)" -eq 0 ] || { echo "FAIL: needs root"; exit 2; }; }
+
+vm_ip() {
+  virsh domifaddr "$VM_NAME" 2>/dev/null \
+    | awk '/ipv4/ {print $4}' | cut -d/ -f1 | head -1
+}
+
+SSH_KEY="${SSH_KEY:-$(ls "$(eval echo "~$VM_USER")"/.ssh/id_ed25519 \
+  "$(eval echo "~$VM_USER")"/.ssh/id_rsa 2>/dev/null | head -1 || true)}"
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+          -o ConnectTimeout=8 -o LogLevel=ERROR -i "$SSH_KEY")
+vssh() { ssh "${SSH_OPTS[@]}" "$VM_USER@$(vm_ip)" "$@"; }
+
+hostdev_xml() {
+  cat > "$HOSTDEV_XML" <<XML
+<hostdev mode='subsystem' type='usb' managed='yes'>
+  <source>
+    <vendor id='0x$VID'/>
+    <product id='0x$PID'/>
+  </source>
+</hostdev>
+XML
+}
+
+wait_ssh() {
+  local i ip
+  for i in $(seq 1 30); do
+    ip="$(vm_ip)"
+    [ -n "$ip" ] && vssh true 2>/dev/null && return 0
+    sleep 3
+  done
+  echo "FAIL: no ssh to $VM_NAME"; return 1
+}
+
+vm_build() {
+  local variant="$1" flags
+  case "$variant" in
+    tdls) flags="CONFIG_TDLS=y" ;;
+    mcc)  flags="CONFIG_MCC_MODE=y CONFIG_BT_COEXIST=n USER_EXTRA_CFLAGS=-DCONFIG_CONCURRENT_MODE" ;;
+    *) echo "FAIL: variant $variant"; exit 2 ;;
+  esac
+  echo "== building VARIANT=$variant in VM =="
+  vssh "cd $VM_DIR/rtl88x2bu && make clean >/dev/null 2>&1; \
+        make $flags -j\$(nproc) >/tmp/build.log 2>&1 \
+        && echo BUILD-OK || { grep -m5 'error:' /tmp/build.log; exit 1; }"
+}
+
+vm_load() {
+  # The fork names the module per-variant (88x2bu_ohd.ko for the default
+  # build, 8812bu.ko when MCC make vars override the Makefile's name).
+  vssh "sudo rmmod 88x2bu_ohd 2>/dev/null; sudo rmmod 8812bu 2>/dev/null; \
+        ko=\$(ls -t $VM_DIR/rtl88x2bu/*.ko | head -1); \
+        sudo modprobe cfg80211 && \
+        sudo insmod \$ko rtw_wifi_spec=1 && \
+        for i in \$(seq 1 20); do \
+          w=\$(ls /sys/class/net | grep -v -e lo -e enp | head -1); \
+          [ -n \"\$w\" ] && { echo NETDEV=\$w; exit 0; }; sleep 0.5; \
+        done; echo FAIL-no-netdev; exit 1"
+}
+
+case "$MODE" in
+  prepare)
+    need_root
+    if [ "$(virsh domstate "$VM_NAME")" != "running" ]; then
+      virsh start "$VM_NAME"
+    fi
+    wait_ssh
+    echo "VM up at $(vm_ip)"
+    vssh "sudo mkdir -p $VM_DIR && sudo chown $VM_USER: $VM_DIR"
+    echo "== pushing sources =="
+    tar -C reference -c --exclude=.git --exclude='*.o' --exclude='*.ko' \
+        --exclude='*.cmd' --exclude='*.mod*' rtl88x2bu \
+      | vssh "tar -C $VM_DIR -x"
+    for f in kchansw_trace.py kchansw_inject.py kchansw_vm_dut.py; do
+      scp -q "${SSH_OPTS[@]}" "tests/$f" "$VM_USER@$(vm_ip):$VM_DIR/"
+    done
+    vm_build tdls
+    # Pin the DUT to USB2 before handing it to the VM: passthrough URBs
+    # still ride the host controller, and phase A wedged it on USB3.
+    if [ -n "$USB3_PORT_DISABLE" ] && [ -e "$USB3_PORT_DISABLE" ]; then
+      echo 1 > "$USB3_PORT_DISABLE" || true
+      sleep 4
+    fi
+    lsusb -d "$DUT_VIDPID" >/dev/null || { echo "FAIL: DUT gone"; exit 1; }
+    hostdev_xml
+    if virsh dumpxml "$VM_NAME" | grep -q "0x$PID"; then
+      echo "  DUT already attached to $VM_NAME"
+    else
+      virsh attach-device "$VM_NAME" "$HOSTDEV_XML" --live
+      sleep 3
+    fi
+    vm_load
+    echo "PASS: VM DUT ready — run: sudo tests/kchansw_setup.sh phase-b-vm"
+    ;;
+  mcc)
+    need_root
+    vm_build mcc
+    vm_load
+    ;;
+  restore)
+    need_root
+    vssh "sudo rmmod 88x2bu_ohd 2>/dev/null; sudo rmmod 8812bu 2>/dev/null" \
+      || true
+    hostdev_xml
+    virsh detach-device "$VM_NAME" "$HOSTDEV_XML" --live 2>/dev/null || true
+    virsh shutdown "$VM_NAME" 2>/dev/null || true
+    echo "restore done (VM shutting down; DUT back on host bus)"
+    ;;
+  status)
+    echo "VM: $VM_NAME ($(virsh domstate "$VM_NAME" 2>/dev/null)) ip=$(vm_ip)"
+    virsh dumpxml "$VM_NAME" 2>/dev/null | grep -A2 "type='usb'" \
+      | grep -E 'vendor|product' | sed 's/^/  /' || true
+    lsusb -d "$DUT_VIDPID" | sed 's/^/  host: /' || true
+    ;;
+  *) echo "usage: $0 {prepare|mcc|restore|status}"; exit 2 ;;
+esac

--- a/tests/kchansw_vm_dut.py
+++ b/tests/kchansw_vm_dut.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""kchansw VM-side DUT driver (phase-b-vm).
+
+Runs INSIDE the pinned-kernel VM as root, next to kchansw_trace.py and
+kchansw_inject.py. Mirrors the bench's set-channel / ROC switch loops on
+the vendor 88x2bu DUT: ftrace session with the vendor kprobes (a kernel
+wedge is contained to the VM), 2 kHz tagged injector, per-switch
+trace_marker + control.jsonl records — all on the VM's CLOCK_MONOTONIC.
+The host orchestrator measures the VM→host clock offset, pulls the files
+back, and stamps `vm_clock_shift_ns` into meta.json for the analyzer.
+
+No recovery ladder here: a mid-run USB drop or silent-TX wedge is recorded
+(kchansw.wedge) and the config aborts — the host side decides whether to
+force-reset the VM.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import kchansw_trace  # noqa: E402
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def log(msg):
+    sys.stderr.write(f"[vm_dut {time.strftime('%H:%M:%S')}] {msg}\n")
+    sys.stderr.flush()
+
+
+def run(cmd, timeout=15):
+    return subprocess.run(cmd, capture_output=True, text=True,
+                          timeout=timeout)
+
+
+def ch_to_freq(ch):
+    return 5000 + 5 * ch if ch > 14 else 2407 + 5 * ch
+
+
+def set_monitor(iface, ch):
+    run(["ip", "link", "set", iface, "down"])
+    r = run(["iw", "dev", iface, "set", "type", "monitor"])
+    if r.returncode != 0:
+        raise RuntimeError(f"set type monitor: {r.stderr.strip()}")
+    run(["ip", "link", "set", iface, "up"])
+    r = run(["iw", "dev", iface, "set", "channel", str(ch)])
+    if r.returncode != 0:
+        raise RuntimeError(f"set channel {ch}: {r.stderr.strip()}")
+
+
+def spawn_injector(iface, out_dir, hz, size=96):
+    out = open(os.path.join(out_dir, "inject.jsonl"), "a")
+    err = open(os.path.join(out_dir, "inject.stderr"), "a")
+    return subprocess.Popen(
+        [sys.executable, os.path.join(HERE, "kchansw_inject.py"),
+         "--iface", iface, "--hz", str(hz), "--size", str(size)],
+        stdout=out, stderr=err)
+
+
+def loop_set_channel(a, ctl, ts):
+    total = a.warmup + a.switches
+    for i in range(total):
+        frm, to = ((a.from_ch, a.to_ch) if i % 2 == 0
+                   else (a.to_ch, a.from_ch))
+        t_req = time.monotonic_ns()
+        ts.marker(f"KCHANSW i={i} prim=set_channel cfg={a.cfg} "
+                  f"from={frm} to={to} mono={t_req}")
+        ctl.write(json.dumps({"ev": "kchansw.req", "i": i, "from": frm,
+                              "to": to, "mono_ns": t_req}) + "\n")
+        r = run(["iw", "dev", a.iface, "set", "channel", str(to)],
+                timeout=10)
+        t_done = time.monotonic_ns()
+        ctl.write(json.dumps({"ev": "kchansw.done", "i": i,
+                              "mono_ns": t_done, "rc": r.returncode,
+                              "err": r.stderr.strip()[:120]}) + "\n")
+        if r.returncode != 0:
+            log(f"i={i}: iw rc={r.returncode} {r.stderr.strip()[:80]}")
+            if "No such device" in r.stderr or "(-19)" in r.stderr:
+                ctl.write(json.dumps({"ev": "kchansw.wedge", "i": i,
+                                      "mono_ns": time.monotonic_ns(),
+                                      "kind": "usb-drop"}) + "\n")
+                log("usb-drop — aborting config (no in-VM recovery)")
+                return False
+        time.sleep(a.dwell_ms / 1e3)
+        if i % 50 == 49:
+            ctl.flush()
+            log(f"progress {i + 1}/{total}")
+    return True
+
+
+def loop_roc(a, ctl, ts):
+    total = a.warmup + a.switches
+    for i in range(total):
+        t_req = time.monotonic_ns()
+        ts.marker(f"KCHANSW i={i} prim=roc cfg={a.cfg} "
+                  f"from={a.from_ch} to={a.to_ch} mono={t_req}")
+        ctl.write(json.dumps({"ev": "kchansw.req", "i": i,
+                              "mono_ns": t_req}) + "\n")
+        r = run(["iw", "dev", a.iface, "offchannel",
+                 str(ch_to_freq(a.to_ch)), str(a.roc_ms)], timeout=10)
+        t_done = time.monotonic_ns()
+        ctl.write(json.dumps({"ev": "kchansw.done", "i": i,
+                              "mono_ns": t_done, "rc": r.returncode,
+                              "err": r.stderr.strip()[:120]}) + "\n")
+        if r.returncode != 0 and i == 0:
+            log(f"offchannel rejected: {r.stderr.strip()[:100]} — aborting")
+            return False
+        time.sleep((a.roc_ms + 120) / 1e3)
+        if i % 50 == 49:
+            ctl.flush()
+            log(f"progress {i + 1}/{total}")
+    return True
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("prim", choices=["set-channel", "roc"])
+    ap.add_argument("--cfg", required=True, help="config name for markers")
+    ap.add_argument("--iface", required=True)
+    ap.add_argument("--from-ch", dest="from_ch", type=int, required=True)
+    ap.add_argument("--to-ch", dest="to_ch", type=int, required=True)
+    ap.add_argument("--switches", type=int, required=True)
+    ap.add_argument("--warmup", type=int, default=10)
+    ap.add_argument("--dwell-ms", type=int, default=150)
+    ap.add_argument("--roc-ms", type=int, default=20)
+    ap.add_argument("--hz", type=float, default=2000.0)
+    ap.add_argument("--roc-monitor-vif", type=int, default=1,
+                    help="0 = trace-only ROC: do NOT add the second monitor "
+                         "vif (the vendor tdls build deadlocks the kernel "
+                         "in the add-interface op — no CONCURRENT_MODE)")
+    ap.add_argument("--settle-s", type=float, default=8.0,
+                    help="air the injector on from-ch before switching, so "
+                         "the host can run its oracle-rate gate")
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+
+    if os.geteuid() != 0:
+        sys.stderr.write("vm_dut: needs root\n")
+        return 2
+    os.makedirs(a.out, exist_ok=True)
+
+    roc_mon = None
+    if a.prim == "set-channel":
+        set_monitor(a.iface, a.from_ch)
+        inj_iface = a.iface
+    else:
+        # ROC needs a managed iface; a second monitor vif carries the
+        # injector on the base channel if the combination is allowed.
+        run(["ip", "link", "set", a.iface, "down"])
+        run(["iw", "dev", a.iface, "set", "type", "managed"])
+        run(["ip", "link", "set", a.iface, "up"])
+        inj_iface = None
+        r = (run(["iw", "dev", a.iface, "interface", "add", "kcmon0",
+                  "type", "monitor"]) if a.roc_monitor_vif
+             else subprocess.CompletedProcess([], 1, "", "skipped"))
+        if r.returncode == 0:
+            run(["ip", "link", "set", "kcmon0", "up"])
+            if run(["iw", "dev", "kcmon0", "set", "channel",
+                    str(a.from_ch)]).returncode == 0:
+                roc_mon = "kcmon0"
+                inj_iface = roc_mon
+        log(f"roc monitor vif: {roc_mon}")
+
+    inj = spawn_injector(inj_iface, a.out, a.hz) if inj_iface else None
+    if inj:
+        log(f"injector up on {inj_iface} @ {a.hz:.0f} Hz; "
+            f"settling {a.settle_s:.0f}s")
+        time.sleep(a.settle_s)
+
+    ctl = open(os.path.join(a.out, "control.jsonl"), "w")
+    ok = False
+    try:
+        with kchansw_trace.TraceSession(
+                a.out, kprobes=kchansw_trace.VENDOR_PROBES) as ts:
+            if a.prim == "set-channel":
+                ok = loop_set_channel(a, ctl, ts)
+            else:
+                ok = loop_roc(a, ctl, ts)
+            with open(os.path.join(a.out, "trace_inventory.json"), "w") as f:
+                json.dump(ts.inventory, f, indent=1)
+    finally:
+        if inj and inj.poll() is None:
+            inj.terminate()
+        ctl.write(json.dumps({"ev": "kchansw.aliveness",
+                              "inj": bool(inj and inj.poll() is None)})
+                  + "\n")
+        ctl.close()
+        if roc_mon:
+            run(["iw", "dev", roc_mon, "del"])
+        with open(os.path.join(a.out, "dmesg.log"), "w") as f:
+            f.write(run(["dmesg"], timeout=10).stdout)
+        with open(os.path.join(a.out, "vmdut_result.json"), "w") as f:
+            json.dump({"ok": ok, "prim": a.prim,
+                       "roc_monitor_vif": roc_mon is not None}, f)
+    log(f"done ok={ok}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #269.

Measurement-only experiment: a like-for-like latency/behavior matrix of every channel-switch primitive the standard Linux/Realtek kernel drivers expose on devourer-supported silicon, with kernel-side instrumentation (ftrace `trace_clock=mono`, cfg80211/mac80211 events, grouped kprobes) and a mandatory on-air oracle — two devourer `rxdemo` receivers whose MAC-latched `tsfl` timestamps are mapped to host time by a robust linear fit (σ 40–280 µs), so *dead air* is measured at the RF, not at the API.

## Headline results (full note: `docs/kernel-channel-switch-baseline.md`)

| driver / primitive (RTL8822BU unless noted) | on-air dead-air med | p99 | gate |
|---|---|---|---|
| **vendor rtl88x2bu set-channel 36↔40** | **1.08 ms** | **4.42 ms** | **advance** |
| rtw88 set-channel 1↔6 (2.4 GHz) | 6.1 ms | 16.6 ms | slow-slot-only |
| rtw88 set-channel 36↔40 | 52.0 ms | 60.6 ms | control |
| rtw89 set-channel 36↔40 (RTL8852BU) | 31.5 ms | 36.3 ms | control |
| rtw89 AP CSA (count=1) | 102.9 ms (≈1 TBTT) | 205.8 ms | control |
| rtw88 AP CSA | — | — | policy-rejected (no AP_CSA flag) |

The silicon retunes in ~1 ms; rtw88's 52 ms is its software sequence. Host-command latency alone (the number an API benchmark would report) overstates the 2.4 GHz RF transition by 14× — the oracle is not optional.

**Go**: exp-2 (#270) targets `rtw_hal_ch_sw_oper_offload` → H2C 0x1C `CHNL_SWITCH_OPER_OFFLOAD` (compiled + runtime-armed in the exact module that measured 1.08 ms); exp-3 (#271) targets the MCC H2C 0x10/0x11/0x18/0x19 family (verified live through `mcc_enable=1`).

## What's in the PR

- `tests/kchansw_{bench,trace,inject,analyze}.py` + `kchansw_setup.sh` — the reusable harness (tracefs session mgr with grouped kprobes + clean teardown, 2 kHz tagged injector immune to kernel seq rewrite, offline analyzer with `--self-test`, wedge-recovery ladder up to a PCI controller revive).
- `tests/kchansw_vm.sh` + `kchansw_vm_dut.py` — the vendor phase runs in the pinned-kernel VM: the vendor TDLS-variant build **livelocks the kernel in its cfg80211 add-interface op with RTNL held** (took the host down twice before isolation; reproducible on demand). DUT is USB-passed-through, oracles stay host-side, VM clock bridged by a min-RTT-midpoint probe (±0.15 ms); the host insmod path is gated behind `KCHANSW_HOST_VENDOR_OK=1`.
- `tests/kchansw_vendor_build.sh` — TDLS/MCC variant builds of the `reference/rtl88x2bu` fork (mutually exclusive families); submodule gains two kernel-compat commits (`tdls_mgmt link_id` ≥ 6.0, `timer_container_of` ≥ 6.16).
- `tests/kchansw_b210_gap.py` — B210 partial-band energy probe quantifying the decode-vs-energy oracle bias.
- `examples/rx/main.cpp` — `rx.frame` per-frame events follow `DEVOURER_RX_AGG_SA` and carry an `sa` field (default behavior unchanged); the oracle enabler.
- `docs/kernel-channel-switch-baseline.md` — method, capability matrix, distributions, endurance/USB-link findings, go/no-go.

Raw per-switch CSVs stay in `/tmp` (regenerable); the doc carries the summary tables per the agreed scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
