### PR TITLE
8822B firmware channel-switch offload isolated + benchmarked: H2C 0x1D at 1 ms dead-air (exp 2/5)

### DIFF
--- a/docs/kernel-channel-switch-offload.md
+++ b/docs/kernel-channel-switch-offload.md
@@ -1,0 +1,123 @@
+# RTL8822B firmware channel-switch offload (H2C 0x1D)
+
+Isolation and benchmark of Realtek's firmware-offloaded channel switch on
+the RTL8822BU — the primitive nominated by the
+[kernel channel-switch baseline](kernel-channel-switch-baseline.md) —
+against devourer's own `FastRetune` on the same silicon, channels and
+on-air oracles. Harness: the kchansw bench (`tests/kchansw_bench.py
+phase-b-vm --pairs ...` with `VM_MODPARAMS=rtw_ch_switch_offload=1`) plus
+`tests/kchansw_fastretune_arm.py` for the devourer arm.
+
+## The mechanism (source-isolated, vendor rtl88x2bu fork)
+
+Two distinct firmware channel-switch families exist in the driver; the
+8822B uses the second:
+
+- **H2C 0x1C `CHNL_SWITCH_OPER_OFFLOAD`** — the TDLS-V1 path
+  (`rtw_hal_ch_sw_oper_offload`, 4-byte payload: channel, bw, 40/80 MHz
+  SC, RFE type; completion = C2H 0x10 `FW_CHNL_SWITCH_COMPLETE` →
+  `rtw_tdls_chsw_oper_done`, 10 ms wait). Compiled only when
+  `CONFIG_TDLS_CH_SW` **without** V2 — on the 8822B, `hal_ic_cfg.h`
+  selects `CONFIG_TDLS_CH_SW_V2`, whose TDLS path is plain
+  `set_channel_bwmode`. 0x1C is therefore dead code on this chip.
+- **H2C 0x1D `SINGLE_CHANNELSWITCH_V2`** — the 8822B's real firmware
+  switch (`rtw_hal_switch_chnl_and_set_bw_offload`, `hal/hal_com.c`).
+  3-byte payload: `b0[7:0]` central channel, `b1[3:0]` primary-channel
+  index, `b1[7:4]` bandwidth, `b2[0]` PWR_IDX_UPDATE_EN, `b2[1]`
+  IQK_UPDATE_EN (the driver sets IQK_UPDATE only). Completion: C2H
+  `CMD_ID_C2H_CUR_CHANNEL` → `rtw_sctx_done(hal->chsw_sctx)`; the host
+  waits ≤ 10 ms. Wired into the *normal* set-channel path
+  (`rtl8822b_switch_chnl_and_set_bw` → `switch_chnl_and_set_bw_by_fw`)
+  behind `hal->ch_switch_offload` — the stock module parameter
+  `rtw_ch_switch_offload` (default 0). No TDLS peer, association, or
+  MAC-ID is involved; `iw set channel` on a monitor interface exercises
+  it directly.
+
+So the "research harness outside TDLS" the experiment called for ships in
+the driver: `insmod 88x2bu_ohd.ko rtw_wifi_spec=1 rtw_ch_switch_offload=1`.
+
+## Results (VM venue, kernel 5.15; oracles + dead-air on the host)
+
+Dead air = first frame decoded on the destination minus last frame
+decoded on the source (chip-clock fits, σ 28–330 µs). All rows RF-
+evidenced; ≥ 10 warm-ups excluded.
+
+| arm (36↔40, 5 GHz, 20 MHz) | n | med | p90 | p99 | max | host cost med |
+|---|---|---|---|---|---|---|
+| fw offload H2C 0x1D | 1000/1000 | **1.03 ms** | 2.43 | 4.33 | 1978.6 | 13.5 ms (nl80211) |
+| driver path (by_drv, same module) | 998/1000 | 1.08 ms | 1.68 | 4.42 | 32.9 | 66.3 ms (nl80211) |
+| devourer `FastRetune` | 1099 | 2.75 ms | 3.59 | 5.44 | **7.1** | 1.82 ms (register writes) |
+
+| arm (36↔44, HT40) | n | med | p99 | gate |
+|---|---|---|---|---|
+| fw offload | 296/300 | 0.98 ms | 4.26 | advance |
+| by_drv | 300/300 | 0.86 ms | 4.08 | advance |
+
+| arm (cross-band / 2.4 GHz) | n | med | p99 | note |
+|---|---|---|---|---|
+| fw offload 36↔6 (per-switch band change) | 100/100 | **1.95 ms** | 11.4 | slow-slot; host-cmd only 15.6 ms |
+| fw offload 1↔6 | 300/300 | 4.16 ms | 23.3 | decode-limited (see below) |
+| by_drv 1↔6 | 300/300 | 4.53 ms | 27.2 | ditto; host-cmd 265 ms both arms |
+| `FastRetune` 1↔6 | 299 | ≤ 20.7 ms | ≤ 45.2 | instrument-limited upper bound |
+
+Reading:
+
+- **The firmware executes the switch in ~2 ms and proves it**: the
+  `kc_fw_ch_sw` kprobe pair (H2C submit → C2H CUR_CHANNEL) spans 1.94 ms
+  median, matching the on-air 1.03 ms dead-air plus completion-report
+  overhead. This is a genuine firmware execution with a hardware-side
+  completion event, not a fire-and-forget.
+- **Against `FastRetune`**: the offload roughly halves the median RF dark
+  time (1.03 vs 2.75 ms) — the headroom the baseline predicted — and it
+  handles **per-switch cross-band retunes in ~2 ms**, which `FastRetune`
+  cannot (band changes fall back to the ~90 ms full path). `FastRetune`
+  wins the tail: max 7.1 ms over 1099 switches versus three ~2 s
+  whole-driver stalls in the fw run (below).
+- **Direction asymmetry** (fw, 36↔40): 36→40 median 1.52 ms, 40→36
+  0.43 ms — the upward retune pays PLL settle the downward one doesn't.
+- **2.4 GHz cells are instrument-limited**: the ch-1 oracle decodes
+  sparsely near-field (in-dwell decode gap p90 ≈ 9 ms), so every 2.4 GHz
+  dead-air row is an upper bound. `FastRetune`'s own register-write time
+  there is 1.26 ms — the 20.7 ms row is the oracle, not the radio.
+
+## Failure classification (issue taxonomy)
+
+- **C2H timeout**: 21/1010 completion waits exceeded the 10 ms sctx
+  timeout. The driver logs and continues; all 21 switches still produced
+  destination-channel RF and the session stayed consistent — the timeout
+  path is benign here.
+- **Whole-driver stalls**: 3/1010 switches (i=374/524/606) went dark
+  ~2 s, `kc_fw_ch_sw` span 2.3–2.4 s — the H2C submit itself blocked on
+  the USB layer (periodic driver housekeeping), not a firmware refusal.
+  These dominate the fw arm's max and are the reason its tail loses to
+  `FastRetune`.
+- **Silent TX after interface restart** (fork bug, both paths equally):
+  the first monitor session after insmod airs; any later `ip link down →
+  set type monitor → up` cycle leaves TX accepted-but-silent until
+  re-insmod. Isolated by cells: fresh-start runs all air (including
+  per-switch cross-band); every post-restart config is silent regardless
+  of `rtw_ch_switch_offload`. Benchmarks here therefore re-insmod per
+  configuration.
+- **Firmware feature absent / H2C rejected / wrong destination /
+  automatic return**: none observed on this chip+firmware — 1696
+  RF-evidenced fw switches across four configurations, every one decoded
+  on the commanded channel, none returned to base autonomously.
+
+## Go/no-go for the series
+
+**Go — and the port target is devourer, not the kernel.** The offload is
+a 3-byte H2C plus a C2H completion on machinery devourer's Jaguar2 HAL
+already has (H2C submit, C2H over the RX path). Adopting it as a
+`FastRetune` fast-path would:
+
+- cut the median hop dark time ~1 ms → ~2.6× (measured headroom, same
+  silicon);
+- add the ~2 ms cross-band hop `FastRetune` lacks;
+- keep devourer's tail discipline (the 2 s stalls are vendor-driver USB
+  housekeeping, absent from devourer's TX path).
+
+Caveats to carry into the port: verify per-rate TX power after fw
+switches (`PWR_IDX_UPDATE_EN` semantics), and the C2H completion must be
+drained — TX-only sessions need `DEVOURER_TX_WITH_RX=thread` or a poll.
+For experiment 3, MCC/FCS remains the scheduler-grade candidate (dwell
+schedules, two contexts); 0x1D is the retune primitive underneath it.

--- a/tests/kchansw_bench.py
+++ b/tests/kchansw_bench.py
@@ -1067,7 +1067,8 @@ def run_vm_config(s: Session, vm: VmDut, cfg: Cfg, vm_iface: str):
         f"--to-ch {cfg.to_ch} --switches {cfg.switches} "
         f"--warmup {cfg.warmup} --dwell-ms {cfg.dwell_ms} "
         f"--roc-ms {cfg.roc_ms} --hz {cfg.inject_hz:.0f} "
-        f"--roc-monitor-vif 0 --out {vm_out}",
+        + (f"--ht {cfg.ht} " if cfg.ht else "")
+        + f"--roc-monitor-vif 0 --out {vm_out}",
         stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True,
         bufsize=1)
     threading.Thread(
@@ -1238,11 +1239,22 @@ def cmd_phase_b_vm(s: Session, a):
     write_manifest(s)
     vm_iface = vm.iface()
     log(f"phase-b-vm: VM kernel {r.stdout.strip()}, DUT iface {vm_iface}")
-    configs = [
-        Cfg("b-set-36-40", "set_channel", 36, 40, a.switches),
-        Cfg("b-roc-36-40", "roc", 36, 40, a.switches_aux,
-            rdev_entry="rdev_remain_on_channel"),
-    ]
+    if a.pairs:
+        # "36:40,1:6,36:44+HT40+" — set-channel only; the first pair gets
+        # the full --switches count, the rest --switches-aux.
+        configs = []
+        for k, spec in enumerate(a.pairs.split(",")):
+            chans, _, ht = spec.partition("+")
+            frm, to = (int(c) for c in chans.split(":"))
+            n = a.switches if k == 0 else a.switches_aux
+            configs.append(Cfg(f"b-set-{frm}-{to}{'-' + ht if ht else ''}",
+                               "set_channel", frm, to, n, ht=ht))
+    else:
+        configs = [
+            Cfg("b-set-36-40", "set_channel", 36, 40, a.switches),
+            Cfg("b-roc-36-40", "roc", 36, 40, a.switches_aux,
+                rdev_entry="rdev_remain_on_channel"),
+        ]
     for cfg in configs:
         if a.primitive not in ("all",) and a.primitive not in cfg.name \
                 and a.primitive != cfg.prim:
@@ -1464,6 +1476,10 @@ def main() -> int:
                                     "phase-b", "phase-b-vm", "phase-c"])
     ap.add_argument("--vm-ssh", default="",
                     help="user@ip of the prepared VM (phase-b-vm)")
+    ap.add_argument("--pairs", default="",
+                    help="phase-b-vm set-channel pair list, e.g. "
+                         "'36:40,1:6,36:44+HT40+' (overrides the default "
+                         "set+roc config list)")
     ap.add_argument("--primitive", default="all",
                     help="filter configs by primitive/name substring")
     ap.add_argument("--dut-pid", default="2357:012d")

--- a/tests/kchansw_fastretune_arm.py
+++ b/tests/kchansw_fastretune_arm.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""FastRetune control arm for the channel-switch offload comparison.
+
+Same instruments as the kchansw kernel benches — two host-side rxdemo
+oracles with tsfl→host-mono fits — but the DUT runs devourer's own
+FastRetune hop loop (txdemo, DEVOURER_HOP_CHANNELS + _FAST), so the
+distributions are directly comparable with the kernel rows: dead air per
+switch = first frame decoded on the destination minus last frame decoded
+on the source.
+
+txdemo hops autonomously (no per-switch request records), so switches are
+segmented from the oracle streams themselves: order all fitted frames,
+every change of decode channel is one switch. With 150 ms dwells and
+~1 ms retunes the alternation edges are unambiguous.
+
+Usage (root, T3U free of kernel drivers):
+  sudo tests/.venv/bin/python tests/kchansw_fastretune_arm.py \
+      --out /tmp/devourer-kchansw-exp2-fastretune \
+      --channels 36,40 --rounds 550 --dwell-frames 300
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import kchansw_bench as kb          # noqa: E402  (Child, spawn_oracle, log)
+import kchansw_analyze as ka        # noqa: E402  (frames, fits)
+import regress                      # noqa: E402
+
+import numpy as np                  # noqa: E402
+
+
+def run_capture(a):
+    out = a.out
+    os.makedirs(out, exist_ok=True)
+    ch_a, ch_b = (int(c) for c in a.channels.split(","))
+    dut = kb.find_dut(a.dut_pid)
+    oa = kb.spawn_oracle("a", kb.find_dut(a.oracle_a_pid), ch_a, "canon", out)
+    ob = kb.spawn_oracle("b", kb.find_dut(a.oracle_b_pid), ch_b, "canon", out)
+    regress.detach_from_host_kernel(dut)
+    env = dict(os.environ)
+    env.update({
+        "DEVOURER_VID": f"0x{dut.vid}", "DEVOURER_PID": f"0x{dut.pid}",
+        "DEVOURER_EVENTS": "stdout", "DEVOURER_LOG_LEVEL": "warn",
+        "DEVOURER_CHANNEL": str(ch_a),
+        "DEVOURER_HOP_CHANNELS": a.channels,
+        "DEVOURER_HOP_DWELL_FRAMES": str(a.dwell_frames),
+        "DEVOURER_HOP_ROUNDS": str(a.rounds),
+        "DEVOURER_HOP_FAST": "1",
+        "DEVOURER_HOP_PROF": "1",
+        "DEVOURER_TX_GAP_US": str(a.tx_gap_us),
+    })
+    if a.hop_bw:
+        env["DEVOURER_HOP_BW"] = a.hop_bw
+    tx = kb.Child("txdemo", [str(kb.REPO / "build" / "txdemo")],
+                  os.path.join(out, "txdemo.jsonl"), env=env, stamp=True,
+                  stderr_path=os.path.join(out, "txdemo.stderr"))
+    kb.log(f"txdemo hopping {a.channels} ×{a.rounds} rounds, "
+           f"dwell {a.dwell_frames} frames @ {1e6 / a.tx_gap_us:.0f} fps")
+    budget = a.rounds * 2 * (a.dwell_frames * a.tx_gap_us / 1e6 + 0.05) + 60
+    end = time.monotonic() + budget
+    while time.monotonic() < end and tx.alive():
+        time.sleep(2)
+    alive = tx.alive()
+    tx.stop()
+    oa.stop()
+    ob.stop()
+    with open(os.path.join(out, "meta.json"), "w") as f:
+        json.dump({"cfg": f"fastretune-{ch_a}-{ch_b}", "from": ch_a,
+                   "to": ch_b, "rounds": a.rounds,
+                   "dwell_frames": a.dwell_frames,
+                   "tx_gap_us": a.tx_gap_us, "hop_bw": a.hop_bw,
+                   "tx_overran": alive}, f, indent=1)
+    kb.log(f"capture done (txdemo overran budget: {alive})")
+
+
+def analyze(a):
+    out = a.out
+    ch_a, ch_b = (str(c) for c in a.channels.split(","))
+    streams = {}
+    for role, ch in (("a", ch_a), ("b", ch_b)):
+        frames = ka.unwrap_tsfl(
+            ka.oracle_frames(os.path.join(out, f"oracle_{role}.jsonl")))
+        fit = ka.fit_tsfl(frames)
+        if not fit.get("ok"):
+            print(f"oracle_{role}: FIT BAD {fit}")
+            return 1
+        for fr in frames:
+            fr["t"] = ka.fitted_ns(fit, fr)
+        frames.sort(key=lambda fr: fr["t"])
+        streams[ch] = frames
+        print(f"oracle_{role}(ch{ch}): n={len(frames)} "
+              f"σ={fit['residual_std_ns'] / 1e3:.0f}µs "
+              f"slope_err={fit['slope_err_ppm']:.0f}ppm")
+    merged = [(fr["t"], ch) for ch, frs in streams.items() for fr in frs]
+    merged.sort()
+    # Collapse to dwell runs; drop micro-runs (isolated cross-channel
+    # decodes would otherwise split one dwell in two). Dead air = gap
+    # between consecutive surviving runs.
+    dead = []
+    edges = []
+    cur = None
+    for t, ch in merged:
+        if ch != cur:
+            edges.append([ch, t, t])
+            cur = ch
+        else:
+            edges[-1][2] = t
+    # Filter out micro-runs (isolated cross-channel decodes).
+    min_run_ns = a.dwell_ms_floor * 1e6
+    edges = [e for e in edges if e[2] - e[1] >= min_run_ns]
+    for k in range(1, len(edges)):
+        dead.append(edges[k][1] - edges[k - 1][2])
+    d = np.array(dead, dtype=float) / 1e6
+    d = d[(d >= 0) & (d < 1000)]
+    res = {
+        "n_switches": int(len(d)),
+        "dead_ms": {"median": float(np.median(d)),
+                    "p90": float(np.percentile(d, 90)),
+                    "p99": float(np.percentile(d, 99)),
+                    "max": float(d.max())},
+    }
+    print(json.dumps(res, indent=2))
+    with open(os.path.join(out, "fastretune_summary.json"), "w") as f:
+        json.dump(res, f, indent=2)
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("mode", choices=["run", "analyze", "both"])
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--channels", default="36,40")
+    ap.add_argument("--rounds", type=int, default=550)
+    ap.add_argument("--dwell-frames", type=int, default=300)
+    ap.add_argument("--tx-gap-us", type=int, default=500)
+    ap.add_argument("--hop-bw", default="")
+    ap.add_argument("--dut-pid", default="2357:012d")
+    ap.add_argument("--oracle-a-pid", default="2357:0120")
+    ap.add_argument("--oracle-b-pid", default="0bda:c812")
+    ap.add_argument("--min-run", type=int, default=10)
+    ap.add_argument("--dwell-ms-floor", type=float, default=20.0,
+                    help="dwell runs shorter than this are decode blips")
+    a = ap.parse_args()
+    if a.mode in ("run", "both"):
+        if os.geteuid() != 0:
+            sys.stderr.write("run mode needs root\n")
+            return 2
+        regress._install_cleanup_handlers()
+        run_capture(a)
+        sudo_user = os.environ.get("SUDO_USER")
+        if sudo_user:
+            import subprocess
+            subprocess.run(["chown", "-R", f"{sudo_user}:", a.out],
+                           capture_output=True)
+    if a.mode in ("analyze", "both"):
+        return analyze(a)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/kchansw_trace.py
+++ b/tests/kchansw_trace.py
@@ -91,6 +91,10 @@ VENDOR_PROBES = [
     ("kc_chip_set_channel", "phy_SwChnlAndSetBwMode8822B", True),
     ("kc_h2c", "rtw_hal_fill_h2c_cmd", True),
     ("kc_tdls_ch_sw_offload", "rtw_hal_ch_sw_oper_offload", True),
+    # The 8822B's actual fw switch (H2C 0x1D SINGLE_CHANNELSWITCH_V2,
+    # armed by rtw_ch_switch_offload=1): entry→return brackets the H2C
+    # submit + the C2H CUR_CHANNEL completion wait (sctx timeout 10 ms).
+    ("kc_fw_ch_sw", "rtw_hal_switch_chnl_and_set_bw_offload", True),
 ]
 RTW89_PROBES = [
     ("kc_drv_set_channel", "rtw89_set_channel", True),

--- a/tests/kchansw_vm.sh
+++ b/tests/kchansw_vm.sh
@@ -20,7 +20,9 @@
 #   tests/kchansw_vm.sh status
 #
 # Env: VM_NAME (devourer-testrig), VM_USER (invoking user), DUT_VIDPID
-# (2357:012d), USB3_PORT_DISABLE (usb10-port2 — empty to skip the USB2 pin).
+# (2357:012d), USB3_PORT_DISABLE (usb10-port2 — empty to skip the USB2 pin),
+# VM_MODPARAMS (extra insmod params, e.g. rtw_ch_switch_offload=1 to route
+# every set-channel through the 8822B fw offload H2C 0x1D).
 
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -90,7 +92,7 @@ vm_load() {
   vssh "sudo rmmod 88x2bu_ohd 2>/dev/null; sudo rmmod 8812bu 2>/dev/null; \
         ko=\$(ls -t $VM_DIR/rtl88x2bu/*.ko | head -1); \
         sudo modprobe cfg80211 && \
-        sudo insmod \$ko rtw_wifi_spec=1 && \
+        sudo insmod \$ko rtw_wifi_spec=1 ${VM_MODPARAMS:-} && \
         for i in \$(seq 1 20); do \
           w=\$(ls /sys/class/net | grep -v -e lo -e enp | head -1); \
           [ -n \"\$w\" ] && { echo NETDEV=\$w; exit 0; }; sleep 0.5; \

--- a/tests/kchansw_vm_dut.py
+++ b/tests/kchansw_vm_dut.py
@@ -41,13 +41,14 @@ def ch_to_freq(ch):
     return 5000 + 5 * ch if ch > 14 else 2407 + 5 * ch
 
 
-def set_monitor(iface, ch):
+def set_monitor(iface, ch, ht=""):
     run(["ip", "link", "set", iface, "down"])
     r = run(["iw", "dev", iface, "set", "type", "monitor"])
     if r.returncode != 0:
         raise RuntimeError(f"set type monitor: {r.stderr.strip()}")
     run(["ip", "link", "set", iface, "up"])
-    r = run(["iw", "dev", iface, "set", "channel", str(ch)])
+    r = run(["iw", "dev", iface, "set", "channel", str(ch)]
+            + ([ht] if ht else []))
     if r.returncode != 0:
         raise RuntimeError(f"set channel {ch}: {r.stderr.strip()}")
 
@@ -71,8 +72,8 @@ def loop_set_channel(a, ctl, ts):
                   f"from={frm} to={to} mono={t_req}")
         ctl.write(json.dumps({"ev": "kchansw.req", "i": i, "from": frm,
                               "to": to, "mono_ns": t_req}) + "\n")
-        r = run(["iw", "dev", a.iface, "set", "channel", str(to)],
-                timeout=10)
+        r = run(["iw", "dev", a.iface, "set", "channel", str(to)]
+                + ([a.ht] if a.ht else []), timeout=10)
         t_done = time.monotonic_ns()
         ctl.write(json.dumps({"ev": "kchansw.done", "i": i,
                               "mono_ns": t_done, "rc": r.returncode,
@@ -127,6 +128,7 @@ def main():
     ap.add_argument("--warmup", type=int, default=10)
     ap.add_argument("--dwell-ms", type=int, default=150)
     ap.add_argument("--roc-ms", type=int, default=20)
+    ap.add_argument("--ht", default="", help="HT40+/HT40- on both endpoints")
     ap.add_argument("--hz", type=float, default=2000.0)
     ap.add_argument("--roc-monitor-vif", type=int, default=1,
                     help="0 = trace-only ROC: do NOT add the second monitor "
@@ -145,7 +147,7 @@ def main():
 
     roc_mon = None
     if a.prim == "set-channel":
-        set_monitor(a.iface, a.from_ch)
+        set_monitor(a.iface, a.from_ch, a.ht)
         inj_iface = a.iface
     else:
         # ROC needs a managed iface; a second monitor vif carries the


### PR DESCRIPTION
Closes #270.

Follows #269's go/no-go nomination and corrects it at the source level: on the 8822B, H2C 0x1C `CHNL_SWITCH_OPER_OFFLOAD` is TDLS-V1 dead code (`hal_ic_cfg.h` selects `CONFIG_TDLS_CH_SW_V2`). The chip's real firmware switch is **H2C 0x1D `SINGLE_CHANNELSWITCH_V2`** — 3-byte payload (central ch / primary-ch idx / bw / PWR+IQK update flags), completion via C2H `CUR_CHANNEL` (≤10 ms sctx wait) — wired into the *normal* set-channel path behind the stock `rtw_ch_switch_offload` module parameter. No TDLS peer, association, or MAC-ID involved: the issue's "research harness outside TDLS" ships in the driver, and every benchmark below is on-air-corroborated by the #269 oracles, never by return code.

## Measured (≥1000 warm switches per headline row, VM venue, host-side oracles)

| arm (36↔40, 5 GHz) | n | dead-air med | p99 | max | host cost |
|---|---|---|---|---|---|
| fw offload H2C 0x1D | 1000/1000 | **1.03 ms** | 4.33 | 1978.6 | 13.5 ms nl80211; H2C→C2H itself **1.94 ms** |
| driver path (same module) | 998/1000 | 1.08 ms | 1.68→4.42 | 32.9 | 66.3 ms |
| devourer `FastRetune` | 1099 | 2.75 ms | 5.44 | **7.1** | 1.82 ms register writes |

Plus: HT40 0.98 ms med (advance), **per-switch cross-band 36↔6 in 1.95 ms** (100/100 — a capability `FastRetune` lacks; band changes fall back to its ~90 ms full path), direction asymmetry 36→40 1.52 ms vs 40→36 0.43 ms.

Failure classification per the issue taxonomy: 21/1010 benign C2H timeouts (RF still switched, state consistent), 3/1010 ~2 s vendor-USB housekeeping stalls (why `FastRetune` keeps the better tail), 2.4 GHz cells flagged decode-limited (ch-1 oracle sparsity), and one fork bug isolated by cell design — TX goes silent after any *second* monitor bring-up until re-insmod, equally on both paths, briefly masquerading as "offload breaks on band change".

**Go/no-go: go — and the port target is devourer, not the kernel.** 0x1D is a 3-byte H2C + C2H completion on machinery the Jaguar2 HAL already has; as a `FastRetune` fast path it buys ~2.6× median dark time and ~2 ms cross-band hops while keeping devourer's tail discipline. Port caveats (TXAGC verification after fw switches, C2H needs the RX path drained) are documented.

## What's in the PR

- `docs/kernel-channel-switch-offload.md` — protocol, call graph, distributions, failure classification, go/no-go.
- `tests/kchansw_fastretune_arm.py` — the devourer control arm: same oracles/fits, txdemo `FastRetune` hopping, oracle-side alternation segmentation (no markers needed), `hop.prof` corroboration.
- kchansw harness extensions: `phase-b-vm --pairs` channel-pair matrix (+ HT plumb-through to the VM DUT driver), `VM_MODPARAMS` on the VM module loader, and a `kc_fw_ch_sw` kprobe pair bracketing the H2C→C2H round trip.

Raw per-switch CSVs stay in `/tmp` (regenerable); the doc carries the summaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)