### PR TITLE
Jaguar2: firmware channel-switch fast path — 1.4 ms hops, 1.9 ms cross-band (8822B H2C 0x1D)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,7 +317,10 @@ temporal layer and injects each at its ladder's rate
 `IRtlDevice::FastRetune(channel)` — lean intra-band, same-bandwidth retune on
 every generation (RF channel switch only, write-only from a compose cache);
 falls back to full `SetMonitorChannel` on a band change. FHSS-grade: ~0.5–2.5 ms
-per hop depending on chip. `send_packet` honours a radiotap `CHANNEL` field, so
+per hop depending on chip. On the 8822B, `DEVOURER_FASTRETUNE_FW=1` hands the
+hop to the chip firmware instead (H2C 0x1D, fire-and-confirm-later): ~1.4 ms
+dead air, and `=2` extends it to **cross-band** hops (~1.9 ms vs the ~90 ms
+full path) — protocol + bench: `docs/kernel-channel-switch-offload.md`. `send_packet` honours a radiotap `CHANNEL` field, so
 hopping is per-packet and radiotap-driven like rate. Demos hop via
 `DEVOURER_HOP_CHANNELS` (SweepSpec grammar: `1,6,11`, `36-48/4`, `5170-5250/5`
 MHz) + `DEVOURER_HOP_DWELL_FRAMES` / `_ROUNDS` / `_FAST` / `_RADIOTAP` /

--- a/docs/kernel-channel-switch-offload.md
+++ b/docs/kernel-channel-switch-offload.md
@@ -103,6 +103,36 @@ Reading:
   RF-evidenced fw switches across four configurations, every one decoded
   on the commanded channel, none returned to base autonomously.
 
+## The devourer port (`DEVOURER_FASTRETUNE_FW`)
+
+The offload is now a `FastRetune` fast path in the Jaguar2 HAL
+(`HalJaguar2::fw_channel_switch`, 8822B only): the H2C rides the classic
+HMEBOX mailboxes devourer already drives, and completion is
+**fire-and-confirm-later** — polling RF18 during the switch measurably
+*stretched* it (the PI reads contend with the firmware's RF-bus writes;
+on-air dead time tripled), and the vendor's C2H wait needs an RX drain a
+TX-only session doesn't have. Instead the next hop corroborates the
+previous switch with one RF18 read (which doubles as the compose-cache
+re-prime); a miss resyncs through the full path. `DEVOURER_FASTRETUNE_FW=1`
+enables it for intra-band 20/40 MHz hops, `=2` also hands **cross-band**
+hops to the firmware (band block reprogrammed by fw; active TX-power knobs
+re-fold host-side).
+
+Same rig, same oracles, same segmentation as the arms above (n≥399 each):
+
+| devourer arm (dead air) | med | p90 | p99 | max |
+|---|---|---|---|---|
+| `FastRetune` software path, 36↔40 | 2.75 ms | 3.59 | 5.44 | 7.10 |
+| fw path (`=1`), 36↔40 | **1.44 ms** | 2.72 | 5.05 | 9.05 |
+| fw path (`=2`), 36↔6 cross-band | **1.86 ms** | 5.95 | 10.76 | 18.23 |
+
+The fw path halves the median dark time and turns the cross-band hop from
+a ~90 ms full-path event into ~2 ms — with none of the vendor driver's
+2 s stalls (1499 devourer fw switches, max 18 ms), and sustained TX
+across 400 consecutive band changes (no silent-TX). Hopping RX is
+unaffected: identical decode counts over identical hop-RX runs with the
+path on and off.
+
 ## Go/no-go for the series
 
 **Go — and the port target is devourer, not the kernel.** The offload is

--- a/examples/common/env_config.cpp
+++ b/examples/common/env_config.cpp
@@ -114,6 +114,8 @@ devourer::DeviceConfig devourer_config_from_env() {
   if (const char *e = env_str("DEVOURER_THERMAL_TRACK"))
     cfg.tuning.thermal_track = std::strcmp(e, "0") != 0;
   cfg.tuning.disable_cca = env_flag("DEVOURER_DIS_CCA");
+  if (env_long("DEVOURER_FASTRETUNE_FW", &v) && v >= 0)
+    cfg.tuning.fastretune_fw = static_cast<int>(v);
   /* Jaguar3 per-packet power-bank step size (qdB per 0x1e70 offset-index
    * step; default 4 = 1 dB) — bench slope-calibration override. */
   if (env_long("DEVOURER_TXPKT_STEP_QDB", &v) && v > 0)

--- a/src/DeviceConfig.h
+++ b/src/DeviceConfig.h
@@ -206,6 +206,14 @@ struct DeviceConfig {
      * MIX_MODE swing compensation (0xc94/0xe94 TXAGC + 0xc1c/0xe1c BB scale)
      * so on-air power holds flat as the PA heats over a sustained TX link. */
     bool thermal_track = true;
+    /* env: DEVOURER_FASTRETUNE_FW — Jaguar2 8822B FastRetune firmware fast
+     * path (H2C 0x1D SINGLE_CHANNELSWITCH_V2, the switch the vendor driver
+     * gates behind rtw_ch_switch_offload): 0 = off (software compose path),
+     * 1 = firmware switch for intra-band 20/40 MHz hops, 2 = additionally
+     * accept cross-band hops (the firmware reprograms the band block; TXAGC
+     * baseline stays the bring-up band's — active power knobs re-fold).
+     * Bench + protocol: docs/kernel-channel-switch-offload.md. */
+    int fastretune_fw = 0;
     /* env: DEVOURER_DIS_CCA — Jaguar2/3 MAC carrier-sense disable at bring-up
      * (primary CCA 0x520[14] + EDCCA [15]): injected/beacon TX stops deferring to
      * a busy channel and punches through co-channel traffic. Runtime equivalent:

--- a/src/jaguar2/CLAUDE.md
+++ b/src/jaguar2/CLAUDE.md
@@ -34,6 +34,14 @@ Jaguar1 (shared `PhyTableLoader`).
   RF18-edge bug.
 - The TXAGC block is write-only, so `GetTxPowerState` reports the software
   shadow (`hw_readback=false`).
+- **8822B firmware channel switch** (H2C 0x1D `SINGLE_CHANNELSWITCH_V2`,
+  `fw_channel_switch` + the `fastretune_fw` knob): the fw executes the whole
+  retune in ~1–2 ms and reports C2H `CUR_CHANNEL`. Never poll RF18 *during*
+  the switch — the PI reads contend with the firmware's RF-bus writes and
+  triple the on-air dark time; confirm the previous switch at the next hop
+  instead (`fw_switch_confirm`). Classic 8-byte H2Cs ride the HMEBOX
+  mailboxes (0x1d0/0x1f0 + 0x1cc busy bits), distinct from MacInit's 32-byte
+  h2c-pkt queue.
 
 ## Per-packet TX power
 

--- a/src/jaguar2/HalJaguar2.cpp
+++ b/src/jaguar2/HalJaguar2.cpp
@@ -827,6 +827,7 @@ void HalJaguar2::set_channel_bw(uint8_t channel, uint8_t bw, uint8_t rfe_type,
   _last_rf_be = -1;
   _last_df18 = -1;
   _last_cck_key = -1;
+  _fw_sw_pending = 0; /* the full set supersedes any in-flight fw switch */
 
   /* Extended-synth channels (below-band 15..35 / above 177, freq =
    * 5000 + 5*ch up to ch 253): the RF tunes them, but the power tables and
@@ -1270,15 +1271,113 @@ bool HalJaguar2::fast_set_bandwidth(uint8_t bw) {
   return true;
 }
 
+void HalJaguar2::send_h2c_raw(uint32_t msg, uint32_t msg_ext) {
+  const uint8_t box = _h2c_box & 0x3;
+  const uint16_t box_reg = static_cast<uint16_t>(0x1d0 + box * 4);
+  const uint16_t box_ex_reg = static_cast<uint16_t>(0x1f0 + box * 4);
+  for (int i = 0; i < 30; ++i) { /* mirrors the vendor's 100 µs × N poll */
+    if (((_device.rtw_read8(0x1cc) >> box) & 0x1) == 0)
+      break;
+    std::this_thread::sleep_for(std::chrono::microseconds(100));
+  }
+  _device.rtw_write32(box_ex_reg, msg_ext); /* ext first, msg triggers */
+  _device.rtw_write32(box_reg, msg);
+  _h2c_box = static_cast<uint8_t>((_h2c_box + 1) & 0x3);
+}
+
+bool HalJaguar2::fw_channel_switch(uint8_t central, uint8_t pri_ch_idx,
+                                   uint8_t bw) {
+  /* Payload (hal_com_h2c.h SET_H2CCMD_SINGLE_CH_SWITCH_V2_*): b0 = central
+   * channel, b1[3:0] = primary-ch idx, b1[7:4] = bw, b2[1] = IQK_UPDATE_EN
+   * (the vendor sets IQK only — PWR_IDX_UPDATE stays 0, so the firmware does
+   * not touch TXAGC and the software power shadow stays truthful).
+   *
+   * Fire-and-confirm-later: the submit returns immediately — polling RF18
+   * here measurably STRETCHES the switch (the PI reads contend with the
+   * firmware's own RF-bus writes; on-air dead time tripled vs the deferred
+   * scheme), and the vendor's C2H completion needs a live RX drain devourer
+   * can't assume. The *previous* switch is corroborated at the next hop via
+   * fw_switch_confirm(), by which point a dwell has passed. */
+  const uint32_t msg = 0x1du | (static_cast<uint32_t>(central) << 8) |
+                       (static_cast<uint32_t>((pri_ch_idx & 0xf) |
+                                              ((bw & 0xf) << 4))
+                        << 16) |
+                       (0x02u << 24);
+  send_h2c_raw(msg, 0);
+  _fw_sw_pending = central;
+  /* The firmware rewrites RF18 (and band/AGC state) under the sw caches. */
+  _cw_primed = false;
+  return true;
+}
+
+bool HalJaguar2::fw_switch_confirm() {
+  if (!_fw_sw_pending)
+    return true;
+  const uint8_t want = _fw_sw_pending;
+  _fw_sw_pending = 0;
+  const uint32_t rf18 = rf_read(0, 0x18);
+  if ((rf18 & 0xff) == want) {
+    _rf18_cache = rf18; /* doubles as the compose-cache RF18 re-prime */
+    return true;
+  }
+  _logger->warn("Jaguar2: fw channel switch to central {} never landed "
+                "(RF18=0x{:05x}) — resyncing via the full path",
+                want, rf18);
+  return false;
+}
+
 bool HalJaguar2::fast_retune(uint8_t channel, uint8_t bw,
                              uint8_t primary_ch_idx, bool cache_rf) {
   if (_last_tuned_ch == 0)
     return false; /* never tuned — unknown band, cold BW/band state */
   const bool cur_2g = _last_tuned_ch <= 14;
-  if (cur_2g != (channel <= 14))
-    return false; /* band change needs RFE pins / band block — full path only */
+  const bool band_change = cur_2g != (channel <= 14);
   if (channel == _last_tuned_ch)
     return true; /* no-op hop */
+
+  /* Firmware fast path (DEVOURER_FASTRETUNE_FW): hand the whole retune to
+   * the 8822B firmware via H2C 0x1D instead of the composed register
+   * sequence below. Mode 2 additionally accepts band changes — the firmware
+   * reprograms the band block itself (bench-measured ~2 ms cross-band,
+   * docs/kernel-channel-switch-offload.md) — which the software path cannot.
+   * 20/40 MHz only (the 80 MHz primary-idx pairing stays on the sw path). */
+  if (_cfg.tuning.fastretune_fw > 0 && _variant == ChipVariant::C8822B &&
+      (!band_change || _cfg.tuning.fastretune_fw >= 2) &&
+      (bw == 0 /*20*/ || bw == 1 /*40*/)) {
+    devourer::HopProf prof(_logger->events(), _cfg.debug.hop_prof, "j2fw",
+                           channel);
+    /* Corroborate the PREVIOUS fw switch before issuing the next (a dwell
+     * has passed — one cheap RF18 read). A miss falls through to the full
+     * path so software state and hardware resync. */
+    if (!fw_switch_confirm())
+      return false;
+    prof.mark("confirm");
+    const uint8_t cch = central_ch(channel, bw, primary_ch_idx);
+    /* get_pri_ch_id encoding: 20 MHz -> 0; 40 MHz upper -> 1, lower -> 2. */
+    uint8_t pri = 0;
+    if (bw == 1)
+      pri = (primary_ch_idx == 2 /*HAL_PRIME_CHNL_OFFSET_UPPER*/) ? 1 : 2;
+    fw_channel_switch(cch, pri, bw);
+    prof.mark("fw");
+    if (band_change) {
+      /* The firmware rewrote the band-keyed state under the sw caches —
+       * invalidate them all; the next sw hop re-primes. */
+      _last_agc_bucket = -1;
+      _last_fc = 0xffffffff;
+      _last_rf_be = -1;
+      _last_df18 = -1;
+      _last_cck_key = -1;
+    }
+    _last_tuned_ch = channel;
+    DVR_DEBUG(_logger, "Jaguar2: fw fast retune -> ch {} (central {})",
+              channel, cch);
+    /* No canary here: the switch is still executing in firmware — a dump
+     * would read mid-transition state (and disturb the RF bus). */
+    return true;
+  }
+
+  if (band_change)
+    return false; /* band change needs RFE pins / band block — full path only */
 
   devourer::HopProf prof(_logger->events(), _cfg.debug.hop_prof, "j2",
                          channel);

--- a/src/jaguar2/HalJaguar2.h
+++ b/src/jaguar2/HalJaguar2.h
@@ -175,6 +175,28 @@ public:
   bool fast_retune(uint8_t channel, uint8_t bw, uint8_t primary_ch_idx,
                    bool cache_rf);
 
+  /* Classic 8-byte H2C over the HMEBOX mailboxes (msg at 0x1d0+box*4, ext at
+   * 0x1f0+box*4, REG_HMETFR 0x1cc busy bits) — the rtw_halmac_send_h2c wire,
+   * distinct from the 32-byte h2c-pkt queue MacInit uses. */
+  void send_h2c_raw(uint32_t msg, uint32_t msg_ext);
+
+  /* Firmware-offloaded channel switch — H2C 0x1D SINGLE_CHANNELSWITCH_V2
+   * (central ch, primary-ch idx, bw, IQK_UPDATE_EN), the switch the vendor
+   * driver runs behind its rtw_ch_switch_offload=1 module parameter. The
+   * 8822B firmware executes the whole RF/BB retune (~1 ms on-air dark time,
+   * bench: docs/kernel-channel-switch-offload.md) and reports C2H
+   * CUR_CHANNEL; devourer corroborates by polling the RF18 channel field
+   * instead, so TX-only sessions need no C2H drain — and the confirm read
+   * doubles as the compose-cache re-prime. Returns false when the readback
+   * never lands (caller falls back to the software path). 8822B only. */
+  bool fw_channel_switch(uint8_t central, uint8_t pri_ch_idx, uint8_t bw);
+
+  /* Corroborate the last fw_channel_switch on hardware (one RF18 read; a
+   * dwell has passed by the time this is called from the next hop). False =
+   * the firmware never landed the switch — caller resyncs via the full
+   * path. */
+  bool fw_switch_confirm();
+
   /* Channel/BW register-canary dump for tests/hop_parity_check.sh — the same
    * grep format as the Jaguar1/Jaguar3 DumpCanary. Emitted by both the full
    * and fast channel paths when DEVOURER_DUMP_CANARY is set. Live registers
@@ -301,6 +323,8 @@ private:
   int _last_df18 = -1;   /* 8822B ch144 RF 0xdf[18] state */
   int _last_cck_key = -1; /* 2G spur (8822B) / CCK-filter (8821C) key: ch14? */
   bool _warned_uncharacterized = false; /* one-shot extended-channel warning */
+  uint8_t _h2c_box = 0; /* round-robin HMEBOX index for send_h2c_raw */
+  uint8_t _fw_sw_pending = 0; /* central ch of an unconfirmed fw switch */
 
   /* fast_set_bandwidth cache: the values a full set_channel_bw computes for the
    * current channel, so a same-channel 20<->5/10 toggle can replay the

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -813,9 +813,17 @@ void RtlJaguar2Device::FastRetune(uint8_t channel, bool cache_rf) {
     return;
   /* Serialize against the thermal-track tick's RF-window read. */
   std::lock_guard<std::mutex> lk(_reg_mu);
+  const bool band_change = (_channel.Channel <= 14) != (channel <= 14);
   if (_hal.fast_retune(channel, static_cast<uint8_t>(_channel.ChannelWidth),
                        _channel.ChannelOffset, cache_rf)) {
     _channel.Channel = channel;
+    /* Only the fw fast path (DEVOURER_FASTRETUNE_FW=2) accepts a band
+     * change; the firmware retunes the chip but TXAGC folding is host-side —
+     * re-fold active power knobs against the new band's table (the same
+     * gating SetMonitorChannel applies). */
+    if (band_change && _brought_up &&
+        (_tx_pwr_offset_steps != 0 || _tx_pwr_override >= 0))
+      apply_tx_power_current();
     return;
   }
   /* Fast path declined (band change / never tuned) — full channel set at the


### PR DESCRIPTION
The devourer-side port that #270's go/no-go nominated: `DEVOURER_FASTRETUNE_FW` hands the FastRetune hop to the 8822B chip firmware via **H2C 0x1D `SINGLE_CHANNELSWITCH_V2`** over the classic HMEBOX mailboxes (Jaguar2 gains `send_h2c_raw`, mirroring Jaguar3's). `=1` covers intra-band 20/40 MHz hops; `=2` additionally accepts **cross-band** hops — the firmware reprograms the band block itself, active TX-power knobs re-fold host-side, and the band-keyed compose caches invalidate.

**Completion is fire-and-confirm-later**, and that design choice is the whole result: polling RF18 *during* the switch contends with the firmware's own RF-bus writes and tripled the on-air dark time (9.4 ms measured). Instead the submit returns immediately and the *next* hop corroborates the previous switch with one RF18 read — which doubles as the compose-cache re-prime; a miss warns and resyncs through the full path. No C2H dependency, so TX-only sessions work. `IQK_UPDATE_EN=1`, `PWR_IDX_UPDATE_EN=0` — the firmware never touches TXAGC, so the software power shadow stays truthful.

## On-air validation (kchansw oracles, chip-clock fits, T3U)

| arm (dead air) | n | med | p90 | p99 | max |
|---|---|---|---|---|---|
| FastRetune software path, 36↔40 | 1099 | 2.75 ms | 3.59 | 5.44 | 7.10 |
| **fw path `=1`, 36↔40** | 1099 | **1.44 ms** | 2.72 | 5.05 | 9.05 |
| **fw path `=2`, 36↔6 cross-band** | 399 | **1.86 ms** | 5.95 | 10.76 | 18.23 |

Median dark time halved; the cross-band hop drops from the ~90 ms full-path fallback to under 2 ms. Sustained TX across 400 consecutive band changes, hopping-RX decode identical with the path on and off (matched 60 s runs), ctest 36/36, and the default (`=0`) software path is behaviorally unchanged.

Docs: port section in `docs/kernel-channel-switch-offload.md`, hopping paragraph in the root `CLAUDE.md`, and the RF18-contention lesson in `src/jaguar2/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)