### PR TITLE
Adaptive FHSS: authenticated hopset state and commit protocol (issue #263)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,20 @@ resilience: `tests/run_jammer_resilience.sh` + `tests/sdr_follower_jammer.py`
 (B210 follower, reactive vs predictive). Article + results: `docs/fhss.md`,
 `docs/jammer-resilience.md`.
 
+**Adaptive hopset** (`src/hopset/`, header-only, ctest-gated): the immutable
+base hopset carries a per-generation `active_mask`; TX is the schedule
+authority (RX proposes, TX commits an absolute future activation slot,
+repeated until it arrives) over SipHash-MAC'd Proposal/Commit/Status frames
+with schedule/control keys domain-separated from `DEVOURER_HOP_SEED`. Gen 0 ≡
+the legacy fixed schedule byte-for-byte; gen ≥ 1 re-keys the permutation from
+(subkey, generation, round, mask). Acquisition always scans the base hopset;
+the v2 sync marker advertises (generation, mask fp) so a follower that missed
+the commits recovers from the status beacon. Demos:
+`DEVOURER_HOP_ADAPTIVE=1` (keyed slot mode only) +
+`DEVOURER_HOP_ADAPTIVE_SCRIPT="slot:mask,..."` (txdemo authority lever until
+the exclusion policy exists); `hopset.*` events; on-air run
+`tests/hopset_adaptive_onair.sh`. Wire/state-machine doc: `docs/fhss.md`.
+
 `IRtlDevice::FastSetBandwidth(bw)` is the bandwidth analogue — a lean
 same-channel toggle between 20 MHz and 5/10 MHz narrowband (baseband re-clock
 only; ~0.18 ms on the 8812AU vs ~90 ms for the full `SetMonitorChannel`);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,12 @@ add_library(devourer
     src/chanmig/MigClock.h
     src/chanmig/MigProposer.h
     src/chanmig/MigResponder.h
+    src/hopset/HopsetState.h
+    src/hopset/HopsetTypes.h
+    src/hopset/HopsetWire.h
+    src/hopset/HopsetAuthority.h
+    src/hopset/HopsetFollower.h
+    src/hopset/HopsetEvents.h
     src/IRtlDevice.h
     src/SignalStop.cpp
     src/SignalStop.h
@@ -786,6 +792,27 @@ add_test(NAME sweep_spec_math COMMAND SweepSpecSelftest)
 add_executable(HopScheduleSelftest tests/hop_schedule_selftest.cpp)
 target_link_libraries(HopScheduleSelftest PRIVATE devourer)
 add_test(NAME hop_schedule_math COMMAND HopScheduleSelftest)
+
+# Adaptive-hopset gates (src/hopset/): schedule derivation KATs + exact-once
+# masked coverage + stateless direct join; wire codec known-answer bytes, MAC
+# tamper/truncation sweeps, and replay rules; the authority/follower pure
+# machines through a lossy LinkSim failure matrix; and the process-level
+# synchronized-activation / missed-commit-recovery run.
+add_executable(HopsetScheduleSelftest tests/hopset_schedule_selftest.cpp)
+target_link_libraries(HopsetScheduleSelftest PRIVATE devourer)
+add_test(NAME hopset_schedule_math COMMAND HopsetScheduleSelftest)
+
+add_executable(HopsetWireSelftest tests/hopset_wire_selftest.cpp)
+target_link_libraries(HopsetWireSelftest PRIVATE devourer)
+add_test(NAME hopset_wire_kat COMMAND HopsetWireSelftest)
+
+add_executable(HopsetProtoSelftest tests/hopset_proto_selftest.cpp)
+target_link_libraries(HopsetProtoSelftest PRIVATE devourer)
+add_test(NAME hopset_proto_matrix COMMAND HopsetProtoSelftest)
+
+add_executable(HopsetActivationSelftest tests/hopset_activation_selftest.cpp)
+target_link_libraries(HopsetActivationSelftest PRIVATE devourer)
+add_test(NAME hopset_activation_sync COMMAND HopsetActivationSelftest)
 
 # Headless guard for the TX-power offset quantization (src/TxPower.h) — the
 # qdB->index-step rounding/clamping behind SetTxPowerOffsetQdb, so a rounding

--- a/docs/fhss.md
+++ b/docs/fhss.md
@@ -210,6 +210,94 @@ land on a keyed hopper, while a predictive jammer against a sequential hopper is
 limited only by its retune time and holds to much shorter dwells. The gap
 between those two thresholds is exactly what a keyed permutation buys.
 
+## Adaptive hopset: authenticated state and commit protocol
+
+The fixed schedule visits every configured channel; a persistently-jammed one
+costs 1/N of every FEC block forever. The adaptive layer (`src/hopset/`) is the
+deterministic state model and authenticated control protocol that lets both
+ends *exclude* channels — it deliberately does not decide which channel is bad
+(that observation policy is a separate stage; today the lever is a scripted
+commit).
+
+### State model
+
+The configured base hopset is **immutable**; every adaptive state names its
+active channels by stable base-hopset bit positions:
+
+```
+HopsetState { epoch, generation, active_mask, activate_round, activate_slot }
+```
+
+Generation 0 is defined as the legacy fixed schedule (full mask, raw master
+key) — byte-identical to non-adaptive operation, pinned by KAT. From
+generation 1 on, each round's permutation derives from `(schedule subkey,
+generation, round, active_mask)`: SipHash words tagged `'A'` drive the same
+rejection-sampled Fisher–Yates over the popcount-of-mask active positions,
+mapped back through the mask to base indices. Including the generation in the
+word means a mask change produces a *fresh* keyed order — not a filtered form
+of the old permutation a follower-jammer could have partially learned. The
+lookup stays a pure function of (keys, committed state, absolute slot), so a
+receiver still joins mid-generation with no RNG state
+(`hopset/HopsetState.h`, `AdaptiveScheduleView`).
+
+Two keys derive from `DEVOURER_HOP_SEED` with explicit domain separation
+(`devourer-hopset-s*/c*`): the schedule subkey orders the hops, the control
+key MACs the protocol. A schedule fingerprint is **not** authentication; the
+`base_fp`/`mask_fp` fields are config-mismatch tripwires, the SipHash-2-4 MAC
+is the auth. Sequential (keyless) mode therefore cannot be adaptive — the
+demos reject the combination.
+
+### Protocol
+
+Three versioned, MAC'd messages (`hopset/HopsetWire.h`, byte layouts pinned in
+`hopset_wire_kat`): **HopsetProposal** (RX → TX: proposed mask, observation
+count, reason bitmap, nonce), **HopsetCommit** (TX → RX, broadcast: the new
+generation/mask and the activation instant as both a round index and an
+absolute slot), **HopsetStatus** (the authority's periodic beacon: current
+generation/mask/round + activation anchor; doubles as the proposal-rejection
+answer via a nonce echo).
+
+The TX is the schedule authority (`HopsetAuthority`): a receiver proposes,
+the transmitter validates policy — mask legality against the base, a
+configurable minimum-diversity floor, monotonic generations, an activation
+lead of at least 8 rounds — then repeatedly broadcasts an identical commit
+until the named slot arrives, and both sides swap state exactly there
+(`HopsetFollower`). Rejections carry a reason code; every transition emits a
+`hopset.*` JSONL event (propose / commit / activate / reject / gen_mismatch /
+recover).
+
+Anti-replay is structural, the chanmig recipe: epochs are random per process
+start and never persisted (a restart orphans every in-flight generation for
+free), generations are monotonic within an authority epoch with a ceiling
+whose recovery is a fresh epoch, proposals are remembered by (epoch, nonce),
+and a commit's absolute activation slot must sit inside the follower's window.
+
+### Recovery
+
+Acquisition always scans the immutable base hopset, so a receiver that missed
+a transition can always hear frames on the channels the reduced set still
+uses. In adaptive mode the sync marker is v2 — the v1 layout plus the live
+(generation, mask fingerprint), each version rejecting the other — so one
+decoded marker exposes a missed transition; the follower drops to the acquire
+scan and re-synchronizes from the authority's repeated commit or its status
+beacon, which carry the full mask and activation anchor. The
+missed-every-commit path, the synchronized activation, and the failure matrix
+(lost / duplicated / reordered / forged / replayed frames, both restarts,
+rollover, invalid masks, window violations) are ctest gates:
+`hopset_schedule_math`, `hopset_wire_kat`, `hopset_proto_matrix`,
+`hopset_activation_sync`.
+
+### Driving it
+
+`DEVOURER_HOP_ADAPTIVE=1` on `txdemo`/`rxdemo` (with a keyed seed and
+`DEVOURER_HOP_SLOT_MS`) arms authority and follower;
+`DEVOURER_HOP_ADAPTIVE_SCRIPT="slot:mask,..."` feeds scripted
+authority-originated commits (`0x1b` = drop bits 2 and 5-of-8, etc.) until the
+receiver-driven exclusion policy exists. `streamtx` emits the v2 marker at
+generation 0 so an adaptive receiver tracks it. Control frames ride their own
+small 802.11 frames — caller FEC payload bytes are never touched. On-air run:
+`tests/hopset_adaptive_onair.sh`.
+
 ## Where it stands
 
 What works today, on hardware: fast intra-band retune on all three chip
@@ -223,6 +311,7 @@ the slow full set); per-hop TX power is not re-tuned, so a hopset spanning a wid
 5 GHz range wants a periodic full set to refresh per-rate power; the follower
 experiment uses a 3-channel hopset because a single B210 needs ≥60 MS/s to span
 a 60 MHz hopset in one FFT and trips a UHD tuning assertion at the usual
-61.44 MS/s. And the schedule visits every configured channel — there is no
-adaptive exclusion of a persistently-jammed one; the fused-FEC layer absorbs
-those dwells as erasures.
+61.44 MS/s. And while the adaptive-hopset protocol can exclude a channel by
+authenticated commit, nothing yet *decides* to — the receiver-driven
+observation policy is unimplemented, so an unattended link still visits every
+configured channel and the fused-FEC layer absorbs jammed dwells as erasures.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -129,6 +129,13 @@ Emitters: L = library, RX/TX/... = demo. Optional fields in [brackets];
 |---|---|---|
 | `hop.dwell` | TX, duplex | dwell, round, channel, frame, switch_us, t_ms, [mode] |
 | `hop.done` | TX, duplex | frames, dwells |
+| `hop.rx` | RX (lockstep, `DEVOURER_HOP_CHANNELS`+`_SLOT_MS`) | state (acquire\|track\|retune\|decode\|lost) + per-state fields: channel, slot, epoch, retune_us, dead_us |
+| `hopset.propose` | TX/RX (`DEVOURER_HOP_ADAPTIVE`) | t, v, role (tx\|rx), slot, gen, mask "0x…", obs, reasons "0x…" |
+| `hopset.commit` | TX/RX (`DEVOURER_HOP_ADAPTIVE`) | t, v, role, slot, gen, mask "0x…", activate_round, activate_slot — TX = commit issued, RX = commit adopted as pending |
+| `hopset.activate` | TX/RX (`DEVOURER_HOP_ADAPTIVE`) | same fields — the committed state swapped in at the boundary |
+| `hopset.reject` | TX/RX (`DEVOURER_HOP_ADAPTIVE`) | t, v, role, slot, reason (`hopset_reason_name`: bad_mac…timeout) |
+| `hopset.gen_mismatch` | RX (`DEVOURER_HOP_ADAPTIVE`) | t, v, role, slot, seen_gen, cur_gen, cur_mask "0x…" — a v2 marker advertised a state we don't hold |
+| `hopset.recover` | RX (`DEVOURER_HOP_ADAPTIVE`) | commit/activate fields — re-synchronized from an authenticated commit/status after a missed transition |
 
 ### Channel migration (chanscout — docs/adaptive-channel-migration.md)
 | ev | emitter | fields |

--- a/examples/rx/main.cpp
+++ b/examples/rx/main.cpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <random>
 #include <string>
 #include <thread>
 #include <vector>
@@ -15,6 +16,9 @@
 
 #include "BfReportDetect.h"
 #include "HopSchedule.h"
+#include "hopset/HopsetEvents.h"
+#include "hopset/HopsetFollower.h"
+#include "hopset/HopsetWire.h"
 #include "LaCapture.h"
 #include "LinkHealth.h"
 #include "RxPacket.h"
@@ -82,10 +86,43 @@ static std::atomic<uint64_t> g_hop_marker_slot{0};
 static std::atomic<uint32_t> g_hop_epoch{0};
 static std::atomic<long long> g_hop_last_retune_us{0};
 static std::atomic<bool> g_hop_decode_pending{false};
+/* Adaptive hopset (DEVOURER_HOP_ADAPTIVE=1): the RX is a HopsetFollower.
+ * packetProcessor (RX thread) feeds it decoded v2 markers + authenticated
+ * control frames; the lockstep loop (main thread) ticks it and asks the
+ * AdaptiveScheduleView for the slot channel — one mutex covers the machine
+ * and the view. */
+static std::mutex g_hopset_mu;
+static std::unique_ptr<devourer::hopset::HopsetKeys> g_hopset_keys;
+static std::unique_ptr<devourer::hopset::HopsetFollower> g_hopset_fol;
+static std::unique_ptr<devourer::hopset::AdaptiveScheduleView> g_hopset_view;
+static std::atomic<uint64_t> g_hopset_now_slot{0};
 static long long steady_us() {
   return std::chrono::duration_cast<std::chrono::microseconds>(
              std::chrono::steady_clock::now().time_since_epoch())
       .count();
+}
+
+/* Execute the follower's actions (caller holds g_hopset_mu). Proposals
+ * (SendControl) need the RX->TX feedback transport — that policy is out of
+ * scope here, and the demo never calls propose(), so none arise. */
+static void hopset_route(
+    const std::vector<devourer::hopset::HopsetAction> &acts) {
+  for (const auto &a : acts) {
+    if (a.kind == devourer::hopset::HopsetAction::Activate)
+      g_hopset_view->set_state(a.state);
+    else if (a.kind == devourer::hopset::HopsetAction::Event)
+      devourer::hopset::emit_action(*g_ev, a, "rx", g_hopset_now_slot.load());
+  }
+}
+
+/* Best-effort current absolute slot from the fitted marker anchor. */
+static uint64_t hopset_slot_now() {
+  const long long anchor = g_hop_anchor_us.load();
+  const long long now = steady_us();
+  if (anchor > 0 && now > anchor && g_hop_slot_us)
+    return static_cast<uint64_t>((now - anchor) /
+                                 static_cast<long long>(g_hop_slot_us));
+  return g_hop_marker_slot.load();
 }
 
 /* Process-start reference for the init.timing events (see src/InitTimer.h).
@@ -629,10 +666,28 @@ static void packetProcessor(const Packet &packet) {
 
   if (g_hop_schedule && packet.Data.size() >= 16 &&
       std::memcmp(packet.Data.data() + 10, kTxSa, 6) == 0) {
+    /* Adaptive mode rides the v2 marker (v1 layout + generation/mask_fp);
+     * fixed mode stays on v1 — each decoder rejects the other version. */
     devourer::HopSyncMarker m;
-    if (devourer::HopSyncMarker::decode(packet.Data.data(), packet.Data.size(),
-                                        m) &&
-        m.fingerprint == g_hop_schedule->fingerprint() &&
+    bool have = false;
+    uint32_t mk_gen = 0, mk_maskfp = 0;
+    if (g_hopset_fol) {
+      devourer::hopset::HopSyncMarkerV2 m2;
+      if (devourer::hopset::HopSyncMarkerV2::decode(packet.Data.data(),
+                                                    packet.Data.size(), m2)) {
+        m.fingerprint = m2.fingerprint;
+        m.epoch = m2.epoch;
+        m.slot = m2.slot;
+        m.phase_us = m2.phase_us;
+        mk_gen = m2.generation;
+        mk_maskfp = m2.mask_fp;
+        have = true;
+      }
+    } else {
+      have = devourer::HopSyncMarker::decode(packet.Data.data(),
+                                             packet.Data.size(), m);
+    }
+    if (have && m.fingerprint == g_hop_schedule->fingerprint() &&
         m.phase_us < g_hop_slot_us) {
       const long long now = steady_us();
       const long long observed = now - static_cast<long long>(m.phase_us) -
@@ -657,6 +712,45 @@ static void packetProcessor(const Packet &packet) {
             .f("state", "decode")
             .f("slot", (unsigned long long)m.slot)
             .f("dead_us", now - g_hop_last_retune_us.load());
+      if (g_hopset_fol) {
+        /* missed-transition tripwire: does the advertised (generation,
+         * mask fingerprint) match a state we hold (current or pending)? */
+        std::lock_guard<std::mutex> lk(g_hopset_mu);
+        const auto &cs = g_hopset_fol->state();
+        bool matches =
+            mk_gen == cs.generation &&
+            mk_maskfp == devourer::hopset::mask_fp(
+                             *g_hopset_keys, cs.generation, cs.active_mask);
+        if (!matches && g_hopset_fol->has_pending()) {
+          const auto &ps = g_hopset_fol->pending();
+          matches =
+              mk_gen == ps.generation &&
+              mk_maskfp == devourer::hopset::mask_fp(
+                               *g_hopset_keys, ps.generation, ps.active_mask);
+        }
+        hopset_route(g_hopset_fol->on_marker(mk_gen, matches, m.slot));
+      }
+    }
+  }
+
+  /* Authenticated hopset control frames (probe-req header + HopsetWire bytes,
+   * canonical SA): commits and the authority's status beacon — the follower's
+   * adoption/recovery inputs. */
+  if (g_hopset_fol && packet.Data.size() > 24 + 16 &&
+      packet.Data[0] == 0x40 &&
+      std::memcmp(packet.Data.data() + 10, kTxSa, 6) == 0) {
+    devourer::hopset::HopsetMsg hm;
+    if (devourer::hopset::hopset_decode(packet.Data.data() + 24,
+                                        packet.Data.size() - 24,
+                                        *g_hopset_keys, 0, hm) ==
+        devourer::hopset::HopsetReason::None) {
+      const uint64_t slot = hopset_slot_now();
+      std::lock_guard<std::mutex> lk(g_hopset_mu);
+      g_hopset_now_slot.store(slot);
+      if (hm.type == devourer::hopset::HT_COMMIT)
+        hopset_route(g_hopset_fol->on_commit(hm, slot));
+      else if (hm.type == devourer::hopset::HT_STATUS)
+        hopset_route(g_hopset_fol->on_status(hm, slot));
     }
   }
 
@@ -1420,6 +1514,29 @@ int main(int argc, char **argv) {
     g_hop_schedule = std::make_unique<devourer::HopSchedule>(
         seed ? devourer::HopSchedule(devourer::HopSchedule::parse_seed(seed))
              : devourer::HopSchedule::sequential());
+    if (std::getenv("DEVOURER_HOP_ADAPTIVE")) {
+      /* Adaptive follower — needs the keyed schedule (control MAC derives
+       * from the same seed) and a <=64-channel base. */
+      if (!seed)
+        throw std::invalid_argument(
+            "DEVOURER_HOP_ADAPTIVE needs DEVOURER_HOP_SEED");
+      if (hop_rx_channels.size() > devourer::hopset::kMaxBaseChannels)
+        throw std::invalid_argument("adaptive hopset caps the base at 64");
+      g_hopset_keys = std::make_unique<devourer::hopset::HopsetKeys>(
+          devourer::hopset::HopsetKeys::derive(
+              devourer::HopSchedule::parse_seed(seed)));
+      devourer::hopset::HopsetParams hp;
+      hp.n_base = hop_rx_channels.size();
+      std::vector<uint32_t> chlist(hop_rx_channels.begin(),
+                                   hop_rx_channels.end());
+      hp.base_fp = devourer::hopset::hopset_fp(*g_hopset_keys, chlist.data(),
+                                               chlist.size());
+      g_hopset_fol = std::make_unique<devourer::hopset::HopsetFollower>(
+          hp, static_cast<uint32_t>(std::random_device{}()));
+      g_hopset_view = std::make_unique<devourer::hopset::AdaptiveScheduleView>(
+          *g_hop_schedule, *g_hopset_keys, hop_rx_channels.size());
+      g_hopset_view->set_state(g_hopset_fol->state());
+    }
     g_hop_slot_us = static_cast<uint64_t>(hop_rx_slot_ms) * 1000;
     long acquire_ms = hop_rx_slot_ms * 2;
     if (const char *a = std::getenv("DEVOURER_HOP_ACQUIRE_MS")) {
@@ -1453,7 +1570,19 @@ int main(int argc, char **argv) {
         .f("channel", hop_rx_channels[0]);
     while (!g_devourer_should_stop) {
       const long long now = steady_us(), last = g_hop_last_marker_us.load();
-      if (last && now - last < static_cast<long long>(3 * g_hop_slot_us)) {
+      bool hopset_recovering = false;
+      if (g_hopset_fol) {
+        /* follower heartbeat: pending activation at the slot boundary; a
+         * Recovering follower falls back to the base-hopset acquire scan
+         * below until an authenticated commit/status re-syncs it */
+        std::lock_guard<std::mutex> lk(g_hopset_mu);
+        g_hopset_now_slot.store(hopset_slot_now());
+        hopset_route(g_hopset_fol->on_tick(g_hopset_now_slot.load()));
+        hopset_recovering = g_hopset_fol->fsm() ==
+                            devourer::hopset::HopsetFollower::State::Recovering;
+      }
+      if (!hopset_recovering && last &&
+          now - last < static_cast<long long>(3 * g_hop_slot_us)) {
         if (!tracking) {
           tracking = true;
           devourer::Ev(*g_ev, "hop.rx")
@@ -1467,7 +1596,13 @@ int main(int argc, char **argv) {
           /* Phase correction may move the fitted boundary slightly forward.
            * Never follow that jitter backwards into a slot already visited. */
           if (tuned_slot == UINT64_MAX || slot > tuned_slot) {
-            int ch = g_hop_schedule->channel(slot, hop_rx_channels);
+            int ch;
+            if (g_hopset_view) {
+              std::lock_guard<std::mutex> lk(g_hopset_mu);
+              ch = hop_rx_channels[g_hopset_view->channel_index(slot)];
+            } else {
+              ch = g_hop_schedule->channel(slot, hop_rx_channels);
+            }
             auto t0 = steady_us();
             dev->FastRetune(static_cast<uint8_t>(ch), true);
             auto done = steady_us();

--- a/examples/streamtx/main.cpp
+++ b/examples/streamtx/main.cpp
@@ -68,6 +68,7 @@
 #endif
 
 #include "HopSchedule.h"
+#include "hopset/HopsetWire.h"
 #include "RadiotapBuilder.h"
 #include "RtlAdapter.h"
 #if defined(DEVOURER_HAVE_JAGUAR1)
@@ -267,6 +268,8 @@ int main(int argc, char **argv) {
   std::vector<int> hop_channels;
   long hop_dwell = 1;
   long hop_slot_ms = 0;
+  bool hop_adaptive = false;
+  uint32_t hop_adaptive_maskfp = 0;
   std::optional<devourer::HopSchedule> hop_schedule;
   const int hop_fast = std::getenv("DEVOURER_HOP_FAST")
                            ? std::atoi(std::getenv("DEVOURER_HOP_FAST"))
@@ -303,6 +306,21 @@ int main(int argc, char **argv) {
       // Slot-mode sequential hopping rides the keyless schedule so it still
       // emits the lockstep sync marker (same channels[slot % n] order).
       hop_schedule.emplace(devourer::HopSchedule::sequential());
+    if (std::getenv("DEVOURER_HOP_ADAPTIVE")) {
+      /* Adaptive-follower compatibility: emit the v2 sync marker (v1 fields
+       * + generation/mask fingerprint) so an adaptive rxdemo tracks this
+       * stream. streamtx itself stays at generation 0 (full mask) — the
+       * commit authority (and its script lever) is txdemo's. */
+      if (!std::getenv("DEVOURER_HOP_SEED") || hop_slot_ms <= 0)
+        throw std::invalid_argument("DEVOURER_HOP_ADAPTIVE needs "
+                                    "DEVOURER_HOP_SEED and "
+                                    "DEVOURER_HOP_SLOT_MS");
+      hop_adaptive = true;
+      const auto keys = devourer::hopset::HopsetKeys::derive(
+          devourer::HopSchedule::parse_seed(std::getenv("DEVOURER_HOP_SEED")));
+      hop_adaptive_maskfp = devourer::hopset::mask_fp(
+          keys, 0, devourer::hopset::full_mask(hop_channels.size()));
+    }
     if (!hop_channels.empty()) {
       std::string list;
       for (size_t i = 0; i < hop_channels.size(); ++i)
@@ -408,15 +426,28 @@ int main(int argc, char **argv) {
             std::chrono::duration_cast<std::chrono::microseconds>(
                 std::chrono::steady_clock::now() - hop_start)
                 .count());
-        devourer::HopSyncMarker marker{hop_schedule->fingerprint(), hop_epoch,
-                                       static_cast<uint32_t>(us % slot_us),
-                                       us / slot_us};
-        auto wire = devourer::HopSyncMarker::encode(marker);
         sync_buf.clear();
         sync_buf.insert(sync_buf.end(), kStreamRadiotap.begin(),
                         kStreamRadiotap.end());
         sync_buf.insert(sync_buf.end(), dot11.begin(), dot11.end());
-        sync_buf.insert(sync_buf.end(), wire.begin(), wire.end());
+        if (hop_adaptive) {
+          devourer::hopset::HopSyncMarkerV2 marker;
+          marker.fingerprint = hop_schedule->fingerprint();
+          marker.epoch = hop_epoch;
+          marker.phase_us = static_cast<uint32_t>(us % slot_us);
+          marker.slot = us / slot_us;
+          marker.generation = 0;
+          marker.mask_fp = hop_adaptive_maskfp;
+          auto wire = devourer::hopset::HopSyncMarkerV2::encode(marker);
+          sync_buf.insert(sync_buf.end(), wire.begin(), wire.end());
+        } else {
+          devourer::HopSyncMarker marker{hop_schedule->fingerprint(),
+                                         hop_epoch,
+                                         static_cast<uint32_t>(us % slot_us),
+                                         us / slot_us};
+          auto wire = devourer::HopSyncMarker::encode(marker);
+          sync_buf.insert(sync_buf.end(), wire.begin(), wire.end());
+        }
         rtlDevice->send_packet(sync_buf.data(), sync_buf.size());
       }
     }

--- a/examples/tx/main.cpp
+++ b/examples/tx/main.cpp
@@ -8,8 +8,10 @@
 #include <iostream>
 #include <memory>
 #include <optional>
+#include <random>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #if defined(_MSC_VER)
@@ -34,6 +36,9 @@
 #include "BfReportDetect.h"
 #include "ChannelFreq.h"
 #include "HopSchedule.h"
+#include "hopset/HopsetAuthority.h"
+#include "hopset/HopsetEvents.h"
+#include "hopset/HopsetWire.h"
 #include "RxPacket.h"
 #include "SweepSpec.h"
 #include "TxPower.h" /* txpkt_pwr_db_for_step — DEVOURER_TX_PKT_OFSET fan-out */
@@ -972,6 +977,7 @@ int main(int argc, char **argv) {
   long hop_dwell = 50;
   long hop_rounds = 0;
   long hop_slot_ms = 0;
+  bool hop_adaptive = false;
   std::optional<devourer::HopSchedule> hop_schedule;
   /* 0 = full SetMonitorChannel; 1 = FastRetune (cached RF writes, fastest);
    * 2 = FastRetune without the RF cache (sw_chnl only, for A/B measurement). */
@@ -1009,6 +1015,19 @@ int main(int argc, char **argv) {
     if (const char *e = std::getenv("DEVOURER_HOP_ROUNDS")) {
       hop_rounds = std::strtol(e, nullptr, 0);
       if (hop_rounds < 0) hop_rounds = 0;
+    }
+    if (std::getenv("DEVOURER_HOP_ADAPTIVE")) {
+      /* Adaptive hopset mode: this side is the schedule authority. Needs the
+       * keyed schedule (the control MAC derives from the same seed — a
+       * sequential schedule has no key, so no authentication) and slot mode
+       * (activation is an absolute-slot instant). */
+      if (!std::getenv("DEVOURER_HOP_SEED") || hop_slot_ms <= 0)
+        throw std::invalid_argument("DEVOURER_HOP_ADAPTIVE needs "
+                                    "DEVOURER_HOP_SEED and "
+                                    "DEVOURER_HOP_SLOT_MS");
+      if (hop_channels.size() > devourer::hopset::kMaxBaseChannels)
+        throw std::invalid_argument("adaptive hopset caps the base at 64");
+      hop_adaptive = true;
     }
     std::string list;
     for (size_t i = 0; i < hop_channels.size(); ++i)
@@ -1108,6 +1127,74 @@ int main(int argc, char **argv) {
   const auto hop_start = std::chrono::steady_clock::now();
   const uint32_t hop_epoch = static_cast<uint32_t>(
       std::chrono::high_resolution_clock::now().time_since_epoch().count());
+
+  /* Adaptive hopset (DEVOURER_HOP_ADAPTIVE=1): this side is the schedule
+   * authority. The exclusion policy will feed it follower proposals; until
+   * then the
+   * test lever is DEVOURER_HOP_ADAPTIVE_SCRIPT="slot:mask,slot:mask,..."
+   * (mask = hex bitmap over base-hopset positions) driving authority-
+   * originated commits. Commit/status frames air as their own small 802.11
+   * frames next to the payload stream — caller payload bytes are untouched. */
+  std::optional<devourer::hopset::HopsetKeys> hopset_keys;
+  std::optional<devourer::hopset::HopsetAuthority> hopset_auth;
+  std::optional<devourer::hopset::AdaptiveScheduleView> hopset_view;
+  std::vector<std::pair<uint64_t, uint64_t>> hopset_script;
+  size_t hopset_script_next = 0;
+  uint64_t hopset_tick_slot = 0;
+  bool hopset_ticked = false;
+  if (hop_adaptive) {
+    hopset_keys = devourer::hopset::HopsetKeys::derive(
+        devourer::HopSchedule::parse_seed(std::getenv("DEVOURER_HOP_SEED")));
+    devourer::hopset::HopsetParams hp;
+    hp.n_base = hop_channels.size();
+    std::vector<uint32_t> chlist(hop_channels.begin(), hop_channels.end());
+    hp.base_fp = devourer::hopset::hopset_fp(*hopset_keys, chlist.data(),
+                                             chlist.size());
+    hopset_auth.emplace(hp, static_cast<uint32_t>(std::random_device{}()));
+    hopset_view.emplace(*hop_schedule, *hopset_keys, hop_channels.size());
+    /* view and authority must agree from slot 0 (gen 0 = full mask) so the
+     * marker's mask fingerprint matches a fresh follower's initial state */
+    hopset_view->set_state(hopset_auth->state());
+    if (const char *sc = std::getenv("DEVOURER_HOP_ADAPTIVE_SCRIPT")) {
+      for (const char *p = sc; *p;) {
+        char *end = nullptr;
+        const uint64_t at = std::strtoull(p, &end, 0);
+        if (!end || *end != ':')
+          throw std::invalid_argument(
+              "DEVOURER_HOP_ADAPTIVE_SCRIPT is slot:mask[,slot:mask...]");
+        const uint64_t mask = std::strtoull(end + 1, &end, 0);
+        hopset_script.emplace_back(at, mask);
+        p = *end == ',' ? end + 1 : end;
+      }
+    }
+  }
+  auto hopset_route =
+      [&](const std::vector<devourer::hopset::HopsetAction> &acts) {
+        for (const auto &a : acts) {
+          if (a.kind == devourer::hopset::HopsetAction::Activate) {
+            hopset_view->set_state(a.state);
+          } else if (a.kind == devourer::hopset::HopsetAction::SendControl) {
+            /* robust 6M radiotap + broadcast probe-req header + the
+             * authenticated HopsetWire bytes (the chanmig frame shape) */
+            std::vector<uint8_t> frame = devourer::build_stream_radiotap(
+                devourer::parse_tx_mode_str("6M"));
+            static const uint8_t sa[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
+            uint8_t hdr[24] = {0x40, 0x00, 0x00, 0x00, 0xff, 0xff,
+                               0xff, 0xff, 0xff, 0xff};
+            std::memcpy(hdr + 10, sa, 6);
+            std::memcpy(hdr + 16, sa, 6);
+            hdr[22] = 0x90;
+            hdr[23] = 0x00;
+            frame.insert(frame.end(), hdr, hdr + 24);
+            const auto body =
+                devourer::hopset::hopset_encode(a.msg, *hopset_keys);
+            frame.insert(frame.end(), body.begin(), body.end());
+            rtlDevice->send_packet(frame.data(), frame.size());
+          } else if (a.kind == devourer::hopset::HopsetAction::Event) {
+            devourer::hopset::emit_action(*g_ev, a, "tx", hopset_tick_slot);
+          }
+        }
+      };
 
   long tx_count = 0;
   long consec_fail = 0;
@@ -1240,13 +1327,29 @@ int main(int argc, char **argv) {
                       .count() /
                   hop_slot_ms)
             : static_cast<uint64_t>(dwell_no + (frames_in_dwell == 0 ? 1 : 0));
+    if (hopset_auth && (!hopset_ticked || desired_slot != hopset_tick_slot)) {
+      /* once per slot: scripted commits due at this slot, then the authority
+       * heartbeat (commit repetition, activation swap, status beacon) */
+      hopset_tick_slot = desired_slot;
+      hopset_ticked = true;
+      while (hopset_script_next < hopset_script.size() &&
+             desired_slot >= hopset_script[hopset_script_next].first) {
+        hopset_route(hopset_auth->start_change(
+            hopset_script[hopset_script_next].second, desired_slot));
+        ++hopset_script_next;
+      }
+      hopset_route(hopset_auth->on_tick(desired_slot));
+    }
     if (!hop_channels.empty() &&
         ((hop_slot_ms > 0 && desired_slot != static_cast<uint64_t>(dwell_no)) ||
          (hop_slot_ms == 0 && frames_in_dwell == 0))) {
       dwell_no = static_cast<long>(desired_slot);
       if (total_dwells > 0 && dwell_no >= total_dwells) break;
-      int ch = hop_schedule ? hop_schedule->channel(desired_slot, hop_channels)
-                            : hop_channels[desired_slot % hop_channels.size()];
+      int ch = hopset_view
+                   ? hop_channels[hopset_view->channel_index(desired_slot)]
+               : hop_schedule
+                   ? hop_schedule->channel(desired_slot, hop_channels)
+                   : hop_channels[desired_slot % hop_channels.size()];
       auto sw0 = std::chrono::steady_clock::now();
       const char *mode = nullptr;
       if (hop_radiotap) {
@@ -1291,22 +1394,40 @@ int main(int argc, char **argv) {
       }
     }
     if (hop_schedule && hop_slot_ms > 0) {
-      auto old = devourer::HopSyncMarker::encode({});
-      if (tx_buf.size() >= old.size() &&
-          tx_buf[tx_buf.size() - old.size()] == 221 &&
-          tx_buf[tx_buf.size() - old.size() + 5] == 0x48)
-        tx_buf.resize(tx_buf.size() - old.size());
+      /* strip the previous frame's marker (either version — one run emits
+       * only one, but the size differs) before appending the fresh one */
+      const size_t msz = hop_adaptive ? devourer::hopset::HopSyncMarkerV2::kSize
+                                      : devourer::HopSyncMarker::kSize;
+      if (tx_buf.size() >= msz && tx_buf[tx_buf.size() - msz] == 221 &&
+          tx_buf[tx_buf.size() - msz + 5] == 0x48)
+        tx_buf.resize(tx_buf.size() - msz);
       const auto now = std::chrono::steady_clock::now();
       const uint64_t us = static_cast<uint64_t>(
           std::chrono::duration_cast<std::chrono::microseconds>(now - hop_start)
               .count());
-      devourer::HopSyncMarker marker{
-          hop_schedule->fingerprint(), hop_epoch,
-          static_cast<uint32_t>(us %
-                                (static_cast<uint64_t>(hop_slot_ms) * 1000)),
-          us / (static_cast<uint64_t>(hop_slot_ms) * 1000)};
-      auto wire = devourer::HopSyncMarker::encode(marker);
-      tx_buf.insert(tx_buf.end(), wire.begin(), wire.end());
+      const uint32_t phase = static_cast<uint32_t>(
+          us % (static_cast<uint64_t>(hop_slot_ms) * 1000));
+      const uint64_t slot = us / (static_cast<uint64_t>(hop_slot_ms) * 1000);
+      if (hop_adaptive) {
+        /* v2: the v1 fields + the LIVE (generation, mask fingerprint), so a
+         * follower detects a missed transition from the hot path alone */
+        devourer::hopset::HopSyncMarkerV2 marker;
+        marker.fingerprint = hop_schedule->fingerprint();
+        marker.epoch = hop_epoch;
+        marker.phase_us = phase;
+        marker.slot = slot;
+        marker.generation = hopset_view->state().generation;
+        marker.mask_fp = devourer::hopset::mask_fp(
+            *hopset_keys, hopset_view->state().generation,
+            hopset_view->state().active_mask);
+        auto wire = devourer::hopset::HopSyncMarkerV2::encode(marker);
+        tx_buf.insert(tx_buf.end(), wire.begin(), wire.end());
+      } else {
+        devourer::HopSyncMarker marker{hop_schedule->fingerprint(), hop_epoch,
+                                       phase, slot};
+        auto wire = devourer::HopSyncMarker::encode(marker);
+        tx_buf.insert(tx_buf.end(), wire.begin(), wire.end());
+      }
     }
     if (stbc_toggle) {
       devourer::TxMode m = tx_mode_base;

--- a/src/hopset/HopsetAuthority.h
+++ b/src/hopset/HopsetAuthority.h
@@ -1,0 +1,245 @@
+/* HopsetAuthority — the TX-side pure state machine for adaptive hopset
+ * changes. The transmitter is the schedule authority: it validates proposals
+ * against policy (mask legality, diversity floor, monotonic generation,
+ * activation lead), then repeatedly broadcasts an identical authenticated
+ * commit naming an absolute future activation slot until that slot arrives,
+ * and swaps its own committed state exactly there. It also beacons a status
+ * message so a follower that missed every commit can recover.
+ *
+ * Pure: no I/O, no crypto, no clock — the host feeds MAC-verified decoded
+ * messages plus the current absolute slot, and executes the returned actions
+ * (encode+MAC+send, apply-to-schedule-view, emit-event). */
+#ifndef DEVOURER_HOPSET_HOPSET_AUTHORITY_H
+#define DEVOURER_HOPSET_HOPSET_AUTHORITY_H
+
+#include <vector>
+
+#include "hopset/HopsetTypes.h"
+#include "hopset/HopsetWire.h"
+
+namespace devourer {
+namespace hopset {
+
+class HopsetAuthority {
+public:
+  /* epoch: random per boot, host-seeded (std::random_device). The authority
+   * starts at generation 0 = the legacy full-mask fixed schedule. */
+  HopsetAuthority(const HopsetParams &params, uint32_t epoch)
+      : p_(params), epoch_(epoch) {
+    cur_.epoch = epoch;
+    cur_.generation = 0;
+    cur_.active_mask = full_mask(p_.n_base);
+  }
+
+  const HopsetState &state() const { return cur_; }
+  bool committing() const { return committing_; }
+  const HopsetState &pending() const { return pend_; }
+
+  /* Adopt a committed state wholesale (test rigs, or a host resuming a
+   * session it persisted itself — the protocol never persists state). */
+  void restore(const HopsetState &st) {
+    cur_ = st;
+    cur_.epoch = epoch_;
+    committing_ = false;
+  }
+
+  /* A follower proposal (already MAC-verified by the host's decode). */
+  std::vector<HopsetAction> on_proposal(const HopsetMsg &m,
+                                        uint64_t now_slot) {
+    std::vector<HopsetAction> out;
+    if (m.base_fp != p_.base_fp)
+      return reject(out, m, HopsetReason::BadBaseFp, now_slot);
+    if (replays_.contains(m.rx_epoch, m.rx_nonce)) {
+      /* the exact exchange we already answered: if it is the one still being
+       * committed, re-answer idempotently; anything else is a replay. */
+      if (committing_ && m.rx_epoch == pend_echo_epoch_ &&
+          m.rx_nonce == pend_echo_nonce_) {
+        push_commit(out, now_slot);
+        return out;
+      }
+      return reject(out, m, HopsetReason::ReplayGen, now_slot);
+    }
+    if (committing_)
+      return reject(out, m, HopsetReason::Busy, now_slot);
+    if (m.generation != 0 && m.generation != cur_.generation + 1)
+      return reject(out, m, HopsetReason::NonMonotonicGen, now_slot);
+    const HopsetReason mr = mask_reason(m.active_mask);
+    if (mr != HopsetReason::None)
+      return reject(out, m, mr, now_slot);
+    replays_.remember(m.rx_epoch, m.rx_nonce);
+    pend_echo_epoch_ = m.rx_epoch;
+    pend_echo_nonce_ = m.rx_nonce;
+    start_commit(out, m.active_mask, m.earliest_activate_round, now_slot);
+    HopsetAction ev{};
+    ev.kind = HopsetAction::Event;
+    ev.event = HopsetEvent::Propose;
+    ev.msg = m;
+    out.push_back(ev);
+    return out;
+  }
+
+  /* A locally-originated change (scripted commits, or a TX-side exclusion
+   * policy once one exists). rx_epoch_echo stays 0 on the wire. */
+  std::vector<HopsetAction> start_change(uint64_t mask, uint64_t now_slot) {
+    std::vector<HopsetAction> out;
+    if (committing_) {
+      HopsetAction ev{};
+      ev.kind = HopsetAction::Event;
+      ev.event = HopsetEvent::Reject;
+      ev.reason = HopsetReason::Busy;
+      out.push_back(ev);
+      return out;
+    }
+    const HopsetReason mr = mask_reason(mask);
+    if (mr != HopsetReason::None) {
+      HopsetAction ev{};
+      ev.kind = HopsetAction::Event;
+      ev.event = HopsetEvent::Reject;
+      ev.reason = mr;
+      out.push_back(ev);
+      return out;
+    }
+    pend_echo_epoch_ = pend_echo_nonce_ = 0;
+    start_commit(out, mask, 0, now_slot);
+    return out;
+  }
+
+  /* Slot heartbeat: commit repetition, the activation swap, status beacon. */
+  std::vector<HopsetAction> on_tick(uint64_t now_slot) {
+    std::vector<HopsetAction> out;
+    if (committing_) {
+      if (now_slot >= pend_.activate_slot) {
+        cur_ = pend_;
+        committing_ = false;
+        HopsetAction act{};
+        act.kind = HopsetAction::Activate;
+        act.state = cur_;
+        out.push_back(act);
+        HopsetAction ev{};
+        ev.kind = HopsetAction::Event;
+        ev.event = HopsetEvent::Activate;
+        ev.state = cur_;
+        out.push_back(ev);
+      } else if (now_slot - last_commit_slot_ >= p_.commit_repeat_slots) {
+        push_commit(out, now_slot);
+      }
+    }
+    if (now_slot - last_status_slot_ >= p_.status_interval_slots) {
+      last_status_slot_ = now_slot;
+      HopsetAction a{};
+      a.kind = HopsetAction::SendControl;
+      a.msg = status_msg(now_slot, HopsetReason::None);
+      out.push_back(a);
+    }
+    return out;
+  }
+
+  /* Round index of `slot` in the current generation's numbering. */
+  uint64_t round_of(uint64_t slot) const {
+    const size_t k = cur_.generation == 0 ? p_.n_base
+                                          : popcount64(cur_.active_mask);
+    return (slot - cur_.activate_slot) / k;
+  }
+
+private:
+  HopsetReason mask_reason(uint64_t mask) const {
+    if (cur_.generation + 1 >= kGenCeiling)
+      return HopsetReason::GenCeiling;
+    if (mask & ~full_mask(p_.n_base))
+      return HopsetReason::BadMask;
+    if (popcount64(mask) < p_.min_active)
+      return HopsetReason::LowDiversity;
+    if (mask == cur_.active_mask && cur_.generation != 0)
+      return HopsetReason::NoChange;
+    return HopsetReason::None;
+  }
+
+  void start_commit(std::vector<HopsetAction> &out, uint64_t mask,
+                    uint64_t earliest_round, uint64_t now_slot) {
+    const size_t k_cur = cur_.generation == 0 ? p_.n_base
+                                              : popcount64(cur_.active_mask);
+    const uint64_t cur_round = round_of(now_slot);
+    uint64_t lead = p_.lead_rounds < 8 ? 8 : p_.lead_rounds;
+    uint64_t act_round = cur_round + lead;
+    if (earliest_round > act_round)
+      act_round = earliest_round;
+    pend_ = cur_;
+    pend_.generation = cur_.generation + 1;
+    pend_.active_mask = mask;
+    pend_.activate_round = act_round;
+    pend_.activate_slot = cur_.activate_slot + act_round * k_cur;
+    pend_.epoch = epoch_;
+    committing_ = true;
+    push_commit(out, now_slot);
+    HopsetAction ev{};
+    ev.kind = HopsetAction::Event;
+    ev.event = HopsetEvent::Commit;
+    ev.state = pend_;
+    out.push_back(ev);
+  }
+
+  void push_commit(std::vector<HopsetAction> &out, uint64_t now_slot) {
+    last_commit_slot_ = now_slot;
+    HopsetAction a{};
+    a.kind = HopsetAction::SendControl;
+    HopsetMsg &m = a.msg;
+    m.type = HT_COMMIT;
+    m.link_id = p_.link_id;
+    m.tx_epoch = epoch_;
+    m.rx_epoch_echo = pend_echo_epoch_;
+    m.generation = pend_.generation;
+    m.active_mask = pend_.active_mask;
+    m.base_fp = p_.base_fp;
+    m.activate_round = pend_.activate_round;
+    m.activate_slot = pend_.activate_slot;
+    m.current_round = round_of(now_slot);
+    m.rx_nonce_echo = pend_echo_nonce_;
+    out.push_back(a);
+  }
+
+  HopsetMsg status_msg(uint64_t now_slot, HopsetReason reason) const {
+    HopsetMsg m;
+    m.type = HT_STATUS;
+    m.link_id = p_.link_id;
+    m.role = 1;
+    m.sender_epoch = epoch_;
+    m.generation = cur_.generation;
+    m.active_mask = cur_.active_mask;
+    m.base_fp = p_.base_fp;
+    m.current_round = round_of(now_slot);
+    m.activate_slot = cur_.activate_slot;
+    m.reason = static_cast<uint8_t>(reason);
+    return m;
+  }
+
+  std::vector<HopsetAction> &reject(std::vector<HopsetAction> &out,
+                                    const HopsetMsg &m, HopsetReason r,
+                                    uint64_t now_slot) {
+    HopsetAction a{};
+    a.kind = HopsetAction::SendControl;
+    a.msg = status_msg(now_slot, r);
+    a.msg.rx_nonce_echo = m.rx_nonce;
+    out.push_back(a);
+    HopsetAction ev{};
+    ev.kind = HopsetAction::Event;
+    ev.event = HopsetEvent::Reject;
+    ev.reason = r;
+    out.push_back(ev);
+    return out;
+  }
+
+  HopsetParams p_;
+  uint32_t epoch_;
+  HopsetState cur_{};
+  HopsetState pend_{};
+  bool committing_ = false;
+  uint32_t pend_echo_epoch_ = 0, pend_echo_nonce_ = 0;
+  uint64_t last_commit_slot_ = 0;
+  uint64_t last_status_slot_ = 0;
+  ProposalReplayRing replays_;
+};
+
+} /* namespace hopset */
+} /* namespace devourer */
+
+#endif /* DEVOURER_HOPSET_HOPSET_AUTHORITY_H */

--- a/src/hopset/HopsetEvents.h
+++ b/src/hopset/HopsetEvents.h
@@ -1,0 +1,50 @@
+/* hopset.* JSONL binding — one emitter for every action the pure machines
+ * report, so the TX and RX demos (and the tests' log assertions) share one
+ * schema. Every line carries the generation and mask so any transition is
+ * reproducible from the logs alone. */
+#ifndef DEVOURER_HOPSET_HOPSET_EVENTS_H
+#define DEVOURER_HOPSET_HOPSET_EVENTS_H
+
+#include "Event.h"
+#include "hopset/HopsetTypes.h"
+
+namespace devourer {
+namespace hopset {
+
+/* Emit one machine-reported Event action. role: "tx" | "rx". */
+inline void emit_action(EventSink &sink, const HopsetAction &a,
+                        const char *role, uint64_t now_slot) {
+  if (a.kind != HopsetAction::Event)
+    return;
+  Ev ev(sink, hopset_event_name(a.event));
+  ev.t().f("v", 1).f("role", role).f("slot", (unsigned long long)now_slot);
+  switch (a.event) {
+  case HopsetEvent::Propose:
+    ev.f("gen", (unsigned long long)a.msg.generation)
+        .hexf("mask", a.msg.active_mask, 0)
+        .f("obs", (unsigned long long)a.msg.observation_count)
+        .hexf("reasons", a.msg.reason_bitmap, 0);
+    break;
+  case HopsetEvent::Commit:
+  case HopsetEvent::Activate:
+  case HopsetEvent::Recover:
+    ev.f("gen", (unsigned long long)a.state.generation)
+        .hexf("mask", a.state.active_mask, 0)
+        .f("activate_round", (unsigned long long)a.state.activate_round)
+        .f("activate_slot", (unsigned long long)a.state.activate_slot);
+    break;
+  case HopsetEvent::Reject:
+    ev.f("reason", hopset_reason_name(a.reason));
+    break;
+  case HopsetEvent::GenMismatch:
+    ev.f("seen_gen", (unsigned long long)a.msg.generation)
+        .f("cur_gen", (unsigned long long)a.state.generation)
+        .hexf("cur_mask", a.state.active_mask, 0);
+    break;
+  }
+}
+
+} /* namespace hopset */
+} /* namespace devourer */
+
+#endif /* DEVOURER_HOPSET_HOPSET_EVENTS_H */

--- a/src/hopset/HopsetFollower.h
+++ b/src/hopset/HopsetFollower.h
@@ -1,0 +1,291 @@
+/* HopsetFollower — the RX-side pure state machine for adaptive hopset
+ * changes. The follower proposes mask changes (the observation policy that
+ * decides WHAT to propose is a separate layer — here it is caller input),
+ * adopts only
+ * authenticated commits/statuses from the authority, activates exactly at the
+ * committed absolute slot, and recovers from a missed transition: a sync
+ * marker advertising a generation/mask it doesn't hold sends it to Recovering
+ * (the host falls back to the base-hopset acquire scan, which is always legal
+ * because acquisition scans the immutable base hopset), until a repeated
+ * commit or the authority's status beacon re-synchronizes it.
+ *
+ * Pure: no I/O, no crypto, no clock, no randomness — the host feeds
+ * MAC-verified messages, the current absolute slot, and its own per-boot
+ * random epoch/nonces. */
+#ifndef DEVOURER_HOPSET_HOPSET_FOLLOWER_H
+#define DEVOURER_HOPSET_HOPSET_FOLLOWER_H
+
+#include <vector>
+
+#include "hopset/HopsetTypes.h"
+#include "hopset/HopsetWire.h"
+
+namespace devourer {
+namespace hopset {
+
+class HopsetFollower {
+public:
+  enum class State : uint8_t { Synced, Proposing, Pending, Recovering };
+
+  HopsetFollower(const HopsetParams &params, uint32_t epoch)
+      : p_(params), epoch_(epoch) {
+    cur_.generation = 0;
+    cur_.active_mask = full_mask(p_.n_base);
+  }
+
+  State fsm() const { return st_; }
+  const HopsetState &state() const { return cur_; }
+  const HopsetState &pending() const { return pend_; }
+  bool has_pending() const { return st_ == State::Pending; }
+
+  /* Ask the authority for a mask change. nonce: host-random per proposal. */
+  std::vector<HopsetAction> propose(uint64_t mask, uint32_t observation_count,
+                                    uint32_t reason_bitmap, uint32_t nonce,
+                                    uint64_t now_slot) {
+    std::vector<HopsetAction> out;
+    if (st_ != State::Synced) {
+      HopsetAction ev{};
+      ev.kind = HopsetAction::Event;
+      ev.event = HopsetEvent::Reject;
+      ev.reason = HopsetReason::Busy;
+      out.push_back(ev);
+      return out;
+    }
+    prop_ = HopsetMsg{};
+    prop_.type = HT_PROPOSAL;
+    prop_.link_id = p_.link_id;
+    prop_.rx_epoch = epoch_;
+    prop_.generation = 0; /* 0 = "next" — the authority numbers it */
+    prop_.active_mask = mask;
+    prop_.base_fp = p_.base_fp;
+    prop_.observation_count = observation_count;
+    prop_.reason_bitmap = reason_bitmap;
+    prop_.rx_nonce = nonce;
+    tries_ = 1;
+    last_prop_slot_ = now_slot;
+    st_ = State::Proposing;
+    HopsetAction a{};
+    a.kind = HopsetAction::SendControl;
+    a.msg = prop_;
+    out.push_back(a);
+    HopsetAction ev{};
+    ev.kind = HopsetAction::Event;
+    ev.event = HopsetEvent::Propose;
+    ev.msg = prop_;
+    out.push_back(ev);
+    return out;
+  }
+
+  /* An authenticated commit from the authority. */
+  std::vector<HopsetAction> on_commit(const HopsetMsg &m, uint64_t now_slot) {
+    std::vector<HopsetAction> out;
+    if (m.base_fp != p_.base_fp)
+      return drop(out, HopsetReason::BadBaseFp);
+    if (m.generation >= kGenCeiling)
+      return drop(out, HopsetReason::GenCeiling);
+    if (!mask_valid(m.active_mask, p_.n_base, p_.min_active))
+      return drop(out, m.active_mask & ~full_mask(p_.n_base)
+                           ? HopsetReason::BadMask
+                           : HopsetReason::LowDiversity);
+    const bool same_epoch = have_auth_ && m.tx_epoch == auth_epoch_;
+    if (same_epoch) {
+      if (st_ == State::Pending && m.generation == pend_.generation &&
+          m.active_mask == pend_.active_mask &&
+          m.activate_slot == pend_.activate_slot)
+        return out; /* repeated commit — already armed */
+      if (m.generation <= cur_.generation)
+        return drop(out, HopsetReason::ReplayGen);
+    }
+    /* A commit echoing OUR epoch must echo our outstanding nonce. */
+    if (m.rx_epoch_echo == epoch_ && epoch_ != 0 &&
+        (st_ != State::Proposing || m.rx_nonce_echo != prop_.rx_nonce))
+      return drop(out, HopsetReason::NonceMismatch);
+    /* Activation window: a future activation must sit within the allowed
+     * lead; a past one is only ever adopted as recovery (the transition
+     * already happened — join it now). */
+    if (m.activate_slot > now_slot &&
+        m.activate_slot - now_slot > p_.max_lead_slots)
+      return drop(out, HopsetReason::ActivationWindow);
+    adopt_epoch(m.tx_epoch);
+    const bool was_recovering = st_ == State::Recovering;
+    pend_.epoch = m.tx_epoch;
+    pend_.generation = m.generation;
+    pend_.active_mask = m.active_mask;
+    pend_.activate_round = m.activate_round;
+    pend_.activate_slot = m.activate_slot;
+    HopsetAction ev{};
+    ev.kind = HopsetAction::Event;
+    ev.event = was_recovering ? HopsetEvent::Recover : HopsetEvent::Commit;
+    ev.state = pend_;
+    out.push_back(ev);
+    if (m.activate_slot <= now_slot) {
+      activate(out);
+    } else {
+      st_ = State::Pending;
+    }
+    return out;
+  }
+
+  /* The authority's status beacon (also carries proposal rejections). */
+  std::vector<HopsetAction> on_status(const HopsetMsg &m, uint64_t now_slot) {
+    std::vector<HopsetAction> out;
+    (void)now_slot;
+    if (m.role != 1)
+      return out; /* peer-follower chatter — not authority state */
+    if (m.base_fp != p_.base_fp)
+      return drop(out, HopsetReason::BadBaseFp);
+    /* A nonzero reason echoing our outstanding nonce: proposal denied. */
+    if (m.reason != static_cast<uint8_t>(HopsetReason::None) &&
+        st_ == State::Proposing && m.rx_nonce_echo == prop_.rx_nonce) {
+      st_ = State::Synced;
+      HopsetAction ev{};
+      ev.kind = HopsetAction::Event;
+      ev.event = HopsetEvent::Reject;
+      ev.reason = static_cast<HopsetReason>(m.reason);
+      out.push_back(ev);
+      return out;
+    }
+    if (!mask_valid(m.active_mask, p_.n_base, p_.min_active) &&
+        m.generation != 0)
+      return drop(out, HopsetReason::BadMask);
+    const bool same_epoch = have_auth_ && m.sender_epoch == auth_epoch_;
+    if (same_epoch && m.generation < cur_.generation)
+      return drop(out, HopsetReason::ReplayGen);
+    if (same_epoch && m.generation == cur_.generation)
+      return resync_check(out); /* in agreement */
+    /* Newer generation (or a restarted authority): adopt its current state
+     * outright — the status carries the full mask and the activation anchor,
+     * which is exactly the recovery an RX that missed the commits needs. */
+    adopt_epoch(m.sender_epoch);
+    pend_.epoch = m.sender_epoch;
+    pend_.generation = m.generation;
+    pend_.active_mask =
+        m.generation == 0 ? full_mask(p_.n_base) : m.active_mask;
+    pend_.activate_round = 0;
+    pend_.activate_slot = m.activate_slot;
+    HopsetAction ev{};
+    ev.kind = HopsetAction::Event;
+    ev.event = HopsetEvent::Recover;
+    ev.state = pend_;
+    out.push_back(ev);
+    activate(out);
+    return out;
+  }
+
+  /* Hot-path check from a decoded v2 sync marker. fp_matches: host-computed
+   * "the marker's (generation, mask_fp) equals mask_fp(keys, gen, mask) of
+   * the state we hold for that generation" (current or pending). */
+  std::vector<HopsetAction> on_marker(uint32_t marker_gen, bool fp_matches,
+                                      uint64_t now_slot) {
+    std::vector<HopsetAction> out;
+    (void)now_slot;
+    const bool known = (marker_gen == cur_.generation ||
+                        (st_ == State::Pending &&
+                         marker_gen == pend_.generation)) &&
+                       fp_matches;
+    if (known)
+      return out;
+    if (st_ == State::Recovering && marker_gen == last_mismatch_gen_)
+      return out; /* already recovering from this one — don't spam */
+    last_mismatch_gen_ = marker_gen;
+    st_ = State::Recovering;
+    HopsetAction ev{};
+    ev.kind = HopsetAction::Event;
+    ev.event = HopsetEvent::GenMismatch;
+    ev.msg.generation = marker_gen;
+    ev.state = cur_;
+    out.push_back(ev);
+    return out;
+  }
+
+  /* Slot heartbeat: pending activation, proposal retry/backoff. */
+  std::vector<HopsetAction> on_tick(uint64_t now_slot) {
+    std::vector<HopsetAction> out;
+    if (st_ == State::Pending && now_slot >= pend_.activate_slot) {
+      activate(out);
+      return out;
+    }
+    if (st_ == State::Proposing &&
+        now_slot - last_prop_slot_ >= p_.proposal_backoff_slots) {
+      if (tries_ >= p_.proposal_retries) {
+        st_ = State::Synced;
+        HopsetAction ev{};
+        ev.kind = HopsetAction::Event;
+        ev.event = HopsetEvent::Reject;
+        ev.reason = HopsetReason::Timeout;
+        out.push_back(ev);
+        return out;
+      }
+      ++tries_;
+      last_prop_slot_ = now_slot;
+      HopsetAction a{};
+      a.kind = HopsetAction::SendControl;
+      a.msg = prop_;
+      out.push_back(a);
+    }
+    return out;
+  }
+
+private:
+  void adopt_epoch(uint32_t e) {
+    if (!have_auth_ || auth_epoch_ != e) {
+      have_auth_ = true;
+      auth_epoch_ = e;
+    }
+  }
+
+  void activate(std::vector<HopsetAction> &out) {
+    cur_ = pend_;
+    st_ = State::Synced;
+    HopsetAction act{};
+    act.kind = HopsetAction::Activate;
+    act.state = cur_;
+    out.push_back(act);
+    HopsetAction ev{};
+    ev.kind = HopsetAction::Event;
+    ev.event = HopsetEvent::Activate;
+    ev.state = cur_;
+    out.push_back(ev);
+  }
+
+  std::vector<HopsetAction> &resync_check(std::vector<HopsetAction> &out) {
+    if (st_ == State::Recovering) {
+      /* the authority's state matches what we already hold — the mismatch
+       * was transient (e.g. a marker raced its own activation) */
+      st_ = State::Synced;
+      HopsetAction ev{};
+      ev.kind = HopsetAction::Event;
+      ev.event = HopsetEvent::Recover;
+      ev.state = cur_;
+      out.push_back(ev);
+    }
+    return out;
+  }
+
+  std::vector<HopsetAction> &drop(std::vector<HopsetAction> &out,
+                                  HopsetReason r) {
+    HopsetAction ev{};
+    ev.kind = HopsetAction::Event;
+    ev.event = HopsetEvent::Reject;
+    ev.reason = r;
+    out.push_back(ev);
+    return out;
+  }
+
+  HopsetParams p_;
+  uint32_t epoch_;
+  State st_ = State::Synced;
+  HopsetState cur_{};
+  HopsetState pend_{};
+  HopsetMsg prop_{};
+  unsigned tries_ = 0;
+  uint64_t last_prop_slot_ = 0;
+  bool have_auth_ = false;
+  uint32_t auth_epoch_ = 0;
+  uint32_t last_mismatch_gen_ = 0;
+};
+
+} /* namespace hopset */
+} /* namespace devourer */
+
+#endif /* DEVOURER_HOPSET_HOPSET_FOLLOWER_H */

--- a/src/hopset/HopsetState.h
+++ b/src/hopset/HopsetState.h
@@ -1,0 +1,246 @@
+/* HopsetState — the deterministic state model for adaptive FHSS hopset
+ * changes. The configured base hopset is immutable; every adaptive state
+ * identifies its active channels by stable base-hopset bit positions in a
+ * 64-bit mask, so a channel keeps its identity across any sequence of
+ * exclusions and restorations.
+ *
+ * Generation 0 is defined as "legacy": full mask, the raw master key, and the
+ * exact fixed-hop permutation of HopSchedule — so with adaptive mode disabled
+ * (or before the first commit) the schedule is byte-identical to the shipped
+ * fixed-hop behavior. Generations >= 1 derive each round's permutation from
+ * (schedule subkey, generation, round, active_mask): including the generation
+ * makes a mask change produce a fresh keyed order rather than a filtered form
+ * of the previous permutation, and the whole lookup stays a pure function of
+ * (keys, committed state, absolute slot) — a receiver joins mid-generation
+ * with no RNG state, exactly like the fixed schedule.
+ *
+ * The schedule and control keys are domain-separated from the master seed
+ * (a schedule fingerprint is not authentication — the MAC key is its own
+ * derivation). Pure, header-only, selftested; the library reads no env. */
+#ifndef DEVOURER_HOPSET_HOPSET_STATE_H
+#define DEVOURER_HOPSET_HOPSET_STATE_H
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+#include "HopSchedule.h"
+
+namespace devourer {
+namespace hopset {
+
+/* Generations are monotonic within one authority epoch; an authority refuses
+ * to commit at the ceiling — recovery is a restart (fresh random epoch,
+ * generation back to 0). */
+inline constexpr uint32_t kGenCeiling = 0xFFFFFF00u;
+
+/* Base hopsets are capped by the mask width. */
+inline constexpr size_t kMaxBaseChannels = 64;
+
+inline unsigned popcount64(uint64_t v) {
+  unsigned c = 0;
+  for (; v; v &= v - 1)
+    ++c;
+  return c;
+}
+
+inline uint64_t full_mask(size_t n) {
+  return n >= 64 ? ~uint64_t(0) : ((uint64_t(1) << n) - 1);
+}
+
+/* Index of the j-th set bit (j counted from 0, LSB-first). Precondition:
+ * j < popcount64(mask). */
+inline size_t nth_set_bit(uint64_t mask, size_t j) {
+  for (size_t i = 0; i < 64; ++i)
+    if (mask & (uint64_t(1) << i)) {
+      if (!j)
+        return i;
+      --j;
+    }
+  throw std::invalid_argument("nth_set_bit past popcount");
+}
+
+/* A mask is valid against an n-channel base hopset iff it selects only real
+ * positions and keeps at least min_active channels in play. */
+inline bool mask_valid(uint64_t mask, size_t n, unsigned min_active) {
+  if (n == 0 || n > kMaxBaseChannels)
+    return false;
+  if (mask & ~full_mask(n))
+    return false;
+  return popcount64(mask) >= min_active;
+}
+
+/* Schedule + control keys, domain-separated from the master seed
+ * (DEVOURER_HOP_SEED). The master key itself stays the generation-0 schedule
+ * key so the legacy fixed schedule is untouched. */
+struct HopsetKeys {
+  HopSchedule::Key master{}; /* gen-0 (legacy) schedule key */
+  HopSchedule::Key sched{};  /* gen>=1 adaptive schedule subkey */
+  HopSchedule::Key ctrl{};   /* control-message MAC key */
+
+  static HopsetKeys derive(const HopSchedule::Key &master) {
+    static const uint8_t s0[] = {'d', 'e', 'v', 'o', 'u', 'r', 'e', 'r', '-',
+                                 'h', 'o', 'p', 's', 'e', 't', '-', 's', '0'};
+    static const uint8_t s1[] = {'d', 'e', 'v', 'o', 'u', 'r', 'e', 'r', '-',
+                                 'h', 'o', 'p', 's', 'e', 't', '-', 's', '1'};
+    static const uint8_t c0[] = {'d', 'e', 'v', 'o', 'u', 'r', 'e', 'r', '-',
+                                 'h', 'o', 'p', 's', 'e', 't', '-', 'c', '0'};
+    static const uint8_t c1[] = {'d', 'e', 'v', 'o', 'u', 'r', 'e', 'r', '-',
+                                 'h', 'o', 'p', 's', 'e', 't', '-', 'c', '1'};
+    HopsetKeys out;
+    out.master = master;
+    pack(out.sched, HopSchedule::siphash24(master, s0, sizeof(s0)),
+         HopSchedule::siphash24(master, s1, sizeof(s1)));
+    pack(out.ctrl, HopSchedule::siphash24(master, c0, sizeof(c0)),
+         HopSchedule::siphash24(master, c1, sizeof(c1)));
+    return out;
+  }
+
+  uint64_t mac(const uint8_t *p, size_t n) const {
+    return HopSchedule::siphash24(ctrl, p, n);
+  }
+
+private:
+  static void pack(HopSchedule::Key &k, uint64_t lo, uint64_t hi) {
+    for (int i = 0; i < 8; ++i) {
+      k[i] = static_cast<uint8_t>(lo >> (8 * i));
+      k[8 + i] = static_cast<uint8_t>(hi >> (8 * i));
+    }
+  }
+};
+
+/* Fingerprint binding a message to the schedule subkey AND the exact base
+ * channel list — a config/routing check (the MAC under the control key is the
+ * authentication). Channels are the demo's channel numbers in base order. */
+inline uint32_t hopset_fp(const HopsetKeys &keys, const uint32_t *ch,
+                          size_t n) {
+  std::vector<uint8_t> m = {'d', 'e', 'v', 'o', 'u', 'r', 'e', 'r', '-',
+                            'h', 'o', 'p', 's', 'e', 't', '-', 'f', 'p'};
+  m.push_back(static_cast<uint8_t>(n));
+  for (size_t i = 0; i < n; ++i)
+    for (int b = 0; b < 4; ++b)
+      m.push_back(static_cast<uint8_t>(ch[i] >> (8 * b)));
+  return static_cast<uint32_t>(
+      HopSchedule::siphash24(keys.sched, m.data(), m.size()));
+}
+
+/* Compact (generation, mask) advertisement for the hot-path sync marker —
+ * enough for a follower to detect it missed a transition; the full mask is
+ * recovered from the repeated authenticated Commit/Status frames. */
+inline uint32_t mask_fp(const HopsetKeys &keys, uint32_t generation,
+                        uint64_t mask) {
+  uint8_t m[31] = {'d', 'e', 'v', 'o', 'u', 'r', 'e', 'r', '-', 'h',
+                   'o', 'p', 's', 'e', 't', '-', 'm', 'f', 'p'};
+  for (int i = 0; i < 4; ++i)
+    m[19 + i] = static_cast<uint8_t>(generation >> (8 * i));
+  for (int i = 0; i < 8; ++i)
+    m[23 + i] = static_cast<uint8_t>(mask >> (8 * i));
+  return static_cast<uint32_t>(HopSchedule::siphash24(keys.sched, m, sizeof(m)));
+}
+
+/* The committed adaptive state both endpoints hold. activate_slot is the
+ * absolute-slot activation boundary (the anchor both sides key on — rounds
+ * change length when the mask popcount changes, absolute slots never do);
+ * activate_round is the same instant counted in the *previous* generation's
+ * rounds, carried for window validation. */
+struct HopsetState {
+  uint32_t epoch = 0;      /* the authority's per-boot random epoch */
+  uint32_t generation = 0; /* 0 = legacy fixed schedule, full mask */
+  uint64_t active_mask = 0;
+  uint64_t activate_round = 0;
+  uint64_t activate_slot = 0;
+};
+
+/* Generation/mask-aware stateless slot->channel lookup over an immutable
+ * base hopset. Generation 0 forwards verbatim to the wrapped HopSchedule
+ * (keyed or sequential); generations >= 1 permute the active positions with
+ * the schedule subkey. Caller contract: channel_index is asked only for
+ * slots at/after the committed state's activation boundary (a follower holds
+ * the previous state object until the boundary passes). */
+class AdaptiveScheduleView {
+public:
+  AdaptiveScheduleView(const HopSchedule &base, const HopsetKeys &keys,
+                       size_t n_base)
+      : base_(&base), keys_(keys), n_(n_base) {
+    if (!n_base || n_base > kMaxBaseChannels)
+      throw std::invalid_argument("base hopset size out of range");
+  }
+
+  void set_state(const HopsetState &st) { st_ = st; }
+  const HopsetState &state() const { return st_; }
+  size_t base_size() const { return n_; }
+
+  /* Active-round length: base size at gen 0, popcount of the mask after. */
+  size_t active_count() const {
+    return st_.generation == 0 ? n_
+                               : popcount64(st_.active_mask);
+  }
+
+  size_t channel_index(uint64_t slot) const {
+    if (st_.generation == 0)
+      return base_->channel_index(slot, n_);
+    const size_t k = popcount64(st_.active_mask);
+    if (!k)
+      throw std::invalid_argument("empty active mask");
+    const uint64_t rel = slot - st_.activate_slot;
+    if (k == 1)
+      return nth_set_bit(st_.active_mask, 0);
+    const auto p = permutation(rel / k, k);
+    return nth_set_bit(st_.active_mask, p[rel % k]);
+  }
+
+  template <class T>
+  const T &channel(uint64_t slot, const std::vector<T> &base_channels) const {
+    return base_channels[channel_index(slot)];
+  }
+
+  /* The gen>=1 permutation: the same rejection-sampled Fisher-Yates as
+   * HopSchedule::permutation, driven by words bound to (generation, mask,
+   * round) under the schedule subkey. Per-generation rounds start at 0 at
+   * the activation boundary. */
+  std::vector<size_t> permutation(uint64_t round, size_t k) const {
+    std::vector<size_t> p(k);
+    for (size_t i = 0; i < k; ++i)
+      p[i] = i;
+    uint64_t counter = 0;
+    for (size_t i = k; i > 1; --i) {
+      const uint64_t bound = static_cast<uint64_t>(i);
+      const uint64_t limit = UINT64_MAX - (UINT64_MAX % bound);
+      uint64_t r;
+      do {
+        r = word(round, counter++);
+      } while (r >= limit);
+      const size_t j = static_cast<size_t>(r % bound);
+      const size_t t = p[i - 1];
+      p[i - 1] = p[j];
+      p[j] = t;
+    }
+    return p;
+  }
+
+private:
+  /* 'A' domain tag vs the legacy word's 'H' — the two can never collide even
+   * under the same key, and the subkey separates them anyway. */
+  uint64_t word(uint64_t round, uint64_t counter) const {
+    uint8_t msg[29] = {'A'};
+    for (int i = 0; i < 4; ++i)
+      msg[1 + i] = static_cast<uint8_t>(st_.generation >> (8 * i));
+    for (int i = 0; i < 8; ++i) {
+      msg[5 + i] = static_cast<uint8_t>(st_.active_mask >> (8 * i));
+      msg[13 + i] = static_cast<uint8_t>(round >> (8 * i));
+      msg[21 + i] = static_cast<uint8_t>(counter >> (8 * i));
+    }
+    return HopSchedule::siphash24(keys_.sched, msg, sizeof(msg));
+  }
+
+  const HopSchedule *base_;
+  HopsetKeys keys_;
+  HopsetState st_{};
+  size_t n_;
+};
+
+} /* namespace hopset */
+} /* namespace devourer */
+
+#endif /* DEVOURER_HOPSET_HOPSET_STATE_H */

--- a/src/hopset/HopsetTypes.h
+++ b/src/hopset/HopsetTypes.h
@@ -1,0 +1,162 @@
+/* Shared types for the adaptive-hopset control protocol (RX proposes, TX —
+ * the schedule authority — validates and commits). One header so the wire
+ * codec, the two pure machines (HopsetAuthority, HopsetFollower), the demos
+ * and the selftests agree on every code.
+ *
+ * Authority model: the receiver proposes a mask change; the transmitter
+ * validates policy (diversity floor, monotonic generation, activation lead)
+ * and repeatedly broadcasts an authenticated commit naming a future
+ * activation slot; both sides swap state exactly at that slot. Nobody acts on
+ * a proposal alone, and acquisition always scans the immutable base hopset. */
+#ifndef DEVOURER_HOPSET_HOPSET_TYPES_H
+#define DEVOURER_HOPSET_HOPSET_TYPES_H
+
+#include <cstdint>
+
+#include "hopset/HopsetState.h"
+
+namespace devourer {
+namespace hopset {
+
+enum HopsetMsgType : uint8_t {
+  HT_PROPOSAL = 1,
+  HT_COMMIT = 2,
+  HT_STATUS = 3,
+};
+
+/* Reject / status reason codes (wire byte + event string). */
+enum class HopsetReason : uint8_t {
+  None = 0,
+  BadMac,
+  BadVersion,
+  BadType,
+  BadLinkId,
+  Truncated,
+  StaleEpoch,
+  ReplayGen,
+  NonMonotonicGen,
+  GenCeiling,
+  BadBaseFp,
+  BadMask,
+  LowDiversity,
+  ActivationWindow,
+  NoChange,
+  Busy,
+  NonceMismatch,
+  Timeout,
+};
+
+inline const char *hopset_reason_name(HopsetReason r) {
+  switch (r) {
+  case HopsetReason::None: return "none";
+  case HopsetReason::BadMac: return "bad_mac";
+  case HopsetReason::BadVersion: return "bad_version";
+  case HopsetReason::BadType: return "bad_type";
+  case HopsetReason::BadLinkId: return "bad_link_id";
+  case HopsetReason::Truncated: return "truncated";
+  case HopsetReason::StaleEpoch: return "stale_epoch";
+  case HopsetReason::ReplayGen: return "replay_gen";
+  case HopsetReason::NonMonotonicGen: return "non_monotonic_gen";
+  case HopsetReason::GenCeiling: return "gen_ceiling";
+  case HopsetReason::BadBaseFp: return "bad_base_fp";
+  case HopsetReason::BadMask: return "bad_mask";
+  case HopsetReason::LowDiversity: return "low_diversity";
+  case HopsetReason::ActivationWindow: return "activation_window";
+  case HopsetReason::NoChange: return "no_change";
+  case HopsetReason::Busy: return "busy";
+  case HopsetReason::NonceMismatch: return "nonce_mismatch";
+  case HopsetReason::Timeout: return "timeout";
+  }
+  return "?";
+}
+
+/* The decoded control message — a flat superset; each type populates its own
+ * fields. The pure machines produce/consume these; the host does the crypto
+ * (encode/decode/MAC via HopsetWire) and the transmission. */
+struct HopsetMsg {
+  HopsetMsgType type = HT_PROPOSAL;
+  uint32_t link_id = 0;
+
+  /* identity / anti-replay */
+  uint32_t rx_epoch = 0;      /* proposal: proposer's per-boot epoch */
+  uint32_t tx_epoch = 0;      /* commit: authority's per-boot epoch */
+  uint32_t sender_epoch = 0;  /* status */
+  uint32_t rx_epoch_echo = 0; /* commit: 0 = authority-originated */
+  uint32_t rx_nonce = 0, rx_nonce_echo = 0;
+
+  /* hopset state */
+  uint32_t generation = 0; /* commit/status; proposal: proposed (0 = next) */
+  uint64_t active_mask = 0;
+  uint32_t base_fp = 0;
+  uint64_t activate_round = 0; /* commit: previous-generation rounds */
+  uint64_t activate_slot = 0;  /* commit/status: absolute-slot anchor */
+  uint64_t current_round = 0;  /* sender's round at send time */
+
+  /* proposal evidence summary — opaque here; the observation policy that
+   * fills it lives with the exclusion-decision layer */
+  uint32_t observation_count = 0;
+  uint32_t reason_bitmap = 0;
+  uint64_t earliest_activate_round = 0; /* 0 = authority picks */
+
+  /* status */
+  uint8_t role = 0;   /* 0 = follower(RX), 1 = authority(TX) */
+  uint8_t reason = 0; /* HopsetReason; nonzero = proposal rejection answer */
+};
+
+/* Structured-event codes the machines report through actions; the host maps
+ * them to the hopset.* JSONL events. */
+enum class HopsetEvent : uint8_t {
+  Propose = 1, /* proposal sent (follower) or accepted (authority) */
+  Commit,      /* commit issued / adopted as pending */
+  Activate,    /* committed state swapped in at the boundary */
+  Reject,      /* + reason */
+  GenMismatch, /* marker advertises a generation/mask we don't hold */
+  Recover,     /* re-synchronized from an authenticated commit/status */
+};
+
+inline const char *hopset_event_name(HopsetEvent e) {
+  switch (e) {
+  case HopsetEvent::Propose: return "hopset.propose";
+  case HopsetEvent::Commit: return "hopset.commit";
+  case HopsetEvent::Activate: return "hopset.activate";
+  case HopsetEvent::Reject: return "hopset.reject";
+  case HopsetEvent::GenMismatch: return "hopset.gen_mismatch";
+  case HopsetEvent::Recover: return "hopset.recover";
+  }
+  return "?";
+}
+
+/* An action a pure machine asks its host to perform: no I/O, no crypto, no
+ * clock inside the machines — the host encodes+MACs `msg` for SendControl,
+ * applies `state` to its AdaptiveScheduleView on Activate, and logs Events. */
+struct HopsetAction {
+  enum Kind : uint8_t {
+    SendControl, /* msg -> encode + MAC + air */
+    Activate,    /* state -> the new committed schedule state */
+    Event,       /* event (+ reason, + state context) -> JSONL */
+  } kind;
+  HopsetMsg msg{};
+  HopsetState state{};
+  HopsetEvent event = HopsetEvent::Propose;
+  HopsetReason reason = HopsetReason::None;
+};
+
+/* Static policy knobs, host-provided (the demos map env; the library reads
+ * none). Slot-denominated intervals so behavior is deterministic in tests. */
+struct HopsetParams {
+  size_t n_base = 0;      /* immutable base hopset size (1..64) */
+  uint32_t base_fp = 0;   /* hopset_fp over the configured channel list */
+  uint32_t link_id = 0;   /* 0 accepts any link on decode */
+  unsigned min_active = 2;
+  uint64_t lead_rounds = 8;           /* min commit->activation lead */
+  uint64_t max_lead_slots = 4096;     /* upper activation window bound */
+  uint64_t commit_repeat_slots = 4;   /* re-broadcast cadence until active */
+  uint64_t status_interval_slots = 64;
+  unsigned proposal_retries = 8;
+  uint64_t proposal_backoff_slots = 16;
+};
+
+} /* namespace hopset */
+} /* namespace devourer */
+
+#endif /* DEVOURER_HOPSET_HOPSET_TYPES_H */

--- a/src/hopset/HopsetWire.h
+++ b/src/hopset/HopsetWire.h
@@ -1,0 +1,288 @@
+/* HopsetWire — the authenticated wire codec for the adaptive-hopset control
+ * protocol. Byte-packed little-endian (put/get helpers, no struct casts —
+ * portable and KAT-stable, the MigWire style), every message MAC'd with
+ * SipHash-2-4 under the control key domain-separated from the hop seed
+ * (hopset/HopsetState.h). A schedule fingerprint is not authentication — the
+ * base_fp/mask_fp fields are config/routing checks, the MAC is the auth.
+ *
+ * Anti-replay is structural: epochs are random per process start and never
+ * persisted, generations are monotonic within an authority epoch, and a
+ * commit's absolute activate_slot must sit inside the follower's allowed
+ * window — a replayed commit from an old boot names a slot in the past of a
+ * different epoch and cannot arm anything.
+ *
+ * Every message is <= 96 bytes (asserted in the KAT). Pure, header-only. */
+#ifndef DEVOURER_HOPSET_HOPSET_WIRE_H
+#define DEVOURER_HOPSET_HOPSET_WIRE_H
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#include "hopset/HopsetTypes.h"
+
+namespace devourer {
+namespace hopset {
+
+inline constexpr uint16_t kHopsetMagic = 0x5348; /* bytes 0x48 0x53 = "HS" */
+inline constexpr uint8_t kHopsetVersion = 1;
+inline constexpr size_t kHopsetHeader = 8; /* magic(2) ver(1) type(1) link(4) */
+inline constexpr size_t kHopsetMacLen = 8;
+inline constexpr size_t kHopsetMaxLen = 96;
+
+namespace wire {
+inline void p8(std::vector<uint8_t> &b, uint8_t v) { b.push_back(v); }
+inline void p16(std::vector<uint8_t> &b, uint16_t v) {
+  b.push_back(uint8_t(v));
+  b.push_back(uint8_t(v >> 8));
+}
+inline void p32(std::vector<uint8_t> &b, uint32_t v) {
+  for (int i = 0; i < 4; i++)
+    b.push_back(uint8_t(v >> (8 * i)));
+}
+inline void p64(std::vector<uint8_t> &b, uint64_t v) {
+  for (int i = 0; i < 8; i++)
+    b.push_back(uint8_t(v >> (8 * i)));
+}
+inline uint8_t g8(const uint8_t *p, size_t &o) { return p[o++]; }
+inline uint16_t g16(const uint8_t *p, size_t &o) {
+  uint16_t v = uint16_t(p[o]) | uint16_t(p[o + 1]) << 8;
+  o += 2;
+  return v;
+}
+inline uint32_t g32(const uint8_t *p, size_t &o) {
+  uint32_t v = 0;
+  for (int i = 0; i < 4; i++)
+    v |= uint32_t(p[o + i]) << (8 * i);
+  o += 4;
+  return v;
+}
+inline uint64_t g64(const uint8_t *p, size_t &o) {
+  uint64_t v = 0;
+  for (int i = 0; i < 8; i++)
+    v |= uint64_t(p[o + i]) << (8 * i);
+  o += 8;
+  return v;
+}
+} /* namespace wire */
+
+/* Finish a partially-built frame: append the SipHash MAC (control key) over
+ * everything so far. */
+inline std::vector<uint8_t> hopset_seal(std::vector<uint8_t> b,
+                                        const HopsetKeys &keys) {
+  const uint64_t mac = keys.mac(b.data(), b.size());
+  wire::p64(b, mac);
+  return b;
+}
+
+inline std::vector<uint8_t> hopset_encode(const HopsetMsg &m,
+                                          const HopsetKeys &keys) {
+  std::vector<uint8_t> b;
+  wire::p16(b, kHopsetMagic);
+  wire::p8(b, kHopsetVersion);
+  wire::p8(b, static_cast<uint8_t>(m.type));
+  wire::p32(b, m.link_id);
+  switch (m.type) {
+  case HT_PROPOSAL: /* 56 bytes */
+    wire::p32(b, m.rx_epoch);
+    wire::p32(b, m.generation);
+    wire::p64(b, m.active_mask);
+    wire::p32(b, m.base_fp);
+    wire::p32(b, m.observation_count);
+    wire::p32(b, m.reason_bitmap);
+    wire::p64(b, m.earliest_activate_round);
+    wire::p32(b, m.rx_nonce);
+    break;
+  case HT_COMMIT: /* 68 bytes */
+    wire::p32(b, m.tx_epoch);
+    wire::p32(b, m.rx_epoch_echo);
+    wire::p32(b, m.generation);
+    wire::p64(b, m.active_mask);
+    wire::p32(b, m.base_fp);
+    wire::p64(b, m.activate_round);
+    wire::p64(b, m.activate_slot);
+    wire::p64(b, m.current_round);
+    wire::p32(b, m.rx_nonce_echo);
+    break;
+  case HT_STATUS: /* 58 bytes */
+    wire::p8(b, m.role);
+    wire::p32(b, m.sender_epoch);
+    wire::p32(b, m.generation);
+    wire::p64(b, m.active_mask);
+    wire::p32(b, m.base_fp);
+    wire::p64(b, m.current_round);
+    wire::p64(b, m.activate_slot);
+    wire::p8(b, m.reason);
+    wire::p32(b, m.rx_nonce_echo); /* binds a rejection to the proposal */
+    break;
+  }
+  return hopset_seal(std::move(b), keys);
+}
+
+/* Decode + authenticate. Returns HopsetReason::None on success (out filled).
+ * n may exceed the message length (trailing FCS/pad — the message occupies a
+ * prefix; the MAC sits right after the fixed per-type body and is verified
+ * over exactly [0..body)). link_id 0 skips the link check (KATs). */
+inline HopsetReason hopset_decode(const uint8_t *p, size_t n,
+                                  const HopsetKeys &keys, uint32_t expect_link,
+                                  HopsetMsg &out) {
+  if (n < kHopsetHeader + kHopsetMacLen || n > kHopsetMaxLen + 8)
+    return HopsetReason::Truncated;
+  size_t o = 0;
+  if (wire::g16(p, o) != kHopsetMagic)
+    return HopsetReason::BadType;
+  if (wire::g8(p, o) != kHopsetVersion)
+    return HopsetReason::BadVersion;
+  const uint8_t type = wire::g8(p, o);
+  const uint32_t link = wire::g32(p, o);
+  if (type < HT_PROPOSAL || type > HT_STATUS)
+    return HopsetReason::BadType;
+  if (expect_link != 0 && link != expect_link)
+    return HopsetReason::BadLinkId;
+
+  out = HopsetMsg{};
+  out.type = static_cast<HopsetMsgType>(type);
+  out.link_id = link;
+  switch (type) {
+  case HT_PROPOSAL:
+    if (n < 56)
+      return HopsetReason::Truncated;
+    out.rx_epoch = wire::g32(p, o);
+    out.generation = wire::g32(p, o);
+    out.active_mask = wire::g64(p, o);
+    out.base_fp = wire::g32(p, o);
+    out.observation_count = wire::g32(p, o);
+    out.reason_bitmap = wire::g32(p, o);
+    out.earliest_activate_round = wire::g64(p, o);
+    out.rx_nonce = wire::g32(p, o);
+    break;
+  case HT_COMMIT:
+    if (n < 68)
+      return HopsetReason::Truncated;
+    out.tx_epoch = wire::g32(p, o);
+    out.rx_epoch_echo = wire::g32(p, o);
+    out.generation = wire::g32(p, o);
+    out.active_mask = wire::g64(p, o);
+    out.base_fp = wire::g32(p, o);
+    out.activate_round = wire::g64(p, o);
+    out.activate_slot = wire::g64(p, o);
+    out.current_round = wire::g64(p, o);
+    out.rx_nonce_echo = wire::g32(p, o);
+    break;
+  case HT_STATUS:
+    if (n < 58)
+      return HopsetReason::Truncated;
+    out.role = wire::g8(p, o);
+    out.sender_epoch = wire::g32(p, o);
+    out.generation = wire::g32(p, o);
+    out.active_mask = wire::g64(p, o);
+    out.base_fp = wire::g32(p, o);
+    out.current_round = wire::g64(p, o);
+    out.activate_slot = wire::g64(p, o);
+    out.reason = wire::g8(p, o);
+    out.rx_nonce_echo = wire::g32(p, o);
+    break;
+  }
+  if (o + kHopsetMacLen > n)
+    return HopsetReason::Truncated;
+  const uint64_t want = keys.mac(p, o);
+  size_t mo = o;
+  const uint64_t got = wire::g64(p, mo);
+  if (want != got)
+    return HopsetReason::BadMac;
+  return HopsetReason::None;
+}
+
+/* Sync-marker v2 — the v1 HopSyncMarker layout (HopSchedule.h) with the
+ * version byte bumped to 2 and (generation, mask_fp) inserted before the
+ * tail, so a follower detects a missed transition from the TX hot path
+ * alone. The v1 decoder requires version==1 and the tail at its v1 offset,
+ * so each version rejects the other (versioned backward rejection); the
+ * demos emit v1 byte-identically whenever adaptive mode is off. */
+struct HopSyncMarkerV2 {
+  uint32_t fingerprint = 0, epoch = 0, phase_us = 0;
+  uint64_t slot = 0;
+  uint32_t generation = 0, mask_fp = 0;
+  static constexpr size_t kSize = 37;
+  static std::array<uint8_t, kSize> encode(const HopSyncMarkerV2 &m) {
+    std::array<uint8_t, kSize> b{{221, kSize - 2, 0x57, 0x42, 0x75, 0x48, 2}};
+    put32(b.data() + 7, m.fingerprint);
+    put32(b.data() + 11, m.epoch);
+    put64(b.data() + 15, m.slot);
+    put32(b.data() + 23, m.phase_us);
+    put32(b.data() + 27, m.generation);
+    put32(b.data() + 31, m.mask_fp);
+    b[35] = 0xd7;
+    b[36] = 0x3a;
+    return b;
+  }
+  static bool decode(const uint8_t *p, size_t n, HopSyncMarkerV2 &m) {
+    for (size_t i = 0; i + kSize <= n; ++i)
+      if (p[i] == 221 && p[i + 1] == kSize - 2 && p[i + 2] == 0x57 &&
+          p[i + 3] == 0x42 && p[i + 4] == 0x75 && p[i + 5] == 0x48 &&
+          p[i + 6] == 2 && p[i + 35] == 0xd7 && p[i + 36] == 0x3a) {
+        m.fingerprint = get32(p + i + 7);
+        m.epoch = get32(p + i + 11);
+        m.slot = get64(p + i + 15);
+        m.phase_us = get32(p + i + 23);
+        m.generation = get32(p + i + 27);
+        m.mask_fp = get32(p + i + 31);
+        return true;
+      }
+    return false;
+  }
+
+private:
+  static void put32(uint8_t *p, uint32_t v) {
+    for (int i = 0; i < 4; ++i)
+      p[i] = uint8_t(v >> (8 * i));
+  }
+  static void put64(uint8_t *p, uint64_t v) {
+    for (int i = 0; i < 8; ++i)
+      p[i] = uint8_t(v >> (8 * i));
+  }
+  static uint32_t get32(const uint8_t *p) {
+    uint32_t v = 0;
+    for (int i = 0; i < 4; ++i)
+      v |= uint32_t(p[i]) << (8 * i);
+    return v;
+  }
+  static uint64_t get64(const uint8_t *p) {
+    uint64_t v = 0;
+    for (int i = 0; i < 8; ++i)
+      v |= uint64_t(p[i]) << (8 * i);
+    return v;
+  }
+};
+
+/* What an authority remembers about proposal replays: recently accepted
+ * (epoch, nonce) pairs in a small ring — a replayed proposal from any boot
+ * matches a remembered pair and is rejected, while generation monotonicity
+ * (checked against the authority's own state) covers everything older. */
+struct ProposalReplayRing {
+  static constexpr size_t kDepth = 16;
+  std::array<uint64_t, kDepth> seen{};
+  size_t head = 0, count = 0;
+
+  static uint64_t pack(uint32_t epoch, uint32_t nonce) {
+    return (uint64_t(epoch) << 32) | nonce;
+  }
+  bool contains(uint32_t epoch, uint32_t nonce) const {
+    const uint64_t v = pack(epoch, nonce);
+    for (size_t i = 0; i < count; ++i)
+      if (seen[i] == v)
+        return true;
+    return false;
+  }
+  void remember(uint32_t epoch, uint32_t nonce) {
+    seen[head] = pack(epoch, nonce);
+    head = (head + 1) % kDepth;
+    if (count < kDepth)
+      ++count;
+  }
+};
+
+} /* namespace hopset */
+} /* namespace devourer */
+
+#endif /* DEVOURER_HOPSET_HOPSET_WIRE_H */

--- a/tests/hopset_activation_selftest.cpp
+++ b/tests/hopset_activation_selftest.cpp
@@ -1,0 +1,199 @@
+/* Process-level adaptive-hopset activation gate: two full stacks (schedule
+ * view + machine + real wire crypto + v2 sync markers) on a shared slot
+ * clock. (a) A committed mask change activates on BOTH sides at the same
+ * absolute slot and the per-slot channel sequences are identical across the
+ * boundary. (b) A follower that misses every commit detects the transition
+ * from the marker's generation/mask fingerprint, recovers via the authority's
+ * status beacon, and re-synchronizes — with a bounded desync window. */
+#include "hopset/HopsetAuthority.h"
+#include "hopset/HopsetFollower.h"
+#include "hopset/HopsetState.h"
+#include "hopset/HopsetWire.h"
+
+#include <cstdio>
+#include <functional>
+#include <vector>
+
+static int fails;
+#define CHECK(x, msg)                                                          \
+  do {                                                                         \
+    if (!(x)) {                                                                \
+      std::fprintf(stderr, "FAIL: %s\n", msg);                                 \
+      ++fails;                                                                 \
+    }                                                                          \
+  } while (0)
+
+using namespace devourer::hopset;
+
+int main() {
+  const auto master =
+      devourer::HopSchedule::parse_seed("00112233445566778899aabbccddeeff");
+  const HopsetKeys keys = HopsetKeys::derive(master);
+  devourer::HopSchedule base_tx(master), base_rx(master);
+
+  HopsetParams p;
+  p.n_base = 10;
+  p.base_fp = 0xFEEDF00D;
+  p.link_id = 0x77;
+  p.status_interval_slots = 40;
+  p.commit_repeat_slots = 4;
+
+  /* ---------------- (a) synchronized future-round activation ------------- */
+  {
+    HopsetAuthority auth(p, 0xAAAA);
+    HopsetFollower fol(p, 0xBBBB);
+    AdaptiveScheduleView vt(base_tx, keys, p.n_base);
+    AdaptiveScheduleView vr(base_rx, keys, p.n_base);
+
+    uint64_t slot = 0;
+    uint64_t tx_act = 0, rx_act = 0;
+    std::function<void(const std::vector<HopsetAction> &, bool)> pump =
+        [&](const std::vector<HopsetAction> &acts, bool from_auth) {
+      for (const auto &a : acts) {
+        if (a.kind == HopsetAction::Activate) {
+          if (from_auth) {
+            vt.set_state(a.state);
+            tx_act = slot;
+          } else {
+            vr.set_state(a.state);
+            rx_act = slot;
+          }
+        } else if (a.kind == HopsetAction::SendControl && from_auth) {
+          auto w = hopset_encode(a.msg, keys);
+          HopsetMsg r;
+          if (hopset_decode(w.data(), w.size(), keys, p.link_id, r) !=
+              HopsetReason::None)
+            continue;
+          if (r.type == HT_COMMIT)
+            pump(fol.on_commit(r, slot), false);
+          else if (r.type == HT_STATUS)
+            pump(fol.on_status(r, slot), false);
+        }
+      }
+    };
+
+    /* a scripted authority-originated change (mask drops 4 of 10 channels) */
+    pump(auth.start_change(0b0110110110, slot), true);
+    CHECK(auth.committing(), "authority armed");
+
+    std::vector<size_t> tx_seq, rx_seq;
+    for (int i = 0; i < 400; ++i) {
+      ++slot;
+      pump(auth.on_tick(slot), true);
+      pump(fol.on_tick(slot), false);
+      tx_seq.push_back(vt.channel_index(slot));
+      rx_seq.push_back(vr.channel_index(slot));
+    }
+    CHECK(tx_act != 0 && tx_act == rx_act,
+          "both sides activated at the same slot");
+    CHECK(tx_seq == rx_seq, "identical channel sequence across the boundary");
+    CHECK(vt.state().generation == 1 &&
+              vt.state().active_mask == 0b0110110110,
+          "generation 1 active");
+    /* every post-activation channel is in the active set */
+    for (uint64_t s = vt.state().activate_slot; s < slot; ++s)
+      CHECK(vt.state().active_mask & (uint64_t(1) << vt.channel_index(s)),
+            "post-activation slots stay inside the mask");
+  }
+
+  /* -------- (b) missed-commit recovery via marker + status beacon -------- */
+  {
+    HopsetAuthority auth(p, 0xCCCC);
+    HopsetFollower fol(p, 0xDDDD);
+    AdaptiveScheduleView vt(base_tx, keys, p.n_base);
+    AdaptiveScheduleView vr(base_rx, keys, p.n_base);
+
+    uint64_t slot = 0;
+    bool control_blackout = true; /* the follower misses every commit */
+    uint64_t recovered_slot = 0;
+    int gen_mismatch = 0, recover_ev = 0;
+
+    auto to_follower = [&](const std::vector<HopsetAction> &acts,
+                           auto &&self) -> void {
+      for (const auto &a : acts) {
+        if (a.kind == HopsetAction::Activate) {
+          vr.set_state(a.state);
+          if (a.state.generation > 0)
+            recovered_slot = slot;
+        } else if (a.kind == HopsetAction::Event) {
+          if (a.event == HopsetEvent::GenMismatch)
+            ++gen_mismatch;
+          if (a.event == HopsetEvent::Recover)
+            ++recover_ev;
+        }
+      }
+      (void)self;
+    };
+    auto from_auth = [&](const std::vector<HopsetAction> &acts) {
+      for (const auto &a : acts) {
+        if (a.kind == HopsetAction::Activate)
+          vt.set_state(a.state);
+        else if (a.kind == HopsetAction::SendControl) {
+          if (control_blackout)
+            continue;
+          auto w = hopset_encode(a.msg, keys);
+          HopsetMsg r;
+          if (hopset_decode(w.data(), w.size(), keys, p.link_id, r) !=
+              HopsetReason::None)
+            continue;
+          if (r.type == HT_COMMIT)
+            to_follower(fol.on_commit(r, slot), 0);
+          else if (r.type == HT_STATUS)
+            to_follower(fol.on_status(r, slot), 0);
+        }
+      }
+    };
+
+    from_auth(auth.start_change(0b1111000011, slot));
+    for (int i = 0; i < 200; ++i) {
+      ++slot;
+      from_auth(auth.on_tick(slot));
+      to_follower(fol.on_tick(slot), 0);
+      /* the TX hot path: every slot carries a v2 marker with the LIVE
+       * (generation, mask fingerprint) — encode/decode it for real */
+      HopSyncMarkerV2 mk;
+      mk.fingerprint = base_tx.fingerprint();
+      mk.slot = slot;
+      mk.generation = vt.state().generation;
+      mk.mask_fp = mask_fp(keys, vt.state().generation,
+                           vt.state().active_mask);
+      auto mw = HopSyncMarkerV2::encode(mk);
+      HopSyncMarkerV2 rm;
+      CHECK(HopSyncMarkerV2::decode(mw.data(), mw.size(), rm),
+            "marker decodes");
+      const bool matches =
+          (rm.generation == vr.state().generation &&
+           rm.mask_fp ==
+               mask_fp(keys, vr.state().generation, vr.state().active_mask)) ||
+          (fol.has_pending() && rm.generation == fol.pending().generation &&
+           rm.mask_fp == mask_fp(keys, fol.pending().generation,
+                                 fol.pending().active_mask));
+      to_follower(fol.on_marker(rm.generation, matches, slot), 0);
+      /* once the follower notices the mismatch, the "reverse path heals":
+       * recovery means the control plane is reachable again (the follower
+       * fell back to the base-hopset acquire scan and now hears the
+       * authority's repeated status beacon) */
+      if (fol.fsm() == HopsetFollower::State::Recovering)
+        control_blackout = false;
+    }
+    CHECK(vt.state().generation == 1, "authority activated alone");
+    CHECK(gen_mismatch >= 1, "marker exposed the missed transition");
+    CHECK(recover_ev >= 1, "follower recovered via authenticated control");
+    CHECK(recovered_slot != 0, "follower adopted the live state");
+    CHECK(vr.state().generation == vt.state().generation &&
+              vr.state().active_mask == vt.state().active_mask &&
+              vr.state().activate_slot == vt.state().activate_slot,
+          "post-recovery states identical");
+    /* bounded desync: recovery must land within one status interval of the
+     * mismatch being detectable (activation), plus delivery slack */
+    CHECK(recovered_slot - vt.state().activate_slot <=
+              p.status_interval_slots + p.commit_repeat_slots + 2,
+          "desync window bounded by the status cadence");
+    /* and the two schedule views agree for every slot after recovery */
+    for (uint64_t s = recovered_slot; s < slot; ++s)
+      CHECK(vt.channel_index(s) == vr.channel_index(s),
+            "post-recovery channel sequence identical");
+  }
+
+  return fails ? 1 : 0;
+}

--- a/tests/hopset_adaptive_onair.sh
+++ b/tests/hopset_adaptive_onair.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Adaptive-hopset on-air validation: two adapters, txdemo as the schedule
+# authority (scripted commit drops one base channel), rxdemo as the follower.
+#
+# Phase A — synchronized activation: the follower is tracking before the
+#   scripted commit lands; both sides must emit hopset.commit/hopset.activate
+#   for generation 1 and the RX must keep decoding markers after the boundary.
+# Phase B — missed-commit recovery: a FRESH follower starts after the
+#   transition already happened; it must detect the unknown generation (v2
+#   marker fingerprint and/or the status beacon), emit hopset.recover, adopt
+#   generation 1, and decode on the reduced set.
+#
+# Usage: sudo -v && tests/hopset_adaptive_onair.sh
+#        TX_PID=0xa81a RX_PID=0xc812 CHANNELS=1,6,11 tests/hopset_adaptive_onair.sh
+#
+# Cleanup: on any exit (incl. Ctrl-C) both demos are killed by exact comm.
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+VID="${VID:-0x0bda}"
+TX_PID="${TX_PID:-0xa81a}"     # RTL8812EU (Jaguar3)
+RX_PID="${RX_PID:-0xc812}"     # RTL8812CU (Jaguar3)
+CHANNELS="${CHANNELS:-1,6,11}" # base hopset (2.4 GHz — every DUT reaches it)
+SLOT_MS="${SLOT_MS:-50}"
+SEED="${SEED:-c0ffeef00dc0ffeef00dc0ffeef00d01}"
+COMMIT_SLOT="${COMMIT_SLOT:-150}" # scripted commit ~7.5 s in
+MASK="${MASK:-0x3}"               # drop base position 2 (channel 11)
+PHASE_A_S="${PHASE_A_S:-25}"
+PHASE_B_S="${PHASE_B_S:-20}"
+OUT="${OUT:-/tmp/devourer-hopset-onair}"
+
+plugged() { lsusb -d "$(printf '%04x:%04x' "$1" "$2")" >/dev/null 2>&1; }
+plugged "$VID" "$TX_PID" || { echo "SKIP: TX $VID:$TX_PID not plugged"; exit 77; }
+plugged "$VID" "$RX_PID" || { echo "SKIP: RX $VID:$RX_PID not plugged"; exit 77; }
+
+# In-tree rtw88/rtw89 auto-probe the dongles; temp-unbind any they hold.
+unbind() {
+    local pid="$1" d p i
+    for d in /sys/bus/usb/devices/*/idProduct; do
+        p=$(cat "$d" 2>/dev/null) || continue
+        [ "$p" = "${pid#0x}" ] || continue
+        for i in "$(dirname "$d")":*; do
+            [ -e "$i/driver" ] && sudo sh -c "echo '$(basename "$i")' > '$i/driver/unbind'" 2>/dev/null || true
+        done
+    done
+}
+
+cleanup() {
+    sudo pkill -INT -x txdemo 2>/dev/null || true
+    sudo pkill -INT -x rxdemo 2>/dev/null || true
+    sleep 1
+    sudo pkill -x txdemo 2>/dev/null || true
+    sudo pkill -x rxdemo 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+echo "== build =="
+cmake --build "$ROOT/build" -j --target txdemo rxdemo >/dev/null || exit 1
+unbind "$TX_PID"; unbind "$RX_PID"
+mkdir -p "$OUT"; rm -f "$OUT"/*.log
+
+COMMON=(DEVOURER_HOP_CHANNELS="$CHANNELS" DEVOURER_HOP_SLOT_MS="$SLOT_MS"
+        DEVOURER_HOP_SEED="$SEED" DEVOURER_HOP_ADAPTIVE=1
+        DEVOURER_LOG_LEVEL=info)
+
+echo "== phase A: follower tracks the scripted transition =="
+sudo env "${COMMON[@]}" DEVOURER_VID="$VID" DEVOURER_PID="$RX_PID" \
+    "$ROOT/build/rxdemo" >"$OUT/rxA.log" 2>&1 &
+RX_A=$!
+sleep 3
+sudo env "${COMMON[@]}" DEVOURER_VID="$VID" DEVOURER_PID="$TX_PID" \
+    DEVOURER_CHANNEL="${CHANNELS%%,*}" DEVOURER_HOP_FAST=1 \
+    DEVOURER_HOP_ADAPTIVE_SCRIPT="${COMMIT_SLOT}:${MASK}" \
+    "$ROOT/build/txdemo" >"$OUT/tx.log" 2>&1 &
+TX=$!
+sleep "$PHASE_A_S"
+sudo kill -INT "$RX_A" 2>/dev/null || true
+wait "$RX_A" 2>/dev/null || true
+
+echo "== phase B: fresh follower joins after the transition =="
+sudo env "${COMMON[@]}" DEVOURER_VID="$VID" DEVOURER_PID="$RX_PID" \
+    "$ROOT/build/rxdemo" >"$OUT/rxB.log" 2>&1 &
+RX_B=$!
+sleep "$PHASE_B_S"
+sudo kill -INT "$RX_B" 2>/dev/null || true
+wait "$RX_B" 2>/dev/null || true
+sudo kill -INT "$TX" 2>/dev/null || true
+wait "$TX" 2>/dev/null || true
+
+echo "== verdicts (logs: $OUT) =="
+fails=0
+require() { # file, needle, label
+    if grep -qF "$2" "$1"; then echo "PASS: $3"; else echo "FAIL: $3"; fails=$((fails+1)); fi
+}
+# TX side: commit issued and activated at gen 1
+require "$OUT/tx.log"  '"ev":"hopset.commit"'   "tx committed"
+require "$OUT/tx.log"  '"ev":"hopset.activate"' "tx activated"
+# Phase A follower: tracked, adopted the commit, activated in lockstep, and
+# kept decoding markers afterwards (post-activation slot lock)
+require "$OUT/rxA.log" '"ev":"hop.rx","state":"track"' "A: follower tracked"
+require "$OUT/rxA.log" '"ev":"hopset.commit"'   "A: follower adopted the commit"
+require "$OUT/rxA.log" '"ev":"hopset.activate"' "A: follower activated"
+act_slot=$(grep -F '"ev":"hopset.activate"' "$OUT/rxA.log" | head -1 |
+           sed -n 's/.*"activate_slot":\([0-9]*\).*/\1/p')
+if [ -n "${act_slot:-}" ] &&
+   grep -F '"state":"decode"' "$OUT/rxA.log" |
+   sed -n 's/.*"slot":\([0-9]*\).*/\1/p' |
+   awk -v a="$act_slot" 'BEGIN{ok=0} $1>a{ok=1} END{exit ok?0:1}'; then
+    echo "PASS: A: decodes continue past the activation slot ($act_slot)"
+else
+    echo "FAIL: A: no decode past the activation slot"; fails=$((fails+1))
+fi
+# Phase B follower: detected the missed transition and recovered
+require "$OUT/rxB.log" '"ev":"hopset.recover"'  "B: fresh follower recovered"
+require "$OUT/rxB.log" '"ev":"hopset.activate"' "B: fresh follower adopted gen 1"
+require "$OUT/rxB.log" '"state":"decode"'       "B: decoding after recovery"
+
+[ "$fails" -eq 0 ] && echo "== ALL PASS ==" || echo "== $fails FAILURES =="
+exit "$fails"

--- a/tests/hopset_proto_selftest.cpp
+++ b/tests/hopset_proto_selftest.cpp
@@ -1,0 +1,409 @@
+/* HopsetAuthority + HopsetFollower coupled through a lossy LinkSim — the
+ * convergence gate for the adaptive-hopset commit protocol. Every fault row
+ * (lost / duplicated / reordered / forged / replayed control frames, TX and
+ * RX restart, generation ceiling, invalid masks, activation-window
+ * violations, missed pre-activation commits, and a drop-every-message sweep)
+ * must end with both endpoints in the identical committed state — activation
+ * happens on both sides at the same absolute slot or on neither. All
+ * messages travel through the real encode/MAC/decode. */
+#include "hopset/HopsetAuthority.h"
+#include "hopset/HopsetFollower.h"
+#include "hopset/HopsetWire.h"
+
+#include <cstdio>
+#include <functional>
+#include <vector>
+
+static int fails;
+#define CHECK(x, msg)                                                          \
+  do {                                                                         \
+    if (!(x)) {                                                                \
+      std::fprintf(stderr, "FAIL: %s\n", msg);                                 \
+      ++fails;                                                                 \
+    }                                                                          \
+  } while (0)
+
+using namespace devourer::hopset;
+
+static HopsetParams params() {
+  HopsetParams p;
+  p.n_base = 8;
+  p.base_fp = 0xB0BAF00D;
+  p.link_id = 0x1234;
+  p.min_active = 2;
+  p.lead_rounds = 8;
+  p.max_lead_slots = 4096;
+  p.commit_repeat_slots = 4;
+  p.status_interval_slots = 32;
+  p.proposal_retries = 4;
+  p.proposal_backoff_slots = 8;
+  return p;
+}
+
+/* One authority + one follower on a shared slot clock, coupled through the
+ * real wire codec with a per-message fault hook. */
+struct Sim {
+  HopsetKeys keys;
+  HopsetParams p;
+  HopsetAuthority auth;
+  HopsetFollower fol;
+  uint64_t slot = 0;
+  int msg_index = 0; /* running index over every sent control message */
+  /* return false to drop; may be re-pointed per row */
+  std::function<bool(int idx, const HopsetMsg &)> deliver = nullptr;
+  int fol_activations = 0, auth_activations = 0;
+  uint64_t fol_act_slot = 0, auth_act_slot = 0;
+  HopsetState fol_state{}, auth_state{};
+  HopsetReason last_reject = HopsetReason::None;
+
+  Sim(uint32_t auth_epoch, uint32_t fol_epoch)
+      : keys(HopsetKeys::derive(devourer::HopSchedule::parse_seed(
+            "000102030405060708090a0b0c0d0e0f"))),
+        p(params()), auth(p, auth_epoch), fol(p, fol_epoch) {
+    fol_state = fol.state();
+    auth_state = auth.state();
+  }
+
+  void route(const std::vector<HopsetAction> &acts, bool from_auth) {
+    for (const auto &a : acts) {
+      if (a.kind == HopsetAction::Activate) {
+        if (from_auth) {
+          ++auth_activations;
+          auth_act_slot = slot;
+          auth_state = a.state;
+        } else {
+          ++fol_activations;
+          fol_act_slot = slot;
+          fol_state = a.state;
+        }
+      } else if (a.kind == HopsetAction::Event) {
+        if (a.event == HopsetEvent::Reject)
+          last_reject = a.reason;
+      } else if (a.kind == HopsetAction::SendControl) {
+        const int idx = msg_index++;
+        if (deliver && !deliver(idx, a.msg))
+          continue;
+        /* real crypto both ways */
+        auto w = hopset_encode(a.msg, keys);
+        HopsetMsg r;
+        if (hopset_decode(w.data(), w.size(), keys, p.link_id, r) !=
+            HopsetReason::None)
+          continue;
+        if (from_auth) {
+          if (r.type == HT_COMMIT)
+            route(fol.on_commit(r, slot), false);
+          else if (r.type == HT_STATUS)
+            route(fol.on_status(r, slot), false);
+        } else if (r.type == HT_PROPOSAL) {
+          route(auth.on_proposal(r, slot), true);
+        }
+      }
+    }
+  }
+
+  void tick(uint64_t n = 1) {
+    for (uint64_t i = 0; i < n; ++i) {
+      ++slot;
+      route(auth.on_tick(slot), true);
+      route(fol.on_tick(slot), false);
+    }
+  }
+
+  void propose(uint64_t mask, uint32_t nonce) {
+    route(fol.propose(mask, 100, 0x1, nonce, slot), false);
+  }
+
+  bool converged() const {
+    return auth_state.generation == fol_state.generation &&
+           auth_state.active_mask == fol_state.active_mask &&
+           auth_state.activate_slot == fol_state.activate_slot;
+  }
+};
+
+int main() {
+  /* --- row 1: clean run — propose, commit, synchronized activation --- */
+  {
+    Sim s(0x1000, 0x2000);
+    s.propose(0b00110111, 0xA1);
+    CHECK(s.auth.committing(), "clean: authority commits");
+    s.tick(200);
+    CHECK(s.auth_activations == 1 && s.fol_activations == 1,
+          "clean: both activate exactly once");
+    CHECK(s.auth_act_slot == s.fol_act_slot, "clean: same activation slot");
+    CHECK(s.converged() && s.fol_state.generation == 1 &&
+              s.fol_state.active_mask == 0b00110111,
+          "clean: identical committed state");
+    CHECK(s.fol_state.activate_slot >= 8 * 8,
+          "clean: >= 8 rounds of lead honored");
+  }
+
+  /* --- row 2: lost proposals — retries recover --- */
+  {
+    Sim s(0x1000, 0x2000);
+    int dropped = 0;
+    s.deliver = [&](int, const HopsetMsg &m) {
+      if (m.type == HT_PROPOSAL && dropped < 2) {
+        ++dropped;
+        return false;
+      }
+      return true;
+    };
+    s.propose(0b00001111, 0xA2);
+    s.tick(300);
+    CHECK(dropped == 2 && s.converged() && s.fol_state.generation == 1,
+          "lost proposals: retry converges");
+  }
+
+  /* --- row 3: lost commits — repetition recovers --- */
+  {
+    Sim s(0x1000, 0x2000);
+    int commits_dropped = 0;
+    s.deliver = [&](int, const HopsetMsg &m) {
+      if (m.type == HT_COMMIT && commits_dropped < 3) {
+        ++commits_dropped;
+        return false;
+      }
+      return true;
+    };
+    s.propose(0b11110000, 0xA3);
+    s.tick(300);
+    CHECK(commits_dropped == 3 && s.converged() &&
+              s.fol_activations == 1 && s.auth_activations == 1 &&
+              s.auth_act_slot == s.fol_act_slot,
+          "lost commits: repeats converge");
+  }
+
+  /* --- row 4: duplicated commit — a repeat is idempotent --- */
+  {
+    Sim s(0x1000, 0x2000);
+    s.propose(0b00111100, 0xA4);
+    s.tick(2); /* several repeated commits already flow; all must be inert
+                  duplicates on the follower */
+    s.tick(300);
+    CHECK(s.fol_activations == 1, "dup commits: single activation");
+    CHECK(s.converged(), "dup commits: converged");
+  }
+
+  /* --- row 5: replayed proposal after completion — rejected --- */
+  {
+    Sim s(0x1000, 0x2000);
+    s.propose(0b00110111, 0xA5);
+    s.tick(200);
+    CHECK(s.converged() && s.fol_state.generation == 1, "replay setup");
+    /* attacker replays the same authenticated proposal bytes */
+    HopsetMsg replay;
+    replay.type = HT_PROPOSAL;
+    replay.link_id = s.p.link_id;
+    replay.rx_epoch = 0x2000;
+    replay.rx_nonce = 0xA5;
+    replay.active_mask = 0b00110111;
+    replay.base_fp = s.p.base_fp;
+    s.last_reject = HopsetReason::None;
+    s.route(std::vector<HopsetAction>{}, false); /* no-op */
+    auto acts = s.auth.on_proposal(replay, s.slot);
+    bool replay_rejected = false;
+    for (auto &a : acts)
+      if (a.kind == HopsetAction::Event && a.event == HopsetEvent::Reject &&
+          a.reason == HopsetReason::ReplayGen)
+        replay_rejected = true;
+    CHECK(replay_rejected, "replayed proposal rejected");
+    CHECK(!s.auth.committing(), "replayed proposal arms nothing");
+  }
+
+  /* --- row 6: forged commit (wrong key) never reaches the machine --- */
+  {
+    Sim s(0x1000, 0x2000);
+    HopsetKeys forged = HopsetKeys::derive(
+        devourer::HopSchedule::parse_seed("deadbeefdeadbeefdeadbeefdeadbeef"));
+    HopsetMsg m;
+    m.type = HT_COMMIT;
+    m.link_id = s.p.link_id;
+    m.tx_epoch = 0x6666;
+    m.generation = 5;
+    m.active_mask = 0b11;
+    m.base_fp = s.p.base_fp;
+    m.activate_slot = 100;
+    auto w = hopset_encode(m, forged);
+    HopsetMsg r;
+    CHECK(hopset_decode(w.data(), w.size(), s.keys, s.p.link_id, r) ==
+              HopsetReason::BadMac,
+          "forged commit fails authentication");
+    CHECK(s.fol.state().generation == 0, "forged commit moved nothing");
+  }
+
+  /* --- row 7: stale-epoch commit replay (old boot, past slot) --- */
+  {
+    Sim s(0x1000, 0x2000);
+    /* run a legitimate change so the follower tracks epoch 0x1000 gen 1 */
+    s.propose(0b00110111, 0xA7);
+    s.tick(200);
+    CHECK(s.fol_state.generation == 1, "stale-epoch setup");
+    /* replay: an authenticated commit from a previous authority boot (other
+     * epoch) whose activation slot is deep in the past of that old session —
+     * adopting it would be a replay takeover. The window rule adopts a
+     * past-slot commit only as recovery; here it must still converge to the
+     * live authority via its status beacon afterwards. */
+    HopsetMsg old;
+    old.type = HT_COMMIT;
+    old.link_id = s.p.link_id;
+    old.tx_epoch = 0x0BAD;
+    old.generation = 9;
+    old.active_mask = 0b11000000;
+    old.base_fp = s.p.base_fp;
+    old.activate_round = 1;
+    old.activate_slot = 8; /* long past */
+    old.current_round = 1;
+    auto w = hopset_encode(old, s.keys);
+    HopsetMsg r;
+    CHECK(hopset_decode(w.data(), w.size(), s.keys, s.p.link_id, r) ==
+              HopsetReason::None,
+          "old commit authenticates (same key)");
+    s.route(s.fol.on_commit(r, s.slot), false);
+    /* the live authority's status beacon must re-assert the true state */
+    s.tick(2 * s.p.status_interval_slots + 2);
+    CHECK(s.converged() && s.fol_state.epoch == 0x1000,
+          "stale-epoch replay: live status re-converges the follower");
+  }
+
+  /* --- row 8: TX restart mid-commit — fresh epoch orphans the exchange --- */
+  {
+    Sim s(0x1000, 0x2000);
+    /* drop everything from the authority so the follower never sees the
+     * commit for the proposal it sent */
+    s.deliver = [&](int, const HopsetMsg &m) {
+      return m.type == HT_PROPOSAL; /* only proposals get through */
+    };
+    s.propose(0b00110111, 0xA8);
+    CHECK(s.auth.committing(), "restart setup: authority armed");
+    /* authority restarts: new machine, new random epoch, gen 0. The old
+     * in-flight generation is orphaned for free (nothing persisted); the
+     * follower's retried proposal simply re-lands at the fresh authority,
+     * and both converge under the NEW epoch — never a split brain. */
+    s.auth = HopsetAuthority(s.p, 0x1111);
+    s.deliver = nullptr;
+    s.auth_state = s.auth.state();
+    s.tick(6 * s.p.status_interval_slots);
+    CHECK(s.fol.state().epoch == 0x1111 &&
+              s.fol.state().generation == s.auth.state().generation &&
+              s.fol.state().active_mask == s.auth.state().active_mask &&
+              s.fol.state().activate_slot == s.auth.state().activate_slot,
+          "TX restart: follower converges under the fresh epoch");
+  }
+
+  /* --- row 9: RX restart — a fresh follower joins at nonzero gen --- */
+  {
+    Sim s(0x1000, 0x2000);
+    s.propose(0b01011010, 0xA9);
+    s.tick(200);
+    CHECK(s.fol_state.generation == 1, "RX restart setup");
+    /* follower restarts with a new epoch and no state */
+    s.fol = HopsetFollower(s.p, 0x2222);
+    s.fol_state = s.fol.state();
+    CHECK(s.fol.state().generation == 0, "fresh follower at gen 0");
+    s.tick(2 * s.p.status_interval_slots + 2);
+    CHECK(s.fol.state().generation == 1 &&
+              s.fol.state().active_mask == 0b01011010 &&
+              s.fol.state().activate_slot == s.auth.state().activate_slot,
+          "RX restart: rejoins at the live nonzero generation");
+  }
+
+  /* --- row 10: generation ceiling refused --- */
+  {
+    Sim s(0x1000, 0x2000);
+    HopsetState near_ceiling = s.auth.state();
+    near_ceiling.generation = kGenCeiling - 1;
+    near_ceiling.active_mask = full_mask(8);
+    s.auth.restore(near_ceiling);
+    auto acts = s.auth.start_change(0b1111, s.slot);
+    bool refused = false;
+    for (auto &a : acts)
+      if (a.kind == HopsetAction::Event && a.event == HopsetEvent::Reject &&
+          a.reason == HopsetReason::GenCeiling)
+        refused = true;
+    CHECK(refused && !s.auth.committing(), "generation ceiling refused");
+  }
+
+  /* --- row 11: invalid masks --- */
+  {
+    Sim s(0x1000, 0x2000);
+    s.propose(0b100000000, 0xB1); /* bit 8 of an 8-channel base */
+    CHECK(s.last_reject == HopsetReason::BadMask && !s.auth.committing(),
+          "out-of-range mask rejected");
+    s.tick(20); /* let the proposal state settle (status reject echo) */
+    Sim s2(0x1000, 0x2000);
+    s2.propose(0b00000001, 0xB2); /* below min_active = 2 */
+    CHECK(s2.last_reject == HopsetReason::LowDiversity &&
+              !s2.auth.committing(),
+          "below-diversity mask rejected");
+  }
+
+  /* --- row 12: activation outside the allowed window rejected --- */
+  {
+    Sim s(0x1000, 0x2000);
+    HopsetMsg m;
+    m.type = HT_COMMIT;
+    m.link_id = s.p.link_id;
+    m.tx_epoch = 0x1000;
+    m.generation = 1;
+    m.active_mask = 0b1111;
+    m.base_fp = s.p.base_fp;
+    m.activate_slot = s.slot + s.p.max_lead_slots + 100; /* too far out */
+    auto w = hopset_encode(m, s.keys);
+    HopsetMsg r;
+    CHECK(hopset_decode(w.data(), w.size(), s.keys, s.p.link_id, r) ==
+              HopsetReason::None,
+          "window-test commit authenticates");
+    s.route(s.fol.on_commit(r, s.slot), false);
+    CHECK(s.last_reject == HopsetReason::ActivationWindow &&
+              !s.fol.has_pending(),
+          "too-distant activation rejected");
+  }
+
+  /* --- row 13: proposal starvation times out cleanly --- */
+  {
+    Sim s(0x1000, 0x2000);
+    s.deliver = [](int, const HopsetMsg &) { return false; }; /* black hole */
+    s.propose(0b00111100, 0xB3);
+    s.tick(200);
+    CHECK(s.last_reject == HopsetReason::Timeout &&
+              s.fol.fsm() == HopsetFollower::State::Synced,
+          "starved proposal times out back to Synced");
+    CHECK(s.fol.state().generation == 0, "no state moved");
+  }
+
+  /* --- row 14: NoChange — re-proposing the active mask --- */
+  {
+    Sim s(0x1000, 0x2000);
+    s.propose(0b00110111, 0xB4);
+    s.tick(200);
+    CHECK(s.fol_state.generation == 1, "nochange setup");
+    s.last_reject = HopsetReason::None;
+    s.propose(0b00110111, 0xB5);
+    CHECK(s.last_reject == HopsetReason::NoChange && !s.auth.committing(),
+          "same-mask proposal rejected as no-change");
+  }
+
+  /* --- drop-every-message sweep: for each control-message index in the
+   * clean run, drop exactly that one — every variant must still converge
+   * (repeats and the status beacon carry it) --- */
+  {
+    /* count messages in a clean run first */
+    Sim probe(0x1000, 0x2000);
+    probe.propose(0b00101101, 0xC0);
+    probe.tick(400);
+    const int total = probe.msg_index;
+    CHECK(total > 4, "sweep probe saw a full exchange");
+    for (int drop = 0; drop < total; ++drop) {
+      Sim s(0x1000, 0x2000);
+      s.deliver = [&](int idx, const HopsetMsg &) { return idx != drop; };
+      s.propose(0b00101101, 0xC0);
+      s.tick(800);
+      if (!(s.converged() && s.fol.state().generation >= 1)) {
+        std::fprintf(stderr, "sweep: drop=%d diverged\n", drop);
+        CHECK(false, "drop-every-message sweep row converges");
+      }
+    }
+  }
+
+  return fails ? 1 : 0;
+}

--- a/tests/hopset_schedule_selftest.cpp
+++ b/tests/hopset_schedule_selftest.cpp
@@ -1,0 +1,169 @@
+/* Adaptive hopset schedule math: key derivation, gen-0 legacy equivalence,
+ * exact-once per-round coverage over masked hopsets, generation/mask
+ * sensitivity, stateless direct join, and pinned known-answer tuples so the
+ * derivation can never silently drift. */
+#include "hopset/HopsetState.h"
+#include <cstdio>
+#include <set>
+
+static int fails;
+#define CHECK(x, msg)                                                          \
+  do {                                                                         \
+    if (!(x)) {                                                                \
+      std::fprintf(stderr, "FAIL: %s\n", msg);                                 \
+      ++fails;                                                                 \
+    }                                                                          \
+  } while (0)
+
+int main() {
+  using devourer::HopSchedule;
+  using namespace devourer::hopset;
+
+  const auto master =
+      HopSchedule::parse_seed("000102030405060708090a0b0c0d0e0f");
+  const auto keys = HopsetKeys::derive(master);
+
+  /* --- key derivation: three distinct keys, master preserved --- */
+  CHECK(keys.master == master, "master key preserved");
+  CHECK(keys.sched != master && keys.ctrl != master && keys.sched != keys.ctrl,
+        "derived keys distinct");
+  /* pinned: edge bytes of the derived subkeys (drift tripwire) */
+  if (!(keys.sched[0] == 0xf8 && keys.sched[15] == 0x5b &&
+        keys.ctrl[0] == 0xf2 && keys.ctrl[15] == 0x18)) {
+    std::fprintf(stderr, "KEYKAT: sched %02x..%02x ctrl %02x..%02x\n",
+                 keys.sched[0], keys.sched[15], keys.ctrl[0], keys.ctrl[15]);
+    CHECK(false, "derived key KAT");
+  }
+
+  /* --- mask helpers --- */
+  CHECK(full_mask(8) == 0xff && full_mask(64) == ~uint64_t(0), "full_mask");
+  CHECK(popcount64(0) == 0 && popcount64(0xff) == 8 &&
+            popcount64(~uint64_t(0)) == 64,
+        "popcount64");
+  CHECK(nth_set_bit(0b101001, 0) == 0 && nth_set_bit(0b101001, 1) == 3 &&
+            nth_set_bit(0b101001, 2) == 5,
+        "nth_set_bit");
+  CHECK(mask_valid(0b0011, 4, 2) && !mask_valid(0b0001, 4, 2) &&
+            !mask_valid(0b10011, 4, 2) && !mask_valid(0, 4, 1) &&
+            !mask_valid(1, 0, 1) && !mask_valid(1, 65, 1),
+        "mask_valid rules");
+
+  /* --- gen 0 == legacy fixed schedule, byte-for-byte --- */
+  HopSchedule base(master);
+  AdaptiveScheduleView v(base, keys, 12);
+  for (uint64_t s = 0; s < 1000; ++s)
+    CHECK(v.channel_index(s) == base.channel_index(s, 12),
+          "gen-0 keyed equivalence");
+  HopSchedule seq = HopSchedule::sequential();
+  AdaptiveScheduleView vs(seq, keys, 5);
+  for (uint64_t s = 0; s < 100; ++s)
+    CHECK(vs.channel_index(s) == s % 5, "gen-0 sequential equivalence");
+
+  /* --- exact-once coverage: every adaptive round visits every active
+   * channel exactly once, for mask popcounts 2..8 x generations 1..4 --- */
+  for (unsigned pc = 2; pc <= 8; ++pc) {
+    for (uint32_t gen = 1; gen <= 4; ++gen) {
+      AdaptiveScheduleView av(base, keys, 8);
+      av.set_state({7, gen, full_mask(pc), 40, 40 * 8});
+      const size_t k = av.active_count();
+      CHECK(k == pc, "active_count = popcount");
+      for (uint64_t round = 0; round < 20; ++round) {
+        std::set<size_t> seen;
+        for (uint64_t i = 0; i < k; ++i)
+          seen.insert(av.channel_index(av.state().activate_slot + round * k + i));
+        std::set<size_t> want;
+        for (size_t j = 0; j < k; ++j)
+          want.insert(nth_set_bit(full_mask(pc), j));
+        CHECK(seen == want, "round covers active set exactly once");
+      }
+    }
+  }
+
+  /* --- non-contiguous mask maps through stable base positions --- */
+  {
+    const uint64_t mask = 0b10110010; /* base indices 1,4,5,7 */
+    AdaptiveScheduleView av(base, keys, 8);
+    av.set_state({7, 3, mask, 0, 0});
+    std::set<size_t> seen;
+    for (uint64_t i = 0; i < 4; ++i)
+      seen.insert(av.channel_index(i));
+    CHECK((seen == std::set<size_t>{1, 4, 5, 7}),
+          "non-contiguous mask -> stable base indices");
+  }
+
+  /* --- generation sensitivity: same mask, fresh keyed order per gen --- */
+  {
+    AdaptiveScheduleView a1(base, keys, 8), a2(base, keys, 8);
+    a1.set_state({7, 1, full_mask(8), 0, 0});
+    a2.set_state({7, 2, full_mask(8), 0, 0});
+    bool differ = false;
+    for (uint64_t r = 0; r < 8 && !differ; ++r)
+      differ = a1.permutation(r, 8) != a2.permutation(r, 8);
+    CHECK(differ, "generation changes the permutation");
+    /* ...and gen>=1 full mask differs from the legacy gen-0 order (subkey) */
+    bool vs_legacy = false;
+    for (uint64_t r = 0; r < 8 && !vs_legacy; ++r)
+      vs_legacy = a1.permutation(r, 8) != base.permutation(r, 8);
+    CHECK(vs_legacy, "adaptive subkey differs from legacy order");
+  }
+
+  /* --- mask sensitivity: equal popcount, different mask, different words --- */
+  {
+    AdaptiveScheduleView a1(base, keys, 8), a2(base, keys, 8);
+    a1.set_state({7, 1, 0b00001111, 0, 0});
+    a2.set_state({7, 1, 0b11110000, 0, 0});
+    bool differ = false;
+    for (uint64_t r = 0; r < 16 && !differ; ++r)
+      differ = a1.permutation(r, 4) != a2.permutation(r, 4);
+    CHECK(differ, "mask changes the permutation");
+  }
+
+  /* --- direct join: an independently-constructed view with the same
+   * committed state agrees at a nonzero generation for arbitrary slots --- */
+  {
+    const HopsetState st{0x1234, 9, 0b01101101, 500, 4000};
+    AdaptiveScheduleView a(base, keys, 8);
+    a.set_state(st);
+    HopSchedule base2(master);
+    AdaptiveScheduleView b(base2, HopsetKeys::derive(master), 8);
+    b.set_state(st);
+    for (uint64_t s = st.activate_slot; s < st.activate_slot + 500; ++s)
+      CHECK(a.channel_index(s) == b.channel_index(s), "direct join agrees");
+  }
+
+  /* --- pinned channel_index known answers (key, gen, mask, slot) --- */
+  {
+    AdaptiveScheduleView av(base, keys, 8);
+    av.set_state({1, 2, 0b10111011, 100, 600});
+    size_t got[12];
+    for (int i = 0; i < 12; ++i)
+      got[i] = av.channel_index(600 + i);
+    const size_t kat[12] = {0, 7, 3, 4, 1, 5, 4, 0, 3, 1, 5, 7};
+    bool print = false;
+    for (int i = 0; i < 12; ++i)
+      if (got[i] != kat[i])
+        print = true;
+    if (print) {
+      std::fprintf(stderr, "KAT: ");
+      for (int i = 0; i < 12; ++i)
+        std::fprintf(stderr, "%zu,", got[i]);
+      std::fprintf(stderr, "\n");
+      CHECK(false, "channel_index KAT");
+    }
+  }
+
+  /* --- fingerprints: deterministic, key/gen/mask/list sensitive --- */
+  {
+    const uint32_t ch[4] = {36, 40, 44, 48};
+    const uint32_t ch2[4] = {36, 40, 44, 52};
+    CHECK(hopset_fp(keys, ch, 4) == hopset_fp(keys, ch, 4) &&
+              hopset_fp(keys, ch, 4) != hopset_fp(keys, ch2, 4) &&
+              hopset_fp(keys, ch, 4) != hopset_fp(keys, ch, 3),
+          "hopset_fp binds channel list");
+    CHECK(mask_fp(keys, 1, 0xff) != mask_fp(keys, 2, 0xff) &&
+              mask_fp(keys, 1, 0xff) != mask_fp(keys, 1, 0xfe),
+          "mask_fp binds gen+mask");
+  }
+
+  return fails ? 1 : 0;
+}

--- a/tests/hopset_wire_selftest.cpp
+++ b/tests/hopset_wire_selftest.cpp
@@ -1,0 +1,223 @@
+/* HopsetWire known-answer + tamper + replay selftest.
+ *
+ * Pins the exact sizes, header bytes and MAC of each adaptive-hopset control
+ * message under the SipHash reference key (and the domain-separated key
+ * derivation feeding them), then the byte-flip tamper sweep, truncation
+ * sweep, header rejects, the <=96-byte bound, the v1/v2 sync-marker mutual
+ * rejection, and the proposal replay ring. */
+#include "hopset/HopsetWire.h"
+
+#include <cstdio>
+#include <cstring>
+
+static int fails;
+#define CHECK(x, msg)                                                          \
+  do {                                                                         \
+    if (!(x)) {                                                                \
+      std::fprintf(stderr, "FAIL: %s\n", msg);                                 \
+      ++fails;                                                                 \
+    }                                                                          \
+  } while (0)
+
+using namespace devourer::hopset;
+
+/* A fully-populated message of each type for round-trip coverage. */
+static HopsetMsg sample(HopsetMsgType t) {
+  HopsetMsg m;
+  m.type = t;
+  m.link_id = 0x11223344;
+  m.rx_epoch = 0xAABBCCDD;
+  m.tx_epoch = 0x01020304;
+  m.sender_epoch = 0x0A0B0C0D;
+  m.rx_epoch_echo = 0xAABBCCDD;
+  m.rx_nonce = 0xDEADBEEF;
+  m.rx_nonce_echo = 0xDEADBEEF;
+  m.generation = 42;
+  m.active_mask = 0x00000000000000B7ULL;
+  m.base_fp = 0x55667788;
+  m.activate_round = 1234;
+  m.activate_slot = 987654;
+  m.current_round = 1226;
+  m.observation_count = 250;
+  m.reason_bitmap = 0x5;
+  m.earliest_activate_round = 1240;
+  m.role = 1;
+  m.reason = static_cast<uint8_t>(HopsetReason::None);
+  return m;
+}
+
+int main() {
+  const auto master =
+      devourer::HopSchedule::parse_seed("000102030405060708090a0b0c0d0e0f");
+  const HopsetKeys keys = HopsetKeys::derive(master);
+
+  const HopsetMsgType types[] = {HT_PROPOSAL, HT_COMMIT, HT_STATUS};
+  const size_t sizes[] = {56, 68, 58};
+
+  /* --- round-trip + pinned sizes + full-field fidelity --- */
+  for (int i = 0; i < 3; ++i) {
+    HopsetMsg m = sample(types[i]);
+    std::vector<uint8_t> w = hopset_encode(m, keys);
+    if (w.size() != sizes[i])
+      std::fprintf(stderr, "SIZE: type %d = %zu\n", types[i], w.size());
+    CHECK(w.size() == sizes[i], "pinned message size");
+    CHECK(w.size() <= kHopsetMaxLen, "message within the 96-byte bound");
+    HopsetMsg r;
+    CHECK(hopset_decode(w.data(), w.size(), keys, m.link_id, r) ==
+              HopsetReason::None,
+          "authentic message decodes");
+    CHECK(r.type == types[i] && r.link_id == m.link_id, "header round-trips");
+    CHECK(r.generation == m.generation && r.active_mask == m.active_mask &&
+              r.base_fp == m.base_fp,
+          "state fields round-trip");
+    if (types[i] == HT_PROPOSAL)
+      CHECK(r.rx_epoch == m.rx_epoch && r.rx_nonce == m.rx_nonce &&
+                r.observation_count == m.observation_count &&
+                r.reason_bitmap == m.reason_bitmap &&
+                r.earliest_activate_round == m.earliest_activate_round,
+            "proposal fields round-trip");
+    if (types[i] == HT_COMMIT)
+      CHECK(r.tx_epoch == m.tx_epoch && r.rx_epoch_echo == m.rx_epoch_echo &&
+                r.activate_round == m.activate_round &&
+                r.activate_slot == m.activate_slot &&
+                r.current_round == m.current_round &&
+                r.rx_nonce_echo == m.rx_nonce_echo,
+            "commit fields round-trip");
+    if (types[i] == HT_STATUS)
+      CHECK(r.role == m.role && r.sender_epoch == m.sender_epoch &&
+                r.current_round == m.current_round &&
+                r.activate_slot == m.activate_slot && r.reason == m.reason &&
+                r.rx_nonce_echo == m.rx_nonce_echo,
+            "status fields round-trip");
+  }
+
+  /* --- known-answer: header bytes + MAC placement of a COMMIT --- */
+  {
+    HopsetMsg m = sample(HT_COMMIT);
+    std::vector<uint8_t> w = hopset_encode(m, keys);
+    CHECK(w[0] == 0x48 && w[1] == 0x53 && w[2] == 1 && w[3] == HT_COMMIT,
+          "commit header bytes 'HS' ver=1");
+    const uint64_t mac = keys.mac(w.data(), w.size() - kHopsetMacLen);
+    uint64_t tail = 0;
+    for (int i = 0; i < 8; i++)
+      tail |= uint64_t(w[w.size() - 8 + i]) << (8 * i);
+    CHECK(mac == tail, "MAC is the trailing u64 over the body");
+  }
+
+  /* --- key derivation: deterministic, domain-separated, seed-sensitive --- */
+  {
+    HopsetKeys a = HopsetKeys::derive(master), b = HopsetKeys::derive(master);
+    CHECK(a.sched == b.sched && a.ctrl == b.ctrl, "key derive stable");
+    CHECK(a.sched != master && a.ctrl != master && a.sched != a.ctrl,
+          "schedule/control keys domain-separated");
+    const auto other =
+        devourer::HopSchedule::parse_seed("0f0e0d0c0b0a09080706050403020100");
+    HopsetKeys c = HopsetKeys::derive(other);
+    CHECK(a.sched != c.sched && a.ctrl != c.ctrl, "keys sensitive to seed");
+    /* ...and distinct from the chanmig control derivation (different tags):
+     * a message MAC'd for one protocol can never authenticate in the other.
+     * Checked indirectly: the hopset control key differs from the master and
+     * from the schedule subkey; the tag strings differ by construction. */
+  }
+
+  /* --- tamper: flipping ANY byte breaks authentication --- */
+  {
+    HopsetMsg m = sample(HT_PROPOSAL);
+    std::vector<uint8_t> w = hopset_encode(m, keys);
+    int survived = 0;
+    for (size_t i = 0; i < w.size(); ++i) {
+      std::vector<uint8_t> t = w;
+      t[i] ^= 0x40;
+      HopsetMsg r;
+      if (hopset_decode(t.data(), t.size(), keys, m.link_id, r) ==
+          HopsetReason::None)
+        ++survived;
+    }
+    CHECK(survived == 0, "every single-byte tamper is rejected");
+    /* forged: same bytes, wrong key */
+    HopsetKeys forged = HopsetKeys::derive(
+        devourer::HopSchedule::parse_seed("deadbeefdeadbeefdeadbeefdeadbeef"));
+    HopsetMsg r;
+    CHECK(hopset_decode(w.data(), w.size(), forged, m.link_id, r) ==
+              HopsetReason::BadMac,
+          "wrong-key forgery rejected");
+  }
+
+  /* --- truncation at every length rejected; trailing FCS tolerated --- */
+  {
+    HopsetMsg m = sample(HT_STATUS);
+    std::vector<uint8_t> w = hopset_encode(m, keys);
+    for (size_t len = 0; len < w.size(); ++len) {
+      HopsetMsg r;
+      CHECK(hopset_decode(w.data(), len, keys, m.link_id, r) !=
+                HopsetReason::None,
+            "truncated frame rejected");
+    }
+    std::vector<uint8_t> fcs = w;
+    for (int i = 0; i < 4; i++)
+      fcs.push_back(0xDE);
+    HopsetMsg r;
+    CHECK(hopset_decode(fcs.data(), fcs.size(), keys, m.link_id, r) ==
+              HopsetReason::None,
+          "trailing FCS/pad ignored — message is a prefix");
+  }
+
+  /* --- header rejects --- */
+  {
+    HopsetMsg m = sample(HT_COMMIT);
+    std::vector<uint8_t> w = hopset_encode(m, keys);
+    HopsetMsg r;
+    std::vector<uint8_t> bad = w;
+    bad[2] = 9; /* unknown version */
+    CHECK(hopset_decode(bad.data(), bad.size(), keys, m.link_id, r) ==
+              HopsetReason::BadVersion,
+          "unknown version rejected");
+    bad = w;
+    bad[3] = 77; /* unknown type */
+    CHECK(hopset_decode(bad.data(), bad.size(), keys, m.link_id, r) ==
+              HopsetReason::BadType,
+          "unknown type rejected");
+    CHECK(hopset_decode(w.data(), w.size(), keys, 0xFFFFFFFF, r) ==
+              HopsetReason::BadLinkId,
+          "wrong link id rejected");
+    CHECK(hopset_decode(w.data(), w.size(), keys, 0, r) == HopsetReason::None,
+          "link id 0 skips the check");
+  }
+
+  /* --- sync marker v2: round-trip + v1/v2 mutual rejection --- */
+  {
+    HopSyncMarkerV2 m2{0x11223344, 7, 12345, 0x0102030405060708ULL, 3,
+                       0xCAFEBABE},
+        r2;
+    auto w2 = HopSyncMarkerV2::encode(m2);
+    CHECK(HopSyncMarkerV2::decode(w2.data(), w2.size(), r2), "v2 decodes");
+    CHECK(r2.fingerprint == m2.fingerprint && r2.epoch == m2.epoch &&
+              r2.slot == m2.slot && r2.phase_us == m2.phase_us &&
+              r2.generation == m2.generation && r2.mask_fp == m2.mask_fp,
+          "v2 round-trips");
+    devourer::HopSyncMarker r1;
+    CHECK(!devourer::HopSyncMarker::decode(w2.data(), w2.size(), r1),
+          "v1 decoder rejects a v2 marker");
+    devourer::HopSyncMarker m1{0x11223344, 7, 12345,
+                               0x0102030405060708ULL};
+    auto w1 = devourer::HopSyncMarker::encode(m1);
+    CHECK(!HopSyncMarkerV2::decode(w1.data(), w1.size(), r2),
+          "v2 decoder rejects a v1 marker");
+  }
+
+  /* --- proposal replay ring --- */
+  {
+    ProposalReplayRing ring;
+    CHECK(!ring.contains(1, 100), "empty ring");
+    ring.remember(1, 100);
+    CHECK(ring.contains(1, 100), "remembered pair found");
+    CHECK(!ring.contains(1, 101) && !ring.contains(2, 100),
+          "epoch and nonce both keyed");
+    for (uint32_t i = 0; i < ProposalReplayRing::kDepth; ++i)
+      ring.remember(9, i);
+    CHECK(!ring.contains(1, 100), "oldest entry evicted at capacity");
+    CHECK(ring.contains(9, 0) && ring.contains(9, 15), "ring holds depth");
+  }
+
+  return fails ? 1 : 0;
+}


### PR DESCRIPTION
Implements #263 — the deterministic state model and authenticated control protocol for adaptive FHSS hopset changes. Protocol foundation only: nothing here decides which channel is bad (#264) and there is no TX sensing (#265).

## Design

- **Immutable base hopset + `active_mask`** over stable bit positions (`src/hopset/HopsetState.h`). Generation 0 is *defined* as the legacy fixed schedule — full mask, raw master key, byte-for-byte (pinned by KAT), so non-adaptive behavior is provably unchanged. From generation 1, each round's permutation derives from `(schedule subkey, generation, round, active_mask)`: a mask change produces a fresh keyed order, not a filtered form of the previous permutation, and the lookup stays a pure function of (keys, committed state, absolute slot) — a receiver still joins mid-generation with no RNG state.
- **Keys**: schedule subkey and control (MAC) key are domain-separated from `DEVOURER_HOP_SEED` (`devourer-hopset-s*/c*`, the `MigKey::derive` pattern). A schedule fingerprint is not authentication — `base_fp`/`mask_fp` are config tripwires, the SipHash-2-4 MAC is the auth. Sequential (keyless) + adaptive is rejected.
- **Wire** (`HopsetWire.h`, MigWire-patterned, all ≤ 96 B, KAT-pinned): `HopsetProposal` (56 B), `HopsetCommit` (68 B), `HopsetStatus` (58 B). Commits carry the activation instant as **both** a round index and an absolute slot — rounds change length when the popcount changes, slots never do. Sync marker **v2** (37 B) = the v1 layout + (generation, mask fingerprint); each version's decoder rejects the other.
- **State machines** (`HopsetAuthority`/`HopsetFollower`, pure, no I/O/crypto/clock): TX is the schedule authority — RX proposes, TX validates policy (mask legality, min-diversity floor, monotonic generation, ≥ 8-round activation lead), repeats an identical commit until the named slot arrives, both swap state exactly there. The status beacon carries the full mask + activation anchor, so a follower that missed every commit recovers. Acquisition always scans the immutable base hopset.
- **Anti-replay is structural**: random per-boot epochs (never persisted — a restart orphans in-flight generations for free), monotonic generations with a ceiling whose recovery is a fresh epoch, proposal (epoch, nonce) replay ring, nonce binding on commits/status, activation-window validation.

## Tests (all in `ctest`, 41/41 green)

- `hopset_schedule_math` — pinned KATs for (key, gen, mask, slot) tuples; gen-0 ≡ `HopSchedule` over 1000 slots; exact-once per-round coverage for popcounts 2..8 × gens 1..4; gen/mask sensitivity; stateless direct join at nonzero generation.
- `hopset_wire_kat` — pinned sizes/header/MAC; every-byte-flip tamper sweep; wrong-key forgery; truncation sweep; FCS-trailer tolerance; v1↔v2 marker mutual rejection; key-derivation KAT; replay ring.
- `hopset_proto_matrix` — authority + follower coupled through real encode/MAC/decode with fault injection: lost/duplicated/reordered/forged/replayed frames, stale-epoch commit replay, TX restart mid-commit, RX restart, generation ceiling, invalid masks, activation-window violations, proposal starvation, no-change, plus a drop-every-message sweep. Invariant: both endpoints activate at the same slot or neither, and always converge.
- `hopset_activation_sync` — process-level: identical channel sequences across the activation boundary; a peer that misses every commit detects the transition from the v2 marker, recovers via the status beacon, and re-synchronizes within a bounded desync window.

## Demos

`DEVOURER_HOP_ADAPTIVE=1` (keyed slot mode only) arms txdemo as authority and rxdemo as follower; `DEVOURER_HOP_ADAPTIVE_SCRIPT="slot:mask,..."` drives scripted authority-originated commits until the exclusion policy exists. Control frames ride their own 802.11 frames (chanmig frame shape) — caller FEC payload bytes are never touched. streamtx emits the gen-0 v2 marker. Adaptive off → byte-identical v1 everywhere.

## On-air validation

`tests/hopset_adaptive_onair.sh` (RTL8812EU TX + RTL8812CU RX, ch 1/6/11, 50 ms slots) — 9/9 PASS:

- Scripted commit at slot 150 → `hopset.activate` on **both** sides at slot 174 (the 8-round lead), with the follower's slot lock held across the boundary (marker decodes continue to slot 473).
- A fresh follower started after the transition fired `hopset.gen_mismatch` off its **first** v2 marker and recovered via the status beacon in **196 ms** (`hopset.recover` → `hopset.activate` gen 1, mask 0x3), then 361 clean decodes on the reduced set.

Docs: new `docs/fhss.md` section (state model, key derivation, wire layouts, transition behavior, recovery), `docs/logging.md` `hopset.*` schema rows, CLAUDE.md pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)