### PR TITLE
Adaptive FHSS: receiver-driven exclusion, recovery probes, anti-herding (issue #264)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ tests/chipid_probe
 # Local lab notes / Claude Code state (never commit)
 INVENTORY.md
 .claude/
+
+# Bench-local UHD radio selection (tests/uhd_select.py) — serials are
+# per-bench, never committed.
+tests/.uhd_args

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,9 +366,27 @@ the legacy fixed schedule byte-for-byte; gen ≥ 1 re-keys the permutation from
 the v2 sync marker advertises (generation, mask fp) so a follower that missed
 the commits recovers from the status beacon. Demos:
 `DEVOURER_HOP_ADAPTIVE=1` (keyed slot mode only) +
-`DEVOURER_HOP_ADAPTIVE_SCRIPT="slot:mask,..."` (txdemo authority lever until
-the exclusion policy exists); `hopset.*` events; on-air run
-`tests/hopset_adaptive_onair.sh`. Wire/state-machine doc: `docs/fhss.md`.
+`DEVOURER_HOP_ADAPTIVE_SCRIPT="slot:mask,..."` (an operator lever, exempt from
+the one-channel-per-update limit; `DEVOURER_HOP_MIN_ACTIVE` lowers the
+authority floor for protocol tests).
+
+`DEVOURER_HOP_POLICY=1` adds the **receiver-driven exclusion policy**
+(`src/hopset/HopsetPolicy.h`, pure): per-dwell delivery evidence (delivery is
+authoritative — energy/link verdicts only classify) drives conservative
+exclude/restore decisions — ≥8 scored rounds, one channel per update, <30%
+delivery for 5 visits *with* a healthy alternative, hard `max(3, configured)`
+active floor, ≥10 rounds between updates (a *refused* proposal spends the
+budget too, so bouncing proposals can't flood control), nothing under broad
+degradation, excluded-fraction cap. Proposals air from rxdemo's own claimed
+handle; txdemo hears them under `DEVOURER_TX_WITH_RX=thread`, and the authority
+enforces its own shape limits (`max_mask_delta`, `min_update_gap_rounds`).
+Excluded channels are revisited by **keyed recovery probes**
+(`DEVOURER_HOP_PROBE_ROUNDS`, default 8, must match both ends): every P rounds
+one data slot is replaced, round/position/channel all keyed so recovery isn't a
+periodic target; sync/control only, never caller FEC payload. `hopset.*` events
+(incl. `hopset.decision`, `hopset.probe`); on-air runs
+`tests/hopset_adaptive_onair.sh` (protocol) and `tests/hopset_adaptive_jammer.sh`
+(`MODE=parked|herding`, B210 interferer). Doc: `docs/fhss.md`.
 
 `IRtlDevice::FastSetBandwidth(bw)` is the bandwidth analogue — a lean
 same-channel toggle between 20 MHz and 5/10 MHz narrowband (baseband re-clock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ add_library(devourer
     src/hopset/HopsetWire.h
     src/hopset/HopsetAuthority.h
     src/hopset/HopsetFollower.h
+    src/hopset/HopsetPolicy.h
     src/hopset/HopsetEvents.h
     src/IRtlDevice.h
     src/SignalStop.cpp
@@ -813,6 +814,22 @@ add_test(NAME hopset_proto_matrix COMMAND HopsetProtoSelftest)
 add_executable(HopsetActivationSelftest tests/hopset_activation_selftest.cpp)
 target_link_libraries(HopsetActivationSelftest PRIVATE devourer)
 add_test(NAME hopset_activation_sync COMMAND HopsetActivationSelftest)
+
+# Receiver-driven exclusion gates: keyed recovery-probe placement (KATs +
+# one-probe-per-window + inertness), the pure exclusion/restoration policy
+# over its threshold / hysteresis / anti-herding matrix, and the end-to-end
+# policy -> proposal -> commit -> activation -> probe -> restoration arc.
+add_executable(HopsetProbeSelftest tests/hopset_probe_selftest.cpp)
+target_link_libraries(HopsetProbeSelftest PRIVATE devourer)
+add_test(NAME hopset_probe_placement COMMAND HopsetProbeSelftest)
+
+add_executable(HopsetPolicySelftest tests/hopset_policy_selftest.cpp)
+target_link_libraries(HopsetPolicySelftest PRIVATE devourer)
+add_test(NAME hopset_policy_matrix COMMAND HopsetPolicySelftest)
+
+add_executable(HopsetAdaptiveE2eSelftest tests/hopset_adaptive_e2e_selftest.cpp)
+target_link_libraries(HopsetAdaptiveE2eSelftest PRIVATE devourer)
+add_test(NAME hopset_adaptive_e2e COMMAND HopsetAdaptiveE2eSelftest)
 
 # Headless guard for the TX-power offset quantization (src/TxPower.h) — the
 # qdB->index-step rounding/clamping behind SetTxPowerOffsetQdb, so a rounding

--- a/docs/fhss.md
+++ b/docs/fhss.md
@@ -287,16 +287,71 @@ rollover, invalid masks, window violations) are ctest gates:
 `hopset_schedule_math`, `hopset_wire_kat`, `hopset_proto_matrix`,
 `hopset_activation_sync`.
 
+### Deciding: receiver-driven exclusion
+
+The receiver decides which channel to drop, because its delivery measurement
+describes the endpoint that actually has to decode — a transmitter's own view
+of the channel is not evidence that the video arrived. Each closed dwell is
+scored (did the marker arrive, how many frames, how many failed FCS, RSSI/SNR/
+EVM, retune-to-first-decode latency) and folded into a per-channel window
+(`src/hopset/HopsetPolicy.h`). Delivery is authoritative; the energy metrics
+and link verdicts only *classify* an impairment — interference, weak signal,
+lost synchronization — into explanation bits. A quiet channel with a dead link
+and a noisy channel that still delivers are opposite decisions, so a channel is
+never excluded on energy alone.
+
+The shipped policy is deliberately timid, because an adaptive exclusion loop is
+an attack surface: anyone who can make channels look bad can otherwise herd the
+link onto one channel and then jam it. So: at least 8 scored rounds before any
+decision; exactly one channel per update; exclusion only after delivery stays
+under 30 % for 5 consecutive visits *while another channel is still healthy*;
+a hard floor of `max(3, configured)` active channels; at least 10 rounds
+between updates (a refused proposal spends that budget too, so a receiver whose
+proposals keep bouncing cannot flood the control channel); nothing excluded
+when most of the band degrades together; and a cap on the excluded fraction.
+The transmitter enforces its own copy of the shape limits — one channel per
+update, the update gap, the diversity floor — because the receiver decides
+*which* channel, never *how much* of the schedule may move at once.
+
+Restoration is the other half: an excluded channel cannot prove it recovered
+unless something goes back and looks. Every `P` rounds one data opportunity is
+replaced by a **keyed recovery probe** on an excluded channel — which round of
+the window, which position in it, and which excluded channel are all keyed
+draws, so recovery does not create a public periodic target for an adversary to
+sit on. Only sync/control rides a probe dwell, never caller FEC payload. Three
+consecutive probes above 70 % delivery restore the channel.
+
 ### Driving it
 
 `DEVOURER_HOP_ADAPTIVE=1` on `txdemo`/`rxdemo` (with a keyed seed and
 `DEVOURER_HOP_SLOT_MS`) arms authority and follower;
-`DEVOURER_HOP_ADAPTIVE_SCRIPT="slot:mask,..."` feeds scripted
-authority-originated commits (`0x1b` = drop bits 2 and 5-of-8, etc.) until the
-receiver-driven exclusion policy exists. `streamtx` emits the v2 marker at
-generation 0 so an adaptive receiver tracks it. Control frames ride their own
-small 802.11 frames — caller FEC payload bytes are never touched. On-air run:
-`tests/hopset_adaptive_onair.sh`.
+`DEVOURER_HOP_POLICY=1` adds the receiver-driven policy (and
+`DEVOURER_HOP_POLICY_EVENTS=2` its per-channel evidence);
+`DEVOURER_HOP_PROBE_ROUNDS` is the probe period (default 8, 0 = off) and must
+match on both ends, like the seed. `DEVOURER_HOP_ADAPTIVE_SCRIPT="slot:mask,..."`
+is the operator's own lever for scripted authority-originated commits, exempt
+from the one-channel-per-update limit; `DEVOURER_HOP_MIN_ACTIVE` lowers the
+authority's floor for protocol tests on a small base hopset (the policy's
+`max(3, ...)` is not lowerable). The proposal travels on the receiver's own
+claimed handle — one bring-up, RX loop plus an occasional control frame — and
+the transmitter listens for it under `DEVOURER_TX_WITH_RX=thread`. `streamtx`
+emits the v2 marker at generation 0 so an adaptive receiver tracks it. Control
+frames ride their own small 802.11 frames — caller FEC payload bytes are never
+touched.
+
+On-air: `tests/hopset_adaptive_onair.sh` (protocol), and
+`tests/hopset_adaptive_jammer.sh` for the decision loop against a real B210
+interferer — `MODE=parked` (exclude, improve, restore once the jammer leaves)
+and `MODE=herding` (the jammer moves onto a newly-active channel after every
+exclusion). Measured on a 4-channel 2.4 GHz base with a narrowband interferer
+parked on one member: delivery 0.72 → 0.83 with the jammed channel excluded and
+probe-driven restoration after the interferer stopped; under herding, the
+active set held at the floor of 3 with committed exclusion depth 1 and no
+collapse. Two rig notes that cost a session: a flat TXAGC index chosen to back
+5 GHz off can put 2.4 GHz below the receiver's sensitivity and look exactly
+like a dead link, and an interferer loud enough to splatter across the whole
+band is broad degradation, not a channel fault — the policy correctly refuses
+to act on it.
 
 ## Where it stands
 
@@ -311,7 +366,9 @@ the slow full set); per-hop TX power is not re-tuned, so a hopset spanning a wid
 5 GHz range wants a periodic full set to refresh per-rate power; the follower
 experiment uses a 3-channel hopset because a single B210 needs ≥60 MS/s to span
 a 60 MHz hopset in one FFT and trips a UHD tuning assertion at the usual
-61.44 MS/s. And while the adaptive-hopset protocol can exclude a channel by
-authenticated commit, nothing yet *decides* to — the receiver-driven
-observation policy is unimplemented, so an unattended link still visits every
-configured channel and the fused-FEC layer absorbs jammed dwells as erasures.
+61.44 MS/s. Adaptive exclusion is receiver-driven and opt-in: with the policy
+off the schedule visits every configured channel and the fused-FEC layer
+absorbs jammed dwells as erasures, and with it on the transmitter never senses
+for itself — it acts only on an authenticated proposal from the endpoint that
+has to decode. A herding jammer cannot be out-run, only survived: the floor
+keeps the link diverse rather than winning the exchange.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -136,6 +136,8 @@ Emitters: L = library, RX/TX/... = demo. Optional fields in [brackets];
 | `hopset.reject` | TX/RX (`DEVOURER_HOP_ADAPTIVE`) | t, v, role, slot, reason (`hopset_reason_name`: bad_mac…timeout) |
 | `hopset.gen_mismatch` | RX (`DEVOURER_HOP_ADAPTIVE`) | t, v, role, slot, seen_gen, cur_gen, cur_mask "0x…" — a v2 marker advertised a state we don't hold |
 | `hopset.recover` | RX (`DEVOURER_HOP_ADAPTIVE`) | commit/activate fields — re-synchronized from an authenticated commit/status after a missed transition |
+| `hopset.decision` | RX (`DEVOURER_HOP_POLICY`) | t, v, role, slot, round, kind (hold\|exclude\|restore), obs, policy "0x…" (config hash), then either hold (`hopset_hold_name`: insufficient_rounds\|cooldown\|proposal_outstanding\|no_impairment\|not_persistent\|broad_degradation\|no_healthy_alternative\|min_active_floor\|max_excluded_frac\|probe_hysteresis_pending) or mask "0x…" + reasons "0x…" (bit0 delivery_floor, 1 persistent, 2 healthy_alt, 3 crc_dominant, 4 energy_interference, 5 weak_signal, 6 sync_loss, 7 probe_recovery, 8 probe_evidence) + target; `DEVOURER_HOP_POLICY_EVENTS=2` adds holds and per-channel c0..cN ("on\|off d=<delivery> p=<probe delivery> v=<visits> imp=<impaired run>") |
+| `hopset.probe` | TX/RX (`DEVOURER_HOP_PROBE_ROUNDS`) | t, v, role, slot, round, base_idx, ch, delivered, frames — one keyed recovery-probe dwell on an excluded channel |
 
 ### Channel migration (chanscout — docs/adaptive-channel-migration.md)
 | ev | emitter | fields |

--- a/examples/rx/main.cpp
+++ b/examples/rx/main.cpp
@@ -18,8 +18,10 @@
 #include "HopSchedule.h"
 #include "hopset/HopsetEvents.h"
 #include "hopset/HopsetFollower.h"
+#include "hopset/HopsetPolicy.h"
 #include "hopset/HopsetWire.h"
 #include "LaCapture.h"
+#include "RadiotapBuilder.h"
 #include "LinkHealth.h"
 #include "RxPacket.h"
 #include "SweepSpec.h"
@@ -96,22 +98,79 @@ static std::unique_ptr<devourer::hopset::HopsetKeys> g_hopset_keys;
 static std::unique_ptr<devourer::hopset::HopsetFollower> g_hopset_fol;
 static std::unique_ptr<devourer::hopset::AdaptiveScheduleView> g_hopset_view;
 static std::atomic<uint64_t> g_hopset_now_slot{0};
+/* Receiver-driven exclusion (DEVOURER_HOP_POLICY=1): the policy scores every
+ * closed dwell and proposes mask changes; proposals leave over the air on
+ * this same claimed handle (one bring-up, RX loop + occasional control TX),
+ * which is the reserved low-rate feedback opportunity. */
+static std::unique_ptr<devourer::hopset::HopsetPolicy> g_hopset_policy;
+static IRtlDevice *g_hopset_dev = nullptr;
+static bool g_hopset_verbose_events = false;
+/* Per-dwell frame accounting, written lock-free from the RX worker and read
+ * by the hop loop when the slot closes. */
+static std::atomic<uint64_t> g_slot_acc_slot{UINT64_MAX};
+static std::atomic<uint32_t> g_slot_acc_frames{0}, g_slot_acc_crc{0};
+static std::atomic<int> g_slot_acc_rssi{0}, g_slot_acc_snr{0},
+    g_slot_acc_evm{0};
+static std::atomic<uint32_t> g_slot_dead_us{0};
 static long long steady_us() {
   return std::chrono::duration_cast<std::chrono::microseconds>(
              std::chrono::steady_clock::now().time_since_epoch())
       .count();
 }
 
-/* Execute the follower's actions (caller holds g_hopset_mu). Proposals
- * (SendControl) need the RX->TX feedback transport — that policy is out of
- * scope here, and the demo never calls propose(), so none arise. */
+/* Which schedule round an absolute slot falls in, under the state the view
+ * currently holds (round length is the active-channel count). */
+static uint64_t hopset_round_of(
+    const devourer::hopset::AdaptiveScheduleView &v, uint64_t slot,
+    size_t n_base) {
+  const auto &st = v.state();
+  const size_t k =
+      st.generation == 0 ? n_base : devourer::hopset::popcount64(st.active_mask);
+  return k && slot >= st.activate_slot ? (slot - st.activate_slot) / k : 0;
+}
+
+/* Air one authenticated control frame: robust 6M radiotap + a broadcast
+ * probe-request header (canonical SA) + the HopsetWire bytes. The caller's
+ * payload stream is never touched — control rides its own MPDU. */
+static void hopset_send(const devourer::hopset::HopsetMsg &m) {
+  if (!g_hopset_dev || !g_hopset_keys)
+    return;
+  static const uint8_t sa[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
+  std::vector<uint8_t> frame =
+      devourer::build_stream_radiotap(devourer::parse_tx_mode_str("6M"));
+  uint8_t hdr[24] = {0x40, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff,
+                     0xff};
+  std::memcpy(hdr + 10, sa, 6);
+  std::memcpy(hdr + 16, sa, 6);
+  hdr[22] = 0x90;
+  hdr[23] = 0x00;
+  frame.insert(frame.end(), hdr, hdr + 24);
+  const auto body = devourer::hopset::hopset_encode(m, *g_hopset_keys);
+  frame.insert(frame.end(), body.begin(), body.end());
+  g_hopset_dev->send_packet(frame.data(), frame.size());
+}
+
+/* Execute the follower's actions (caller holds g_hopset_mu). */
 static void hopset_route(
     const std::vector<devourer::hopset::HopsetAction> &acts) {
   for (const auto &a : acts) {
-    if (a.kind == devourer::hopset::HopsetAction::Activate)
+    if (a.kind == devourer::hopset::HopsetAction::Activate) {
       g_hopset_view->set_state(a.state);
-    else if (a.kind == devourer::hopset::HopsetAction::Event)
+      if (g_hopset_policy)
+        g_hopset_policy->on_activation(a.state.active_mask,
+                                       g_hopset_now_slot.load());
+    } else if (a.kind == devourer::hopset::HopsetAction::SendControl) {
+      hopset_send(a.msg);
+    } else if (a.kind == devourer::hopset::HopsetAction::Event) {
+      /* a rejected or timed-out proposal releases the policy's latch — the
+       * pure machine only reports the outcome, the host owns the handshake */
+      if (g_hopset_policy &&
+          a.event == devourer::hopset::HopsetEvent::Reject)
+        g_hopset_policy->clear_outstanding(hopset_round_of(
+            *g_hopset_view, g_hopset_now_slot.load(),
+            g_hopset_view->base_size()));
       devourer::hopset::emit_action(*g_ev, a, "rx", g_hopset_now_slot.load());
+    }
   }
 }
 
@@ -707,11 +766,15 @@ static void packetProcessor(const Packet &packet) {
       g_hop_last_marker_us.store(now);
       g_hop_marker_slot.store(m.slot);
       g_hop_epoch.store(m.epoch);
-      if (g_hop_decode_pending.exchange(false))
+      if (g_hop_decode_pending.exchange(false)) {
+        const long long dead = now - g_hop_last_retune_us.load();
+        g_slot_dead_us.store(
+            static_cast<uint32_t>(dead > 0 && dead < 1000000 ? dead : 0));
         devourer::Ev(*g_ev, "hop.rx")
             .f("state", "decode")
             .f("slot", (unsigned long long)m.slot)
-            .f("dead_us", now - g_hop_last_retune_us.load());
+            .f("dead_us", dead);
+      }
       if (g_hopset_fol) {
         /* missed-transition tripwire: does the advertised (generation,
          * mask fingerprint) match a state we hold (current or pending)? */
@@ -752,6 +815,20 @@ static void packetProcessor(const Packet &packet) {
       else if (hm.type == devourer::hopset::HT_STATUS)
         hopset_route(g_hopset_fol->on_status(hm, slot));
     }
+  }
+
+  /* Per-dwell delivery accounting for the exclusion policy: count this
+   * transmitter's frames (and the corrupt ones, when the RX surfaces them)
+   * against the slot the hop loop is currently parked on. Lock-free — the
+   * loop drains it when the dwell closes. */
+  if (g_hopset_policy && packet.Data.size() >= 16 &&
+      std::memcmp(packet.Data.data() + 10, kTxSa, 6) == 0) {
+    g_slot_acc_frames.fetch_add(1);
+    if (packet.RxAtrib.crc_err || packet.RxAtrib.icv_err)
+      g_slot_acc_crc.fetch_add(1);
+    g_slot_acc_rssi.fetch_add(packet.RxAtrib.rssi[0]);
+    g_slot_acc_snr.fetch_add(packet.RxAtrib.snr[0]);
+    g_slot_acc_evm.fetch_add(packet.RxAtrib.evm[0]);
   }
 
   /* Feed the rolling per-frame RSSI/SNR/EVM aggregate for DEVOURER_RX_ENERGY_MS
@@ -1531,11 +1608,54 @@ int main(int argc, char **argv) {
                                    hop_rx_channels.end());
       hp.base_fp = devourer::hopset::hopset_fp(*g_hopset_keys, chlist.data(),
                                                chlist.size());
+      /* Keyed recovery probes: every N rounds one data opportunity is spent
+       * on an excluded channel so it can prove it recovered. Shared config —
+       * the transmitter derives the same placement from the same seed. */
+      unsigned probe_rounds = 8;
+      if (const char *pr = std::getenv("DEVOURER_HOP_PROBE_ROUNDS"))
+        probe_rounds = static_cast<unsigned>(std::strtoul(pr, nullptr, 0));
+      /* Receiver-driven exclusion. Without it the follower still tracks
+       * commits, it just never proposes one. */
+      if (std::getenv("DEVOURER_HOP_POLICY")) {
+        devourer::hopset::HopsetPolicyConfig pc;
+        auto envu = [](const char *n, uint32_t &dst) {
+          if (const char *e = std::getenv(n))
+            dst = static_cast<uint32_t>(std::strtoul(e, nullptr, 0));
+        };
+        auto envd = [](const char *n, double &dst) {
+          if (const char *e = std::getenv(n))
+            dst = std::strtod(e, nullptr);
+        };
+        envu("DEVOURER_HOP_POLICY_MIN_ROUNDS", pc.min_obs_rounds);
+        envu("DEVOURER_HOP_POLICY_IMPAIRED_ROUNDS", pc.impaired_rounds);
+        envd("DEVOURER_HOP_POLICY_EXCLUDE_DELIVERY", pc.exclude_delivery);
+        envd("DEVOURER_HOP_POLICY_HEALTHY_DELIVERY", pc.healthy_delivery);
+        envu("DEVOURER_HOP_POLICY_MIN_ACTIVE", pc.min_active);
+        envd("DEVOURER_HOP_POLICY_RESTORE_DELIVERY", pc.restore_delivery);
+        envu("DEVOURER_HOP_POLICY_RESTORE_PROBES", pc.restore_probes);
+        if (const char *e = std::getenv("DEVOURER_HOP_POLICY_COOLDOWN_ROUNDS"))
+          pc.update_cooldown_rounds = std::strtoull(e, nullptr, 0);
+        /* the hard floor is max(3, configured) — the policy applies it, the
+         * authority enforces its own copy */
+        if (pc.min_active < 3)
+          pc.min_active = 3;
+        if (hp.min_active < pc.min_active)
+          hp.min_active = pc.min_active;
+        g_hopset_policy = std::make_unique<devourer::hopset::HopsetPolicy>(
+            pc, hop_rx_channels.size());
+        if (const char *v = std::getenv("DEVOURER_HOP_POLICY_EVENTS"))
+          g_hopset_verbose_events = std::atoi(v) >= 2;
+        logger->info("DEVOURER_HOP_POLICY — receiver-driven exclusion armed "
+                     "(min_active={}, probe every {} rounds, policy 0x{:08x})",
+                     pc.min_active, probe_rounds, pc.policy_hash());
+      }
       g_hopset_fol = std::make_unique<devourer::hopset::HopsetFollower>(
           hp, static_cast<uint32_t>(std::random_device{}()));
       g_hopset_view = std::make_unique<devourer::hopset::AdaptiveScheduleView>(
           *g_hop_schedule, *g_hopset_keys, hop_rx_channels.size());
       g_hopset_view->set_state(g_hopset_fol->state());
+      g_hopset_view->set_probe_period(probe_rounds);
+      g_hopset_dev = rtlDevice.get();
     }
     g_hop_slot_us = static_cast<uint64_t>(hop_rx_slot_ms) * 1000;
     long acquire_ms = hop_rx_slot_ms * 2;
@@ -1596,10 +1716,62 @@ int main(int argc, char **argv) {
           /* Phase correction may move the fitted boundary slightly forward.
            * Never follow that jitter backwards into a slot already visited. */
           if (tuned_slot == UINT64_MAX || slot > tuned_slot) {
+            /* Close out the dwell we are leaving before retuning: whether
+             * the transmitter's marker arrived is this channel's score for
+             * the round, and the frame counters refine it into a ratio. */
+            if (g_hopset_policy && tuned_slot != UINT64_MAX) {
+              const bool decoded = !g_hop_decode_pending.load();
+              const uint32_t frames = g_slot_acc_frames.exchange(0);
+              const uint32_t crc = g_slot_acc_crc.exchange(0);
+              const int rssi_sum = g_slot_acc_rssi.exchange(0);
+              const int snr_sum = g_slot_acc_snr.exchange(0);
+              const int evm_sum = g_slot_acc_evm.exchange(0);
+              std::lock_guard<std::mutex> lk(g_hopset_mu);
+              const auto closed = g_hopset_view->slot_info(tuned_slot);
+              devourer::hopset::SlotObservation o;
+              o.slot = tuned_slot;
+              o.round = hopset_round_of(*g_hopset_view, tuned_slot,
+                                        hop_rx_channels.size());
+              o.base_index = static_cast<uint32_t>(closed.base_index);
+              o.is_probe = closed.is_probe;
+              o.decoded = decoded;
+              o.frames = frames;
+              o.crc_errs = crc;
+              o.dead_us = g_slot_dead_us.exchange(0);
+              if (frames) {
+                o.rssi = rssi_sum / static_cast<int>(frames);
+                o.snr = snr_sum / static_cast<int>(frames);
+                o.evm = evm_sum / static_cast<int>(frames);
+              }
+              g_hopset_policy->ingest(o);
+              if (closed.is_probe)
+                devourer::hopset::emit_probe(
+                    *g_ev, "rx", tuned_slot, o.round, o.base_index,
+                    hop_rx_channels[closed.base_index], decoded, frames);
+              /* A round just closed: let the policy speak, and if it wants a
+               * change, send the proposal now — right after the boundary is
+               * the reserved low-rate control opportunity. */
+              const uint64_t r_now = hopset_round_of(*g_hopset_view, slot,
+                                                     hop_rx_channels.size());
+              if (r_now != o.round) {
+                auto d = g_hopset_policy->decide(r_now);
+                if (d.kind != devourer::hopset::HopsetDecision::Kind::Hold ||
+                    g_hopset_verbose_events)
+                  devourer::hopset::emit_decision(*g_ev, d, slot, r_now,
+                                                  g_hopset_verbose_events);
+                if (d.kind != devourer::hopset::HopsetDecision::Kind::Hold)
+                  hopset_route(g_hopset_fol->propose(
+                      d.proposed_mask, d.observation_count, d.reason_bitmap,
+                      static_cast<uint32_t>(std::random_device{}()), slot));
+              }
+            }
             int ch;
+            bool probe = false;
             if (g_hopset_view) {
               std::lock_guard<std::mutex> lk(g_hopset_mu);
-              ch = hop_rx_channels[g_hopset_view->channel_index(slot)];
+              const auto si = g_hopset_view->slot_info(slot);
+              ch = hop_rx_channels[si.base_index];
+              probe = si.is_probe;
             } else {
               ch = g_hop_schedule->channel(slot, hop_rx_channels);
             }
@@ -1608,12 +1780,19 @@ int main(int argc, char **argv) {
             auto done = steady_us();
             g_hop_last_retune_us.store(done);
             g_hop_decode_pending.store(true);
+            g_slot_acc_frames.store(0);
+            g_slot_acc_crc.store(0);
+            g_slot_acc_rssi.store(0);
+            g_slot_acc_snr.store(0);
+            g_slot_acc_evm.store(0);
             tuned_slot = slot;
-            devourer::Ev(*g_ev, "hop.rx")
-                .f("state", "retune")
+            devourer::Ev ev(*g_ev, "hop.rx");
+            ev.f("state", "retune")
                 .f("slot", (unsigned long long)slot)
                 .f("channel", ch)
                 .f("retune_us", done - t0);
+            if (probe)
+              ev.f("probe", true);
           }
         }
       } else {

--- a/examples/tx/main.cpp
+++ b/examples/tx/main.cpp
@@ -130,6 +130,49 @@ static std::vector<uint8_t> build_frame_with_pkt_pwr(int8_t db,
   return f;
 }
 
+/* Adaptive hopset (DEVOURER_HOP_ADAPTIVE=1): this side is the schedule
+ * authority. File-scope because packetProcessor — a free function running on
+ * the RX thread under DEVOURER_TX_WITH_RX=thread — is where follower
+ * proposals arrive; the mutex covers the machine and the view together. */
+static std::mutex g_hopset_mu;
+static std::optional<devourer::hopset::HopsetKeys> g_hopset_keys;
+static std::optional<devourer::hopset::HopsetAuthority> g_hopset_auth;
+static std::optional<devourer::hopset::AdaptiveScheduleView> g_hopset_view;
+static IRtlDevice *g_hopset_dev = nullptr;
+static std::atomic<uint64_t> g_hopset_tick_slot{0};
+
+/* Execute the authority's actions (caller holds g_hopset_mu). Commit and
+ * status frames air as their own small MPDUs beside the payload stream, so
+ * caller payload bytes are never touched. */
+static void hopset_route(
+    const std::vector<devourer::hopset::HopsetAction> &acts) {
+  for (const auto &a : acts) {
+    if (a.kind == devourer::hopset::HopsetAction::Activate) {
+      g_hopset_view->set_state(a.state);
+    } else if (a.kind == devourer::hopset::HopsetAction::SendControl) {
+      /* robust 6M radiotap + broadcast probe-req header + the authenticated
+       * HopsetWire bytes */
+      std::vector<uint8_t> frame =
+          devourer::build_stream_radiotap(devourer::parse_tx_mode_str("6M"));
+      static const uint8_t sa[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
+      uint8_t hdr[24] = {0x40, 0x00, 0x00, 0x00, 0xff, 0xff,
+                         0xff, 0xff, 0xff, 0xff};
+      std::memcpy(hdr + 10, sa, 6);
+      std::memcpy(hdr + 16, sa, 6);
+      hdr[22] = 0x90;
+      hdr[23] = 0x00;
+      frame.insert(frame.end(), hdr, hdr + 24);
+      const auto body = devourer::hopset::hopset_encode(a.msg, *g_hopset_keys);
+      frame.insert(frame.end(), body.begin(), body.end());
+      if (g_hopset_dev)
+        g_hopset_dev->send_packet(frame.data(), frame.size());
+    } else if (a.kind == devourer::hopset::HopsetAction::Event) {
+      devourer::hopset::emit_action(*g_ev, a, "tx",
+                                    g_hopset_tick_slot.load());
+    }
+  }
+}
+
 static int g_rx_count = 0;
 static void packetProcessor(const Packet &packet) {
   /* C2H packets are chip-side status (one per TX during concurrent TX+RX on
@@ -161,6 +204,23 @@ static void packetProcessor(const Packet &packet) {
           .f("hits", hits)
           .f("total_rx", g_rx_count)
           .f("len", packet.Data.size());
+    }
+  }
+  /* The receiver's feedback opportunity: an authenticated exclusion or
+   * restoration proposal. The authority validates it against its own
+   * structural limits and answers with a commit (or a status carrying the
+   * rejection reason) — the receiver decides which channel, never how much
+   * of the schedule may change at once. */
+  if (g_hopset_auth && packet.Data.size() > 24 + 16 &&
+      packet.Data[0] == 0x40) {
+    devourer::hopset::HopsetMsg hm;
+    if (devourer::hopset::hopset_decode(packet.Data.data() + 24,
+                                        packet.Data.size() - 24,
+                                        *g_hopset_keys, 0, hm) ==
+            devourer::hopset::HopsetReason::None &&
+        hm.type == devourer::hopset::HT_PROPOSAL) {
+      std::lock_guard<std::mutex> lk(g_hopset_mu);
+      hopset_route(g_hopset_auth->on_proposal(hm, g_hopset_tick_slot.load()));
     }
   }
 }
@@ -1135,26 +1195,37 @@ int main(int argc, char **argv) {
    * (mask = hex bitmap over base-hopset positions) driving authority-
    * originated commits. Commit/status frames air as their own small 802.11
    * frames next to the payload stream — caller payload bytes are untouched. */
-  std::optional<devourer::hopset::HopsetKeys> hopset_keys;
-  std::optional<devourer::hopset::HopsetAuthority> hopset_auth;
-  std::optional<devourer::hopset::AdaptiveScheduleView> hopset_view;
   std::vector<std::pair<uint64_t, uint64_t>> hopset_script;
   size_t hopset_script_next = 0;
-  uint64_t hopset_tick_slot = 0;
   bool hopset_ticked = false;
+  bool hop_probe_slot = false;
   if (hop_adaptive) {
-    hopset_keys = devourer::hopset::HopsetKeys::derive(
+    g_hopset_keys = devourer::hopset::HopsetKeys::derive(
         devourer::HopSchedule::parse_seed(std::getenv("DEVOURER_HOP_SEED")));
     devourer::hopset::HopsetParams hp;
     hp.n_base = hop_channels.size();
     std::vector<uint32_t> chlist(hop_channels.begin(), hop_channels.end());
-    hp.base_fp = devourer::hopset::hopset_fp(*hopset_keys, chlist.data(),
+    hp.base_fp = devourer::hopset::hopset_fp(*g_hopset_keys, chlist.data(),
                                              chlist.size());
-    hopset_auth.emplace(hp, static_cast<uint32_t>(std::random_device{}()));
-    hopset_view.emplace(*hop_schedule, *hopset_keys, hop_channels.size());
+    /* The authority's own diversity floor. The receiver's policy applies a
+     * hard max(3, configured) to anything it proposes; this copy is what
+     * stops a buggy or hostile proposal, and an operator driving the
+     * scripted lever on a small base hopset can lower it deliberately. */
+    hp.min_active = 3;
+    if (const char *ma = std::getenv("DEVOURER_HOP_MIN_ACTIVE"))
+      hp.min_active = static_cast<unsigned>(std::strtoul(ma, nullptr, 0));
+    if (hp.min_active < 2)
+      hp.min_active = 2;
+    g_hopset_auth.emplace(hp, static_cast<uint32_t>(std::random_device{}()));
+    g_hopset_view.emplace(*hop_schedule, *g_hopset_keys, hop_channels.size());
     /* view and authority must agree from slot 0 (gen 0 = full mask) so the
      * marker's mask fingerprint matches a fresh follower's initial state */
-    hopset_view->set_state(hopset_auth->state());
+    g_hopset_view->set_state(g_hopset_auth->state());
+    unsigned probe_rounds = 8;
+    if (const char *pr = std::getenv("DEVOURER_HOP_PROBE_ROUNDS"))
+      probe_rounds = static_cast<unsigned>(std::strtoul(pr, nullptr, 0));
+    g_hopset_view->set_probe_period(probe_rounds);
+    g_hopset_dev = rtlDevice.get();
     if (const char *sc = std::getenv("DEVOURER_HOP_ADAPTIVE_SCRIPT")) {
       for (const char *p = sc; *p;) {
         char *end = nullptr;
@@ -1168,34 +1239,6 @@ int main(int argc, char **argv) {
       }
     }
   }
-  auto hopset_route =
-      [&](const std::vector<devourer::hopset::HopsetAction> &acts) {
-        for (const auto &a : acts) {
-          if (a.kind == devourer::hopset::HopsetAction::Activate) {
-            hopset_view->set_state(a.state);
-          } else if (a.kind == devourer::hopset::HopsetAction::SendControl) {
-            /* robust 6M radiotap + broadcast probe-req header + the
-             * authenticated HopsetWire bytes (the chanmig frame shape) */
-            std::vector<uint8_t> frame = devourer::build_stream_radiotap(
-                devourer::parse_tx_mode_str("6M"));
-            static const uint8_t sa[6] = {0x57, 0x42, 0x75, 0x05, 0xd6, 0x00};
-            uint8_t hdr[24] = {0x40, 0x00, 0x00, 0x00, 0xff, 0xff,
-                               0xff, 0xff, 0xff, 0xff};
-            std::memcpy(hdr + 10, sa, 6);
-            std::memcpy(hdr + 16, sa, 6);
-            hdr[22] = 0x90;
-            hdr[23] = 0x00;
-            frame.insert(frame.end(), hdr, hdr + 24);
-            const auto body =
-                devourer::hopset::hopset_encode(a.msg, *hopset_keys);
-            frame.insert(frame.end(), body.begin(), body.end());
-            rtlDevice->send_packet(frame.data(), frame.size());
-          } else if (a.kind == devourer::hopset::HopsetAction::Event) {
-            devourer::hopset::emit_action(*g_ev, a, "tx", hopset_tick_slot);
-          }
-        }
-      };
-
   long tx_count = 0;
   long consec_fail = 0;
   /* If the TX path isn't enabled the chip NAKs every bulk-OUT; hammering a
@@ -1327,29 +1370,48 @@ int main(int argc, char **argv) {
                       .count() /
                   hop_slot_ms)
             : static_cast<uint64_t>(dwell_no + (frames_in_dwell == 0 ? 1 : 0));
-    if (hopset_auth && (!hopset_ticked || desired_slot != hopset_tick_slot)) {
+    if (g_hopset_auth && (!hopset_ticked ||
+                          desired_slot != g_hopset_tick_slot.load())) {
       /* once per slot: scripted commits due at this slot, then the authority
        * heartbeat (commit repetition, activation swap, status beacon) */
-      hopset_tick_slot = desired_slot;
+      g_hopset_tick_slot.store(desired_slot);
       hopset_ticked = true;
+      std::lock_guard<std::mutex> lk(g_hopset_mu);
       while (hopset_script_next < hopset_script.size() &&
              desired_slot >= hopset_script[hopset_script_next].first) {
-        hopset_route(hopset_auth->start_change(
+        hopset_route(g_hopset_auth->start_change(
             hopset_script[hopset_script_next].second, desired_slot));
         ++hopset_script_next;
       }
-      hopset_route(hopset_auth->on_tick(desired_slot));
+      hopset_route(g_hopset_auth->on_tick(desired_slot));
     }
     if (!hop_channels.empty() &&
         ((hop_slot_ms > 0 && desired_slot != static_cast<uint64_t>(dwell_no)) ||
          (hop_slot_ms == 0 && frames_in_dwell == 0))) {
       dwell_no = static_cast<long>(desired_slot);
       if (total_dwells > 0 && dwell_no >= total_dwells) break;
-      int ch = hopset_view
-                   ? hop_channels[hopset_view->channel_index(desired_slot)]
-               : hop_schedule
-                   ? hop_schedule->channel(desired_slot, hop_channels)
-                   : hop_channels[desired_slot % hop_channels.size()];
+      int ch;
+      if (g_hopset_view) {
+        std::lock_guard<std::mutex> lk(g_hopset_mu);
+        const auto si = g_hopset_view->slot_info(desired_slot);
+        ch = hop_channels[si.base_index];
+        /* A keyed recovery probe: this dwell airs on an excluded channel so
+         * the receiver can see whether it came back. Only sync/control goes
+         * out — the payload stream stays on the active set. */
+        hop_probe_slot = si.is_probe;
+        if (si.is_probe)
+          devourer::hopset::emit_probe(
+              *g_ev, "tx", desired_slot,
+              (desired_slot - g_hopset_view->state().activate_slot) /
+                  (g_hopset_view->active_count()
+                       ? g_hopset_view->active_count()
+                       : 1),
+              static_cast<uint32_t>(si.base_index), ch, true, 0);
+      } else {
+        hop_probe_slot = false;
+        ch = hop_schedule ? hop_schedule->channel(desired_slot, hop_channels)
+                          : hop_channels[desired_slot % hop_channels.size()];
+      }
       auto sw0 = std::chrono::steady_clock::now();
       const char *mode = nullptr;
       if (hop_radiotap) {
@@ -1391,6 +1453,12 @@ int main(int argc, char **argv) {
           ev.hexf("seed_fp", hop_schedule->fingerprint(), 8);
         if (mode != nullptr)
           ev.f("mode", mode);
+        /* On a probe dwell the beacon this demo airs IS the small known
+         * probe body — it carries the sync marker and nothing else. A demo
+         * streaming caller payload would suppress that payload here instead;
+         * probes must never spend FEC shards on an excluded channel. */
+        if (hop_probe_slot)
+          ev.f("probe", true);
       }
     }
     if (hop_schedule && hop_slot_ms > 0) {
@@ -1416,10 +1484,11 @@ int main(int argc, char **argv) {
         marker.epoch = hop_epoch;
         marker.phase_us = phase;
         marker.slot = slot;
-        marker.generation = hopset_view->state().generation;
+        std::lock_guard<std::mutex> lk(g_hopset_mu);
+        marker.generation = g_hopset_view->state().generation;
         marker.mask_fp = devourer::hopset::mask_fp(
-            *hopset_keys, hopset_view->state().generation,
-            hopset_view->state().active_mask);
+            *g_hopset_keys, g_hopset_view->state().generation,
+            g_hopset_view->state().active_mask);
         auto wire = devourer::hopset::HopSyncMarkerV2::encode(marker);
         tx_buf.insert(tx_buf.end(), wire.begin(), wire.end());
       } else {

--- a/src/hopset/HopsetAuthority.h
+++ b/src/hopset/HopsetAuthority.h
@@ -66,6 +66,18 @@ public:
     const HopsetReason mr = mask_reason(m.active_mask);
     if (mr != HopsetReason::None)
       return reject(out, m, mr, now_slot);
+    /* Structural limits the authority enforces on its own account: a
+     * follower is the decision-maker but not trusted with the shape of the
+     * change. One channel per update, a floor on how often updates may
+     * happen — a buggy or hostile proposer cannot walk the link down in one
+     * step or by flooding. Locally-originated changes (start_change) are
+     * exempt: they are the operator's own lever. */
+    if (p_.max_mask_delta &&
+        popcount64(m.active_mask ^ cur_.active_mask) > p_.max_mask_delta)
+      return reject(out, m, HopsetReason::MaskDelta, now_slot);
+    if (p_.min_update_gap_rounds && have_activation_ &&
+        round_of(now_slot) - last_activation_round_ < p_.min_update_gap_rounds)
+      return reject(out, m, HopsetReason::Cooldown, now_slot);
     replays_.remember(m.rx_epoch, m.rx_nonce);
     pend_echo_epoch_ = m.rx_epoch;
     pend_echo_nonce_ = m.rx_nonce;
@@ -111,6 +123,8 @@ public:
       if (now_slot >= pend_.activate_slot) {
         cur_ = pend_;
         committing_ = false;
+        last_activation_round_ = round_of(now_slot);
+        have_activation_ = true;
         HopsetAction act{};
         act.kind = HopsetAction::Activate;
         act.state = cur_;
@@ -148,6 +162,10 @@ private:
     if (mask & ~full_mask(p_.n_base))
       return HopsetReason::BadMask;
     if (popcount64(mask) < p_.min_active)
+      return HopsetReason::LowDiversity;
+    if (p_.max_excluded_frac_pct < 100 &&
+        popcount64(full_mask(p_.n_base) & ~mask) * 100 >
+            p_.max_excluded_frac_pct * p_.n_base)
       return HopsetReason::LowDiversity;
     if (mask == cur_.active_mask && cur_.generation != 0)
       return HopsetReason::NoChange;
@@ -236,6 +254,8 @@ private:
   uint32_t pend_echo_epoch_ = 0, pend_echo_nonce_ = 0;
   uint64_t last_commit_slot_ = 0;
   uint64_t last_status_slot_ = 0;
+  uint64_t last_activation_round_ = 0;
+  bool have_activation_ = false;
   ProposalReplayRing replays_;
 };
 

--- a/src/hopset/HopsetEvents.h
+++ b/src/hopset/HopsetEvents.h
@@ -6,6 +6,7 @@
 #define DEVOURER_HOPSET_HOPSET_EVENTS_H
 
 #include "Event.h"
+#include "hopset/HopsetPolicy.h"
 #include "hopset/HopsetTypes.h"
 
 namespace devourer {
@@ -42,6 +43,55 @@ inline void emit_action(EventSink &sink, const HopsetAction &a,
         .hexf("cur_mask", a.state.active_mask, 0);
     break;
   }
+}
+
+/* One policy verdict. `verbose` adds the per-channel evidence the decision
+ * was made from, so a log replay can re-derive it without the receiver. */
+inline void emit_decision(EventSink &sink, const HopsetDecision &d,
+                          uint64_t slot, uint64_t round, bool verbose) {
+  Ev ev(sink, "hopset.decision");
+  ev.t().f("v", 1).f("role", "rx").f("slot", (unsigned long long)slot)
+      .f("round", (unsigned long long)round);
+  ev.f("kind", d.kind == HopsetDecision::Kind::ProposeExclude   ? "exclude"
+                : d.kind == HopsetDecision::Kind::ProposeRestore ? "restore"
+                                                                 : "hold");
+  ev.f("obs", (unsigned long long)d.observation_count)
+      .hexf("policy", d.policy_hash, 8);
+  if (d.kind == HopsetDecision::Kind::Hold) {
+    ev.f("hold", hopset_hold_name(d.hold));
+  } else {
+    ev.hexf("mask", d.proposed_mask, 0)
+        .hexf("reasons", d.reason_bitmap, 0)
+        .f("target", (unsigned long long)d.target_index);
+  }
+  if (!verbose)
+    return;
+  for (size_t i = 0; i < d.chans.size(); ++i) {
+    char key[8], buf[64];
+    std::snprintf(key, sizeof(key), "c%zu", i);
+    std::snprintf(buf, sizeof(buf), "%s d=%.2f p=%.2f v=%u imp=%u",
+                  d.chans[i].active ? "on" : "off", d.chans[i].delivery,
+                  d.chans[i].probe_delivery, d.chans[i].visits,
+                  d.chans[i].impaired_run);
+    ev.f(key, buf);
+  }
+}
+
+/* One keyed recovery-probe dwell: the transmitter logs that it aired on the
+ * excluded channel, the receiver logs whether anything arrived. */
+inline void emit_probe(EventSink &sink, const char *role, uint64_t slot,
+                       uint64_t round, uint32_t base_index, int channel,
+                       bool delivered, uint32_t frames) {
+  Ev(sink, "hopset.probe")
+      .t()
+      .f("v", 1)
+      .f("role", role)
+      .f("slot", (unsigned long long)slot)
+      .f("round", (unsigned long long)round)
+      .f("base_idx", (unsigned long long)base_index)
+      .f("ch", channel)
+      .f("delivered", delivered)
+      .f("frames", (unsigned long long)frames);
 }
 
 } /* namespace hopset */

--- a/src/hopset/HopsetPolicy.h
+++ b/src/hopset/HopsetPolicy.h
@@ -1,0 +1,445 @@
+/* HopsetPolicy — the receiver-side exclusion/restoration decision engine for
+ * adaptive FHSS. The receiver decides because its delivery measurement
+ * describes the endpoint that must actually decode; the transmitter validates
+ * the proposal structurally and owns the commit.
+ *
+ * Delivery is authoritative. RSSI/SNR/EVM, energy counters and link verdicts
+ * only *classify* an impairment (interference vs weak signal vs lost
+ * synchronization) — they set explanation bits and never independently
+ * trigger an exclusion, because a quiet channel with a dead link and a noisy
+ * channel that still delivers are opposite decisions.
+ *
+ * Everything here is conservative by construction, because an adaptive
+ * exclusion loop is an attack surface: an adversary who can make a channel
+ * look bad can otherwise herd the link onto a single channel it then jams.
+ * Hence the hard active-channel floor, one exclusion per update, the update
+ * cooldown, the broad-degradation stop, the excluded-fraction cap, and
+ * mandatory keyed probes before anything is restored.
+ *
+ * Pure: no I/O, no clock, no env, no randomness — the host feeds closed-slot
+ * observations plus the current round and executes the decision. */
+#ifndef DEVOURER_HOPSET_HOPSET_POLICY_H
+#define DEVOURER_HOPSET_HOPSET_POLICY_H
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+#include "hopset/HopsetState.h"
+
+namespace devourer {
+namespace hopset {
+
+/* Explanation bits carried in the proposal's reason_bitmap. Bits 0..2 are the
+ * decision's own evidence; 3..6 classify the impairment (never triggers);
+ * 7..8 are the probe-driven restoration evidence. */
+enum HopsetReasonBit : uint32_t {
+  RB_DELIVERY_FLOOR = 1u << 0,      /* target delivery below the exclusion floor */
+  RB_PERSISTENT = 1u << 1,          /* sustained for impaired_rounds rounds */
+  RB_HEALTHY_ALT = 1u << 2,         /* another active channel is healthy */
+  RB_CRC_DOMINANT = 1u << 3,        /* frames arrive but fail FCS */
+  RB_ENERGY_INTERFERENCE = 1u << 4, /* link verdict says interference */
+  RB_WEAK_SIGNAL = 1u << 5,         /* link verdict says weak signal */
+  RB_SYNC_LOSS = 1u << 6,           /* nothing decoded at all on the visit */
+  RB_PROBE_RECOVERY = 1u << 7,      /* probes cleared the restoration bar */
+  RB_PROBE_EVIDENCE = 1u << 8,      /* decision used keyed-probe observations */
+};
+
+/* Why a decide() returned Hold — every path names exactly one. */
+enum class HopsetHold : uint8_t {
+  None = 0,
+  InsufficientRounds,
+  Cooldown,
+  ProposalOutstanding,
+  NoImpairment,
+  NotPersistent,
+  BroadDegradation,
+  NoHealthyAlternative,
+  MinActiveFloor,
+  MaxExcludedFrac,
+  ProbeHysteresisPending,
+};
+
+inline const char *hopset_hold_name(HopsetHold h) {
+  switch (h) {
+  case HopsetHold::None: return "none";
+  case HopsetHold::InsufficientRounds: return "insufficient_rounds";
+  case HopsetHold::Cooldown: return "cooldown";
+  case HopsetHold::ProposalOutstanding: return "proposal_outstanding";
+  case HopsetHold::NoImpairment: return "no_impairment";
+  case HopsetHold::NotPersistent: return "not_persistent";
+  case HopsetHold::BroadDegradation: return "broad_degradation";
+  case HopsetHold::NoHealthyAlternative: return "no_healthy_alternative";
+  case HopsetHold::MinActiveFloor: return "min_active_floor";
+  case HopsetHold::MaxExcludedFrac: return "max_excluded_frac";
+  case HopsetHold::ProbeHysteresisPending: return "probe_hysteresis_pending";
+  }
+  return "?";
+}
+
+/* Conservative shipping defaults. Every field is caller-tunable; the hash
+ * stamps the exact configuration into each decision so a log replay is
+ * reproducible. */
+struct HopsetPolicyConfig {
+  uint32_t min_obs_rounds = 8;       /* scored rounds before any decision */
+  uint32_t impaired_rounds = 5;      /* consecutive impaired visits required */
+  double exclude_delivery = 0.30;    /* per-visit delivery below this = impaired */
+  double healthy_delivery = 0.70;    /* windowed delivery at/above this = healthy */
+  uint32_t min_active = 3;           /* hard floor on active channels */
+  uint64_t update_cooldown_rounds = 10;
+  double restore_delivery = 0.70;    /* probe delivery above this counts */
+  uint32_t restore_probes = 3;       /* consecutive good probes to restore */
+  double broad_degrade_frac = 0.50;  /* impaired share that stops exclusion */
+  double max_excluded_frac = 0.50;   /* cap on excluded/base */
+  uint32_t ring_rounds = 16;         /* per-channel sliding window depth */
+
+  uint32_t policy_hash() const {
+    uint32_t h = 2166136261u;
+    auto fold = [&h](uint64_t v) {
+      for (int i = 0; i < 8; ++i) {
+        h ^= static_cast<uint32_t>((v >> (8 * i)) & 0xff);
+        h *= 16777619u;
+      }
+    };
+    /* doubles fold as fixed-point so the hash is bit-identical everywhere */
+    auto foldd = [&fold](double d) {
+      fold(static_cast<uint64_t>(static_cast<int64_t>(d * 10000.0 + 0.5)));
+    };
+    fold(min_obs_rounds);
+    fold(impaired_rounds);
+    foldd(exclude_delivery);
+    foldd(healthy_delivery);
+    fold(min_active);
+    fold(update_cooldown_rounds);
+    foldd(restore_delivery);
+    fold(restore_probes);
+    foldd(broad_degrade_frac);
+    foldd(max_excluded_frac);
+    fold(ring_rounds);
+    return h;
+  }
+};
+
+/* One closed slot, snapshotted by the host at the dwell boundary. `decoded`
+ * is the schedule-level fact (did the transmitter's marker arrive at all);
+ * frames/crc_errs refine it into a ratio when the receiver surfaces corrupt
+ * frames. verdict is an optional LinkVerdict value — classification only. */
+struct SlotObservation {
+  uint64_t slot = 0;
+  uint64_t round = 0;
+  uint32_t base_index = 0;
+  bool is_probe = false;
+  bool decoded = false;
+  uint32_t frames = 0;    /* own-transmitter frames delivered in the dwell */
+  uint32_t crc_errs = 0;  /* frames that arrived corrupt (when surfaced) */
+  int rssi = -1;          /* raw PWDB mean, <0 = no reading */
+  int snr = 0;
+  int evm = 0;
+  uint32_t dead_us = 0;   /* retune -> first decode; 0 when nothing decoded */
+  uint8_t verdict = 255;  /* LinkVerdict, 255 = none */
+};
+
+/* A per-channel evidence summary, carried on the decision so the event log
+ * explains it without re-deriving anything. */
+struct HopsetChanScore {
+  uint32_t visits = 0;
+  uint32_t decoded = 0;
+  double delivery = 0.0;       /* windowed, data visits */
+  double probe_delivery = 0.0; /* windowed, probe visits */
+  uint32_t probes = 0;
+  uint32_t impaired_run = 0;
+  bool active = false;
+  bool scored = false;
+};
+
+struct HopsetDecision {
+  enum class Kind : uint8_t { Hold, ProposeExclude, ProposeRestore } kind =
+      Kind::Hold;
+  uint64_t proposed_mask = 0;
+  uint32_t reason_bitmap = 0;
+  uint32_t observation_count = 0;
+  HopsetHold hold = HopsetHold::None;
+  size_t target_index = 0;
+  uint32_t policy_hash = 0;
+  std::vector<HopsetChanScore> chans;
+};
+
+class HopsetPolicy {
+public:
+  HopsetPolicy(const HopsetPolicyConfig &cfg, size_t n_base)
+      : cfg_(cfg), n_(n_base), ch_(n_base) {
+    if (!n_base || n_base > kMaxBaseChannels)
+      throw std::invalid_argument("base hopset size out of range");
+    mask_ = full_mask(n_base);
+  }
+
+  const HopsetPolicyConfig &config() const { return cfg_; }
+  uint64_t active_mask() const { return mask_; }
+
+  /* Fold one closed slot. Each active channel is visited exactly once per
+   * round, so a data visit *is* that channel's round score — no separate
+   * round-closing step, and a probe-displaced visit simply doesn't advance
+   * that channel's run. */
+  void ingest(const SlotObservation &o) {
+    if (o.base_index >= n_)
+      return;
+    if (!any_seen_) {
+      any_seen_ = true;
+      rounds_seen_ = 1;
+      last_round_ = o.round;
+    } else if (o.round != last_round_) {
+      ++rounds_seen_;
+      last_round_ = o.round;
+    }
+    Chan &c = ch_[o.base_index];
+    const double d = delivery_of(o);
+    if (o.is_probe) {
+      push(c.probe_ring, c.probe_n, c.probe_head, d);
+      c.probe_good_run = d > cfg_.restore_delivery ? c.probe_good_run + 1 : 0;
+      c.probes++;
+      c.saw_probe = true;
+    } else {
+      push(c.ring, c.ring_n, c.ring_head, d);
+      c.visits++;
+      if (d > 0.0)
+        c.decoded++;
+      c.impaired_run = d < cfg_.exclude_delivery ? c.impaired_run + 1 : 0;
+      /* classification: never a trigger, only an explanation */
+      if (o.frames > 0 && o.crc_errs * 2 >= o.frames)
+        c.crc_dominant = true;
+      if (!o.decoded && o.frames == 0)
+        c.sync_loss = true;
+      if (o.verdict == kVerdictInterference)
+        c.energy_interference = true;
+      if (o.verdict == kVerdictWeak)
+        c.weak_signal = true;
+    }
+  }
+
+  /* A committed state took effect: re-anchor the cooldown, adopt the mask,
+   * and clear the evidence of whatever just changed so a restored channel
+   * starts from a clean slate instead of its pre-exclusion history. */
+  void on_activation(uint64_t mask, uint64_t now_round) {
+    const uint64_t changed = mask ^ mask_;
+    for (size_t i = 0; i < n_; ++i)
+      if (changed & (uint64_t(1) << i))
+        ch_[i] = Chan{};
+    mask_ = mask;
+    last_update_round_ = now_round;
+    have_update_ = true;
+    outstanding_ = false;
+  }
+
+  /* The proposal was answered (rejected, or timed out) without activating.
+   * A refused attempt still consumes the update budget: otherwise a receiver
+   * whose proposals keep bouncing — exactly what happens against a jammer
+   * that moves after every exclusion — re-proposes on every round boundary
+   * and floods the control channel. */
+  void clear_outstanding(uint64_t now_round) {
+    outstanding_ = false;
+    last_update_round_ = now_round;
+    have_update_ = true;
+  }
+  bool proposal_outstanding() const { return outstanding_; }
+
+  HopsetDecision decide(uint64_t now_round) {
+    HopsetDecision d;
+    d.policy_hash = cfg_.policy_hash();
+    d.observation_count = rounds_seen_;
+    d.chans = summarize();
+
+    if (rounds_seen_ < cfg_.min_obs_rounds)
+      return hold(d, HopsetHold::InsufficientRounds);
+    if (outstanding_)
+      return hold(d, HopsetHold::ProposalOutstanding);
+    if (have_update_ && now_round - last_update_round_ <
+                            cfg_.update_cooldown_rounds)
+      return hold(d, HopsetHold::Cooldown);
+
+    /* --- restoration first: giving a channel back is the safer move, and
+     * it keeps a herding adversary from ratcheting the set down --- */
+    const uint64_t excluded = full_mask(n_) & ~mask_;
+    bool probe_pending = false;
+    for (size_t i = 0; i < n_; ++i) {
+      if (!(excluded & (uint64_t(1) << i)))
+        continue;
+      const Chan &c = ch_[i];
+      if (c.probe_good_run >= cfg_.restore_probes) {
+        d.kind = HopsetDecision::Kind::ProposeRestore;
+        d.target_index = i;
+        d.proposed_mask = mask_ | (uint64_t(1) << i);
+        d.reason_bitmap = RB_PROBE_RECOVERY | RB_PROBE_EVIDENCE;
+        outstanding_ = true;
+        return d;
+      }
+      if (c.saw_probe)
+        probe_pending = true;
+    }
+
+    /* --- exclusion: the worst sustained-impaired active channel --- */
+    size_t worst = 0;
+    bool have_worst = false;
+    double worst_delivery = 1.0;
+    unsigned impaired_active = 0, active_scored = 0;
+    bool healthy_alt = false, any_impaired = false;
+    for (size_t i = 0; i < n_; ++i) {
+      if (!(mask_ & (uint64_t(1) << i)))
+        continue;
+      const Chan &c = ch_[i];
+      if (!c.ring_n)
+        continue;
+      ++active_scored;
+      const double w = window_delivery(c);
+      if (w < cfg_.healthy_delivery)
+        ++impaired_active;
+      if (c.impaired_run > 0)
+        any_impaired = true;
+      /* the trigger is the sustained run of impaired visits, exactly as the
+       * policy is stated; the windowed mean only ranks the candidates */
+      if (c.impaired_run >= cfg_.impaired_rounds &&
+          (!have_worst || w < worst_delivery)) {
+        have_worst = true;
+        worst = i;
+        worst_delivery = w;
+      }
+    }
+    for (size_t i = 0; i < n_; ++i) {
+      if (!(mask_ & (uint64_t(1) << i)) || (have_worst && i == worst))
+        continue;
+      const Chan &c = ch_[i];
+      if (c.ring_n && window_delivery(c) >= cfg_.healthy_delivery)
+        healthy_alt = true;
+    }
+
+    if (!have_worst) {
+      if (probe_pending)
+        return hold(d, HopsetHold::ProbeHysteresisPending);
+      return hold(d, any_impaired ? HopsetHold::NotPersistent
+                                  : HopsetHold::NoImpairment);
+    }
+    /* When most of the band degrades together the problem is not the
+     * channel — excluding would only shrink diversity for nothing. */
+    if (active_scored &&
+        static_cast<double>(impaired_active) /
+                static_cast<double>(active_scored) >=
+            cfg_.broad_degrade_frac)
+      return hold(d, HopsetHold::BroadDegradation);
+    if (!healthy_alt)
+      return hold(d, HopsetHold::NoHealthyAlternative);
+
+    const uint64_t after = mask_ & ~(uint64_t(1) << worst);
+    const uint32_t floor_active =
+        cfg_.min_active < 3u ? 3u : cfg_.min_active;
+    if (popcount64(after) < floor_active)
+      return hold(d, HopsetHold::MinActiveFloor);
+    if (static_cast<double>(popcount64(full_mask(n_) & ~after)) /
+            static_cast<double>(n_) >
+        cfg_.max_excluded_frac)
+      return hold(d, HopsetHold::MaxExcludedFrac);
+
+    d.kind = HopsetDecision::Kind::ProposeExclude;
+    d.target_index = worst;
+    d.proposed_mask = after;
+    d.reason_bitmap = RB_DELIVERY_FLOOR | RB_PERSISTENT | RB_HEALTHY_ALT;
+    const Chan &c = ch_[worst];
+    if (c.crc_dominant)
+      d.reason_bitmap |= RB_CRC_DOMINANT;
+    if (c.sync_loss)
+      d.reason_bitmap |= RB_SYNC_LOSS;
+    if (c.energy_interference)
+      d.reason_bitmap |= RB_ENERGY_INTERFERENCE;
+    if (c.weak_signal)
+      d.reason_bitmap |= RB_WEAK_SIGNAL;
+    outstanding_ = true;
+    return d;
+  }
+
+private:
+  /* LinkVerdict values used for classification, kept as plain constants so
+   * this header stays free of the RX-sensor headers. */
+  static constexpr uint8_t kVerdictInterference = 2;
+  static constexpr uint8_t kVerdictWeak = 3;
+  static constexpr size_t kRing = 64;
+
+  struct Chan {
+    /* rings hold the per-visit delivery RATIO, not a pass/fail bit: the
+     * windowed mean is what "another channel remains healthy" and "most
+     * channels degraded together" have to read, and a bit would score a
+     * half-delivering channel as healthy. */
+    double ring[kRing]{};
+    uint32_t ring_n = 0, ring_head = 0;
+    double probe_ring[kRing]{};
+    uint32_t probe_n = 0, probe_head = 0;
+    uint32_t visits = 0, decoded = 0, probes = 0;
+    uint32_t impaired_run = 0, probe_good_run = 0;
+    bool crc_dominant = false, sync_loss = false;
+    bool energy_interference = false, weak_signal = false;
+    bool saw_probe = false;
+  };
+
+  void push(double *ring, uint32_t &n, uint32_t &head, double v) {
+    const uint32_t depth =
+        cfg_.ring_rounds < kRing ? cfg_.ring_rounds : uint32_t(kRing);
+    ring[head] = v;
+    head = (head + 1) % (depth ? depth : 1);
+    if (n < depth)
+      ++n;
+  }
+
+  static double ratio(const double *ring, uint32_t n) {
+    if (!n)
+      return 0.0;
+    double sum = 0.0;
+    for (uint32_t i = 0; i < n; ++i)
+      sum += ring[i];
+    return sum / static_cast<double>(n);
+  }
+
+  static double window_delivery(const Chan &c) { return ratio(c.ring, c.ring_n); }
+
+  double delivery_of(const SlotObservation &o) const {
+    if (!o.decoded)
+      return 0.0;
+    if (o.frames == 0)
+      return 1.0; /* the marker decoded; no per-frame detail surfaced */
+    const uint32_t good = o.frames > o.crc_errs ? o.frames - o.crc_errs : 0;
+    return static_cast<double>(good) / static_cast<double>(o.frames);
+  }
+
+  std::vector<HopsetChanScore> summarize() const {
+    std::vector<HopsetChanScore> out(n_);
+    for (size_t i = 0; i < n_; ++i) {
+      const Chan &c = ch_[i];
+      HopsetChanScore &s = out[i];
+      s.visits = c.visits;
+      s.decoded = c.decoded;
+      s.delivery = window_delivery(c);
+      s.probe_delivery = ratio(c.probe_ring, c.probe_n);
+      s.probes = c.probes;
+      s.impaired_run = c.impaired_run;
+      s.active = (mask_ & (uint64_t(1) << i)) != 0;
+      s.scored = c.ring_n != 0 || c.probe_n != 0;
+    }
+    return out;
+  }
+
+  static HopsetDecision &hold(HopsetDecision &d, HopsetHold h) {
+    d.kind = HopsetDecision::Kind::Hold;
+    d.hold = h;
+    return d;
+  }
+
+  HopsetPolicyConfig cfg_;
+  size_t n_;
+  std::vector<Chan> ch_;
+  uint64_t mask_ = 0;
+  uint64_t last_round_ = 0, last_update_round_ = 0;
+  uint32_t rounds_seen_ = 0;
+  bool any_seen_ = false, have_update_ = false, outstanding_ = false;
+};
+
+} /* namespace hopset */
+} /* namespace devourer */
+
+#endif /* DEVOURER_HOPSET_HOPSET_POLICY_H */

--- a/src/hopset/HopsetState.h
+++ b/src/hopset/HopsetState.h
@@ -195,6 +195,46 @@ public:
     return base_channels[channel_index(slot)];
   }
 
+  /* --- keyed recovery probes ---------------------------------------------
+   * An excluded channel cannot prove recovery unless deliberately revisited.
+   * With a probe period P (shared config, like the seed), every P rounds ONE
+   * data opportunity is replaced by a probe dwell on an excluded channel.
+   * Which round of the P-window, which position within that round, and which
+   * excluded channel are all keyed draws ('P'-tagged words per window), so
+   * recovery never creates a public periodic target. Inert whenever the
+   * period is 0, the mask is full, or the state is generation 0 — slot_info
+   * then degenerates to {channel_index(slot), false} and every fixed-hop /
+   * no-exclusion behavior is untouched. */
+  struct SlotInfo {
+    size_t base_index;
+    bool is_probe;
+  };
+
+  void set_probe_period(unsigned rounds) { probe_period_ = rounds; }
+  unsigned probe_period() const { return probe_period_; }
+
+  SlotInfo slot_info(uint64_t slot) const {
+    if (probe_period_ == 0 || st_.generation == 0)
+      return {channel_index(slot), false};
+    const uint64_t excluded = full_mask(n_) & ~st_.active_mask;
+    const size_t x = popcount64(excluded);
+    if (!x)
+      return {channel_index(slot), false};
+    const size_t k = popcount64(st_.active_mask);
+    const uint64_t rel = slot - st_.activate_slot;
+    const uint64_t round = rel / k, pos = rel % k;
+    const uint64_t window = round / probe_period_;
+    uint64_t counter = 0;
+    const uint64_t probe_round = probe_draw(window, counter, probe_period_);
+    if (round % probe_period_ != probe_round)
+      return {channel_index(slot), false};
+    const uint64_t probe_pos = probe_draw(window, counter, k);
+    if (pos != probe_pos)
+      return {channel_index(slot), false};
+    const uint64_t pick = probe_draw(window, counter, x);
+    return {nth_set_bit(excluded, static_cast<size_t>(pick)), true};
+  }
+
   /* The gen>=1 permutation: the same rejection-sampled Fisher-Yates as
    * HopSchedule::permutation, driven by words bound to (generation, mask,
    * round) under the schedule subkey. Per-generation rounds start at 0 at
@@ -234,10 +274,37 @@ private:
     return HopSchedule::siphash24(keys_.sched, msg, sizeof(msg));
   }
 
+  /* 'P'-tagged word for probe placement — same 29-byte shape, keyed by the
+   * probe window so all draws of one window share a counter stream. */
+  uint64_t probe_word(uint64_t window, uint64_t counter) const {
+    uint8_t msg[29] = {'P'};
+    for (int i = 0; i < 4; ++i)
+      msg[1 + i] = static_cast<uint8_t>(st_.generation >> (8 * i));
+    for (int i = 0; i < 8; ++i) {
+      msg[5 + i] = static_cast<uint8_t>(st_.active_mask >> (8 * i));
+      msg[13 + i] = static_cast<uint8_t>(window >> (8 * i));
+      msg[21 + i] = static_cast<uint8_t>(counter >> (8 * i));
+    }
+    return HopSchedule::siphash24(keys_.sched, msg, sizeof(msg));
+  }
+
+  /* Unbiased uniform draw in [0, bound) — the permutation()'s rejection-
+   * sampling idiom, advancing the caller's counter. */
+  uint64_t probe_draw(uint64_t window, uint64_t &counter,
+                      uint64_t bound) const {
+    const uint64_t limit = UINT64_MAX - (UINT64_MAX % bound);
+    uint64_t r;
+    do {
+      r = probe_word(window, counter++);
+    } while (r >= limit);
+    return r % bound;
+  }
+
   const HopSchedule *base_;
   HopsetKeys keys_;
   HopsetState st_{};
   size_t n_;
+  unsigned probe_period_ = 0;
 };
 
 } /* namespace hopset */

--- a/src/hopset/HopsetTypes.h
+++ b/src/hopset/HopsetTypes.h
@@ -44,6 +44,8 @@ enum class HopsetReason : uint8_t {
   Busy,
   NonceMismatch,
   Timeout,
+  MaskDelta,
+  Cooldown,
 };
 
 inline const char *hopset_reason_name(HopsetReason r) {
@@ -66,6 +68,8 @@ inline const char *hopset_reason_name(HopsetReason r) {
   case HopsetReason::Busy: return "busy";
   case HopsetReason::NonceMismatch: return "nonce_mismatch";
   case HopsetReason::Timeout: return "timeout";
+  case HopsetReason::MaskDelta: return "mask_delta";
+  case HopsetReason::Cooldown: return "cooldown";
   }
   return "?";
 }
@@ -154,6 +158,11 @@ struct HopsetParams {
   uint64_t status_interval_slots = 64;
   unsigned proposal_retries = 8;
   uint64_t proposal_backoff_slots = 16;
+  /* Structural limits the authority enforces on follower proposals (a
+   * locally-originated start_change is exempt). 0 disables a check. */
+  unsigned max_mask_delta = 1;         /* channels changed per update */
+  uint64_t min_update_gap_rounds = 10; /* rounds between accepted updates */
+  unsigned max_excluded_frac_pct = 50; /* cap on excluded/base */
 };
 
 } /* namespace hopset */

--- a/tests/README.md
+++ b/tests/README.md
@@ -99,6 +99,25 @@ probe on kernels 6.15+ (`failed to download firmware`, `error -22`), but
 - `iw`, `tcpdump`, `ip` on PATH
 - Passwordless `sudo`, or run directly as root
 
+### Choosing the SDR (benches with more than one radio)
+
+Every UHD tool here (`sdr_duty.py`, `sdr_interferer.py`, `hop_rx_probe.py`,
+`sdr_follower_jammer.py`, …) resolves its radio through `uhd_select.py`:
+an explicit `--args`, else `DEVOURER_UHD_ARGS`, else the untracked
+`tests/.uhd_args`, else the only device present. With two or more radios and
+no selection it **fails with the serial list** rather than picking one — B210
+variants share USB id `2500:0020`, so a silent pick means half your runs
+measure the wrong antenna and nothing in the log says so.
+
+Set it once per bench. Use the file, not the variable: nearly every harness
+invokes its SDR tool through `sudo`, which scrubs the environment.
+
+```sh
+uhd_find_devices                          # read off the serials
+echo serial=XXXXXXX > tests/.uhd_args     # survives sudo; gitignored
+python3 tests/uhd_select.py               # prints what would be opened
+```
+
 ### For local mode
 
 - Kernel driver(s) installed and `modprobe`-able for your DUTs (rtw88 or

--- a/tests/bf_ndpa_probe.py
+++ b/tests/bf_ndpa_probe.py
@@ -21,6 +21,12 @@ Run:  .venv/bin/python bf_ndpa_probe.py --freq 5500e6 --rate 10e6 --duration 10
 """
 from __future__ import annotations
 
+# Which radio to open — see tests/uhd_select.py (a bench with two B210s
+# makes an unpinned MultiUSRP("") a coin flip).
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import uhd_select  # noqa: E402
+
 import argparse
 import sys
 
@@ -42,7 +48,9 @@ def main() -> int:
     ap.add_argument("--rate", type=float, default=10e6)
     ap.add_argument("--gain", type=float, default=40.0)
     ap.add_argument("--antenna", default="RX2")
-    ap.add_argument("--args", default="", help="UHD device args")
+    ap.add_argument("--args", default=uhd_select.device_args(None, allow_ambiguous=True),
+        help="UHD device args, e.g. serial=XXXXXXX (default: $DEVOURER_UHD_ARGS "
+             "or tests/.uhd_args)")
     ap.add_argument("--duration", type=float, default=10.0)
     ap.add_argument("--thresh-db", type=float, default=12.0,
                     help="burst threshold above per-chunk median floor (dB)")
@@ -50,7 +58,7 @@ def main() -> int:
                     help="gap window (us) classifying a burst pair")
     args = ap.parse_args()
 
-    usrp = uhd.usrp.MultiUSRP(args.args)
+    usrp = uhd.usrp.MultiUSRP(uhd_select.device_args(args.args))
     usrp.set_rx_rate(args.rate)
     usrp.set_rx_freq(uhd.types.TuneRequest(args.freq))
     usrp.set_rx_gain(args.gain)

--- a/tests/cw_tone_probe.py
+++ b/tests/cw_tone_probe.py
@@ -25,6 +25,12 @@ orchestrator (cw_tone_sdr.sh) can aggregate the sweep. Example:
 """
 from __future__ import annotations
 
+# Which radio to open — see tests/uhd_select.py (a bench with two B210s
+# makes an unpinned MultiUSRP("") a coin flip).
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import uhd_select  # noqa: E402
+
 import argparse
 import json
 import sys
@@ -44,7 +50,7 @@ except ImportError:
 
 
 def _open(args) -> "uhd.usrp.MultiUSRP":
-    usrp = uhd.usrp.MultiUSRP(args.args)
+    usrp = uhd.usrp.MultiUSRP(uhd_select.device_args(args.args))
     usrp.set_rx_rate(args.rate)
     usrp.set_rx_freq(uhd.types.TuneRequest(args.freq))
     usrp.set_rx_gain(args.gain)
@@ -136,7 +142,9 @@ def main() -> int:
     ap.add_argument("--rate", type=float, default=10e6, help="sample rate (Hz)")
     ap.add_argument("--gain", type=float, default=40.0, help="RX gain (dB)")
     ap.add_argument("--antenna", default="RX2", help="RX antenna port")
-    ap.add_argument("--args", default="", help="UHD device args (e.g. type=b200)")
+    ap.add_argument("--args", default=uhd_select.device_args(None, allow_ambiguous=True),
+        help="UHD device args, e.g. serial=XXXXXXX (default: $DEVOURER_UHD_ARGS "
+             "or tests/.uhd_args)")
     ap.add_argument("--nfft", type=int, default=8192, help="FFT / PSD resolution")
     ap.add_argument("--secs", type=float, default=0.2, help="capture length (s)")
     ap.add_argument("--guard-khz", type=float, default=500.0,

--- a/tests/hop_rx_probe.py
+++ b/tests/hop_rx_probe.py
@@ -35,6 +35,12 @@ dwell no longer sinks the whole match.
 """
 from __future__ import annotations
 
+# Which radio to open — see tests/uhd_select.py (a bench with two B210s
+# makes an unpinned MultiUSRP("") a coin flip).
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import uhd_select  # noqa: E402
+
 import argparse
 import os
 import sys
@@ -167,7 +173,7 @@ def capture(args, channels) -> tuple[float, float, int, int]:
         def __init__(self):
             gr.top_block.__init__(self, "hop_capture")
             self.src = gruhd.usrp_source(
-                args.args,
+                uhd_select.device_args(args.args),
                 gruhd.stream_args(cpu_format="fc32", channels=[0]))
             self.src.set_samp_rate(args.rate)
             self.src.set_center_freq(args.center, 0)
@@ -488,7 +494,8 @@ def main() -> int:
                     help="sample rate (Hz); must span all channels")
     ap.add_argument("--gain", type=float, default=45.0, help="RX gain (dB)")
     ap.add_argument("--antenna", default="RX2", help="RX antenna port")
-    ap.add_argument("--args", default="", help="UHD device args (e.g. type=b200)")
+    ap.add_argument("--args", default=uhd_select.device_args(None, allow_ambiguous=True),
+        help="UHD device args, e.g. serial=XXXXXXX (default: $DEVOURER_UHD_ARGS)")
     ap.add_argument("--duration", type=float, default=6.0, help="capture seconds")
     ap.add_argument("--raw", default="/tmp/devourer-hop-iq.fc32",
                     help="raw fc32 capture path")

--- a/tests/hopset_adaptive_e2e_selftest.cpp
+++ b/tests/hopset_adaptive_e2e_selftest.cpp
@@ -1,0 +1,324 @@
+/* The complete receiver-driven adaptive loop, end to end: two full stacks
+ * (RX = policy + follower + schedule view, TX = authority + schedule view)
+ * on a shared slot clock, coupled by the real wire codec and MAC, over a
+ * per-channel delivery model. A jammed channel must be observed, proposed,
+ * committed, activated on both sides at the same slot, then revisited by
+ * keyed probes; when the jammer leaves, the probes must restore it. At no
+ * point may the two sides hold different schedules, and the diversity floor
+ * must hold under a herding jammer that moves after every exclusion. */
+#include "hopset/HopsetAuthority.h"
+#include "hopset/HopsetFollower.h"
+#include "hopset/HopsetPolicy.h"
+#include "hopset/HopsetState.h"
+#include "hopset/HopsetWire.h"
+
+#include <cstdio>
+#include <functional>
+#include <set>
+#include <vector>
+
+static int fails;
+#define CHECK(x, msg)                                                          \
+  do {                                                                         \
+    if (!(x)) {                                                                \
+      std::fprintf(stderr, "FAIL: %s\n", msg);                                 \
+      ++fails;                                                                 \
+    }                                                                          \
+  } while (0)
+
+using namespace devourer::hopset;
+
+namespace {
+
+constexpr size_t kBase = 6;
+constexpr unsigned kProbeRounds = 4;
+
+/* One simulated link: both endpoints, real crypto between them. */
+struct Sim {
+  devourer::HopSchedule base_tx, base_rx;
+  HopsetKeys keys;
+  HopsetParams params;
+  HopsetPolicyConfig pcfg;
+  HopsetAuthority auth;
+  HopsetFollower fol;
+  HopsetPolicy policy;
+  AdaptiveScheduleView vt, vr;
+
+  uint64_t slot = 0;
+  int jammed = -1;         /* base index the interferer sits on, -1 = clean */
+  bool drop_proposals = false, drop_commits = false;
+  int proposals_sent = 0, commits_sent = 0;
+  int activations_tx = 0, activations_rx = 0;
+  int probes_seen = 0, probes_on_jammed = 0;
+  std::set<size_t> probed_channels;
+  std::vector<uint64_t> rx_masks, tx_masks;
+
+  Sim()
+      : base_tx(devourer::HopSchedule::parse_seed(
+            "0f1e2d3c4b5a69788796a5b4c3d2e1f0")),
+        base_rx(devourer::HopSchedule::parse_seed(
+            "0f1e2d3c4b5a69788796a5b4c3d2e1f0")),
+        keys(HopsetKeys::derive(devourer::HopSchedule::parse_seed(
+            "0f1e2d3c4b5a69788796a5b4c3d2e1f0"))),
+        params(mk_params()), pcfg(mk_policy()),
+        auth(params, 0xA11CE), fol(params, 0xB0B),
+        policy(pcfg, kBase), vt(base_tx, keys, kBase), vr(base_rx, keys, kBase) {
+    vt.set_state(auth.state());
+    vr.set_state(fol.state());
+    vt.set_probe_period(kProbeRounds);
+    vr.set_probe_period(kProbeRounds);
+  }
+
+  static HopsetParams mk_params() {
+    HopsetParams p;
+    p.n_base = kBase;
+    p.base_fp = 0xFACEB00C;
+    p.link_id = 0x2264;
+    p.min_active = 3;
+    p.commit_repeat_slots = 4;
+    p.status_interval_slots = 48;
+    p.proposal_retries = 6;
+    p.proposal_backoff_slots = 12;
+    return p;
+  }
+  static HopsetPolicyConfig mk_policy() {
+    HopsetPolicyConfig c;
+    c.min_obs_rounds = 8;
+    c.update_cooldown_rounds = 10;
+    return c;
+  }
+
+  /* Deliver an authority action to the follower (or a follower action to the
+   * authority) through encode -> MAC -> decode. */
+  void route(const std::vector<HopsetAction> &acts, bool from_auth) {
+    for (const auto &a : acts) {
+      if (a.kind == HopsetAction::Activate) {
+        if (from_auth) {
+          if (a.state.active_mask != vt.state().active_mask) {
+            ++activations_tx;
+            tx_masks.push_back(a.state.active_mask);
+          }
+          vt.set_state(a.state);
+        } else {
+          if (a.state.active_mask != vr.state().active_mask) {
+            ++activations_rx;
+            rx_masks.push_back(a.state.active_mask);
+          }
+          vr.set_state(a.state);
+          policy.on_activation(a.state.active_mask, round_rx());
+        }
+        continue;
+      }
+      /* a rejected or timed-out proposal releases the policy's latch — the
+       * host owns that handshake, the pure machine only reports it */
+      if (a.kind == HopsetAction::Event) {
+        if (a.event == HopsetEvent::Reject && !from_auth)
+          policy.clear_outstanding(round_rx());
+        continue;
+      }
+      if (a.kind != HopsetAction::SendControl)
+        continue;
+      if (from_auth) {
+        ++commits_sent;
+        if (drop_commits && a.msg.type == HT_COMMIT)
+          continue;
+      } else {
+        ++proposals_sent;
+        if (drop_proposals)
+          continue;
+      }
+      const auto w = hopset_encode(a.msg, keys);
+      HopsetMsg r;
+      if (hopset_decode(w.data(), w.size(), keys, params.link_id, r) !=
+          HopsetReason::None)
+        continue;
+      if (from_auth) {
+        if (r.type == HT_COMMIT)
+          route(fol.on_commit(r, slot), false);
+        else if (r.type == HT_STATUS) {
+          route(fol.on_status(r, slot), false);
+          if (r.reason != 0)
+            policy.clear_outstanding(round_rx());
+        }
+      } else if (r.type == HT_PROPOSAL) {
+        route(auth.on_proposal(r, slot), true);
+      }
+    }
+  }
+
+  uint64_t round_rx() const {
+    const auto &st = vr.state();
+    const size_t k = st.generation == 0 ? kBase : popcount64(st.active_mask);
+    return (slot - st.activate_slot) / k;
+  }
+
+  /* Advance one slot: both sides retune from their own committed state, a
+   * frame is delivered iff they agree on the channel and it is not jammed,
+   * the receiver scores the closed dwell, and at each round boundary the
+   * policy gets to decide. */
+  void tick() {
+    const auto ti = vt.slot_info(slot);
+    const auto ri = vr.slot_info(slot);
+    const bool agree = ti.base_index == ri.base_index;
+    const bool clear = static_cast<int>(ri.base_index) != jammed;
+    const bool delivered = agree && clear;
+
+    SlotObservation o;
+    o.slot = slot;
+    o.round = round_rx();
+    o.base_index = static_cast<uint32_t>(ri.base_index);
+    o.is_probe = ri.is_probe;
+    o.decoded = delivered;
+    o.frames = delivered ? 8 : 0;
+    policy.ingest(o);
+    if (ri.is_probe) {
+      ++probes_seen;
+      probed_channels.insert(ri.base_index);
+      if (static_cast<int>(ri.base_index) == jammed)
+        ++probes_on_jammed;
+    }
+
+    const uint64_t r_before = round_rx();
+    route(auth.on_tick(slot), true);
+    route(fol.on_tick(slot), false);
+    ++slot;
+    if (round_rx() != r_before) { /* a round just closed */
+      auto d = policy.decide(round_rx());
+      if (d.kind != HopsetDecision::Kind::Hold)
+        route(fol.propose(d.proposed_mask, d.observation_count,
+                          d.reason_bitmap,
+                          0xC0DE0000u + static_cast<uint32_t>(slot), slot),
+              false);
+    }
+  }
+
+  void run(uint64_t slots) {
+    for (uint64_t i = 0; i < slots; ++i)
+      tick();
+  }
+
+  bool converged() const {
+    return vt.state().generation == vr.state().generation &&
+           vt.state().active_mask == vr.state().active_mask &&
+           vt.state().activate_slot == vr.state().activate_slot;
+  }
+};
+
+} // namespace
+
+int main() {
+  /* --- the full arc: jam -> exclude -> probe -> unjam -> restore --- */
+  {
+    Sim s;
+    s.jammed = 3;
+    s.run(1200);
+    CHECK(s.vr.state().generation >= 1, "an exclusion was committed");
+    CHECK((s.vr.state().active_mask & (uint64_t(1) << 3)) == 0,
+          "the jammed channel was excluded");
+    CHECK(s.converged(), "both sides hold the same schedule");
+    CHECK(s.activations_tx == s.activations_rx,
+          "activation counts match (no split-brain)");
+    CHECK(s.tx_masks == s.rx_masks, "identical committed mask history");
+    CHECK(s.probes_seen > 0 && s.probes_on_jammed > 0,
+          "keyed probes revisit the excluded channel");
+    CHECK(s.probed_channels.size() == 1 && *s.probed_channels.begin() == 3,
+          "probes only visit excluded channels");
+    const uint64_t excluded_at = s.slot;
+
+    /* the interferer leaves; probe hysteresis must bring the channel back */
+    s.jammed = -1;
+    s.run(1600);
+    CHECK(s.vr.state().active_mask == full_mask(6),
+          "the recovered channel was restored");
+    CHECK(s.vr.state().generation >= 2, "restoration is its own generation");
+    CHECK(s.converged() && s.tx_masks == s.rx_masks,
+          "still converged after restoration");
+    CHECK(s.slot > excluded_at, "restoration followed exclusion");
+  }
+
+  /* --- schedules stay identical slot-by-slot across every transition --- */
+  {
+    Sim s;
+    s.jammed = 1;
+    for (int i = 0; i < 1500; ++i) {
+      const auto a = s.vt.slot_info(s.slot), b = s.vr.slot_info(s.slot);
+      CHECK(a.base_index == b.base_index && a.is_probe == b.is_probe,
+            "per-slot schedules identical");
+      s.tick();
+    }
+    CHECK(s.vr.state().generation >= 1, "transition happened during the run");
+  }
+
+  /* --- a clean link never excludes anything --- */
+  {
+    Sim s;
+    s.run(1500);
+    CHECK(s.vr.state().active_mask == full_mask(6) && s.activations_rx == 0,
+          "no exclusion without impairment");
+    CHECK(s.probes_seen == 0, "no probes while the mask is full");
+  }
+
+  /* --- broad degradation: everything jammed excludes nothing --- */
+  {
+    Sim s;
+    /* jam by making every channel disagree: an impossible channel index */
+    s.jammed = -2; /* matches nothing... so instead drop every frame: */
+    for (int i = 0; i < 1200; ++i) {
+      SlotObservation o;
+      o.slot = s.slot;
+      o.round = s.round_rx();
+      o.base_index = static_cast<uint32_t>(s.vr.slot_info(s.slot).base_index);
+      o.decoded = false;
+      s.policy.ingest(o);
+      auto d = s.policy.decide(s.round_rx());
+      CHECK(d.kind == HopsetDecision::Kind::Hold,
+            "broad degradation never excludes");
+      ++s.slot;
+    }
+  }
+
+  /* --- feedback loss: dropped proposals and commits still converge --- */
+  {
+    Sim s;
+    s.jammed = 3;
+    s.drop_proposals = true;
+    s.run(400);
+    CHECK(s.proposals_sent > 0 && s.vr.state().generation == 0,
+          "proposals were sent and lost");
+    s.drop_proposals = false;
+    s.drop_commits = true;
+    s.run(400);
+    s.drop_commits = false;
+    s.run(1200);
+    CHECK(s.vr.state().generation >= 1 && s.converged(),
+          "the loop converges after proposal and commit loss");
+    CHECK((s.vr.state().active_mask & (uint64_t(1) << 3)) == 0,
+          "the right channel was still excluded");
+    CHECK(s.tx_masks == s.rx_masks, "no split-brain through the losses");
+  }
+
+  /* --- herding: the jammer follows every exclusion; the floor must hold --- */
+  {
+    Sim s;
+    s.jammed = 0;
+    for (int step = 0; step < 40; ++step) {
+      s.run(200);
+      /* move onto the lowest still-active channel */
+      const uint64_t m = s.vr.state().generation == 0 ? full_mask(6)
+                                                      : s.vr.state().active_mask;
+      for (size_t i = 0; i < 6; ++i)
+        if (m & (uint64_t(1) << i)) {
+          s.jammed = static_cast<int>(i);
+          break;
+        }
+      const size_t active =
+          s.vr.state().generation == 0 ? 6 : popcount64(s.vr.state().active_mask);
+      CHECK(active >= 3, "herding never breaches the diversity floor");
+      CHECK(s.converged(), "herding never splits the schedule");
+    }
+    CHECK(popcount64(s.vr.state().active_mask) >= 3,
+          "final active set at or above the floor");
+  }
+
+  return fails ? 1 : 0;
+}

--- a/tests/hopset_adaptive_jammer.sh
+++ b/tests/hopset_adaptive_jammer.sh
@@ -51,10 +51,10 @@ PROBE_ROUNDS="${PROBE_ROUNDS:-4}"
 # on it, correctly. Re-calibrate with NO_JAM=1 then a short gain sweep if the
 # antennas move.
 JAM_GAIN="${JAM_GAIN:-50}"
-# UHD device args. This bench has two B210-class radios (a TinySDR "MyB210"
-# and the LibreSDR B220-mini); an unpinned MultiUSRP("") picks whichever it
-# enumerates first, so the jammer is pinned by serial for reproducibility.
-SDR_ARGS="${SDR_ARGS:-serial=REHZ9ZB}"
+# UHD device selection. Empty = let tests/uhd_select.py resolve it (env, then
+# the untracked tests/.uhd_args, then the only device present — and a hard
+# error rather than a coin flip when a bench has more than one radio).
+SDR_ARGS="${SDR_ARGS-}"
 TX_PWR="${TX_PWR-}"              # flat TXAGC index; empty = efuse default
 BASELINE_S="${BASELINE_S:-25}"
 ADAPT_S="${ADAPT_S:-70}"
@@ -64,8 +64,11 @@ OUT="${OUT:-/tmp/devourer-hopset-jammer}"
 plugged() { lsusb -d "$(printf '%04x:%04x' "$1" "$2")" >/dev/null 2>&1; }
 plugged "$VID" "$TX_PID" || { echo "SKIP: TX $VID:$TX_PID not plugged"; exit 77; }
 plugged "$VID" "$RX_PID" || { echo "SKIP: RX $VID:$RX_PID not plugged"; exit 77; }
-uhd_find_devices --args "$SDR_ARGS" >/dev/null 2>&1 || {
-    echo "SKIP: no UHD device matching '$SDR_ARGS'"; exit 77; }
+SDR_SEL="$(python3 "$HERE/uhd_select.py" ${SDR_ARGS:+"$SDR_ARGS"} 2>/dev/null)" || {
+    python3 "$HERE/uhd_select.py" ${SDR_ARGS:+"$SDR_ARGS"} >&2
+    exit 1; }
+uhd_find_devices ${SDR_SEL:+--args "$SDR_SEL"} >/dev/null 2>&1 || {
+    echo "SKIP: no UHD device matching '${SDR_SEL:-any}'"; exit 77; }
 
 # In-tree rtw88/rtw89 auto-probe the dongles; temp-unbind any they hold.
 unbind() {
@@ -104,7 +107,7 @@ PY="$HERE/.venv/bin/python"
 start_jammer() { # channel
     [ "$NO_JAM" = "1" ] && return 0
     kill_jammer
-    sudo "$PY" "$HERE/sdr_interferer.py" --args "$SDR_ARGS" \
+    sudo "$PY" "$HERE/sdr_interferer.py" ${SDR_SEL:+--args "$SDR_SEL"} \
         --channel "$1" --tx-gain "$JAM_GAIN" --rate "$JAM_RATE" \
         >>"$OUT/jammer.log" 2>&1 &
     sleep 2

--- a/tests/hopset_adaptive_jammer.sh
+++ b/tests/hopset_adaptive_jammer.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# Receiver-driven adaptive-exclusion validation against a real interferer.
+#
+# Three radios: a TX (schedule authority), an RX (lockstep follower running
+# the exclusion policy), and a B210 parked on ONE base-hopset channel
+# (tests/sdr_interferer.py). The receiver must observe the jammed channel,
+# propose its exclusion, the authority must commit it, both must activate in
+# lockstep, and delivery on the remaining set must improve. Killing the
+# jammer must then let the keyed recovery probes restore the channel.
+#
+#   MODE=parked   (default) exclude -> improve -> restore after the jam ends
+#   MODE=herding  the jammer moves onto a newly-active channel after every
+#                 exclusion; the diversity floor must hold and the link must
+#                 never oscillate
+#
+# Usage: sudo -v && tests/hopset_adaptive_jammer.sh
+#        MODE=herding CHANNELS=1,6,11,3,8 tests/hopset_adaptive_jammer.sh
+#
+# Cleanup: on any exit (incl. Ctrl-C) both demos and the SDR are killed by
+# exact comm / exact arg — never a broad pattern.
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HERE="$ROOT/tests"
+
+MODE="${MODE:-parked}"
+VID="${VID:-0x0bda}"
+TX_PID="${TX_PID:-0xa81a}"      # RTL8812EU (Jaguar3)
+RX_PID="${RX_PID:-0xc812}"      # RTL8812CU (Jaguar3)
+# Four ADJACENT BUT NON-OVERLAPPING 2.4 GHz channels: 1/5/9/13 sit on 2412,
+# 2432, 2452, 2472 — 20 MHz apart, so their passbands abut without overlapping.
+# The interferer has to degrade ONE hopset member and leave the rest healthy;
+# the usual 1/6/11 set has only three members (no room above the max(3, ...)
+# diversity floor), and any closer spacing spills into the neighbours, which
+# the policy correctly reads as broad degradation and refuses to act on.
+#
+# 2.4 GHz and not 5 GHz because this bench's SDR antenna is 2.4-tuned: measured
+# here, a 5 GHz interferer at max TX gain (85 dB) leaves a near-field link at
+# 100% delivery on every channel, while 2.4 GHz bites hard. Keep the jammer
+# NARROWBAND (JAM_RATE) so it stays inside the one channel it is aimed at.
+CHANNELS="${CHANNELS:-1,5,9,13}"
+JAM_CHANNEL="${JAM_CHANNEL:-5}"   # must be a member of CHANNELS
+JAM_RATE="${JAM_RATE:-5e6}"
+NO_JAM="${NO_JAM:-0}"             # 1 = rig sanity run, no interferer at all
+SLOT_MS="${SLOT_MS:-50}"
+SEED="${SEED:-a5a5c3c3f00d1234deadbeef00c0ffee}"
+PROBE_ROUNDS="${PROBE_ROUNDS:-4}"
+# Bench setpoint, measured on this rig with the 5 MHz narrowband interferer:
+# 50 dB puts the jammed channel at 0.00 delivery and leaves every other hopset
+# member at 1.00. At 65 dB it splatters (0.09 / 0.24 / 0.61 across the set),
+# which is broad degradation, not a channel fault — the policy refuses to act
+# on it, correctly. Re-calibrate with NO_JAM=1 then a short gain sweep if the
+# antennas move.
+JAM_GAIN="${JAM_GAIN:-50}"
+# UHD device args. This bench has two B210-class radios (a TinySDR "MyB210"
+# and the LibreSDR B220-mini); an unpinned MultiUSRP("") picks whichever it
+# enumerates first, so the jammer is pinned by serial for reproducibility.
+SDR_ARGS="${SDR_ARGS:-serial=REHZ9ZB}"
+TX_PWR="${TX_PWR-}"              # flat TXAGC index; empty = efuse default
+BASELINE_S="${BASELINE_S:-25}"
+ADAPT_S="${ADAPT_S:-70}"
+RESTORE_S="${RESTORE_S:-70}"
+OUT="${OUT:-/tmp/devourer-hopset-jammer}"
+
+plugged() { lsusb -d "$(printf '%04x:%04x' "$1" "$2")" >/dev/null 2>&1; }
+plugged "$VID" "$TX_PID" || { echo "SKIP: TX $VID:$TX_PID not plugged"; exit 77; }
+plugged "$VID" "$RX_PID" || { echo "SKIP: RX $VID:$RX_PID not plugged"; exit 77; }
+uhd_find_devices --args "$SDR_ARGS" >/dev/null 2>&1 || {
+    echo "SKIP: no UHD device matching '$SDR_ARGS'"; exit 77; }
+
+# In-tree rtw88/rtw89 auto-probe the dongles; temp-unbind any they hold.
+unbind() {
+    local pid="$1" d p i
+    for d in /sys/bus/usb/devices/*/idProduct; do
+        p=$(cat "$d" 2>/dev/null) || continue
+        [ "$p" = "${pid#0x}" ] || continue
+        for i in "$(dirname "$d")":*; do
+            [ -e "$i/driver" ] && sudo sh -c "echo '$(basename "$i")' > '$i/driver/unbind'" 2>/dev/null || true
+        done
+    done
+}
+
+kill_jammer() { sudo pkill -f "sdr_interferer.py" 2>/dev/null || true; }
+cleanup() {
+    kill_jammer
+    sudo pkill -INT -x txdemo 2>/dev/null || true
+    sudo pkill -INT -x rxdemo 2>/dev/null || true
+    sleep 1
+    sudo pkill -x txdemo 2>/dev/null || true
+    sudo pkill -x rxdemo 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+echo "== build =="
+cmake --build "$ROOT/build" -j --target txdemo rxdemo >/dev/null || exit 1
+unbind "$TX_PID"; unbind "$RX_PID"
+mkdir -p "$OUT"; rm -f "$OUT"/*.log "$OUT"/*.jsonl
+
+# uv venv for the SDR script (system site-packages for the uhd bindings)
+if [ ! -d "$HERE/.venv" ]; then uv venv --system-site-packages "$HERE/.venv" >/dev/null 2>&1 || true; fi
+PY="$HERE/.venv/bin/python"
+[ -x "$PY" ] || PY="$(command -v python3)"
+"$PY" -c "import uhd" 2>/dev/null || PY="$(command -v python3)"
+
+start_jammer() { # channel
+    [ "$NO_JAM" = "1" ] && return 0
+    kill_jammer
+    sudo "$PY" "$HERE/sdr_interferer.py" --args "$SDR_ARGS" \
+        --channel "$1" --tx-gain "$JAM_GAIN" --rate "$JAM_RATE" \
+        >>"$OUT/jammer.log" 2>&1 &
+    sleep 2
+}
+
+COMMON=(DEVOURER_HOP_CHANNELS="$CHANNELS" DEVOURER_HOP_SLOT_MS="$SLOT_MS"
+        DEVOURER_HOP_SEED="$SEED" DEVOURER_HOP_ADAPTIVE=1
+        DEVOURER_HOP_PROBE_ROUNDS="$PROBE_ROUNDS" DEVOURER_LOG_LEVEL=info)
+
+start_tx() { # logfile
+    # TX_PWR="" leaves the efuse-calibrated default alone. A flat TXAGC index
+    # is per-band on these dies — an index that merely backs 5 GHz off can put
+    # 2.4 GHz below the receiver's sensitivity and look like a dead rig.
+    local pwr=()
+    [ -n "$TX_PWR" ] && pwr=(DEVOURER_TX_PWR="$TX_PWR")
+    sudo env "${COMMON[@]}" "${pwr[@]}" DEVOURER_VID="$VID" \
+        DEVOURER_PID="$TX_PID" DEVOURER_CHANNEL="${CHANNELS%%,*}" \
+        DEVOURER_HOP_FAST=1 DEVOURER_TX_WITH_RX=thread \
+        "$ROOT/build/txdemo" >"$1" 2>&1 &
+}
+start_rx() { # logfile, policy(0|1)
+    local pol=()
+    [ "$2" = "1" ] && pol=(DEVOURER_HOP_POLICY=1 DEVOURER_HOP_POLICY_EVENTS=2)
+    sudo env "${COMMON[@]}" "${pol[@]}" DEVOURER_VID="$VID" \
+        DEVOURER_PID="$RX_PID" "$ROOT/build/rxdemo" >"$1" 2>&1 &
+}
+
+# Delivery proxy, straight from the hop.rx event stream: a dwell counts as
+# delivered when a marker decoded before the next retune. This is exactly what
+# the policy scores, so the two must agree.
+delivery() { # logfile
+    awk -F'"' '/"ev":"hop.rx"/ {
+        for (i = 1; i < NF; i++) if ($i == "state") s = $(i+2);
+        if (s == "retune") r++; if (s == "decode") d++;
+    } END { if (r) printf "%.3f", d / r; else print "0" }' "$1"
+}
+
+# Per-channel delivery — the diagnostic that tells "one channel is jammed"
+# apart from "the whole band is desensed" (a too-hot interferer near-fields
+# the receiver on every channel and the policy correctly refuses to act).
+per_channel() { # logfile
+    awk -F'"' '
+        /"ev":"hop.rx"/ {
+            s = ""; ch = "";
+            for (i = 1; i < NF; i++) {
+                if ($i == "state") s = $(i+2);
+                if ($i == "channel") { v = $(i+1); gsub(/[:,}]/, "", v); ch = v+0 }
+            }
+            if (s == "retune") { cur = ch; tot[ch]++; pend = 1 }
+            else if (s == "decode" && pend) { dec[cur]++; pend = 0 }
+        }
+        END {
+            n = asorti(tot, idx);
+            for (j = 1; j <= n; j++) {
+                c = idx[j];
+                printf "      ch%-4s %5d dwells  delivery %.3f\n",
+                       c, tot[c], (tot[c] ? dec[c] / tot[c] : 0);
+            }
+        }' "$1" 2>/dev/null || true
+}
+
+echo "== jammer parked on ch$JAM_CHANNEL (gain $JAM_GAIN) =="
+start_jammer "$JAM_CHANNEL"
+
+echo "== phase A: fixed keyed hopset (policy off), ${BASELINE_S}s =="
+start_rx "$OUT/rx_baseline.log" 0
+sleep 3
+start_tx "$OUT/tx_baseline.log"
+sleep "$BASELINE_S"
+sudo pkill -INT -x rxdemo 2>/dev/null || true
+sudo pkill -INT -x txdemo 2>/dev/null || true
+sleep 2
+BASE_DELIV=$(delivery "$OUT/rx_baseline.log")
+
+echo "== phase B: receiver-driven exclusion (policy on), ${ADAPT_S}s =="
+start_rx "$OUT/rx_adapt.log" 1
+sleep 3
+start_tx "$OUT/tx_adapt.log"
+
+if [ "$MODE" = "herding" ]; then
+    # Follow every exclusion: park the jammer on the lowest channel that is
+    # still active according to the receiver's own committed mask.
+    IFS=',' read -r -a CHLIST <<<"$CHANNELS"
+    end=$((SECONDS + ADAPT_S))
+    last_mask=""
+    while [ "$SECONDS" -lt "$end" ]; do
+        sleep 5
+        mask=$(grep -F '"ev":"hopset.activate"' "$OUT/rx_adapt.log" 2>/dev/null |
+               tail -1 | sed -n 's/.*"mask":"0x\([0-9a-f]*\)".*/\1/p')
+        [ -n "$mask" ] && [ "$mask" != "$last_mask" ] || continue
+        last_mask="$mask"
+        dec=$((16#$mask))
+        for i in "${!CHLIST[@]}"; do
+            if (( (dec >> i) & 1 )); then
+                echo "   herding: mask 0x$mask -> jam ch${CHLIST[$i]}"
+                start_jammer "${CHLIST[$i]}"
+                break
+            fi
+        done
+    done
+else
+    sleep "$ADAPT_S"
+fi
+ADAPT_DELIV=$(delivery "$OUT/rx_adapt.log")
+
+if [ "$MODE" = "parked" ]; then
+    echo "== phase C: jammer off — probes must restore the channel, ${RESTORE_S}s =="
+    kill_jammer
+    : > "$OUT/rx_restore_mark"
+    sleep "$RESTORE_S"
+fi
+sudo pkill -INT -x rxdemo 2>/dev/null || true
+sudo pkill -INT -x txdemo 2>/dev/null || true
+sleep 2
+
+echo "== verdicts (logs: $OUT) =="
+fails=0
+require() { # file, needle, label
+    if grep -qF "$2" "$1"; then echo "PASS: $3"; else echo "FAIL: $3"; fails=$((fails+1)); fi
+}
+jam_idx=$(awk -v c="$JAM_CHANNEL" -F, '{for(i=1;i<=NF;i++) if($i==c) print i-1}' <<<"$CHANNELS")
+
+echo "   baseline delivery=$BASE_DELIV   adaptive delivery=$ADAPT_DELIV"
+echo "   per-channel, baseline (policy off):"
+per_channel "$OUT/rx_baseline.log"
+echo "   per-channel, adaptive (policy on):"
+per_channel "$OUT/rx_adapt.log"
+if [ "$NO_JAM" = "1" ]; then
+    echo "   NO_JAM=1 — rig sanity run only, no exclusion expected"
+    [ "$(awk -v d="$BASE_DELIV" 'BEGIN{print (d > 0.5) ? 1 : 0}')" = "1" ] &&
+        echo "== RIG OK (baseline delivery $BASE_DELIV) ==" ||
+        echo "== RIG BAD: link does not deliver without an interferer =="
+    exit 0
+fi
+require "$OUT/rx_adapt.log" '"ev":"hopset.decision","t"' "policy emitted decisions"
+if grep -F '"ev":"hopset.decision"' "$OUT/rx_adapt.log" | grep -qF '"kind":"exclude"'; then
+    echo "PASS: receiver proposed an exclusion"
+else
+    echo "FAIL: receiver proposed an exclusion"; fails=$((fails+1))
+fi
+require "$OUT/tx_adapt.log" '"ev":"hopset.commit"' "authority committed it"
+require "$OUT/rx_adapt.log" '"ev":"hopset.activate"' "receiver activated it"
+require "$OUT/rx_adapt.log" '"ev":"hop.rx","state":"track"' "lockstep held"
+
+# The excluded channel must be the jammed one. Only meaningful while the
+# interferer stays put — in herding mode it has already moved by the time the
+# first exclusion lands, and targeting wherever it went is the correct answer.
+target=$(grep -F '"kind":"exclude"' "$OUT/rx_adapt.log" | head -1 |
+         sed -n 's/.*"target":\([0-9]*\).*/\1/p')
+if [ "$MODE" = "parked" ]; then
+    if [ "${target:-x}" = "${jam_idx:-y}" ]; then
+        echo "PASS: excluded the jammed channel (base index $jam_idx)"
+    else
+        echo "FAIL: excluded base index '${target:-none}', jammed is '$jam_idx'"
+        fails=$((fails+1))
+    fi
+else
+    echo "NOTE: first exclusion targeted base index ${target:-none} (jammer moves)"
+fi
+
+# the diversity floor must hold in every committed mask
+minactive=$(grep -F '"ev":"hopset.activate"' "$OUT/rx_adapt.log" |
+    sed -n 's/.*"mask":"0x\([0-9a-f]*\)".*/\1/p' |
+    awk '{ n = 0; v = strtonum("0x" $0); while (v) { n += v % 2; v = int(v/2) }
+           if (m == "" || n < m) m = n } END { print (m == "" ? 99 : m) }')
+if [ "${minactive:-0}" -ge 3 ]; then
+    echo "PASS: diversity floor held (min active = $minactive)"
+else
+    echo "FAIL: active set fell to $minactive"; fails=$((fails+1))
+fi
+
+if [ "$MODE" = "parked" ]; then
+    awk -v b="$BASE_DELIV" -v a="$ADAPT_DELIV" 'BEGIN { exit !(a > b) }' &&
+        echo "PASS: delivery improved ($BASE_DELIV -> $ADAPT_DELIV)" ||
+        { echo "FAIL: delivery did not improve ($BASE_DELIV -> $ADAPT_DELIV)"
+          fails=$((fails+1)); }
+    require "$OUT/rx_adapt.log" '"ev":"hopset.probe"' "keyed probes aired"
+    if grep -F '"ev":"hopset.probe"' "$OUT/rx_adapt.log" | grep -qF '"delivered":true'; then
+        echo "PASS: probes delivered after the jammer left"
+    else
+        echo "FAIL: no probe ever delivered"; fails=$((fails+1))
+    fi
+    if grep -F '"ev":"hopset.decision"' "$OUT/rx_adapt.log" | grep -qF '"kind":"restore"'; then
+        echo "PASS: receiver proposed restoration"
+    else
+        echo "FAIL: receiver never proposed restoration"; fails=$((fails+1))
+    fi
+else
+    # Against a jammer that moves after every exclusion the link SHOULD keep
+    # deciding: exclude whichever channel is jammed now, restore whichever one
+    # the probes prove recovered. Repeated decisions are the system tracking a
+    # moving interferer, not damage. What must never happen is the set being
+    # walked down — so the invariant is on the NET exclusion depth, not on the
+    # number of decisions.
+    seq=$(grep -F '"ev":"hopset.decision"' "$OUT/rx_adapt.log" |
+          sed -n 's/.*"kind":"\([a-z]*\)".*"target":\([0-9]*\).*/\1:\2/p')
+    echo "   decision sequence: $(echo "$seq" | tr '\n' ' ')"
+    nch=$(( $(tr -cd ',' <<<"$CHANNELS" | wc -c) + 1 ))
+    budget=$(( nch - 3 ))
+    # Measured on the COMMITTED masks, not on proposals: a proposal the
+    # authority refuses (its own cooldown / diversity limits) never moved the
+    # link, and counting those would score the defences as damage.
+    depth=$(grep -F '"ev":"hopset.activate"' "$OUT/rx_adapt.log" |
+        sed -n 's/.*"mask":"0x\([0-9a-f]*\)".*/\1/p' |
+        awk -v n="$nch" '{ c = 0; v = strtonum("0x" $0);
+                           while (v) { c += v % 2; v = int(v/2) }
+                           d = n - c; if (d > max) max = d }
+                         END { print max+0 }')
+    if [ "${depth:-0}" -le "$budget" ]; then
+        echo "PASS: committed exclusion depth $depth within the floor budget $budget"
+    else
+        echo "FAIL: committed exclusion depth $depth exceeds budget $budget"
+        fails=$((fails+1))
+    fi
+    # A herding jammer cannot be out-run — with the set floored at 3 it can
+    # always sit on an active channel, so delivery is not expected to improve.
+    # What must not happen is a collapse: the adaptive link has to stay in the
+    # same league as the fixed one while keeping its diversity.
+    awk -v b="$BASE_DELIV" -v a="$ADAPT_DELIV" 'BEGIN { exit !(a >= 0.8 * b) }' &&
+        echo "PASS: no collapse under a moving jammer ($BASE_DELIV -> $ADAPT_DELIV)" ||
+        { echo "FAIL: delivery collapsed ($BASE_DELIV -> $ADAPT_DELIV)"
+          fails=$((fails+1)); }
+fi
+
+[ "$fails" -eq 0 ] && echo "== ALL PASS ==" || echo "== $fails FAILURES =="
+exit "$fails"

--- a/tests/hopset_adaptive_onair.sh
+++ b/tests/hopset_adaptive_onair.sh
@@ -59,9 +59,13 @@ cmake --build "$ROOT/build" -j --target txdemo rxdemo >/dev/null || exit 1
 unbind "$TX_PID"; unbind "$RX_PID"
 mkdir -p "$OUT"; rm -f "$OUT"/*.log
 
+# This is a protocol test (commit -> activate -> recover), not a policy test:
+# it drives the operator's scripted lever on a 3-channel base, so the
+# authority's diversity floor is lowered to the protocol minimum. The
+# receiver-driven policy's own max(3, configured) floor is not involved.
 COMMON=(DEVOURER_HOP_CHANNELS="$CHANNELS" DEVOURER_HOP_SLOT_MS="$SLOT_MS"
         DEVOURER_HOP_SEED="$SEED" DEVOURER_HOP_ADAPTIVE=1
-        DEVOURER_LOG_LEVEL=info)
+        DEVOURER_HOP_MIN_ACTIVE=2 DEVOURER_LOG_LEVEL=info)
 
 echo "== phase A: follower tracks the scripted transition =="
 sudo env "${COMMON[@]}" DEVOURER_VID="$VID" DEVOURER_PID="$RX_PID" \

--- a/tests/hopset_policy_selftest.cpp
+++ b/tests/hopset_policy_selftest.cpp
@@ -1,0 +1,357 @@
+/* The receiver-side exclusion/restoration policy over its full decision
+ * matrix: thresholds, persistence hysteresis, the update cooldown, broad
+ * degradation, the diversity floor and excluded-fraction cap, the
+ * probe-driven restoration cycle, the adversarial rows (a flapping jammer
+ * that must never accumulate persistence, a herding jammer that must hit the
+ * floor instead of walking the link down), the classify-never-triggers rule,
+ * and determinism + policy-hash stability. */
+#include "hopset/HopsetPolicy.h"
+#include <cstdio>
+#include <vector>
+
+static int fails;
+#define CHECK(x, msg)                                                          \
+  do {                                                                         \
+    if (!(x)) {                                                                \
+      std::fprintf(stderr, "FAIL: %s\n", msg);                                 \
+      ++fails;                                                                 \
+    }                                                                          \
+  } while (0)
+
+using namespace devourer::hopset;
+
+namespace {
+
+/* Feed `rounds` rounds over the active set of `mask`, giving channel
+ * `bad_index` the delivery `bad` and everyone else `good`. Returns the round
+ * index just past the feed. */
+uint64_t feed(HopsetPolicy &p, uint64_t mask, size_t n, uint64_t from_round,
+              uint32_t rounds, int bad_index, double bad, double good) {
+  uint64_t r = from_round;
+  for (uint32_t i = 0; i < rounds; ++i, ++r) {
+    for (size_t c = 0; c < n; ++c) {
+      if (!(mask & (uint64_t(1) << c)))
+        continue;
+      SlotObservation o;
+      o.round = r;
+      o.slot = r * 64 + c;
+      o.base_index = static_cast<uint32_t>(c);
+      const double d =
+          (bad_index >= 0 && c == static_cast<size_t>(bad_index)) ? bad : good;
+      /* express the ratio through frames/crc so the delivery math is
+       * exercised, not just the decoded flag */
+      o.decoded = d > 0.0;
+      o.frames = 10;
+      o.crc_errs = static_cast<uint32_t>(10.0 * (1.0 - d) + 0.5);
+      if (!o.decoded) {
+        o.frames = 0;
+        o.crc_errs = 0;
+      }
+      p.ingest(o);
+    }
+  }
+  return r;
+}
+
+void probe(HopsetPolicy &p, uint64_t round, size_t index, double delivery) {
+  SlotObservation o;
+  o.round = round;
+  o.slot = round * 64 + index;
+  o.base_index = static_cast<uint32_t>(index);
+  o.is_probe = true;
+  o.decoded = delivery > 0.0;
+  o.frames = delivery > 0.0 ? 10 : 0;
+  o.crc_errs = delivery > 0.0
+                   ? static_cast<uint32_t>(10.0 * (1.0 - delivery) + 0.5)
+                   : 0;
+  p.ingest(o);
+}
+
+} // namespace
+
+int main() {
+  const HopsetPolicyConfig def;
+
+  /* --- policy hash: deterministic, field-sensitive --- */
+  {
+    HopsetPolicyConfig a, b;
+    CHECK(a.policy_hash() == b.policy_hash(), "policy hash stable");
+    b.impaired_rounds = 6;
+    CHECK(a.policy_hash() != b.policy_hash(), "policy hash tracks fields");
+    HopsetPolicyConfig c;
+    c.exclude_delivery = 0.31;
+    CHECK(a.policy_hash() != c.policy_hash(), "policy hash tracks doubles");
+  }
+
+  /* --- insufficient rounds: no decision before the observation bar --- */
+  {
+    HopsetPolicy p(def, 6);
+    uint64_t r = feed(p, full_mask(6), 6, 0, 4, 2, 0.0, 1.0);
+    auto d = p.decide(r);
+    CHECK(d.kind == HopsetDecision::Kind::Hold &&
+              d.hold == HopsetHold::InsufficientRounds,
+          "holds below min_obs_rounds");
+  }
+
+  /* --- the canonical exclusion: one channel dead, others healthy --- */
+  {
+    HopsetPolicy p(def, 6);
+    uint64_t r = feed(p, full_mask(6), 6, 0, 12, 2, 0.0, 1.0);
+    auto d = p.decide(r);
+    CHECK(d.kind == HopsetDecision::Kind::ProposeExclude, "proposes exclusion");
+    CHECK(d.target_index == 2, "targets the impaired channel");
+    CHECK(d.proposed_mask == (full_mask(6) & ~(uint64_t(1) << 2)),
+          "mask drops exactly one bit");
+    CHECK((d.reason_bitmap &
+           (RB_DELIVERY_FLOOR | RB_PERSISTENT | RB_HEALTHY_ALT)) ==
+              (RB_DELIVERY_FLOOR | RB_PERSISTENT | RB_HEALTHY_ALT),
+          "evidence bits set");
+    CHECK((d.reason_bitmap & RB_SYNC_LOSS) != 0,
+          "classification: nothing decoded = sync loss");
+    CHECK(d.observation_count >= 12, "observation count reported");
+    CHECK(d.chans.size() == 6 && d.chans[2].impaired_run >= 5 &&
+              d.chans[0].delivery > 0.9,
+          "per-channel evidence summary");
+    /* a second decide while the proposal is outstanding must hold */
+    auto d2 = p.decide(r);
+    CHECK(d2.kind == HopsetDecision::Kind::Hold &&
+              d2.hold == HopsetHold::ProposalOutstanding,
+          "one proposal at a time");
+  }
+
+  /* --- threshold edge: 0.29 delivery excludes, 0.31 does not --- */
+  {
+    HopsetPolicy p(def, 6);
+    uint64_t r = feed(p, full_mask(6), 6, 0, 14, 2, 0.30, 1.0); /* 3/10 good */
+    auto d = p.decide(r);
+    CHECK(d.kind == HopsetDecision::Kind::Hold, "delivery at the floor holds");
+    HopsetPolicy q(def, 6);
+    r = feed(q, full_mask(6), 6, 0, 14, 2, 0.20, 1.0);
+    CHECK(q.decide(r).kind == HopsetDecision::Kind::ProposeExclude,
+          "delivery below the floor excludes");
+  }
+
+  /* --- persistence hysteresis: 4 impaired rounds is not enough --- */
+  {
+    HopsetPolicy p(def, 6);
+    uint64_t r = feed(p, full_mask(6), 6, 0, 10, -1, 0.0, 1.0);
+    r = feed(p, full_mask(6), 6, r, 4, 2, 0.0, 1.0);
+    auto d = p.decide(r);
+    CHECK(d.kind == HopsetDecision::Kind::Hold &&
+              d.hold == HopsetHold::NotPersistent,
+          "4 impaired rounds hold as not-persistent");
+    r = feed(p, full_mask(6), 6, r, 1, 2, 0.0, 1.0);
+    CHECK(p.decide(r).kind == HopsetDecision::Kind::ProposeExclude,
+          "the 5th impaired round trips it");
+  }
+
+  /* --- flapping jammer: alternating rounds never accumulate persistence --- */
+  {
+    HopsetPolicy p(def, 6);
+    uint64_t r = 0;
+    for (int i = 0; i < 40; ++i)
+      r = feed(p, full_mask(6), 6, r, 1, 2, (i & 1) ? 1.0 : 0.0, 1.0);
+    auto d = p.decide(r);
+    CHECK(d.kind == HopsetDecision::Kind::Hold,
+          "a flapping channel is never excluded");
+  }
+
+  /* --- broad degradation: everything bad excludes nothing --- */
+  {
+    HopsetPolicy p(def, 6);
+    uint64_t r = feed(p, full_mask(6), 6, 0, 14, -1, 0.0, 0.0);
+    auto d = p.decide(r);
+    CHECK(d.kind == HopsetDecision::Kind::Hold &&
+              d.hold == HopsetHold::BroadDegradation,
+          "broad degradation stops exclusion");
+  }
+
+  /* --- no healthy alternative: the others are merely mediocre --- */
+  {
+    HopsetPolicyConfig cfg = def;
+    cfg.broad_degrade_frac = 1.01; /* isolate the healthy-alt gate */
+    HopsetPolicy p(cfg, 6);
+    uint64_t r = feed(p, full_mask(6), 6, 0, 14, 2, 0.0, 0.5);
+    auto d = p.decide(r);
+    CHECK(d.kind == HopsetDecision::Kind::Hold &&
+              d.hold == HopsetHold::NoHealthyAlternative,
+          "no healthy alternative holds");
+  }
+
+  /* --- diversity floor: never below max(3, configured) --- */
+  {
+    HopsetPolicy p(def, 4);
+    const uint64_t m = 0b0111; /* one already excluded, 3 active */
+    p.on_activation(m, 0);
+    uint64_t r = feed(p, m, 4, 1, 20, 1, 0.0, 1.0);
+    auto d = p.decide(r);
+    CHECK(d.kind == HopsetDecision::Kind::Hold &&
+              d.hold == HopsetHold::MinActiveFloor,
+          "the hard active floor holds at 3");
+  }
+
+  /* --- excluded-fraction cap --- */
+  {
+    HopsetPolicyConfig cfg = def;
+    cfg.min_active = 1; /* the floor is still max(3, ...) — cap must bind */
+    cfg.max_excluded_frac = 0.10; /* 1-of-8 = 0.125 already exceeds it */
+    HopsetPolicy p(cfg, 8);
+    uint64_t r = feed(p, full_mask(8), 8, 0, 14, 2, 0.0, 1.0);
+    auto d = p.decide(r);
+    CHECK(d.kind == HopsetDecision::Kind::Hold &&
+              d.hold == HopsetHold::MaxExcludedFrac,
+          "excluded-fraction cap holds");
+  }
+
+  /* --- cooldown latch between updates --- */
+  {
+    HopsetPolicy p(def, 6);
+    uint64_t r = feed(p, full_mask(6), 6, 0, 12, 2, 0.0, 1.0);
+    auto d = p.decide(r);
+    CHECK(d.kind == HopsetDecision::Kind::ProposeExclude, "cooldown setup");
+    p.on_activation(d.proposed_mask, r);
+    r = feed(p, d.proposed_mask, 6, r, 8, 4, 0.0, 1.0);
+    auto d2 = p.decide(r);
+    CHECK(d2.kind == HopsetDecision::Kind::Hold &&
+              d2.hold == HopsetHold::Cooldown,
+          "second exclusion inside the cooldown holds");
+    r = feed(p, d.proposed_mask, 6, r, 4, 4, 0.0, 1.0);
+    auto d3 = p.decide(r);
+    CHECK(d3.kind == HopsetDecision::Kind::ProposeExclude &&
+              d3.target_index == 4,
+          "past the cooldown a second exclusion is allowed");
+  }
+
+  /* --- herding jammer: the interferer moves to each newly-active channel;
+   * the policy must ratchet down to the floor and stop, never oscillate --- */
+  {
+    HopsetPolicy p(def, 6);
+    uint64_t mask = full_mask(6), r = 0;
+    int excluded = 0;
+    for (int step = 0; step < 12; ++step) {
+      /* the jammer sits on the lowest active channel each step */
+      int victim = -1;
+      for (size_t i = 0; i < 6 && victim < 0; ++i)
+        if (mask & (uint64_t(1) << i))
+          victim = static_cast<int>(i);
+      r = feed(p, mask, 6, r, 14, victim, 0.0, 1.0);
+      auto d = p.decide(r);
+      if (d.kind == HopsetDecision::Kind::ProposeExclude) {
+        ++excluded;
+        mask = d.proposed_mask;
+        p.on_activation(mask, r);
+      } else {
+        p.clear_outstanding(r);
+      }
+      CHECK(popcount64(mask) >= 3, "herding never breaches the floor");
+    }
+    CHECK(popcount64(mask) == 3, "herding converges to the floor");
+    CHECK(excluded == 3, "exactly one exclusion per update, then it stops");
+    auto d = p.decide(r + 100);
+    CHECK(d.kind == HopsetDecision::Kind::Hold &&
+              (d.hold == HopsetHold::MinActiveFloor ||
+               d.hold == HopsetHold::BroadDegradation),
+          "at the floor the policy refuses further exclusions");
+  }
+
+  /* --- classification never triggers: bad energy, fine delivery --- */
+  {
+    HopsetPolicy p(def, 6);
+    uint64_t r = 0;
+    for (int i = 0; i < 14; ++i, ++r)
+      for (size_t c = 0; c < 6; ++c) {
+        SlotObservation o;
+        o.round = r;
+        o.base_index = static_cast<uint32_t>(c);
+        o.decoded = true;
+        o.frames = 10;
+        o.crc_errs = 0;
+        o.verdict = 2; /* Interference on every channel */
+        o.rssi = 20;
+        p.ingest(o);
+      }
+    auto d = p.decide(r);
+    CHECK(d.kind == HopsetDecision::Kind::Hold &&
+              d.hold == HopsetHold::NoImpairment,
+          "energy verdicts alone never exclude");
+  }
+
+  /* --- restoration cycle: probes must clear the bar --- */
+  {
+    HopsetPolicy p(def, 6);
+    const uint64_t m = full_mask(6) & ~(uint64_t(1) << 2);
+    p.on_activation(m, 0);
+    uint64_t r = feed(p, m, 6, 1, 20, -1, 0.0, 1.0);
+    probe(p, r++, 2, 1.0);
+    probe(p, r++, 2, 1.0);
+    auto d = p.decide(r);
+    CHECK(d.kind == HopsetDecision::Kind::Hold &&
+              d.hold == HopsetHold::ProbeHysteresisPending,
+          "two good probes are not enough");
+    probe(p, r++, 2, 1.0);
+    auto d2 = p.decide(r);
+    CHECK(d2.kind == HopsetDecision::Kind::ProposeRestore &&
+              d2.target_index == 2 && d2.proposed_mask == full_mask(6),
+          "three good probes restore");
+    CHECK((d2.reason_bitmap & (RB_PROBE_RECOVERY | RB_PROBE_EVIDENCE)) ==
+              (RB_PROBE_RECOVERY | RB_PROBE_EVIDENCE),
+          "restoration evidence bits");
+  }
+
+  /* --- a failed probe resets the restoration run --- */
+  {
+    HopsetPolicy p(def, 6);
+    const uint64_t m = full_mask(6) & ~(uint64_t(1) << 2);
+    p.on_activation(m, 0);
+    uint64_t r = feed(p, m, 6, 1, 20, -1, 0.0, 1.0);
+    probe(p, r++, 2, 1.0);
+    probe(p, r++, 2, 1.0);
+    probe(p, r++, 2, 0.0); /* still jammed */
+    probe(p, r++, 2, 1.0);
+    probe(p, r++, 2, 1.0);
+    auto d = p.decide(r);
+    CHECK(d.kind == HopsetDecision::Kind::Hold,
+          "a failed probe resets the restoration run");
+    probe(p, r++, 2, 1.0);
+    CHECK(p.decide(r).kind == HopsetDecision::Kind::ProposeRestore,
+          "the run completes after three consecutive good probes");
+  }
+
+  /* --- restoration is preferred over a fresh exclusion --- */
+  {
+    HopsetPolicy p(def, 6);
+    const uint64_t m = full_mask(6) & ~(uint64_t(1) << 2);
+    p.on_activation(m, 0);
+    uint64_t r = feed(p, m, 6, 1, 20, 4, 0.0, 1.0); /* ch4 now bad */
+    probe(p, r++, 2, 1.0);
+    probe(p, r++, 2, 1.0);
+    probe(p, r++, 2, 1.0);
+    auto d = p.decide(r);
+    CHECK(d.kind == HopsetDecision::Kind::ProposeRestore,
+          "giving a channel back outranks taking one away");
+  }
+
+  /* --- determinism: the same feed twice yields the same decision stream --- */
+  {
+    std::vector<int> kinds[2];
+    std::vector<uint32_t> holds[2];
+    for (int pass = 0; pass < 2; ++pass) {
+      HopsetPolicy p(def, 6);
+      uint64_t mask = full_mask(6), r = 0;
+      for (int step = 0; step < 20; ++step) {
+        r = feed(p, mask, 6, r, 3, step % 5, step % 3 ? 0.0 : 1.0, 1.0);
+        auto d = p.decide(r);
+        kinds[pass].push_back(static_cast<int>(d.kind));
+        holds[pass].push_back(static_cast<uint32_t>(d.hold));
+        if (d.kind != HopsetDecision::Kind::Hold) {
+          mask = d.proposed_mask;
+          p.on_activation(mask, r);
+        }
+      }
+    }
+    CHECK(kinds[0] == kinds[1] && holds[0] == holds[1],
+          "identical feeds decide identically");
+  }
+
+  return fails ? 1 : 0;
+}

--- a/tests/hopset_probe_selftest.cpp
+++ b/tests/hopset_probe_selftest.cpp
@@ -1,0 +1,153 @@
+/* Keyed recovery-probe placement: pinned known answers for which rounds,
+ * positions, and excluded channels the probe draws select; the structural
+ * invariants (exactly one probe opportunity per window, probe channel always
+ * excluded, data slots unchanged everywhere else); and the inertness
+ * guarantees (period 0 / full mask / generation 0 leave slot_info identical
+ * to channel_index over long spans). */
+#include "hopset/HopsetState.h"
+#include <cstdio>
+#include <set>
+
+static int fails;
+#define CHECK(x, msg)                                                          \
+  do {                                                                         \
+    if (!(x)) {                                                                \
+      std::fprintf(stderr, "FAIL: %s\n", msg);                                 \
+      ++fails;                                                                 \
+    }                                                                          \
+  } while (0)
+
+int main() {
+  using devourer::HopSchedule;
+  using namespace devourer::hopset;
+
+  const auto master =
+      HopSchedule::parse_seed("000102030405060708090a0b0c0d0e0f");
+  const auto keys = HopsetKeys::derive(master);
+  HopSchedule base(master);
+
+  /* committed state: 8-channel base, mask drops indices 2 and 5 */
+  const uint64_t mask = 0b11011011;
+  const HopsetState st{7, 3, mask, 40, 40 * 8};
+  const size_t k = popcount64(mask); /* 6 */
+  const unsigned P = 4;
+
+  /* --- inertness: period 0, gen 0, and full mask --- */
+  {
+    AdaptiveScheduleView v(base, keys, 8);
+    v.set_state(st); /* period defaults to 0 */
+    for (uint64_t s = st.activate_slot; s < st.activate_slot + 10000; ++s) {
+      const auto si = v.slot_info(s);
+      CHECK(!si.is_probe && si.base_index == v.channel_index(s),
+            "period-0 slot_info == channel_index");
+    }
+    AdaptiveScheduleView g0(base, keys, 8);
+    g0.set_probe_period(P); /* gen 0 state */
+    for (uint64_t s = 0; s < 10000; ++s) {
+      const auto si = g0.slot_info(s);
+      CHECK(!si.is_probe && si.base_index == g0.channel_index(s),
+            "gen-0 slot_info == channel_index");
+    }
+    AdaptiveScheduleView fullv(base, keys, 8);
+    fullv.set_state({7, 2, full_mask(8), 0, 0});
+    fullv.set_probe_period(P);
+    for (uint64_t s = 0; s < 10000; ++s) {
+      const auto si = fullv.slot_info(s);
+      CHECK(!si.is_probe && si.base_index == fullv.channel_index(s),
+            "full-mask slot_info == channel_index");
+    }
+  }
+
+  AdaptiveScheduleView v(base, keys, 8);
+  v.set_state(st);
+  v.set_probe_period(P);
+
+  /* --- structure over 40 windows: exactly one probe slot per window, probe
+   * channel always in the excluded set, every non-probe slot identical to
+   * the data schedule --- */
+  {
+    const uint64_t excluded = full_mask(8) & ~mask;
+    for (uint64_t w = 0; w < 40; ++w) {
+      unsigned probes = 0;
+      for (uint64_t r = w * P; r < (w + 1) * P; ++r)
+        for (uint64_t pos = 0; pos < k; ++pos) {
+          const uint64_t slot = st.activate_slot + r * k + pos;
+          const auto si = v.slot_info(slot);
+          if (si.is_probe) {
+            ++probes;
+            CHECK(excluded & (uint64_t(1) << si.base_index),
+                  "probe channel is excluded");
+          } else {
+            CHECK(si.base_index == v.channel_index(slot),
+                  "non-probe slot rides the data schedule");
+          }
+        }
+      CHECK(probes == 1, "exactly one probe per window");
+    }
+  }
+
+  /* --- determinism: an independently constructed view agrees --- */
+  {
+    HopSchedule base2(master);
+    AdaptiveScheduleView v2(base2, HopsetKeys::derive(master), 8);
+    v2.set_state(st);
+    v2.set_probe_period(P);
+    for (uint64_t s = st.activate_slot; s < st.activate_slot + 5000; ++s) {
+      const auto a = v.slot_info(s), b = v2.slot_info(s);
+      CHECK(a.base_index == b.base_index && a.is_probe == b.is_probe,
+            "independent views agree on probes");
+    }
+  }
+
+  /* --- keyed placement varies across windows (no fixed phase/position) --- */
+  {
+    std::set<uint64_t> phases, picks;
+    for (uint64_t w = 0; w < 32; ++w)
+      for (uint64_t r = w * P; r < (w + 1) * P; ++r)
+        for (uint64_t pos = 0; pos < k; ++pos) {
+          const uint64_t slot = st.activate_slot + r * k + pos;
+          if (v.slot_info(slot).is_probe) {
+            phases.insert(r % P);
+            picks.insert(v.slot_info(slot).base_index);
+          }
+        }
+    CHECK(phases.size() > 1, "probe phase varies across windows");
+    CHECK(picks.size() == 2, "both excluded channels get probed");
+  }
+
+  /* --- pinned known answers: (window -> probe round-in-window, pos, chan)
+   * for the reference key/state — the drift tripwire --- */
+  {
+    struct Kat {
+      uint64_t rphase, pos;
+      size_t chan;
+    };
+    const Kat kat[6] = {{2, 4, 5}, {0, 3, 5}, {2, 2, 2},
+                        {1, 4, 5}, {2, 2, 5}, {1, 1, 2}};
+    bool print = false;
+    Kat got[6]{};
+    for (uint64_t w = 0; w < 6; ++w)
+      for (uint64_t r = w * P; r < (w + 1) * P; ++r)
+        for (uint64_t pos = 0; pos < k; ++pos) {
+          const uint64_t slot = st.activate_slot + r * k + pos;
+          const auto si = v.slot_info(slot);
+          if (si.is_probe)
+            got[w] = {r % P, pos, si.base_index};
+        }
+    for (int w = 0; w < 6; ++w)
+      if (got[w].rphase != kat[w].rphase || got[w].pos != kat[w].pos ||
+          got[w].chan != kat[w].chan)
+        print = true;
+    if (print) {
+      std::fprintf(stderr, "PROBEKAT: ");
+      for (int w = 0; w < 6; ++w)
+        std::fprintf(stderr, "{%llu,%llu,%zu},",
+                     (unsigned long long)got[w].rphase,
+                     (unsigned long long)got[w].pos, got[w].chan);
+      std::fprintf(stderr, "\n");
+      CHECK(false, "probe placement KAT");
+    }
+  }
+
+  return fails ? 1 : 0;
+}

--- a/tests/hopset_proto_selftest.cpp
+++ b/tests/hopset_proto_selftest.cpp
@@ -124,14 +124,14 @@ int main() {
   /* --- row 1: clean run — propose, commit, synchronized activation --- */
   {
     Sim s(0x1000, 0x2000);
-    s.propose(0b00110111, 0xA1);
+    s.propose(0b11110111, 0xA1);
     CHECK(s.auth.committing(), "clean: authority commits");
     s.tick(200);
     CHECK(s.auth_activations == 1 && s.fol_activations == 1,
           "clean: both activate exactly once");
     CHECK(s.auth_act_slot == s.fol_act_slot, "clean: same activation slot");
     CHECK(s.converged() && s.fol_state.generation == 1 &&
-              s.fol_state.active_mask == 0b00110111,
+              s.fol_state.active_mask == 0b11110111,
           "clean: identical committed state");
     CHECK(s.fol_state.activate_slot >= 8 * 8,
           "clean: >= 8 rounds of lead honored");
@@ -148,7 +148,7 @@ int main() {
       }
       return true;
     };
-    s.propose(0b00001111, 0xA2);
+    s.propose(0b11101111, 0xA2);
     s.tick(300);
     CHECK(dropped == 2 && s.converged() && s.fol_state.generation == 1,
           "lost proposals: retry converges");
@@ -165,7 +165,7 @@ int main() {
       }
       return true;
     };
-    s.propose(0b11110000, 0xA3);
+    s.propose(0b01111111, 0xA3);
     s.tick(300);
     CHECK(commits_dropped == 3 && s.converged() &&
               s.fol_activations == 1 && s.auth_activations == 1 &&
@@ -176,7 +176,7 @@ int main() {
   /* --- row 4: duplicated commit — a repeat is idempotent --- */
   {
     Sim s(0x1000, 0x2000);
-    s.propose(0b00111100, 0xA4);
+    s.propose(0b11111110, 0xA4);
     s.tick(2); /* several repeated commits already flow; all must be inert
                   duplicates on the follower */
     s.tick(300);
@@ -187,7 +187,7 @@ int main() {
   /* --- row 5: replayed proposal after completion — rejected --- */
   {
     Sim s(0x1000, 0x2000);
-    s.propose(0b00110111, 0xA5);
+    s.propose(0b11110111, 0xA5);
     s.tick(200);
     CHECK(s.converged() && s.fol_state.generation == 1, "replay setup");
     /* attacker replays the same authenticated proposal bytes */
@@ -196,7 +196,7 @@ int main() {
     replay.link_id = s.p.link_id;
     replay.rx_epoch = 0x2000;
     replay.rx_nonce = 0xA5;
-    replay.active_mask = 0b00110111;
+    replay.active_mask = 0b11110111;
     replay.base_fp = s.p.base_fp;
     s.last_reject = HopsetReason::None;
     s.route(std::vector<HopsetAction>{}, false); /* no-op */
@@ -235,7 +235,7 @@ int main() {
   {
     Sim s(0x1000, 0x2000);
     /* run a legitimate change so the follower tracks epoch 0x1000 gen 1 */
-    s.propose(0b00110111, 0xA7);
+    s.propose(0b11110111, 0xA7);
     s.tick(200);
     CHECK(s.fol_state.generation == 1, "stale-epoch setup");
     /* replay: an authenticated commit from a previous authority boot (other
@@ -273,7 +273,7 @@ int main() {
     s.deliver = [&](int, const HopsetMsg &m) {
       return m.type == HT_PROPOSAL; /* only proposals get through */
     };
-    s.propose(0b00110111, 0xA8);
+    s.propose(0b11110111, 0xA8);
     CHECK(s.auth.committing(), "restart setup: authority armed");
     /* authority restarts: new machine, new random epoch, gen 0. The old
      * in-flight generation is orphaned for free (nothing persisted); the
@@ -293,7 +293,7 @@ int main() {
   /* --- row 9: RX restart — a fresh follower joins at nonzero gen --- */
   {
     Sim s(0x1000, 0x2000);
-    s.propose(0b01011010, 0xA9);
+    s.propose(0b11011111, 0xA9);
     s.tick(200);
     CHECK(s.fol_state.generation == 1, "RX restart setup");
     /* follower restarts with a new epoch and no state */
@@ -302,7 +302,7 @@ int main() {
     CHECK(s.fol.state().generation == 0, "fresh follower at gen 0");
     s.tick(2 * s.p.status_interval_slots + 2);
     CHECK(s.fol.state().generation == 1 &&
-              s.fol.state().active_mask == 0b01011010 &&
+              s.fol.state().active_mask == 0b11011111 &&
               s.fol.state().activate_slot == s.auth.state().activate_slot,
           "RX restart: rejoins at the live nonzero generation");
   }
@@ -363,7 +363,7 @@ int main() {
   {
     Sim s(0x1000, 0x2000);
     s.deliver = [](int, const HopsetMsg &) { return false; }; /* black hole */
-    s.propose(0b00111100, 0xB3);
+    s.propose(0b11111110, 0xB3);
     s.tick(200);
     CHECK(s.last_reject == HopsetReason::Timeout &&
               s.fol.fsm() == HopsetFollower::State::Synced,
@@ -374,13 +374,58 @@ int main() {
   /* --- row 14: NoChange — re-proposing the active mask --- */
   {
     Sim s(0x1000, 0x2000);
-    s.propose(0b00110111, 0xB4);
+    s.propose(0b11110111, 0xB4);
     s.tick(200);
     CHECK(s.fol_state.generation == 1, "nochange setup");
     s.last_reject = HopsetReason::None;
-    s.propose(0b00110111, 0xB5);
+    s.propose(0b11110111, 0xB5);
     CHECK(s.last_reject == HopsetReason::NoChange && !s.auth.committing(),
           "same-mask proposal rejected as no-change");
+  }
+
+  /* --- row 15: the authority's structural limits on a proposal. A follower
+   * decides WHICH channel to drop, but not how much of the schedule may
+   * change at once or how fast updates may come — a buggy or hostile
+   * proposer must not be able to walk the link down. --- */
+  {
+    Sim s(0x1000, 0x2000);
+    s.propose(0b11000111, 0xD1); /* three channels at once */
+    CHECK(s.last_reject == HopsetReason::MaskDelta && !s.auth.committing(),
+          "multi-channel proposal rejected");
+    /* the same shape from the operator's own lever is allowed */
+    Sim s2(0x1000, 0x2000);
+    s2.route(s2.auth.start_change(0b11000111, s2.slot), true);
+    CHECK(s2.auth.committing(), "start_change is exempt from the delta limit");
+    s2.tick(200);
+    CHECK(s2.converged() && s2.fol_state.active_mask == 0b11000111,
+          "operator-driven multi-channel change still converges");
+  }
+  {
+    /* a second proposal too soon after an activation is refused */
+    Sim s(0x1000, 0x2000);
+    s.propose(0b11110111, 0xD2);
+    s.tick(200);
+    CHECK(s.fol_state.generation == 1, "cooldown setup activated");
+    s.last_reject = HopsetReason::None;
+    auto acts = s.auth.on_proposal(
+        [&] {
+          HopsetMsg m;
+          m.type = HT_PROPOSAL;
+          m.link_id = s.p.link_id;
+          m.rx_epoch = 0x2000;
+          m.rx_nonce = 0xD3;
+          m.active_mask = 0b11110011;
+          m.base_fp = s.p.base_fp;
+          return m;
+        }(),
+        s.auth.state().activate_slot + 2);
+    bool cooled = false;
+    for (auto &a : acts)
+      if (a.kind == HopsetAction::Event && a.event == HopsetEvent::Reject &&
+          a.reason == HopsetReason::Cooldown)
+        cooled = true;
+    CHECK(cooled && !s.auth.committing(),
+          "proposal inside the update gap rejected as cooldown");
   }
 
   /* --- drop-every-message sweep: for each control-message index in the
@@ -389,14 +434,14 @@ int main() {
   {
     /* count messages in a clean run first */
     Sim probe(0x1000, 0x2000);
-    probe.propose(0b00101101, 0xC0);
+    probe.propose(0b11101111, 0xC0);
     probe.tick(400);
     const int total = probe.msg_index;
     CHECK(total > 4, "sweep probe saw a full exchange");
     for (int drop = 0; drop < total; ++drop) {
       Sim s(0x1000, 0x2000);
       s.deliver = [&](int idx, const HopsetMsg &) { return idx != drop; };
-      s.propose(0b00101101, 0xC0);
+      s.propose(0b11101111, 0xC0);
       s.tick(800);
       if (!(s.converged() && s.fol.state().generation >= 1)) {
         std::fprintf(stderr, "sweep: drop=%d diverged\n", drop);

--- a/tests/kchansw_b210_gap.py
+++ b/tests/kchansw_b210_gap.py
@@ -20,6 +20,12 @@ Usage:  tests/.venv/bin/python tests/kchansw_b210_gap.py \
             --freq 5200e6 --rate 8e6 --secs 20 --out /tmp/b210_gap.json
 """
 
+# Which radio to open — see tests/uhd_select.py (a bench with two B210s
+# makes an unpinned MultiUSRP("") a coin flip).
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import uhd_select  # noqa: E402
+
 import argparse
 import json
 import sys
@@ -29,7 +35,7 @@ import numpy as np
 
 def capture(freq, rate, secs, gain):
     import uhd
-    usrp = uhd.usrp.MultiUSRP("type=b200")
+    usrp = uhd.usrp.MultiUSRP(uhd_select.device_args("type=b200"))
     usrp.set_rx_rate(rate)
     usrp.set_rx_freq(uhd.libpyuhd.types.tune_request(freq))
     usrp.set_rx_gain(gain)

--- a/tests/la_sdr_compare.py
+++ b/tests/la_sdr_compare.py
@@ -39,6 +39,12 @@ catch tone-mapping / spectral-inversion errors end to end.
         --notch=-21,-20,-19,7,8,9
 """
 
+# Which radio to open — see tests/uhd_select.py (a bench with two B210s
+# makes an unpinned MultiUSRP("") a coin flip).
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import uhd_select  # noqa: E402
+
 import argparse
 import json
 import os
@@ -58,7 +64,7 @@ def chan_to_freq(ch):
 
 def do_capture(args):
     import uhd
-    usrp = uhd.usrp.MultiUSRP(args.args)
+    usrp = uhd.usrp.MultiUSRP(uhd_select.device_args(args.args))
     rate = 20e6
     usrp.set_rx_rate(rate)
     usrp.set_rx_freq(uhd.types.TuneRequest(chan_to_freq(args.channel)))
@@ -173,7 +179,7 @@ def do_txltf(args):
     # Long precomputed buffer (~40 bursts / 4.6 ms per send) — per-burst
     # send calls underrun the B210 from python and nothing airs.
     frame = np.tile(one, 40).astype(np.complex64)
-    usrp = uhd.usrp.MultiUSRP(args.args)
+    usrp = uhd.usrp.MultiUSRP(uhd_select.device_args(args.args))
     rate = 20e6
     usrp.set_tx_rate(rate)
     usrp.set_tx_freq(uhd.types.TuneRequest(chan_to_freq(args.channel)))
@@ -258,7 +264,9 @@ def main():
     c.add_argument("--channel", type=int, default=6)
     c.add_argument("--secs", type=float, default=0.5)
     c.add_argument("--gain", type=float, default=50)
-    c.add_argument("--args", default="")
+    c.add_argument("--args", default=uhd_select.device_args(None, allow_ambiguous=True),
+        help="UHD device args, e.g. serial=XXXXXXX (default: $DEVOURER_UHD_ARGS "
+             "or tests/.uhd_args)")
     c.add_argument("--out", required=True)
     m = sub.add_parser("compare")
     m.add_argument("--sdr", required=True, help="complex64 file (capture)")
@@ -272,7 +280,9 @@ def main():
     t.add_argument("--secs", type=float, default=40)
     t.add_argument("--gain", type=float, default=60)
     t.add_argument("--amplitude", type=float, default=0.5)
-    t.add_argument("--args", default="")
+    t.add_argument("--args", default=uhd_select.device_args(None, allow_ambiguous=True),
+        help="UHD device args, e.g. serial=XXXXXXX (default: $DEVOURER_UHD_ARGS "
+             "or tests/.uhd_args)")
     n = sub.add_parser("check-notch")
     n.add_argument("--chip", required=True)
     n.add_argument("--notch", required=True)

--- a/tests/sdr_burst_len.py
+++ b/tests/sdr_burst_len.py
@@ -10,6 +10,13 @@ burst against the expected airtime (issue #238 MCS4+ bisect).
   sudo python3 tests/sdr_burst_len.py --freq 5180e6 --secs 4
 """
 from __future__ import annotations
+
+# Which radio to open — see tests/uhd_select.py (a bench with two B210s
+# makes an unpinned MultiUSRP("") a coin flip).
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import uhd_select  # noqa: E402
+
 import argparse, sys
 import numpy as np
 
@@ -30,7 +37,7 @@ def main() -> int:
                     help="burst threshold above noise floor")
     a = ap.parse_args()
 
-    usrp = uhd.usrp.MultiUSRP("")
+    usrp = uhd.usrp.MultiUSRP(uhd_select.device_args())
     usrp.set_rx_rate(a.rate)
     usrp.set_rx_freq(uhd.types.TuneRequest(a.freq))
     usrp.set_rx_gain(a.gain)

--- a/tests/sdr_cw_peak.py
+++ b/tests/sdr_cw_peak.py
@@ -5,6 +5,13 @@ xtal_cfo_sweep.sh). Parabolic-interpolated for sub-bin resolution. USRP B210.
 
   python3 tests/sdr_cw_peak.py 5220e6
 """
+
+# Which radio to open — see tests/uhd_select.py (a bench with two B210s
+# makes an unpinned MultiUSRP("") a coin flip).
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import uhd_select  # noqa: E402
+
 import sys
 import numpy as np
 import uhd
@@ -14,7 +21,7 @@ rate = 46.08e6
 gain = 50
 n = int(8e5)
 
-u = uhd.usrp.MultiUSRP()
+u = uhd.usrp.MultiUSRP(uhd_select.device_args())
 s = u.recv_num_samps(n, freq, rate, [0], gain)[0]
 s = s - np.mean(s)  # drop the DC/LO-leakage bin so it can't win the argmax
 

--- a/tests/sdr_duty.py
+++ b/tests/sdr_duty.py
@@ -16,6 +16,13 @@ inject_beacon at the same config — higher duty = more on air.
   sudo python3 sdr_duty.py --freq 5745e6 --secs 4 --mcs 7 --bw 20
 """
 from __future__ import annotations
+
+# Which radio to open — see tests/uhd_select.py (a bench with two B210s
+# makes an unpinned MultiUSRP("") a coin flip).
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import uhd_select  # noqa: E402
+
 import argparse, math, sys, time
 import numpy as np
 
@@ -58,7 +65,7 @@ def main() -> int:
                          "channel and pass it here.")
     args = ap.parse_args()
 
-    usrp = uhd.usrp.MultiUSRP("")
+    usrp = uhd.usrp.MultiUSRP(uhd_select.device_args())
     usrp.set_rx_rate(args.rate)
     usrp.set_rx_freq(uhd.types.TuneRequest(args.freq))
     usrp.set_rx_gain(args.gain)

--- a/tests/sdr_follower_jammer.py
+++ b/tests/sdr_follower_jammer.py
@@ -28,6 +28,12 @@ retune_us). Run under sudo (UHD).
 """
 from __future__ import annotations
 
+# Which radio to open — see tests/uhd_select.py (a bench with two B210s
+# makes an unpinned MultiUSRP("") a coin flip).
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import uhd_select  # noqa: E402
+
 import argparse
 import json
 import signal
@@ -45,7 +51,9 @@ def chan_to_freq(ch: int) -> float:
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--args", default="", help="UHD device args")
+    ap.add_argument("--args", default=uhd_select.device_args(None, allow_ambiguous=True),
+        help="UHD device args, e.g. serial=XXXXXXX (default: $DEVOURER_UHD_ARGS "
+             "or tests/.uhd_args)")
     ap.add_argument("--channels", default="36,40,44,48")
     ap.add_argument("--center", type=float, default=0.0,
                     help="RX sense center Hz (0 = hopset midpoint)")
@@ -83,7 +91,7 @@ def main(argv=None) -> int:
                 f"span the hopset\n")
             return 2
 
-    u = uhd.usrp.MultiUSRP(args.args)
+    u = uhd.usrp.MultiUSRP(uhd_select.device_args(args.args))
     u.set_rx_rate(args.rate)
     u.set_tx_rate(args.jam_rate)
     u.set_rx_gain(args.rx_gain)

--- a/tests/sdr_interferer.py
+++ b/tests/sdr_interferer.py
@@ -23,6 +23,12 @@ corrupted. Use only on a bench you control.
 """
 from __future__ import annotations
 
+# Which radio to open — see tests/uhd_select.py (a bench with two B210s
+# makes an unpinned MultiUSRP("") a coin flip).
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import uhd_select  # noqa: E402
+
 import argparse
 import signal
 import sys
@@ -40,7 +46,9 @@ def chan_to_freq(channel: int) -> float:
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--args", default="", help="UHD device args (e.g. type=b200)")
+    ap.add_argument("--args", default=uhd_select.device_args(None, allow_ambiguous=True),
+        help="UHD device args, e.g. serial=XXXXXXX (default: $DEVOURER_UHD_ARGS "
+             "or tests/.uhd_args)")
     ap.add_argument("--channel", type=int, default=None,
                     help="Wi-Fi channel (sets --freq); 2.4 GHz 1-14 / 5 GHz 36+")
     ap.add_argument("--freq", type=float, default=None, help="center freq Hz")
@@ -78,7 +86,7 @@ def main(argv=None) -> int:
                          "must be importable (system uhd, as in sdr_power_probe.py)\n")
         return 2
 
-    usrp = uhd.usrp.MultiUSRP(args.args)
+    usrp = uhd.usrp.MultiUSRP(uhd_select.device_args(args.args))
     usrp.set_tx_rate(args.rate)
     usrp.set_tx_freq(uhd.types.TuneRequest(args.freq))
     usrp.set_tx_gain(args.tx_gain)

--- a/tests/sdr_power_probe.py
+++ b/tests/sdr_power_probe.py
@@ -22,6 +22,12 @@ Run standalone to sanity-check the SDR:
 """
 from __future__ import annotations
 
+# Which radio to open — see tests/uhd_select.py (a bench with two B210s
+# makes an unpinned MultiUSRP("") a coin flip).
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import uhd_select  # noqa: E402
+
 import argparse
 import math
 import sys
@@ -46,7 +52,9 @@ def main() -> int:
     ap.add_argument("--rate", type=float, default=4e6, help="sample rate (Hz)")
     ap.add_argument("--gain", type=float, default=40.0, help="RX gain (dB)")
     ap.add_argument("--antenna", default="RX2", help="RX antenna port")
-    ap.add_argument("--args", default="", help="UHD device args (e.g. type=b200)")
+    ap.add_argument("--args", default=uhd_select.device_args(None, allow_ambiguous=True),
+        help="UHD device args, e.g. serial=XXXXXXX (default: $DEVOURER_UHD_ARGS "
+             "or tests/.uhd_args)")
     ap.add_argument("--window", type=int, default=0,
                     help="samples per power reading (0 = ~rate/20, ~50ms)")
     ap.add_argument("--duration", type=float, default=0.0,
@@ -63,7 +71,7 @@ def main() -> int:
 
     window = args.window if args.window > 0 else max(1024, int(args.rate / 20))
 
-    usrp = uhd.usrp.MultiUSRP(args.args)
+    usrp = uhd.usrp.MultiUSRP(uhd_select.device_args(args.args))
     usrp.set_rx_rate(args.rate)
     usrp.set_rx_freq(uhd.types.TuneRequest(args.freq))
     usrp.set_rx_gain(args.gain)

--- a/tests/sdr_spectrum.py
+++ b/tests/sdr_spectrum.py
@@ -14,6 +14,12 @@ Uncalibrated relative dBFS, like sdr_power_probe.py. Pair with a fixed geometry.
 """
 from __future__ import annotations
 
+# Which radio to open — see tests/uhd_select.py (a bench with two B210s
+# makes an unpinned MultiUSRP("") a coin flip).
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import uhd_select  # noqa: E402
+
 import argparse
 import sys
 
@@ -28,7 +34,7 @@ except ImportError:
 
 
 def capture(freq, rate, gain, antenna, dev_args, nsamp):
-    usrp = uhd.usrp.MultiUSRP(dev_args)
+    usrp = uhd.usrp.MultiUSRP(uhd_select.device_args(dev_args))
     usrp.set_rx_rate(rate)
     usrp.set_rx_freq(uhd.types.TuneRequest(freq))
     usrp.set_rx_gain(gain)
@@ -80,7 +86,9 @@ def main() -> int:
     ap.add_argument("--rate", type=float, default=25e6)
     ap.add_argument("--gain", type=float, default=40.0)
     ap.add_argument("--antenna", default="RX2")
-    ap.add_argument("--args", default="type=b200")
+    ap.add_argument("--args", default=uhd_select.device_args(None, allow_ambiguous=True),
+        help="UHD device args, e.g. serial=XXXXXXX (default: $DEVOURER_UHD_ARGS "
+             "or tests/.uhd_args)")
     ap.add_argument("--duration", type=float, default=1.5)
     ap.add_argument("--label", default="")
     ap.add_argument("--dump", default=None,

--- a/tests/sdr_tx_probe.py
+++ b/tests/sdr_tx_probe.py
@@ -18,6 +18,13 @@ is the one test script outside the uv-managed Python subtree.
   python3 tests/sdr_tx_probe.py --freq 5180e6 --label baseline
   python3 tests/sdr_tx_probe.py --freq 5180e6 --label tx --json /tmp/tx.json
 """
+
+# Which radio to open — see tests/uhd_select.py (a bench with two B210s
+# makes an unpinned MultiUSRP("") a coin flip).
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+import uhd_select  # noqa: E402
+
 import argparse
 import json
 import sys
@@ -27,7 +34,7 @@ import uhd
 
 
 def measure(freq, rate, gain, nsamps, median=False):
-    usrp = uhd.usrp.MultiUSRP("")
+    usrp = uhd.usrp.MultiUSRP(uhd_select.device_args())
     # recv_num_samps tunes, sets rate+gain, streams, and returns a complex64
     # array shaped (channels, nsamps). One channel (RX A).
     samps = usrp.recv_num_samps(int(nsamps), float(freq), float(rate), [0], float(gain))

--- a/tests/uhd_select.py
+++ b/tests/uhd_select.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""One place that decides WHICH UHD radio a test harness opens.
+
+A bench with two B210-class radios (they share USB id 2500:0020, so lsusb
+cannot tell them apart) makes `MultiUSRP("")` a coin flip: half your runs
+measure the wrong antenna and nothing in the log says so. Every tool here
+routes its device-args through `device_args()`, which resolves in order:
+
+  1. an explicit `--args` on the command line;
+  2. the DEVOURER_UHD_ARGS environment variable;
+  3. `tests/.uhd_args`, an untracked one-line file — the reliable one on this
+     suite, because nearly every harness invokes its SDR tool through `sudo`,
+     which scrubs the environment: an exported variable does NOT survive
+     `sudo python3 tests/sdr_duty.py`, but a file on disk does;
+  4. nothing — allowed only when exactly one device is present. With more than
+     one it is an error listing the serials, not a silent pick.
+
+Set it once per bench:
+
+    echo serial=XXXXXXX > tests/.uhd_args
+
+`uhd_find_devices` prints the serials. A tool that genuinely wants to address
+several radios at once passes `--args` explicitly and bypasses the guard.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+ENV_VAR = "DEVOURER_UHD_ARGS"
+ARGS_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".uhd_args")
+
+
+def _from_file() -> str:
+    try:
+        with open(ARGS_FILE) as fh:
+            for line in fh:
+                line = line.split("#", 1)[0].strip()
+                if line:
+                    return line
+    except OSError:
+        pass
+    return ""
+
+
+def _find(args: str = ""):
+    """Enumerated UHD devices, or None when the bindings can't be imported."""
+    try:
+        import uhd  # noqa: F401  (import cost is paid once, at call time)
+
+        return list(uhd.find(args))
+    except Exception:
+        return None
+
+
+def device_args(cli: str | None = None, *, allow_ambiguous: bool = False) -> str:
+    """Resolve the UHD device-args string a tool should open with."""
+    if cli:
+        return cli
+    env = os.environ.get(ENV_VAR, "").strip()
+    if env:
+        return env
+    from_file = _from_file()
+    if from_file:
+        return from_file
+    if allow_ambiguous:
+        return ""
+    found = _find()
+    if found is None or len(found) <= 1:
+        return ""  # single radio (or no bindings): nothing to disambiguate
+    lines = []
+    for d in found:
+        # str(device_addr) is a "Device Address:\n    key: value\n..." block
+        keys = {}
+        for row in str(d).splitlines():
+            if ":" in row and not row.startswith("Device"):
+                k, _, v = row.partition(":")
+                keys[k.strip()] = v.strip()
+        lines.append(
+            "    serial={:<10} name={}".format(
+                keys.get("serial", "?"), keys.get("name", keys.get("product", "?"))
+            )
+        )
+    sys.exit(
+        "error: {} UHD devices present and no device selected.\n".format(len(found))
+        + "\n".join(lines)
+        + "\n  Pick one with --args serial=..., or (survives sudo):"
+        + "\n    echo serial=... > {}".format(ARGS_FILE)
+    )
+
+
+def add_args_argument(ap, help_extra: str = "") -> None:
+    """Register the standard --args option, defaulting from the environment."""
+    ap.add_argument(
+        "--args",
+        default=os.environ.get(ENV_VAR, ""),
+        help="UHD device args, e.g. serial=XXXXXXX (default: ${}){}".format(
+            ENV_VAR, help_extra
+        ),
+    )
+
+
+if __name__ == "__main__":  # tiny CLI: print what would be opened
+    print(device_args(sys.argv[1] if len(sys.argv) > 1 else None) or "<any>")


### PR DESCRIPTION
Implements #264 on top of the authenticated hopset protocol from #263. The protocol could already change the active set; nothing decided to. Now the receiver does.

## Why the receiver decides

Its delivery measurement describes the endpoint that actually has to decode — a transmitter's own view of a channel is not evidence that the video arrived. So RX scores every closed dwell, a pure policy proposes, and TX validates and commits.

**Delivery is authoritative.** RSSI/SNR/EVM, CRC counts and link verdicts only *classify* an impairment (interference / weak signal / lost sync) into explanation bits. A quiet channel with a dead link and a noisy channel that still delivers are opposite decisions, so nothing is ever excluded on energy alone.

## Conservative by construction

An adaptive exclusion loop is an attack surface: anyone who can make channels look bad could otherwise herd the link onto one channel and jam it. Hence:

- ≥ 8 scored rounds before any decision; exactly one channel per update
- exclusion only after delivery stays < 30 % for 5 consecutive visits **while another channel is still healthy**
- hard `max(3, configured)` active floor, and a cap on the excluded fraction
- ≥ 10 rounds between updates — and a *refused* proposal spends that budget too, so a receiver whose proposals keep bouncing cannot flood the control channel (this one was found on air, under the herding jammer)
- nothing excluded when most of the band degrades together

The authority enforces its own copy of the shape limits (`max_mask_delta`, `min_update_gap_rounds`, the floor): the receiver decides *which* channel, never *how much* of the schedule may move at once. The operator's scripted lever stays exempt.

## Keyed recovery probes

An excluded channel cannot prove it recovered unless something goes back and looks. Every `P` rounds one data opportunity becomes a probe on an excluded channel — which round of the window, which position within it, and which channel are all keyed draws, so recovery never becomes a public periodic target. Probes carry sync/control only, never caller FEC payload. Three consecutive probes above 70 % restore the channel.

Probe placement is inert at generation 0, with a full mask, or at period 0, so every #263 KAT is untouched.

## Feedback transport

Proposals air from the receiver's own claimed handle (RX loop plus an occasional control frame); the transmitter listens under `DEVOURER_TX_WITH_RX=thread`. Control frames are their own small MPDUs — caller payload bytes are never touched. All of it is inert unless `DEVOURER_HOP_POLICY` / `DEVOURER_HOP_PROBE_ROUNDS` are set.

## Tests (44/44 green)

- `hopset_probe_placement` — probe KATs, exactly one probe per window, channel always excluded, inertness over 10k slots, independent-view determinism
- `hopset_policy_matrix` — threshold edges, persistence hysteresis, cooldown, broad degradation, both floors, restoration cycle, adversarial rows (flapping jammer never accumulates persistence; herding jammer converges to the floor and stops), classify-never-triggers, determinism, policy-hash stability
- `hopset_adaptive_e2e` — the whole arc through real crypto: jam → exclude → commit → activate in lockstep → probes visit the excluded channel → unjam → restore, plus dropped-proposal/dropped-commit rows, asserting no split-brain at any slot
- new authority rows in `hopset_proto_matrix` (mask-delta and cooldown rejections; `start_change` exempt)

## On-air validation

`tests/hopset_adaptive_jammer.sh` (B210 interferer, 4-channel 2.4 GHz base, both modes ALL PASS):

- **parked** — delivery 0.745 → 0.852, excluded exactly the jammed channel, lockstep held, probes restored it once the interferer stopped
- **herding** (jammer moves onto a newly-active channel after every exclusion) — active set held at the floor of 3, committed exclusion depth 1, no collapse

Two rig facts that cost a session and are now documented in the script and `docs/fhss.md`: a flat TXAGC index chosen to back 5 GHz off can put 2.4 GHz below the receiver's sensitivity and look exactly like a dead link; and an interferer loud enough to splatter across the band is broad degradation, not a channel fault — the policy correctly refuses to act on it.

## Second commit: SDR selection

While validating this I hit a rig hazard worth fixing separately. B210 variants share USB id `2500:0020`, so on a bench with two of them `MultiUSRP("")` is a coin flip — half the runs measure the wrong antenna and nothing in the log says so. Thirteen UHD tools each opened the radio their own way and the ~20 shell harnesses driving them passed no selection at all.

`tests/uhd_select.py` resolves it in one place: explicit `--args` → `DEVOURER_UHD_ARGS` → the untracked `tests/.uhd_args` → the only device present → **error listing the serials** rather than a silent pick. The file matters more than the variable, because nearly every harness invokes its tool through `sudo`, which scrubs the environment. Serials are per-bench, so the file is gitignored and nothing here hardcodes one; single-radio benches are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)