### PR TITLE
Quiesce TX before libusb teardown (#281); fix Kestrel CCK + wide-bandwidth RX (#343)

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -200,6 +200,34 @@ jobs:
         working-directory: build
         run: ctest --output-on-failure
 
+  # Sanitized build of the whole tree (library + demos + selftests) with the
+  # headless suite run under ASan/UBSan. Leak detection is off here: the
+  # selftests are pure computation and never open a device, so the only
+  # allocations still live at exit would come from libusb in demo code this
+  # job never runs — leak triage belongs to the on-hardware runs.
+  build-sanitizers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependency libraries
+        run: sudo apt install libusb-1.0-0-dev
+
+      - name: Configure (ASan + UBSan)
+        run: >
+          cmake -B build-asan -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          -DDEVOURER_SANITIZE=address+undefined -S ${{ github.workspace }}
+
+      - name: Build (ASan + UBSan)
+        run: cmake --build build-asan -j
+
+      - name: Test (ASan + UBSan)
+        working-directory: build-asan
+        env:
+          ASAN_OPTIONS: detect_leaks=0
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+        run: ctest --output-on-failure
+
   # Invalid option combinations must fail at configure time, not silently
   # produce a broken binary.
   reject-bad-configs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 compile_commands.json
 build
+# Out-of-tree build dirs: build-asan (DEVOURER_SANITIZE), per-config trees.
+build-*/
 .cache
 __pycache__/
 *.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,9 +102,21 @@ group exports a PUBLIC `DEVOURER_HAVE_*` define; sites referencing a dropped
 group sit behind `#if defined(DEVOURER_HAVE_*)`, and the factory returns
 `nullptr` (logs) for a chip whose support isn't built.
 
+`DEVOURER_SANITIZE=address|address+undefined|thread` (default off) builds the
+library, demos and selftests instrumented; the vendored halbb/halrf C is
+exempted from UBSan (Realtek's sources are full of unaligned loads and signed
+shifts — noise we would never act on). MSVC has AddressSanitizer only and
+rejects the other values rather than silently degrading. The demos are worth
+running under it on hardware, not just `ctest`: the lifetime bugs it finds
+(teardown, in-flight URBs) need a real device —
+`tests/tx_teardown_asan.sh` (max-duty TX killed mid-flight, incl. a real
+VBUS-cut wedge) and `tests/teardown_gen_sanity.sh` (every plugged generation
+init + teardown).
+
 CI (`.github/workflows/cmake-multi-platform.yml`): GCC/Clang/MSVC ×
 Ubuntu/macOS/Windows matrix, a `build-mingw` job, a `build-configs` matrix over
-each per-chip subset, and `reject-bad-configs` for the invalid option combos.
+each per-chip subset, `build-sanitizers` (ASan+UBSan `ctest`), and
+`reject-bad-configs` for the invalid option combos.
 `ctest` runs in every job (headless selftests — math guards + the
 `stream_stdin_binary` framing round-trip). Hardware testing is out-of-band.
 
@@ -508,6 +520,16 @@ thin — `libusb_init`, device open, kernel-driver detach, and
 to the factory. `examples/rx/main.cpp` is the canonical boilerplate;
 `devourer::claim_interface_then_reset` (src/UsbOpen.h) is the recommended
 open path (advisory per-adapter lock before reset).
+
+Owning libusb means owning the **teardown order**: destroy the `IRtlDevice`
+first, then release the interface, close the handle, and only then
+`libusb_exit`. The device is what quiesces TX (`IRtlDevice::Stop`, and the
+destructor as a backstop: Jaguar1's async bulk-OUT URBs must be cancelled and
+reaped while the context still exists), so tearing libusb down first is a
+crash, not a leak — and only under enough TX load to keep URBs outstanding at
+exit. `examples/common/DeviceSession.h` is the demos' RAII holder for exactly
+that order; the transport logs a diagnostic naming this if it is destroyed
+with TX still in flight.
 
 **Chip identity is resolved at construction** from the `SYS_CFG2` chip-id +
 USB PID. `CreateRtlDevice` returns an `IRtlDevice` (`Init` = bring-up + RX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,53 @@ if(DEVOURER_PCIE)
     endif()
 endif()
 
+# ---------------------------------------------------------------------------
+# Sanitizers. Off by default; the value applies to the library, the examples
+# and the selftests alike, so `ctest` and an on-hardware demo run share one
+# instrumented build. The vendored halbb/halrf C is exempted from UBSan below
+# (unaligned loads / signed shifts are pervasive in Realtek's sources and are
+# not ours to fix).
+#   cmake -S . -B build-asan -DDEVOURER_SANITIZE=address+undefined
+# ---------------------------------------------------------------------------
+set(DEVOURER_SANITIZE "" CACHE STRING
+    "Sanitizer build: address, address+undefined, thread (empty = off)")
+set_property(CACHE DEVOURER_SANITIZE PROPERTY STRINGS
+    "" address address+undefined thread)
+if(NOT DEVOURER_SANITIZE STREQUAL "")
+    if(MSVC)
+        # MSVC ships AddressSanitizer only — no UBSan, no TSan, no LSan.
+        # Degrade loudly rather than silently building something weaker than
+        # the caller asked for.
+        if(NOT DEVOURER_SANITIZE STREQUAL "address")
+            message(FATAL_ERROR
+                "DEVOURER_SANITIZE=${DEVOURER_SANITIZE} is unsupported on MSVC — "
+                "it implements /fsanitize=address only. Use "
+                "-DDEVOURER_SANITIZE=address, or build with GCC/Clang for "
+                "undefined/thread.")
+        endif()
+        add_compile_options(/fsanitize=address)
+        # ASan is incompatible with the runtime checks and with incremental
+        # linking; both are on by default in Debug.
+        add_compile_options($<$<CONFIG:Debug>:/Oy->)
+        add_link_options(/INCREMENTAL:NO)
+    else()
+        if(DEVOURER_SANITIZE STREQUAL "address")
+            set(_devourer_san "address")
+        elseif(DEVOURER_SANITIZE STREQUAL "address+undefined")
+            set(_devourer_san "address,undefined")
+        elseif(DEVOURER_SANITIZE STREQUAL "thread")
+            set(_devourer_san "thread")
+        else()
+            message(FATAL_ERROR
+                "DEVOURER_SANITIZE=${DEVOURER_SANITIZE} — must be one of "
+                "address, address+undefined, thread (or empty).")
+        endif()
+        add_compile_options(-fsanitize=${_devourer_san} -fno-omit-frame-pointer -g)
+        add_link_options(-fsanitize=${_devourer_san})
+    endif()
+    message(STATUS "devourer: sanitizer build (${DEVOURER_SANITIZE})")
+endif()
+
 # Find pkg-config and then use it to locate libusb.
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(libusb REQUIRED IMPORTED_TARGET libusb-1.0)
@@ -393,6 +440,13 @@ if(DEVOURER_KESTREL)
         set(_kestrel_vendor_cflags /W0 /Gy)
     else()
         set(_kestrel_vendor_cflags -w -ffunction-sections -fdata-sections)
+        # Realtek's sources are full of unaligned loads, signed shifts and
+        # out-of-range enum stores. They are vendored verbatim (edit the
+        # extractors, never these files), so UBSan on them reports noise we
+        # would never act on and drowns the findings from our own code.
+        if(DEVOURER_SANITIZE MATCHES "undefined")
+            list(APPEND _kestrel_vendor_cflags -fno-sanitize=undefined)
+        endif()
     endif()
 
     file(GLOB KESTREL_HALBB_C "${CMAKE_CURRENT_SOURCE_DIR}/hal/halbb/g6/vendor/*.c")
@@ -488,6 +542,8 @@ if(DEVOURER_KESTREL)
         examples/kestrelprobe/main.cpp
     )
     target_link_libraries(kestrelprobe PUBLIC devourer PRIVATE PkgConfig::libusb)
+    # DeviceSession.h (shared teardown-order holder) lives in examples/common/.
+    target_include_directories(kestrelprobe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/examples/common)
 endif()
 
 # reglat — register round-trip latency microbench (USB ctrl-xfer vs PCIe MMIO).
@@ -677,6 +733,17 @@ add_executable(ToneMaskSelftest
 target_link_libraries(ToneMaskSelftest PRIVATE devourer)
 
 add_test(NAME tone_mask_math COMMAND ToneMaskSelftest)
+
+# Headless guard for the TX quiesce seam (IRtlTransport::quiesce_tx via
+# RtlAdapter): the explicit "stop TX and wait it out" call every device makes
+# before anything is released. UsbTransport's cancel/drain is validated on
+# hardware under ASan — the test header says what it does and does not cover.
+add_executable(TxQuiesceSelftest
+    tests/tx_quiesce_selftest.cpp
+)
+target_link_libraries(TxQuiesceSelftest PRIVATE devourer PkgConfig::libusb)
+
+add_test(NAME tx_quiesce_seam COMMAND TxQuiesceSelftest)
 
 # Headless guard for the active idle-noise-floor math (src/NoiseFloorMath.h): the
 # phydm sign/pwdb helpers the Jaguar1 0x0FA0 debug-port measurement uses. Pure

--- a/examples/chanmig/main.cpp
+++ b/examples/chanmig/main.cpp
@@ -34,6 +34,7 @@
 #include <thread>
 #include <vector>
 
+#include "DeviceSession.h"
 #include "RadiotapBuilder.h"
 #include "RxPacket.h"
 #include "SignalStop.h"
@@ -455,6 +456,11 @@ int main(int argc, char **argv) {
   g_ev = &logger->events();
   install_devourer_signal_handlers();
 
+  /* Owns the teardown order (device -> interface -> handle -> context; see
+   * DeviceSession.h). Declared before every thread below, so the threads are
+   * joined before the adapter is released. */
+  devourer::DeviceSession session{logger};
+
   std::string role;
   for (int i = 1; i + 1 < argc; i++)
     if (std::strcmp(argv[i], "--role") == 0)
@@ -508,23 +514,25 @@ int main(int argc, char **argv) {
   libusb_context *ctx = nullptr;
   if (libusb_init(&ctx) < 0)
     return 1;
+  session.adopt_context(ctx);
   static constexpr uint16_t kPids[] = {0x8812, 0xc812, 0xa81a, 0x881a,
                                        0xc82c, 0xe822, 0x8813};
   UsbPick pick;
   libusb_device_handle *handle = open_selected_usb(
       ctx, logger, kPids, sizeof(kPids) / sizeof(kPids[0]), &pick);
-  if (!handle) {
-    libusb_exit(ctx);
+  if (!handle)
     return 1;
-  }
   std::shared_ptr<devourer::UsbDeviceLock> lock;
   if (devourer::claim_interface_reset_reopen(
           ctx, handle, logger, std::getenv("DEVOURER_SKIP_RESET") == nullptr,
           lock) != 0) {
-    libusb_close(handle);
-    libusb_exit(ctx);
+    /* The claim failed, so nothing owns the handle yet — hand it to the
+     * session purely so the unwind closes it. */
+    session.adopt_handle(handle);
     return 1;
   }
+  session.adopt_handle(handle);
+  session.adopt_lock(lock);
   /* Jaguar3 needs the RX filters opened at bring-up for reliable duplex. */
 #ifdef _WIN32
   _putenv_s("DEVOURER_TX_WITH_RX", "thread");
@@ -532,12 +540,17 @@ int main(int argc, char **argv) {
   ::setenv("DEVOURER_TX_WITH_RX", "thread", 1);
 #endif
   WiFiDriver driver(logger);
-  auto dev = driver.CreateRtlDevice(handle, ctx, lock, devourer_config_from_env());
-  if (!dev) {
+  auto owned_device =
+      driver.CreateRtlDevice(handle, ctx, lock, devourer_config_from_env());
+  if (!owned_device) {
     logger->error("no driver for this chip");
     return 1;
   }
-  g_dev = dev.get();
+  /* The session owns the device from here: it is what guarantees the device
+   * (and its in-flight TX) dies before libusb does. */
+  session.adopt_device(std::move(owned_device));
+  IRtlDevice *const dev = session.device();
+  g_dev = dev;
 
   Ev(*g_ev, "migrate.id").t().f("role", role.c_str())
       .f("chip", pick.pid).f("source", source.str().c_str())
@@ -726,8 +739,6 @@ int main(int argc, char **argv) {
     g_dev = nullptr;
   }
   dev->Stop();
-  libusb_release_interface(handle, 0);
-  libusb_close(handle);
-  libusb_exit(ctx);
+  session.close();
   return 0;
 }

--- a/examples/chanscout/main.cpp
+++ b/examples/chanscout/main.cpp
@@ -43,6 +43,7 @@
 #include <thread>
 #include <vector>
 
+#include "DeviceSession.h"
 #include "RxPacket.h"
 #include "SignalStop.h"
 #include "UsbOpen.h"
@@ -172,6 +173,11 @@ int main() {
   g_ev = &logger->events();
   install_devourer_signal_handlers();
 
+  /* Owns the teardown order (device -> interface -> handle -> context; see
+   * DeviceSession.h). Declared before the RX thread below, so it is joined
+   * before the adapter is released. */
+  devourer::DeviceSession session{logger};
+
   /* --- plan --- */
   const char *plan_env = std::getenv("DEVOURER_SCOUT_PLAN");
   cm::ScanPlanConfig cfg;
@@ -236,6 +242,7 @@ int main() {
   int rc = libusb_init(&ctx);
   if (rc < 0)
     return rc;
+  session.adopt_context(ctx);
   libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL,
                     std::getenv("DEVOURER_USB_DEBUG") ? LIBUSB_LOG_LEVEL_DEBUG
                                                       : LIBUSB_LOG_LEVEL_WARNING);
@@ -250,29 +257,33 @@ int main() {
   UsbPick pick;
   libusb_device_handle *handle = open_selected_usb(
       ctx, logger, kPids, sizeof(kPids) / sizeof(kPids[0]), &pick);
-  if (handle == nullptr) {
-    libusb_exit(ctx);
+  if (handle == nullptr)
     return 1;
-  }
   std::shared_ptr<devourer::UsbDeviceLock> usb_lock;
   rc = devourer::claim_interface_reset_reopen(
       ctx, handle, logger, std::getenv("DEVOURER_SKIP_RESET") == nullptr,
       usb_lock);
   if (rc != 0) {
-    if (handle != nullptr)
-      libusb_close(handle);
-    libusb_exit(ctx);
+    /* The claim failed, so nothing owns the handle yet — hand it to the
+     * session purely so the unwind closes it. */
+    session.adopt_handle(handle);
     return 1;
   }
+  session.adopt_handle(handle);
+  session.adopt_lock(usb_lock);
 
   WiFiDriver driver(logger);
-  auto dev = driver.CreateRtlDevice(handle, ctx, usb_lock,
-                                    devourer_config_from_env());
-  if (!dev) {
+  auto owned_device = driver.CreateRtlDevice(handle, ctx, usb_lock,
+                                             devourer_config_from_env());
+  if (!owned_device) {
     logger->error("No driver for this chip in this build — exiting");
     return 1;
   }
-  devourer::emit_adapter_caps(*g_ev, dev.get());
+  /* The session owns the device from here: it is what guarantees the device
+   * (and its in-flight TX) dies before libusb does. */
+  session.adopt_device(std::move(owned_device));
+  IRtlDevice *const dev = session.device();
+  devourer::emit_adapter_caps(*g_ev, dev);
   const devourer::AdapterCaps caps = dev->GetAdapterCaps();
 
   /* Stable scout identity = the physical binding + silicon (FNV-1a). This is
@@ -349,7 +360,7 @@ int main() {
   cm::ScanScheduler sched(cfg);
 
   /* --- RX loop on a worker thread (rxdemo sweep pattern) --- */
-  IRtlDevice *devp = dev.get();
+  IRtlDevice *devp = dev;
   const cm::ScanScheduler::DwellPlan first = sched.next(steady_ms());
   std::thread rx([devp, first, &logger]() {
     try {
@@ -671,8 +682,6 @@ int main() {
   if (rx.joinable())
     rx.join();
   devp->Stop();
-  libusb_release_interface(handle, 0);
-  libusb_close(handle);
-  libusb_exit(ctx);
+  session.close();
   return sched.consecutive_failures() >= 15 ? 3 : 0;
 }

--- a/examples/common/DeviceSession.h
+++ b/examples/common/DeviceSession.h
@@ -1,0 +1,102 @@
+#ifndef DEVOURER_EXAMPLES_DEVICE_SESSION_H
+#define DEVOURER_EXAMPLES_DEVICE_SESSION_H
+
+/* DeviceSession — the teardown-order invariant for the demos, in one place.
+ *
+ * The caller owns libusb (see the architecture note in CLAUDE.md), which means
+ * the caller also owns the order things die in. That order is not arbitrary:
+ *
+ *   1. destroy the IRtlDevice   — quiesces TX (cancels and reaps the in-flight
+ *                                 bulk-OUT URBs) and drops the transport, all
+ *                                 while the libusb context is still valid;
+ *   2. libusb_release_interface — the chip is no longer being driven;
+ *   3. libusb_close             — no transfer references the handle any more;
+ *   4. libusb_exit              — nothing references the context any more.
+ *
+ * Getting this backwards is not a leak, it is a crash: a device destroyed
+ * after libusb_exit reaps its completions against a freed context and dies
+ * inside libusb, and only under enough TX load to keep URBs outstanding at
+ * exit (which is why it hides from low-duty runs).
+ *
+ * Holding all four in one object makes the order structural instead of a
+ * sequence every demo has to re-type at every early return: adopt each piece
+ * as it is acquired, then just `return`.
+ *
+ * Header-only and demo-local by design — the library never touches libusb
+ * lifetime. */
+
+#include <memory>
+#include <utility>
+
+#include <libusb.h>
+
+#include "IRtlDevice.h"
+#include "UsbDeviceLock.h"
+#include "UsbOpen.h" /* find_wifi_interface — the interface the claim used */
+#include "logger.h"
+
+namespace devourer {
+
+class DeviceSession {
+public:
+  explicit DeviceSession(Logger_t logger) : _logger{std::move(logger)} {}
+
+  DeviceSession(const DeviceSession &) = delete;
+  DeviceSession &operator=(const DeviceSession &) = delete;
+
+  ~DeviceSession() { close(); }
+
+  /* Adopt each resource as it is acquired, so an early return from any point
+   * in the bring-up unwinds whatever exists so far, in order. */
+  void adopt_context(libusb_context *ctx) { _ctx = ctx; }
+  /* `iface` defaults to whichever interface the claim helpers pick — the
+   * vendor bulk one, which is 2 on a composite RTL8822BU, not 0. Pass it
+   * explicitly only when the demo claimed a fixed interface itself. */
+  void adopt_handle(libusb_device_handle *handle, int iface = -1) {
+    _handle = handle;
+    _iface = iface >= 0 ? iface : find_wifi_interface(handle);
+  }
+  void adopt_lock(std::shared_ptr<UsbDeviceLock> lock) {
+    _lock = std::move(lock);
+  }
+  void adopt_device(std::unique_ptr<IRtlDevice> dev) { _dev = std::move(dev); }
+
+  libusb_context *context() const { return _ctx; }
+  libusb_device_handle *handle() const { return _handle; }
+  IRtlDevice *device() const { return _dev.get(); }
+  const std::shared_ptr<UsbDeviceLock> &lock() const { return _lock; }
+
+  /* Explicit teardown for demos that have work to do after the adapter is
+   * released (final statistics, a summary event). Idempotent; the destructor
+   * calls it. */
+  void close() {
+    _dev.reset();
+    if (_handle != nullptr) {
+      /* Tolerant: an adapter that already dropped off the bus (a TX-path
+       * wedge, an unplug) fails the release — log it, never abort. */
+      const int rc = libusb_release_interface(_handle, _iface);
+      if (rc != 0 && _logger)
+        _logger->info("libusb_release_interface rc={} (device already gone?)",
+                      rc);
+      libusb_close(_handle);
+      _handle = nullptr;
+    }
+    if (_ctx != nullptr) {
+      libusb_exit(_ctx);
+      _ctx = nullptr;
+    }
+    _lock.reset();
+  }
+
+private:
+  Logger_t _logger;
+  std::unique_ptr<IRtlDevice> _dev;
+  std::shared_ptr<UsbDeviceLock> _lock;
+  libusb_device_handle *_handle = nullptr;
+  libusb_context *_ctx = nullptr;
+  int _iface = 0;
+};
+
+} /* namespace devourer */
+
+#endif /* DEVOURER_EXAMPLES_DEVICE_SESSION_H */

--- a/examples/doctor/main.cpp
+++ b/examples/doctor/main.cpp
@@ -65,6 +65,7 @@
 
 #include "AdapterHealth.h"
 #include "caps_event.h"
+#include "DeviceSession.h"
 #include "RxPacket.h"
 #include "SignalStop.h"
 #include "UsbOpen.h"
@@ -178,11 +179,18 @@ int main(int argc, char **argv) {
   auto logger = std::make_shared<Logger>();
   install_devourer_signal_handlers();
 
+  /* Owns the teardown order (device -> interface -> handle -> context; see
+   * DeviceSession.h). Declared before the RX-smoke thread below, so it is
+   * joined before the adapter is released. Each early return from here on
+   * unwinds whatever has been adopted so far. */
+  devourer::DeviceSession session{logger};
+
   libusb_context *ctx = nullptr;
   if (libusb_init(&ctx) < 0) {
     logger->error("libusb_init failed");
     return 3;
   }
+  session.adopt_context(ctx);
   libusb_device_handle *handle = nullptr;
   if (a.bus >= 0) {
     handle = open_by_topology(ctx, a, logger);
@@ -198,17 +206,19 @@ int main(int argc, char **argv) {
   }
   if (!handle) {
     logger->error("no adapter found (vid {:04x})", a.vid);
-    libusb_exit(ctx);
     return 3;
   }
 
   std::shared_ptr<devourer::UsbDeviceLock> lock;
   if (devourer::claim_interface_then_reset(handle, devourer::find_wifi_interface(handle), logger, true, lock) !=
       0) {
-    libusb_close(handle);
-    libusb_exit(ctx);
+    /* The claim failed, so nothing owns the handle yet — hand it to the
+     * session purely so the unwind closes it. */
+    session.adopt_handle(handle);
     return 3;
   }
+  session.adopt_handle(handle);
+  session.adopt_lock(lock);
 
   /* keep_corrupted so the RX smoke can report the corrupt-frame count too
    * (informational only); enable_with_tx so Jaguar3's InitWrite keeps the RX
@@ -218,16 +228,18 @@ int main(int argc, char **argv) {
   cfg.rx.enable_with_tx = true;
 
   WiFiDriver driver(logger);
-  std::unique_ptr<IRtlDevice> dev =
+  std::unique_ptr<IRtlDevice> owned_device =
       driver.CreateRtlDevice(handle, ctx, lock, cfg);
-  if (!dev) {
+  if (!owned_device) {
     logger->error("CreateRtlDevice failed (chip support not built?)");
-    libusb_close(handle);
-    libusb_exit(ctx);
     return 3;
   }
+  /* The session owns the device from here: it is what guarantees the device
+   * (and its in-flight TX) dies before libusb does. */
+  session.adopt_device(std::move(owned_device));
+  IRtlDevice *const dev = session.device();
 
-  devourer::emit_adapter_caps(logger->events(), dev.get());
+  devourer::emit_adapter_caps(logger->events(), dev);
 
   devourer::AdapterHealthInput in;
 
@@ -337,8 +349,7 @@ int main(int argc, char **argv) {
       .f("init", in.init_completed ? 1 : 0);
 
   dev->Stop();
-  libusb_close(handle);
-  libusb_exit(ctx);
+  session.close();
   switch (v) {
   case devourer::AdapterVerdict::Healthy:
     return 0;

--- a/examples/duplex/main.cpp
+++ b/examples/duplex/main.cpp
@@ -61,6 +61,7 @@
   #include <libusb-1.0/libusb.h>
 #endif
 
+#include "DeviceSession.h"
 #include "RxPacket.h"
 #include "RadiotapBuilder.h"
 #include "RtlAdapter.h"
@@ -298,10 +299,17 @@ int main(int argc, char **argv) {
   libusb_device_handle *handle = nullptr;
   int rc;
 
+  /* Owns the teardown order (device -> interface -> handle -> context; see
+   * DeviceSession.h). Declared before the TX thread below, so that thread is
+   * joined before the adapter is released. Each early return from here on
+   * unwinds whatever has been adopted so far. */
+  devourer::DeviceSession session{logger};
+
   if (termux_fd > 0) {
     libusb_set_option(NULL, LIBUSB_OPTION_NO_DEVICE_DISCOVERY);
     libusb_set_option(NULL, LIBUSB_OPTION_WEAK_AUTHORITY);
     libusb_init(&context);
+    session.adopt_context(context);
     rc = libusb_wrap_sys_device(context, (intptr_t)termux_fd, &handle);
     if (rc < 0) {
       logger->error("libusb_wrap_sys_device: {}", rc);
@@ -310,6 +318,7 @@ int main(int argc, char **argv) {
   } else {
     rc = libusb_init(&context);
     if (rc < 0) return rc;
+    session.adopt_context(context);
     /* Match rxdemo's libusb log level convention — WARNING by
      * default, DEVOURER_USB_DEBUG=1 opts into DEBUG. */
     libusb_set_option(context, LIBUSB_OPTION_LOG_LEVEL,
@@ -337,7 +346,6 @@ int main(int argc, char **argv) {
     }
     if (handle == NULL) {
       logger->error("No supported device found under VID {:04x}", target_vid);
-      libusb_exit(context);
       return 1;
     }
   }
@@ -346,17 +354,25 @@ int main(int argc, char **argv) {
    * guard — a second devourer on this adapter gets BUSY here and bails before
    * the reset, so it can't re-enumerate the adapter out from under the owner. */
   std::shared_ptr<devourer::UsbDeviceLock> usb_lock;
-  rc = devourer::claim_interface_then_reset(handle, devourer::find_wifi_interface(handle), logger,
+  const int wifi_iface = devourer::find_wifi_interface(handle);
+  rc = devourer::claim_interface_then_reset(handle, wifi_iface, logger,
       termux_fd == 0 && std::getenv("DEVOURER_SKIP_RESET") == nullptr, usb_lock);
   if (rc != 0) {
-    libusb_close(handle);
-    libusb_exit(context);
+    /* The claim failed, so nothing owns the handle yet — hand it to the
+     * session purely so the unwind closes it. */
+    session.adopt_handle(handle, wifi_iface);
     return 1;
   }
+  session.adopt_handle(handle, wifi_iface);
+  session.adopt_lock(usb_lock);
 
   WiFiDriver wifi_driver{logger};
-  auto rtlDevice = wifi_driver.CreateRtlDevice(handle, nullptr, usb_lock,
-                                               devourer_config_from_env());
+  auto owned_device = wifi_driver.CreateRtlDevice(handle, nullptr, usb_lock,
+                                                  devourer_config_from_env());
+  /* The session owns the device from here: it is what guarantees the device
+   * (and its in-flight TX) dies before libusb does. */
+  session.adopt_device(std::move(owned_device));
+  IRtlDevice *const rtlDevice = session.device();
 
   int channel = 6;
   if (const char *ch_env = std::getenv("DEVOURER_CHANNEL")) {
@@ -374,7 +390,7 @@ int main(int argc, char **argv) {
   // Spawn TX thread first; it'll block on stdin until our peer pushes a
   // length-prefixed PSDU. Then drop into Init() (the RX loop) in the main
   // thread.
-  TxArgs txa{rtlDevice.get(), interval_ms, max_psdu, &should_stop, logger};
+  TxArgs txa{rtlDevice, interval_ms, max_psdu, &should_stop, logger};
   std::thread tx{tx_thread, std::move(txa)};
 
   logger->info("duplex entering RX loop on ch {} — TX thread ready",
@@ -391,8 +407,9 @@ int main(int argc, char **argv) {
   // the TX thread).
   should_stop = true;
   if (tx.joinable()) tx.join();
-  libusb_release_interface(handle, 0);
-  libusb_close(handle);
-  libusb_exit(context);
+  /* Device, then interface, handle and context (DeviceSession.h). Explicit
+   * only because the process has nothing left to do here — the destructor
+   * does exactly the same on every other exit path. */
+  session.close();
   return 0;
 }

--- a/examples/dwelltx/main.cpp
+++ b/examples/dwelltx/main.cpp
@@ -61,6 +61,7 @@
 #endif
 
 #include "ChannelFreq.h"
+#include "DeviceSession.h"
 #include "Event.h"
 #include "HopSchedule.h"
 #include "RadiotapBuilder.h"
@@ -106,32 +107,41 @@ int main() {
   apply_logging_env(*logger);
   auto &ev = logger->events();
 
+  // Owns the teardown order (device -> interface -> handle -> context; see
+  // DeviceSession.h).
+  devourer::DeviceSession session{logger};
+
   libusb_context *ctx = nullptr;
   if (libusb_init(&ctx) < 0)
     return 1;
+  session.adopt_context(ctx);
   static const uint16_t kDefaultPids[] = {0x8812, 0xb812, 0xc811, 0xc820,
                                           0xc82c, 0x8814, 0xb82c};
   libusb_device_handle *handle = open_selected_usb(
       ctx, logger, kDefaultPids, sizeof(kDefaultPids) / sizeof(kDefaultPids[0]));
-  if (!handle) {
-    libusb_exit(ctx);
+  if (!handle)
     return 1;
-  }
   std::shared_ptr<devourer::UsbDeviceLock> usb_lock;
   if (devourer::claim_interface_reset_reopen(
           ctx, handle, logger, std::getenv("DEVOURER_SKIP_RESET") == nullptr,
           usb_lock) != 0) {
-    libusb_exit(ctx);
+    // The claim failed, so nothing owns the handle yet — hand it to the
+    // session purely so the unwind closes it.
+    session.adopt_handle(handle);
     return 1;
   }
+  session.adopt_handle(handle);
+  session.adopt_lock(usb_lock);
 
   WiFiDriver driver{logger};
   auto cfg = devourer_config_from_env(); // honors DEVOURER_FASTRETUNE_FW
-  auto dev = driver.CreateRtlDevice(handle, nullptr, usb_lock, cfg);
-  if (!dev) {
-    libusb_exit(ctx);
+  auto owned_device = driver.CreateRtlDevice(handle, nullptr, usb_lock, cfg);
+  if (!owned_device)
     return 1;
-  }
+  // The session owns the device from here: it is what guarantees the device
+  // (and its in-flight TX) dies before libusb does.
+  session.adopt_device(std::move(owned_device));
+  IRtlDevice *const dev = session.device();
 
   // --- schedule + admission parameters ---------------------------------------
   std::vector<int> chans;
@@ -150,7 +160,6 @@ int main() {
   }
   if (chans.size() < 2) {
     logger->error("DEVOURER_DWELL_CHANNELS must name at least two channels");
-    libusb_exit(ctx);
     return 2;
   }
   const long slot_ms = env_long("DEVOURER_DWELL_SLOT_MS", 20);
@@ -290,11 +299,9 @@ int main() {
       .f("admitted", admitted_ct)
       .f("dropped_late", dropped_late_ct)
       .f("empty", empty_ct);
-  /* Release the device (its handle + any worker threads — e.g. the Kestrel
-   * planes) BEFORE libusb_exit; otherwise libusb tears down under a live
-   * handle and asserts in its mutex teardown. */
-  dev.reset();
-  usb_lock.reset();
-  libusb_exit(ctx);
+  /* Device, then interface, handle and context (DeviceSession.h). Explicit
+   * only because the process has nothing left to do here — the destructor
+   * does exactly the same on every other exit path. */
+  session.close();
   return 0;
 }

--- a/examples/kestrelprobe/main.cpp
+++ b/examples/kestrelprobe/main.cpp
@@ -35,6 +35,7 @@
 #include <string>
 #include <thread>
 
+#include "DeviceSession.h"
 #include "Event.h"
 #include "RtlAdapter.h"
 #include "SignalStop.h" /* g_devourer_should_stop — SIGINT/SIGTERM flag */
@@ -96,11 +97,19 @@ int main(int argc, char **argv) {
 
   auto logger = std::make_shared<Logger>();
 
+  /* Owns the teardown order (interface -> handle -> context; see
+   * DeviceSession.h). The RtlKestrelDevice below is a stack local declared
+   * after this, so it is destroyed first — the device-before-libusb half of
+   * the invariant falls out of declaration order. Each early return from here
+   * on unwinds whatever has been adopted so far. */
+  devourer::DeviceSession session{logger};
+
   libusb_context *ctx = nullptr;
   if (libusb_init(&ctx) < 0) {
     logger->error("libusb_init failed");
     return 1;
   }
+  session.adopt_context(ctx);
 
   libusb_device_handle *handle = nullptr;
   kestrel::ChipVariant variant = kestrel::ChipVariant::C8852B;
@@ -111,7 +120,6 @@ int main(int argc, char **argv) {
       logger->error("{:04x}:{:04x} is not in the Kestrel PID table "
                     "(kestrel/KestrelUsbIds.h)",
                     want_vid, want_pid);
-      libusb_exit(ctx);
       return 2;
     }
     handle = libusb_open_device_with_vid_pid(ctx, want_vid, want_pid);
@@ -137,17 +145,21 @@ int main(int argc, char **argv) {
     devourer::Ev(logger->events(), "kestrel.id")
         .f("ok", false)
         .f("why", "open");
-    libusb_exit(ctx);
     return 1;
   }
 
   std::shared_ptr<devourer::UsbDeviceLock> lock;
   if (devourer::claim_interface_then_reset(handle, 0, logger, true, lock) !=
       0) {
-    libusb_close(handle);
-    libusb_exit(ctx);
+    /* The claim failed, so nothing owns the handle yet — hand it to the
+     * session purely so the unwind closes it. */
+    session.adopt_handle(handle, 0);
     return 1;
   }
+  /* This probe claims interface 0 explicitly (above), so the release must
+   * name it rather than re-resolving. */
+  session.adopt_handle(handle, 0);
+  session.adopt_lock(lock);
 
   /* ---- stage id: register plane only, no power, no DMA ---- */
   RtlKestrelDevice dev(RtlAdapter(handle, logger, ctx, lock, {}), logger,
@@ -167,8 +179,6 @@ int main(int argc, char **argv) {
       .hexf("die_id", info.die_id, 2)
       .f("cut", info.cut);
   if (!id_ok || want < 1) {
-    libusb_close(handle);
-    libusb_exit(ctx);
     return id_ok ? 0 : 1;
   }
 
@@ -196,8 +206,6 @@ int main(int argc, char **argv) {
       .hexf("rfe", efuse.rfe_type, 2)
       .f("autoload", efuse.autoload_ok);
   if (!power_ok || want < 2) {
-    libusb_close(handle);
-    libusb_exit(ctx);
     return power_ok ? 0 : 1;
   }
 
@@ -224,16 +232,12 @@ int main(int argc, char **argv) {
   if (want < 3) {
     logger->info("fw: fw_ok={}", fw_ok);
     devourer::Ev(logger->events(), "kestrel.fw").f("ok", fw_ok);
-    libusb_close(handle);
-    libusb_exit(ctx);
     return fw_ok ? 0 : 1;
   }
   if (want < 4) {
     /* ---- stage trx: DMAC + CMAC MAC TRX init ---- */
     logger->info("trx: trx_ok={}", fw_ok);
     devourer::Ev(logger->events(), "kestrel.trx").f("ok", fw_ok);
-    libusb_close(handle);
-    libusb_exit(ctx);
     return fw_ok ? 0 : 1;
   }
 
@@ -241,8 +245,6 @@ int main(int argc, char **argv) {
     /* ---- stage phy: BB + RF table apply ---- */
     logger->info("phy: phy_ok={}", fw_ok);
     devourer::Ev(logger->events(), "kestrel.phy").f("ok", fw_ok);
-    libusb_close(handle);
-    libusb_exit(ctx);
     return fw_ok ? 0 : 1;
   }
 
@@ -321,8 +323,6 @@ int main(int argc, char **argv) {
           .f("mode", "ul_fixinfo")
           .f("chan", chan);
       dev.Stop();
-      libusb_close(handle);
-      libusb_exit(ctx);
       return ulok ? 0 : 1;
     }
 
@@ -340,11 +340,10 @@ int main(int argc, char **argv) {
         .f("count", count)
         .f("mode", cfg.mode)
         .f("chan", chan);
-    /* InitWrite started the WP-drain thread — join it before libusb_exit or a
-     * thread still inside libusb trips usbi_mutex_destroy (SIGABRT). */
+    /* InitWrite started the WP-drain thread — join it before the session
+     * unwinds libusb, or a thread still inside libusb trips
+     * usbi_mutex_destroy (SIGABRT). */
     dev.Stop();
-    libusb_close(handle);
-    libusb_exit(ctx);
     return ok ? 0 : 1;
   }
 
@@ -376,7 +375,5 @@ int main(int argc, char **argv) {
       .f("ofdma_cmd", ofdma_ok)
       .f("chan", chan);
   dev.Stop(); /* join the WP-drain thread before libusb teardown (see trig) */
-  libusb_close(handle);
-  libusb_exit(ctx);
   return twt_ok ? 0 : 1;
 }

--- a/examples/precoder/main.cpp
+++ b/examples/precoder/main.cpp
@@ -56,6 +56,7 @@
   #include <libusb-1.0/libusb.h>
 #endif
 
+#include "DeviceSession.h"
 #include "RtlAdapter.h"
 #include "UsbOpen.h"
 #include "WiFiDriver.h"
@@ -153,11 +154,17 @@ int main(int argc, char **argv) {
   libusb_device_handle *handle = nullptr;
   int rc;
 
+  /* Owns the teardown order (device -> interface -> handle -> context; see
+   * DeviceSession.h). Each early return from here on unwinds whatever has
+   * been adopted so far. */
+  devourer::DeviceSession session{logger};
+
   if (termux_fd > 0) {
     logger->info("Termux mode: wrapping fd {}", termux_fd);
     libusb_set_option(NULL, LIBUSB_OPTION_NO_DEVICE_DISCOVERY);
     libusb_set_option(NULL, LIBUSB_OPTION_WEAK_AUTHORITY);
     libusb_init(&context);
+    session.adopt_context(context);
     rc = libusb_wrap_sys_device(context, (intptr_t)termux_fd, &handle);
     if (rc < 0) {
       logger->error("libusb_wrap_sys_device: {}", rc);
@@ -166,6 +173,7 @@ int main(int argc, char **argv) {
   } else {
     rc = libusb_init(&context);
     if (rc < 0) return rc;
+    session.adopt_context(context);
 
     uint16_t target_pid = 0;
     if (const char *pid_env = std::getenv("DEVOURER_PID")) {
@@ -190,7 +198,6 @@ int main(int argc, char **argv) {
     }
     if (handle == NULL) {
       logger->error("No supported device found under VID {:04x}", target_vid);
-      libusb_exit(context);
       return 1;
     }
   }
@@ -199,17 +206,25 @@ int main(int argc, char **argv) {
    * guard — a second devourer on this adapter gets BUSY here and bails before
    * the reset, so it can't re-enumerate the adapter out from under the owner. */
   std::shared_ptr<devourer::UsbDeviceLock> usb_lock;
-  rc = devourer::claim_interface_then_reset(handle, devourer::find_wifi_interface(handle), logger,
+  const int wifi_iface = devourer::find_wifi_interface(handle);
+  rc = devourer::claim_interface_then_reset(handle, wifi_iface, logger,
       termux_fd == 0 && std::getenv("DEVOURER_SKIP_RESET") == nullptr, usb_lock);
   if (rc != 0) {
-    libusb_close(handle);
-    libusb_exit(context);
+    /* The claim failed, so nothing owns the handle yet — hand it to the
+     * session purely so the unwind closes it. */
+    session.adopt_handle(handle, wifi_iface);
     return 1;
   }
+  session.adopt_handle(handle, wifi_iface);
+  session.adopt_lock(usb_lock);
 
   WiFiDriver wifi_driver{logger};
-  auto rtlDevice = wifi_driver.CreateRtlDevice(handle, nullptr, usb_lock,
-                                               devourer_config_from_env());
+  auto owned_device = wifi_driver.CreateRtlDevice(handle, nullptr, usb_lock,
+                                                  devourer_config_from_env());
+  /* The session owns the device from here: it is what guarantees the device
+   * (and its in-flight TX) dies before libusb does. */
+  session.adopt_device(std::move(owned_device));
+  IRtlDevice *const rtlDevice = session.device();
 
   // 2.4 GHz channel 6 is the plan's matrix-validated cell for these chips.
   int channel = 6;
@@ -259,8 +274,9 @@ int main(int argc, char **argv) {
     std::this_thread::sleep_for(std::chrono::milliseconds(interval_ms));
   }
 
-  libusb_release_interface(handle, 0);
-  libusb_close(handle);
-  libusb_exit(context);
+  /* Device, then interface, handle and context (DeviceSession.h). Explicit
+   * only because the process has nothing left to do here — the destructor
+   * does exactly the same on every other exit path. */
+  session.close();
   return 0;
 }

--- a/examples/rx/main.cpp
+++ b/examples/rx/main.cpp
@@ -15,6 +15,7 @@
 #include <libusb.h>
 
 #include "BfReportDetect.h"
+#include "DeviceSession.h"
 #include "HopSchedule.h"
 #include "hopset/HopsetEvents.h"
 #include "hopset/HopsetFollower.h"
@@ -1159,6 +1160,12 @@ int main(int argc, char **argv) {
    * `timeout` SIGTERM killed us mid-RX, leaving the chip's USB core hung. */
   install_devourer_signal_handlers();
 
+  /* Owns the teardown order (device -> interface -> handle -> context; see
+   * DeviceSession.h). Declared before every thread below, so the threads are
+   * joined before the adapter is released. Each early return from here on
+   * unwinds whatever has been adopted so far. */
+  devourer::DeviceSession session{logger};
+
 #if defined(DEVOURER_HAVE_PCIE)
   /* DEVOURER_PCIE_BDF=0000:01:00.0 — drive a PCIe adapter (RTL8821CE) through
    * the vfio transport instead of libusb. The device must be bound to vfio-pci
@@ -1179,16 +1186,20 @@ int main(int argc, char **argv) {
         .f("stage", "demo.open_device")
         .f("ms", ms_since_start());
     WiFiDriver wifi_driver(logger);
-    auto dev = wifi_driver.CreateRtlDevicePcie(std::move(transport),
-                                               devourer_config_from_env());
-    if (!dev) {
+    auto owned_device = wifi_driver.CreateRtlDevicePcie(
+        std::move(transport), devourer_config_from_env());
+    if (!owned_device) {
       logger->error("No driver for this PCIe chip in this build — exiting");
       return 1;
     }
+    /* The session owns the device from here: it is what guarantees the device
+     * (and its in-flight TX) dies before the transport behind it. */
+    session.adopt_device(std::move(owned_device));
+    IRtlDevice *const dev = session.device();
     devourer::Ev(*g_ev, "init.timing")
         .f("stage", "demo.create_device")
         .f("ms", ms_since_start());
-    devourer::emit_adapter_caps(*g_ev, dev.get());
+    devourer::emit_adapter_caps(*g_ev, dev);
     int pch = 36;
     if (const char *ch_env = std::getenv("DEVOURER_CHANNEL"))
       pch = std::atoi(ch_env);
@@ -1214,7 +1225,7 @@ int main(int argc, char **argv) {
         logger->error("DEVOURER_LA_CAPTURE: bad spec '{}'", g_la_spec);
         return 1;
       }
-      auto runner = la_runner_for(dev.get());
+      auto runner = la_runner_for(dev);
       if (!runner) {
         logger->error("DEVOURER_LA_CAPTURE: no LA support wired for this "
                       "generation yet");
@@ -1266,6 +1277,7 @@ int main(int argc, char **argv) {
   if (rc < 0) {
     return rc;
   }
+  session.adopt_context(ctx);
 
   /* libusb log level: WARNING by default. DEBUG is opt-in via
    * DEVOURER_USB_DEBUG=1 — it emits ~7 MB per 15s run (has filled /tmp and
@@ -1284,7 +1296,6 @@ int main(int argc, char **argv) {
     if (rc != 0 || dev_handle == nullptr) {
       logger->error("libusb_wrap_sys_device(fd={}) failed: {} ({})", termux_fd,
                     libusb_error_name(rc), rc);
-      libusb_exit(ctx);
       return 1;
     }
   } else {
@@ -1295,7 +1306,6 @@ int main(int argc, char **argv) {
         sizeof(kRealtekProductIds) / sizeof(kRealtekProductIds[0]));
   }
   if (dev_handle == NULL) {
-    libusb_exit(ctx);
     return 1;
   }
 
@@ -1321,32 +1331,38 @@ int main(int argc, char **argv) {
       .f("ms", ms_since_start());
   if (rc != 0) {
     /* BUSY => another process owns the adapter; any other error => open failed.
-     * Either way, exit cleanly rather than asserting. */
-    if (dev_handle != nullptr)
-      libusb_close(dev_handle);
-    libusb_exit(ctx);
+     * Either way, exit cleanly rather than asserting. The claim failed, so
+     * nothing owns the handle yet — hand it to the session purely so the
+     * unwind closes it. */
+    session.adopt_handle(dev_handle);
     return 1;
   }
+  session.adopt_handle(dev_handle);
+  session.adopt_lock(usb_lock);
 
   WiFiDriver wifi_driver(logger);
-  auto rtlDevice = wifi_driver.CreateRtlDevice(dev_handle, ctx, usb_lock,
-                                               devourer_config_from_env());
-  if (!rtlDevice) {
+  auto owned_device = wifi_driver.CreateRtlDevice(dev_handle, ctx, usb_lock,
+                                                  devourer_config_from_env());
+  if (!owned_device) {
     /* The factory returns null when the plugged chip's generation wasn't
      * compiled in (per-chip CMake options); it already logged which. */
     logger->error("No driver for this chip in this build — exiting");
     return 1;
   }
+  /* The session owns the device from here: it is what guarantees the device
+   * (and its in-flight TX) dies before libusb does. */
+  session.adopt_device(std::move(owned_device));
+  IRtlDevice *const rtlDevice = session.device();
   devourer::Ev(*g_ev, "init.timing")
       .f("stage", "demo.create_device")
       .f("ms", ms_since_start());
-  devourer::emit_adapter_caps(*g_ev, rtlDevice.get());
+  devourer::emit_adapter_caps(*g_ev, rtlDevice);
   /* The BB-debug-port / queue-depth / thermal research helpers are Jaguar1-only,
    * so they live on RtlJaguarDevice rather than the IRtlDevice interface. The
    * whole block compiles out when Jaguar1 support isn't built; when it is, the
    * dynamic_cast yields nullptr for a Jaguar3 device, disabling them cleanly. */
 #if defined(DEVOURER_HAVE_JAGUAR1)
-  g_rtl_device = dynamic_cast<RtlJaguarDevice *>(rtlDevice.get());
+  g_rtl_device = dynamic_cast<RtlJaguarDevice *>(rtlDevice);
   std::atomic<bool> qd_emitter_stop{false};
   std::thread qd_emitter;
   if (g_qd_poll_ms > 0 && g_rtl_device != nullptr) {
@@ -1418,7 +1434,7 @@ int main(int argc, char **argv) {
   if (g_rx_energy_ms > 0) {
     logger->info("DEVOURER_RX_ENERGY_MS={} — starting RX energy telemetry",
                  g_rx_energy_ms);
-    IRtlDevice *dev = rtlDevice.get();
+    IRtlDevice *dev = rtlDevice;
     energy_emitter = std::thread([&energy_emitter_stop, dev]() {
       auto nap = [&](uint32_t ms) {
         for (uint32_t s = 0; s < ms && !energy_emitter_stop.load(); s += 50)
@@ -1691,7 +1707,7 @@ int main(int argc, char **argv) {
           *g_hop_schedule, *g_hopset_keys, hop_rx_channels.size());
       g_hopset_view->set_state(g_hopset_fol->state());
       g_hopset_view->set_probe_period(probe_rounds);
-      g_hopset_dev = rtlDevice.get();
+      g_hopset_dev = rtlDevice;
       if (std::getenv("DEVOURER_HOP_MUTE")) {
         g_hopset_mute = true;
         logger->warn("DEVOURER_HOP_MUTE — uplink muted: this side follows but "
@@ -1705,7 +1721,7 @@ int main(int argc, char **argv) {
       if (acquire_ms < 1)
         acquire_ms = 1;
     }
-    IRtlDevice *dev = rtlDevice.get();
+    IRtlDevice *dev = rtlDevice;
     SelectedChannel first{static_cast<uint8_t>(hop_rx_channels[0]), ch_offset,
                           width};
     std::thread rx([dev, first, &logger]() {
@@ -1863,9 +1879,7 @@ int main(int argc, char **argv) {
     if (rx.joinable())
       rx.join();
     dev->Stop();
-    libusb_release_interface(dev_handle, 0);
-    libusb_close(dev_handle);
-    libusb_exit(ctx);
+    session.close();
     return 0;
   }
 
@@ -1875,7 +1889,7 @@ int main(int argc, char **argv) {
   if (!g_rx_sweep.empty()) {
     logger->info("DEVOURER_RX_SWEEP: {} bins, dwell {} ms — live spectrum map",
                  g_rx_sweep.size(), g_rx_sweep_dwell_ms);
-    IRtlDevice *dev = rtlDevice.get();
+    IRtlDevice *dev = rtlDevice;
     SelectedChannel first{static_cast<uint8_t>(g_rx_sweep[0]), ch_offset, width};
     std::thread rx([dev, first, &logger]() {
       try {
@@ -1964,11 +1978,7 @@ int main(int argc, char **argv) {
     if (rx.joinable())
       rx.join();
     dev->Stop();
-    rc = libusb_release_interface(dev_handle, 0);
-    if (rc != 0)
-      logger->info("libusb_release_interface rc={}", rc);
-    libusb_close(dev_handle);
-    libusb_exit(ctx);
+    session.close();
     return 0;
   }
 
@@ -1985,7 +1995,7 @@ int main(int argc, char **argv) {
       logger->error("DEVOURER_LA_CAPTURE: bad spec '{}'", g_la_spec);
       return 1;
     }
-    auto runner = la_runner_for(rtlDevice.get());
+    auto runner = la_runner_for(rtlDevice);
     if (!runner) {
       logger->error("DEVOURER_LA_CAPTURE: no LA support wired for this "
                     "generation yet");
@@ -2030,12 +2040,10 @@ int main(int argc, char **argv) {
    * the adapter re-enumerates instead of hanging its USB core. */
   rtlDevice->Stop();
 
-  rc = libusb_release_interface(dev_handle, 0);
-  assert(rc == 0);
-
-  libusb_close(dev_handle);
-
-  libusb_exit(ctx);
+  /* Device, then interface, handle and context (DeviceSession.h). Explicit
+   * only because the process has nothing left to do here — the destructor
+   * does exactly the same on every other exit path. */
+  session.close();
 
   return 0;
 }

--- a/examples/sense/main.cpp
+++ b/examples/sense/main.cpp
@@ -34,6 +34,7 @@
 #include <vector>
 
 #include "BfReportDecode.h"
+#include "DeviceSession.h"
 #include "RadiotapBuilder.h"
 #include "RxPacket.h"
 #include "SignalStop.h"
@@ -328,34 +329,50 @@ static void run_display(Sensor &sensor) {
 }
 
 /* ------------------------------------------------------------ USB helpers --- */
+/* Each adapter owns its whole stack — device, interface, handle and its own
+ * libusb context — through one DeviceSession, so the two of them unwind
+ * independently and each in the required order (see DeviceSession.h). */
 struct Adapter {
-  libusb_context *ctx = nullptr;
-  libusb_device_handle *handle = nullptr;
-  std::shared_ptr<devourer::UsbDeviceLock> lock;
-  std::unique_ptr<IRtlDevice> dev;
+  explicit Adapter(const Logger_t &logger) : session(logger) {}
+  devourer::DeviceSession session;
+
+  libusb_device_handle *handle() const { return session.handle(); }
+  IRtlDevice *dev() const { return session.device(); }
 };
 
 /* Open one adapter by VID:PID on its own libusb context, claim + reset, and build
  * the device (not yet brought up). Returns false (logged) on failure. */
 static bool open_adapter(Adapter &a, uint16_t vid, uint16_t pid,
                          const Logger_t &logger) {
-  if (libusb_init(&a.ctx) < 0)
+  libusb_context *ctx = nullptr;
+  if (libusb_init(&ctx) < 0)
     return false;
-  a.handle = libusb_open_device_with_vid_pid(a.ctx, vid, pid);
-  if (!a.handle) {
+  a.session.adopt_context(ctx);
+  libusb_device_handle *handle = libusb_open_device_with_vid_pid(ctx, vid, pid);
+  if (!handle) {
     logger->error("could not open {:04x}:{:04x} — is it plugged in? (a prior "
                   "hang can drop an adapter off the bus; unplug/replug it)",
                   vid, pid);
     return false;
   }
+  std::shared_ptr<devourer::UsbDeviceLock> lock;
   int rc = devourer::claim_interface_then_reset(
-      a.handle, devourer::find_wifi_interface(a.handle), logger, true, a.lock);
-  if (rc != 0)
+      handle, devourer::find_wifi_interface(handle), logger, true, lock);
+  if (rc != 0) {
+    /* The claim failed, so nothing owns the handle yet — hand it to the
+     * session purely so the unwind closes it. */
+    a.session.adopt_handle(handle);
     return false;
+  }
+  a.session.adopt_handle(handle);
+  a.session.adopt_lock(lock);
   WiFiDriver driver(logger);
-  a.dev = driver.CreateRtlDevice(a.handle, a.ctx, a.lock,
-                                 devourer_config_from_env());
-  return a.dev != nullptr;
+  auto owned_device =
+      driver.CreateRtlDevice(handle, ctx, lock, devourer_config_from_env());
+  if (!owned_device)
+    return false;
+  a.session.adopt_device(std::move(owned_device));
+  return true;
 }
 
 static bool read_mac(libusb_device_handle *h, uint8_t mac[6]) {
@@ -371,22 +388,26 @@ static bool read_mac(libusb_device_handle *h, uint8_t mac[6]) {
 static int run_active(uint16_t snd_vid, uint16_t snd_pid, uint16_t bfe_vid,
                       uint16_t bfe_pid, int channel, const Logger_t &logger,
                       Sensor &sensor) {
+  /* Both adapters are declared before any thread below, so every thread is
+   * joined before the session that owns the handle it touches is unwound. */
+  Adapter bfe{logger}, snd{logger};
+
   /* Beamformee first: arm it (env, read at Init), bring it up on a thread. */
   set_env("DEVOURER_BF_ARM_BFEE", "57:42:75:05:d6:00");
   set_env("DEVOURER_BF_ARM_BFEE_MU", "1");
-  Adapter bfe;
   if (!open_adapter(bfe, bfe_vid, bfe_pid, logger)) {
     logger->error("active: failed to open beamformee {:04x}", bfe_pid);
     return 1;
   }
   std::thread bfe_thread([&bfe, channel]() {
-    bfe.dev->Init([](const Packet &) {}, /* responds in hardware; RX ignored */
-                  SelectedChannel{.Channel = (uint8_t)channel, .ChannelOffset = 0,
-                                  .ChannelWidth = CHANNEL_WIDTH_20});
+    bfe.dev()->Init([](const Packet &) {}, /* responds in hardware; RX ignored */
+                    SelectedChannel{.Channel = (uint8_t)channel,
+                                    .ChannelOffset = 0,
+                                    .ChannelWidth = CHANNEL_WIDTH_20});
   });
   std::this_thread::sleep_for(std::chrono::milliseconds(1500)); /* bring-up + MAC */
   uint8_t bfe_mac[6];
-  if (!read_mac(bfe.handle, bfe_mac)) {
+  if (!read_mac(bfe.handle(), bfe_mac)) {
     logger->error("active: could not read beamformee MAC (REG_MACID)");
     g_devourer_should_stop = true;
     bfe_thread.join();
@@ -401,22 +422,21 @@ static int run_active(uint16_t snd_vid, uint16_t snd_pid, uint16_t bfe_vid,
    * keeps its RX filters open for the self-capture (no-op on Jaguar1/2). */
   set_env("DEVOURER_BF_ARM_SOUNDER", "1");
   set_env("DEVOURER_TX_WITH_RX", "thread");
-  Adapter snd;
   if (!open_adapter(snd, snd_vid, snd_pid, logger)) {
     logger->error("active: failed to open sounder {:04x}", snd_pid);
     g_devourer_should_stop = true;
     bfe_thread.join();
     return 1;
   }
-  snd.dev->InitWrite(SelectedChannel{.Channel = (uint8_t)channel,
+  snd.dev()->InitWrite(SelectedChannel{.Channel = (uint8_t)channel,
                                      .ChannelOffset = 0,
                                      .ChannelWidth = CHANNEL_WIDTH_20});
-  snd.dev->SetTxMode(devourer::parse_tx_mode_str("VHT2SS_MCS0"));
+  snd.dev()->SetTxMode(devourer::parse_tx_mode_str("VHT2SS_MCS0"));
   set_env("DEVOURER_TX_NDPA", "1"); /* send_packet marks the NDPA descriptor */
 
   /* Self-capture the returned reports on the sounder's RX loop. */
   std::thread snd_rx([&snd, &sensor]() {
-    snd.dev->StartRxLoop(
+    snd.dev()->StartRxLoop(
         [&sensor](const Packet &p) { sensor.feed(p.Data.data(), p.Data.size()); });
   });
   std::thread disp(run_display, std::ref(sensor));
@@ -441,7 +461,7 @@ static int run_active(uint16_t snd_vid, uint16_t snd_pid, uint16_t bfe_vid,
   auto last_adv = clk::now();
   bool stalled = false;
   while (!g_devourer_should_stop) {
-    if (!snd.dev->send_packet(ndpa.data(), ndpa.size()))
+    if (!snd.dev()->send_packet(ndpa.data(), ndpa.size()))
       std::this_thread::sleep_for(std::chrono::milliseconds(2));
     std::this_thread::sleep_for(std::chrono::milliseconds(3));
     long t = sensor.snapshot().total;
@@ -466,13 +486,13 @@ static int run_active(uint16_t snd_vid, uint16_t snd_pid, uint16_t bfe_vid,
     std::this_thread::sleep_for(std::chrono::seconds(4));
     std::_Exit(0);
   }).detach();
-  snd.dev->StopRxLoop();
-  bfe.dev->StopRxLoop();
+  snd.dev()->StopRxLoop();
+  bfe.dev()->StopRxLoop();
   disp.join();
   snd_rx.join();
   bfe_thread.join();
-  snd.dev->Stop();
-  bfe.dev->Stop();
+  snd.dev()->Stop();
+  bfe.dev()->Stop();
   return stalled ? 2 : 0;
 }
 

--- a/examples/streamtx/main.cpp
+++ b/examples/streamtx/main.cpp
@@ -67,6 +67,7 @@
   #include <libusb-1.0/libusb.h>
 #endif
 
+#include "DeviceSession.h"
 #include "HopSchedule.h"
 #include "hopset/HopsetWire.h"
 #include "RadiotapBuilder.h"
@@ -151,11 +152,18 @@ int main(int argc, char **argv) {
   libusb_device_handle *handle = nullptr;
   int rc;
 
+  /* Owns the teardown order (device -> interface -> handle -> context; see
+   * DeviceSession.h). Declared before every thread below, so the threads are
+   * joined before the adapter is released. Each early return from here on
+   * unwinds whatever has been adopted so far. */
+  devourer::DeviceSession session{logger};
+
   if (termux_fd > 0) {
     logger->info("Termux mode: wrapping fd {}", termux_fd);
     libusb_set_option(NULL, LIBUSB_OPTION_NO_DEVICE_DISCOVERY);
     libusb_set_option(NULL, LIBUSB_OPTION_WEAK_AUTHORITY);
     libusb_init(&context);
+    session.adopt_context(context);
     rc = libusb_wrap_sys_device(context, (intptr_t)termux_fd, &handle);
     if (rc < 0) {
       logger->error("libusb_wrap_sys_device: {}", rc);
@@ -164,6 +172,7 @@ int main(int argc, char **argv) {
   } else {
     rc = libusb_init(&context);
     if (rc < 0) return rc;
+    session.adopt_context(context);
 
     uint16_t target_pid = 0;
     if (const char *pid_env = std::getenv("DEVOURER_PID")) {
@@ -187,7 +196,6 @@ int main(int argc, char **argv) {
     }
     if (handle == NULL) {
       logger->error("No supported device found under VID {:04x}", target_vid);
-      libusb_exit(context);
       return 1;
     }
   }
@@ -201,11 +209,13 @@ int main(int argc, char **argv) {
   rc = devourer::claim_interface_reset_reopen(context, handle, logger,
       termux_fd == 0 && std::getenv("DEVOURER_SKIP_RESET") == nullptr, usb_lock);
   if (rc != 0) {
-    if (handle != nullptr)
-      libusb_close(handle);
-    libusb_exit(context);
+    /* The claim failed, so nothing owns the handle yet — hand it to the
+     * session purely so the unwind closes it. */
+    session.adopt_handle(handle);
     return 1;
   }
+  session.adopt_handle(handle);
+  session.adopt_lock(usb_lock);
 
   WiFiDriver wifi_driver{logger};
   auto stream_cfg = devourer_config_from_env();
@@ -216,13 +226,17 @@ int main(int argc, char **argv) {
    * it. Explicit DEVOURER_DIS_CCA=0 still forces standard carrier-sense back on. */
   if (std::getenv("DEVOURER_DIS_CCA") == nullptr)
     stream_cfg.tuning.disable_cca = true;
-  auto rtlDevice = wifi_driver.CreateRtlDevice(handle, nullptr, usb_lock,
-                                               stream_cfg);
+  auto owned_device = wifi_driver.CreateRtlDevice(handle, nullptr, usb_lock,
+                                                  stream_cfg);
+  /* The session owns the device from here: it is what guarantees the device
+   * (and its in-flight TX) dies before libusb does. */
+  session.adopt_device(std::move(owned_device));
+  IRtlDevice *const rtlDevice = session.device();
   /* Jaguar1-only research features (TXAGC override, fast-retune hopping) aren't
    * on the IRtlDevice contract — downcast for them; jag is null on Jaguar3, and
    * the downcast plus its call sites compile out when Jaguar1 isn't built. */
 #if defined(DEVOURER_HAVE_JAGUAR1)
-  RtlJaguarDevice *jag = dynamic_cast<RtlJaguarDevice *>(rtlDevice.get());
+  RtlJaguarDevice *jag = dynamic_cast<RtlJaguarDevice *>(rtlDevice);
 #endif
 
   int channel = 6;
@@ -474,14 +488,9 @@ int main(int argc, char **argv) {
   }
 
   devourer::Ev(logger->events(), "stream.done").f("sent", tx_count);
-  // Destruct the device before tearing down libusb: on Jaguar1 the TX path is
-  // asynchronous, and closing the handle with transfers still in flight reaps
-  // completions against a freed handle (segfault, and the crash leaks the USB
-  // claim so the next run hits "adapter in use"). reset() runs the dtor, which
-  // drains outstanding transfers while the handle is still valid.
-  rtlDevice.reset();
-  libusb_release_interface(handle, 0);
-  libusb_close(handle);
-  libusb_exit(context);
+  /* Device, then interface, handle and context (DeviceSession.h). Explicit
+   * only because the process has nothing left to do here — the destructor
+   * does exactly the same on every other exit path. */
+  session.close();
   return 0;
 }

--- a/examples/svctx/main.cpp
+++ b/examples/svctx/main.cpp
@@ -59,6 +59,7 @@
   #include <libusb-1.0/libusb.h>
 #endif
 
+#include "DeviceSession.h"
 #include "RadiotapBuilder.h"
 #include "RtlAdapter.h"
 #include "UsbOpen.h"
@@ -123,15 +124,21 @@ int main(int argc, char** argv) {
   libusb_context* context = nullptr;
   libusb_device_handle* handle = nullptr;
   int rc;
+  /* Owns the teardown order (device -> interface -> handle -> context; see
+   * DeviceSession.h). Each early return from here on unwinds whatever has
+   * been adopted so far. */
+  devourer::DeviceSession session{logger};
   if (termux_fd > 0) {
     libusb_set_option(NULL, LIBUSB_OPTION_NO_DEVICE_DISCOVERY);
     libusb_set_option(NULL, LIBUSB_OPTION_WEAK_AUTHORITY);
     libusb_init(&context);
+    session.adopt_context(context);
     rc = libusb_wrap_sys_device(context, (intptr_t)termux_fd, &handle);
     if (rc < 0) { logger->error("wrap_sys_device: {}", rc); return 1; }
   } else {
     rc = libusb_init(&context);
     if (rc < 0) return rc;
+    session.adopt_context(context);
     uint16_t target_pid = 0;
     if (const char* p = std::getenv("DEVOURER_PID"))
       target_pid = static_cast<uint16_t>(std::strtoul(p, nullptr, 0));
@@ -145,24 +152,32 @@ int main(int argc, char** argv) {
     }
     if (handle == NULL && target_pid != 0)
       handle = libusb_open_device_with_vid_pid(context, target_vid, target_pid);
-    if (handle == NULL) { logger->error("No supported device"); libusb_exit(context); return 1; }
+    if (handle == NULL) { logger->error("No supported device"); return 1; }
   }
 
   /* Claim-before-reset (see src/UsbOpen.h): the exclusive claim is the primary
    * guard — a second devourer on this adapter gets BUSY here and bails before
    * the reset, so it can't re-enumerate the adapter out from under the owner. */
   std::shared_ptr<devourer::UsbDeviceLock> usb_lock;
-  rc = devourer::claim_interface_then_reset(handle, devourer::find_wifi_interface(handle), logger,
+  const int wifi_iface = devourer::find_wifi_interface(handle);
+  rc = devourer::claim_interface_then_reset(handle, wifi_iface, logger,
       termux_fd == 0 && std::getenv("DEVOURER_SKIP_RESET") == nullptr, usb_lock);
   if (rc != 0) {
-    libusb_close(handle);
-    libusb_exit(context);
+    /* The claim failed, so nothing owns the handle yet — hand it to the
+     * session purely so the unwind closes it. */
+    session.adopt_handle(handle, wifi_iface);
     return 1;
   }
+  session.adopt_handle(handle, wifi_iface);
+  session.adopt_lock(usb_lock);
 
   WiFiDriver wifi_driver{logger};
-  auto rtlDevice = wifi_driver.CreateRtlDevice(handle, nullptr, usb_lock,
-                                               devourer_config_from_env());
+  auto owned_device = wifi_driver.CreateRtlDevice(handle, nullptr, usb_lock,
+                                                  devourer_config_from_env());
+  /* The session owns the device from here: it is what guarantees the device
+   * (and its in-flight TX) dies before libusb does. */
+  session.adopt_device(std::move(owned_device));
+  IRtlDevice *const rtlDevice = session.device();
 
   int channel = 6;
   if (const char* ch = std::getenv("DEVOURER_CHANNEL")) channel = std::atoi(ch);
@@ -241,5 +256,9 @@ int main(int argc, char** argv) {
       }
     }
   }
+  /* Device, then interface, handle and context (DeviceSession.h). Explicit
+   * only because the process has nothing left to do here — the destructor
+   * does exactly the same on every other exit path. */
+  session.close();
   return 0;
 }

--- a/examples/tdma/main.cpp
+++ b/examples/tdma/main.cpp
@@ -40,6 +40,7 @@ static inline void sleep_us(long us) {
   std::this_thread::sleep_for(std::chrono::microseconds(us));
 }
 
+#include "DeviceSession.h"
 #include "RadiotapBuilder.h"
 #include "RxPacket.h"
 #include "SignalStop.h"
@@ -301,19 +302,33 @@ int main() {
   apply_logging_env(*logger);
   install_devourer_signal_handlers();
 
+  // Owns the teardown order (device -> interface -> handle -> context; see
+  // DeviceSession.h): the role loops below only return once their RX thread is
+  // joined, so the adapter is released with nothing in flight.
+  devourer::DeviceSession session{logger};
+
   tdma::Config c = tdma::config_from_env();
   g_tsf_mode = (c.role == tdma::Role::RxSync && c.sync == tdma::Sync::Tsf);
 
   libusb_context* ctx = nullptr;
   std::shared_ptr<devourer::UsbDeviceLock> lock;
   auto* handle = open_device(logger, &ctx, lock);
-  if (!handle) { if (ctx) libusb_exit(ctx); return 1; }
+  session.adopt_context(ctx);
+  if (!handle) return 1;
+  session.adopt_handle(handle, devourer::find_wifi_interface(handle));
+  session.adopt_lock(lock);
 
   WiFiDriver wifi(logger);
-  auto dev = wifi.CreateRtlDevice(handle, ctx, lock, devourer_config_from_env());
-  if (!dev) { logger->error("no driver for this chip"); return 1; }
+  auto owned_device =
+      wifi.CreateRtlDevice(handle, ctx, lock, devourer_config_from_env());
+  if (!owned_device) { logger->error("no driver for this chip"); return 1; }
+  // The session owns the device from here: it is what guarantees the device
+  // (and its in-flight TX) dies before libusb does.
+  session.adopt_device(std::move(owned_device));
+  IRtlDevice* const dev = session.device();
 
-  if (c.role == tdma::Role::Tx) run_tx(dev.get(), c);
-  else run_rx(dev.get(), c);
+  if (c.role == tdma::Role::Tx) run_tx(dev, c);
+  else run_rx(dev, c);
+  session.close();
   return 0;
 }

--- a/examples/timesync/main.cpp
+++ b/examples/timesync/main.cpp
@@ -53,6 +53,7 @@
   #include <libusb-1.0/libusb.h>
 #endif
 
+#include "DeviceSession.h"
 #include "RadiotapBuilder.h"
 #include "RxPacket.h"
 #include "SignalStop.h"
@@ -476,11 +477,17 @@ int main() {
   apply_logging_env(*logger);
   install_devourer_signal_handlers();
 
+  // Owns the teardown order (device -> interface -> handle -> context; see
+  // DeviceSession.h): the role loops below only return once their RX thread is
+  // joined, so the adapter is released with nothing in flight. On the PCIe
+  // path there is no handle to adopt — the transport dies with the device.
+  devourer::DeviceSession session{logger};
+
   timesync::Config c = timesync::config_from_env();
   g_hwbeacon = c.hwbeacon;   // slave reads the standard 802.11 beacon timestamp
 
   WiFiDriver wifi(logger);
-  std::unique_ptr<IRtlDevice> dev;
+  std::unique_ptr<IRtlDevice> owned_device;
   libusb_context* ctx = nullptr;
   /* DEVOURER_PCIE_BDF=0000:01:00.0 — drive a PCIe adapter (RTL8821CE) through
    * the vfio transport instead of libusb (DEVOURER_PCIE builds; mirrors the
@@ -491,7 +498,8 @@ int main() {
   if (pcie_bdf) {
     auto transport = devourer::PcieTransport::Open(pcie_bdf, logger);
     if (!transport) return 1;
-    dev = wifi.CreateRtlDevicePcie(std::move(transport), devourer_config_from_env());
+    owned_device =
+        wifi.CreateRtlDevicePcie(std::move(transport), devourer_config_from_env());
   } else
 #endif
   {
@@ -501,14 +509,23 @@ int main() {
     }
     std::shared_ptr<devourer::UsbDeviceLock> lock;
     auto* handle = open_device(logger, &ctx, lock);
-    if (!handle) { if (ctx) libusb_exit(ctx); return 1; }
-    dev = wifi.CreateRtlDevice(handle, ctx, lock, devourer_config_from_env());
+    session.adopt_context(ctx);
+    if (!handle) return 1;
+    session.adopt_handle(handle, devourer::find_wifi_interface(handle));
+    session.adopt_lock(lock);
+    owned_device =
+        wifi.CreateRtlDevice(handle, ctx, lock, devourer_config_from_env());
   }
-  if (!dev) { logger->error("no driver for this chip"); return 1; }
+  if (!owned_device) { logger->error("no driver for this chip"); return 1; }
+  // The session owns the device from here: it is what guarantees the device
+  // (and its in-flight TX) dies before libusb does.
+  session.adopt_device(std::move(owned_device));
+  IRtlDevice* const dev = session.device();
 
-  if (c.role == timesync::Role::Ue) run_ue(dev.get(), c);
-  else if (c.role == timesync::Role::Master && c.uplink) run_master_ta(dev.get(), c);
-  else if (c.role == timesync::Role::Master) run_master(dev.get(), c);
-  else run_slave(dev.get(), c);
+  if (c.role == timesync::Role::Ue) run_ue(dev, c);
+  else if (c.role == timesync::Role::Master && c.uplink) run_master_ta(dev, c);
+  else if (c.role == timesync::Role::Master) run_master(dev, c);
+  else run_slave(dev, c);
+  session.close();
   return 0;
 }

--- a/examples/tx/main.cpp
+++ b/examples/tx/main.cpp
@@ -35,6 +35,7 @@
 
 #include "BfReportDetect.h"
 #include "ChannelFreq.h"
+#include "DeviceSession.h"
 #include "HopSchedule.h"
 #include "hopset/HopsetAuthority.h"
 #include "hopset/HopsetEvents.h"
@@ -411,6 +412,12 @@ int main(int argc, char **argv) {
    * harness's `timeout` doesn't leave the adapter's USB core hung. */
   install_devourer_signal_handlers();
 
+  /* Owns the teardown order (device -> interface -> handle -> context; see
+   * DeviceSession.h). Declared before every thread below, so the threads are
+   * joined before the adapter is released. Each early return from here on
+   * unwinds whatever has been adopted so far. */
+  devourer::DeviceSession session{logger};
+
   /* Two modes:
    *  1. Termux/Android: argv[1] = numeric USB fd (wrapped via
    *     libusb_wrap_sys_device).
@@ -430,15 +437,18 @@ int main(int argc, char **argv) {
     rc = libusb_init(&context);
     if (rc < 0)
       return rc;
+    session.adopt_context(context);
   } else if (termux_mode) {
     logger->info("Termux mode: wrapping fd {}", fd);
     libusb_set_option(NULL, LIBUSB_OPTION_NO_DEVICE_DISCOVERY);
     libusb_set_option(NULL, LIBUSB_OPTION_WEAK_AUTHORITY);
     rc = libusb_init(&context);
+    session.adopt_context(context);
     rc = libusb_wrap_sys_device(context, (intptr_t)fd, &handle);
   } else {
     rc = libusb_init(&context);
     if (rc < 0) return rc;
+    session.adopt_context(context);
 
     const char *pid_env = std::getenv("DEVOURER_PID");
     uint16_t target_pid = 0;
@@ -507,7 +517,6 @@ int main(int argc, char **argv) {
       if (handle == NULL) {
         logger->error("DEVOURER_USB_BUS={} PORT={} matched no device", want_bus,
                       port_env ? port_env : "(any)");
-        libusb_exit(context);
         return 1;
       }
     }
@@ -532,7 +541,6 @@ int main(int argc, char **argv) {
     }
     if (handle == NULL) {
       logger->error("No supported device found under VID {:04x}", target_vid);
-      libusb_exit(context);
       return 1;
     }
   }
@@ -561,11 +569,13 @@ int main(int argc, char **argv) {
         .f("stage", "txdemo.usb_reset")
         .f("ms", ms_since_start());
     if (rc != 0) {
-      if (handle != nullptr)
-        libusb_close(handle);
-      libusb_exit(context);
+      /* The claim failed, so nothing owns the handle yet — hand it to the
+       * session purely so the unwind closes it. */
+      session.adopt_handle(handle);
       return 1;
     }
+    session.adopt_handle(handle);
+    session.adopt_lock(usb_lock);
   }
 
   /* USB-wire sentinel writes — gated behind DEVOURER_USB_SENTINEL=1. Used by
@@ -674,7 +684,7 @@ int main(int argc, char **argv) {
   }
 
   WiFiDriver wifi_driver{logger};
-  std::unique_ptr<IRtlDevice> rtlDevice;
+  std::unique_ptr<IRtlDevice> owned_device;
 #if defined(DEVOURER_HAVE_PCIE)
   if (pcie_bdf) {
     auto transport = devourer::PcieTransport::Open(pcie_bdf, logger);
@@ -683,8 +693,8 @@ int main(int argc, char **argv) {
     devourer::Ev(*g_ev, "init.timing")
         .f("stage", "txdemo.open_device")
         .f("ms", ms_since_start());
-    rtlDevice = wifi_driver.CreateRtlDevicePcie(std::move(transport),
-                                                devourer_config_from_env());
+    owned_device = wifi_driver.CreateRtlDevicePcie(std::move(transport),
+                                                   devourer_config_from_env());
   } else
 #endif
   {
@@ -692,19 +702,23 @@ int main(int argc, char **argv) {
       logger->error("DEVOURER_PCIE_BDF set but this build has DEVOURER_PCIE=OFF");
       return 1;
     }
-    rtlDevice = wifi_driver.CreateRtlDevice(handle, nullptr, usb_lock,
-                                            devourer_config_from_env());
+    owned_device = wifi_driver.CreateRtlDevice(handle, nullptr, usb_lock,
+                                               devourer_config_from_env());
   }
-  if (!rtlDevice) {
+  if (!owned_device) {
     /* Factory returns null when this chip's generation wasn't compiled in
      * (per-chip CMake options); it already logged which. */
     logger->error("No driver for this chip in this build — exiting");
     return 1;
   }
+  /* The session owns the device from here: it is what guarantees the device
+   * (and its in-flight TX) dies before libusb does. */
+  session.adopt_device(std::move(owned_device));
+  IRtlDevice *const rtlDevice = session.device();
   devourer::Ev(*g_ev, "init.timing")
       .f("stage", "txdemo.create_device")
       .f("ms", ms_since_start());
-  devourer::emit_adapter_caps(*g_ev, rtlDevice.get());
+  devourer::emit_adapter_caps(*g_ev, rtlDevice);
 
   /* Jaguar1-only research features (TX-mode default, fast-retune hopping,
    * thermal telemetry, TXAGC override, BB-reg probe) are not part of the
@@ -712,15 +726,15 @@ int main(int argc, char **argv) {
    * where those call sites are skipped, and compiled out entirely when Jaguar1
    * support isn't built. */
 #if defined(DEVOURER_HAVE_JAGUAR1)
-  RtlJaguarDevice *jag = dynamic_cast<RtlJaguarDevice *>(rtlDevice.get());
+  RtlJaguarDevice *jag = dynamic_cast<RtlJaguarDevice *>(rtlDevice);
 #endif
   /* Jaguar2 (8822BU) downcast — used only for the CW single-tone idle-hold. */
 #if defined(DEVOURER_HAVE_JAGUAR2)
-  RtlJaguar2Device *jag2 = dynamic_cast<RtlJaguar2Device *>(rtlDevice.get());
+  RtlJaguar2Device *jag2 = dynamic_cast<RtlJaguar2Device *>(rtlDevice);
 #endif
   /* Jaguar3 (8822C/E) downcast — used only for the CW single-tone idle-hold. */
 #if defined(DEVOURER_HAVE_JAGUAR3)
-  RtlJaguar3Device *jag3 = dynamic_cast<RtlJaguar3Device *>(rtlDevice.get());
+  RtlJaguar3Device *jag3 = dynamic_cast<RtlJaguar3Device *>(rtlDevice);
 #endif
 
   int channel = 161;
@@ -1409,7 +1423,7 @@ int main(int argc, char **argv) {
     if (const char *pr = std::getenv("DEVOURER_HOP_PROBE_ROUNDS"))
       probe_rounds = static_cast<unsigned>(std::strtoul(pr, nullptr, 0));
     g_hopset_view->set_probe_period(probe_rounds);
-    g_hopset_dev = rtlDevice.get();
+    g_hopset_dev = rtlDevice;
     g_hopset_fusion.mode = hop_fusion_mode;
     if (tx_sense) {
       /* The aux flood threads send from their own threads and `send_packets`
@@ -1760,7 +1774,7 @@ int main(int argc, char **argv) {
         if (committing) {
           sense_armed = false;
         } else {
-          hopset_sense_window(rtlDevice.get(), tx_sense_settle_us,
+          hopset_sense_window(rtlDevice, tx_sense_settle_us,
                               tx_sense_window_us, tx_sense_nhm,
                               devourer::hopset::SensePhase::PreBurst,
                               desired_slot, round,
@@ -1793,7 +1807,7 @@ int main(int argc, char **argv) {
           gen = g_hopset_view->state().generation;
         }
         sense_post_done = true;
-        hopset_sense_window(rtlDevice.get(), 0, tx_sense_post_us,
+        hopset_sense_window(rtlDevice, 0, tx_sense_post_us,
                             tx_sense_nhm,
                             devourer::hopset::SensePhase::PostBurst,
                             desired_slot, round,
@@ -2043,19 +2057,14 @@ int main(int argc, char **argv) {
   if (usb_thread.joinable())
     usb_thread.join();
 
-  /* Clean chip de-init before releasing the interface (card-disable PWR_SEQ), so
-   * the adapter re-enumerates instead of hanging its USB core. */
+  /* Clean chip de-init before releasing the interface: card-disable PWR_SEQ on
+   * the HalMAC families, TX quiesce on Jaguar1 — so the adapter re-enumerates
+   * instead of hanging its USB core. */
   rtlDevice->Stop();
 
-  /* Tolerant teardown: if the chip already dropped off the bus (e.g. a TX-path
-   * wedge), release_interface returns an error — log it, don't assert/abort.
-   * PCIe runs have no USB handle; the transport tears down with the device. */
-  if (handle != nullptr) {
-    rc = libusb_release_interface(handle, 0);
-    if (rc != 0)
-      logger->info("libusb_release_interface rc={} (device already gone?)", rc);
-    libusb_close(handle);
-  }
-  libusb_exit(context);
+  /* Device, then interface, handle and context (DeviceSession.h). Explicit
+   * only because the process has nothing left to do here — the destructor
+   * does exactly the same on every other exit path. */
+  session.close();
   return 0;
 }

--- a/examples/txpower/main.cpp
+++ b/examples/txpower/main.cpp
@@ -59,6 +59,7 @@
 #include <string>
 #include <thread>
 
+#include "DeviceSession.h"
 #include "SignalStop.h"
 #include "ThermalStatus.h"
 #include "TxPower.h"
@@ -242,11 +243,17 @@ int main(int argc, char **argv) {
   g_ev = &logger->events();
   install_devourer_signal_handlers();
 
+  /* Owns the teardown order (device -> interface -> handle -> context; see
+   * DeviceSession.h). Each early return from here on unwinds whatever has been
+   * adopted so far. */
+  devourer::DeviceSession session{logger};
+
   libusb_context *ctx = nullptr;
   if (libusb_init(&ctx) < 0) {
     logger->error("libusb_init failed");
     return 1;
   }
+  session.adopt_context(ctx);
   libusb_device_handle *handle = nullptr;
   if (a.pid >= 0) {
     handle = libusb_open_device_with_vid_pid(ctx, a.vid,
@@ -261,29 +268,33 @@ int main(int argc, char **argv) {
   if (!handle) {
     logger->error("no adapter found ({:04x}:{})", a.vid,
                   a.pid >= 0 ? "requested pid" : "any Realtek pid");
-    libusb_exit(ctx);
     return 1;
   }
 
   std::shared_ptr<devourer::UsbDeviceLock> lock;
   if (devourer::claim_interface_then_reset(handle, devourer::find_wifi_interface(handle), logger, true, lock) !=
       0) {
-    libusb_close(handle);
-    libusb_exit(ctx);
+    /* The claim failed, so nothing owns the handle yet — hand it to the
+     * session purely so the unwind closes it. */
+    session.adopt_handle(handle);
     return 1;
   }
+  session.adopt_handle(handle);
+  session.adopt_lock(lock);
 
   WiFiDriver driver(logger);
-  std::unique_ptr<IRtlDevice> dev =
+  std::unique_ptr<IRtlDevice> owned_device =
       driver.CreateRtlDevice(handle, ctx, lock, devourer_config_from_env());
-  if (!dev) {
+  if (!owned_device) {
     logger->error("CreateRtlDevice failed (chip support not built?)");
-    libusb_close(handle);
-    libusb_exit(ctx);
     return 1;
   }
+  /* The session owns the device from here: it is what guarantees the device
+   * (and its in-flight TX) dies before libusb does. */
+  session.adopt_device(std::move(owned_device));
+  IRtlDevice *const dev = session.device();
 
-  devourer::emit_adapter_caps(*g_ev, dev.get());
+  devourer::emit_adapter_caps(*g_ev, dev);
 
   const devourer::TxPowerCaps caps = dev->GetTxPowerCaps();
   devourer::Ev(*g_ev, "txpwr.caps")
@@ -296,8 +307,6 @@ int main(int argc, char **argv) {
   if (!caps.supported) {
     logger->error("TX-power API not wired for this family yet");
     dev->Stop();
-    libusb_close(handle);
-    libusb_exit(ctx);
     return 3;
   }
 
@@ -307,12 +316,12 @@ int main(int argc, char **argv) {
   logger->info("brought up on ch{} bw{}", a.channel, a.bw);
 
   /* Baseline state before any knob moves (the offset=0 parity reference). */
-  print_state(dev.get(), a.thermal);
+  print_state(dev, a.thermal);
 
   if (a.flat >= -1) {
     dev->SetTxPowerIndexOverride(a.flat);
     logger->info("flat index override -> {}", a.flat);
-    print_state(dev.get(), a.thermal);
+    print_state(dev, a.thermal);
   }
 
   if (a.have_rate_diffs) {
@@ -323,16 +332,16 @@ int main(int argc, char **argv) {
       const bool ok = dev->SetTxPowerRateDiffs(a.rate_diffs);
       logger->info("rate-diffs -> {}", ok ? "applied" : "unsupported");
     }
-    print_state(dev.get(), a.thermal);
+    print_state(dev, a.thermal);
   }
 
   if (a.have_flat_pulse) {
     dev->SetTxPowerIndexOverride(a.flat_pulse);
     logger->info("flat pulse -> {}", a.flat_pulse);
-    print_state(dev.get(), a.thermal);
+    print_state(dev, a.thermal);
     dev->SetTxPowerIndexOverride(-1);
     logger->info("flat pulse cleared");
-    print_state(dev.get(), a.thermal);
+    print_state(dev, a.thermal);
   }
 
   if (a.have_ramp) {
@@ -344,7 +353,7 @@ int main(int argc, char **argv) {
          q += inc) {
       const int applied = dev->SetTxPowerOffsetQdb(q);
       devourer::Ev(*g_ev, "txpwr.offset").f("requested", q).f("applied", applied);
-      print_state(dev.get(), a.thermal);
+      print_state(dev, a.thermal);
       std::this_thread::sleep_for(std::chrono::milliseconds(a.step_ms));
     }
   }
@@ -356,18 +365,17 @@ int main(int argc, char **argv) {
                         .ChannelWidth = bw_enum(a.bw)});
     logger->info("SetMonitorChannel -> ch{} (offset must re-fold)",
                  a.switch_channel);
-    print_state(dev.get(), a.thermal);
+    print_state(dev, a.thermal);
   }
 
   if (a.retune > 0 && !g_devourer_should_stop) {
     dev->FastRetune(static_cast<uint8_t>(a.retune));
     logger->info("FastRetune -> ch{} (TXAGC registers must be untouched)",
                  a.retune);
-    print_state(dev.get(), a.thermal);
+    print_state(dev, a.thermal);
   }
 
   dev->Stop();
-  libusb_close(handle);
-  libusb_exit(ctx);
+  session.close();
   return 0;
 }

--- a/src/RtlAdapter.h
+++ b/src/RtlAdapter.h
@@ -141,6 +141,11 @@ public:
   }
   void bulk_clear_halt(uint8_t ep) { _transport->clear_halt(ep); }
 
+  /* Stop TX and wait out everything already submitted (IRtlTransport::
+   * quiesce_tx). Must run while the caller's bus context is still alive —
+   * the device Stop()/destructor does it, so callers rarely need this. */
+  void quiesce_tx() { _transport->quiesce_tx(); }
+
   /* Snapshot of the TX submission counters (see TxStats.h). */
   devourer::TxStats GetTxStats() const { return _transport->tx_stats(); }
 

--- a/src/RtlTransport.h
+++ b/src/RtlTransport.h
@@ -89,6 +89,13 @@ public:
     return -1;
   }
   virtual void clear_halt(uint8_t ep) { (void)ep; }
+  /* Stop the TX engine and return only once nothing is in flight: cancel every
+   * outstanding transfer, reap the completions, and refuse further sends. The
+   * caller-owned bus context (libusb here) must still be alive, so this has to
+   * run BEFORE any of it is torn down — which is exactly why it is an explicit
+   * call and not destructor work. Idempotent. Default no-op: a transport whose
+   * TX is synchronous has nothing outstanding by construction. */
+  virtual void quiesce_tx() {}
 
   /* ---- lifecycle / info ---- */
   /* Pre-power-on HCI programming, re-run per bring-up attempt (rtw88's

--- a/src/UsbTransport.cpp
+++ b/src/UsbTransport.cpp
@@ -1,9 +1,11 @@
 #include "UsbTransport.h"
 
+#include <algorithm>
 #include <chrono>
 #include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <deque>
 #include <mutex>
 #include <string>
@@ -258,16 +260,20 @@ UsbTransport::UsbTransport(libusb_device_handle *dev_handle, Logger_t logger,
 }
 
 UsbTransport::~UsbTransport() {
-  /* Drain any async-TX completions still in flight so their transfers are
-   * freed (transfer_callback runs here, on THIS thread) before the device
-   * handle / context are torn down. We reap in the caller's thread, never a
-   * background pump, so there is no thread racing the caller-owned
-   * libusb_exit. A bounded loop so a genuinely dead endpoint can't hang
-   * teardown. */
-  for (int i = 0; i < 50 && _tx_inflight.load() > 0; ++i) {
-    struct timeval tv {0, 20000};
-    libusb_handle_events_timeout_completed(_ctx, &tv, nullptr);
-  }
+  /* Backstop only. The device's Stop()/destructor quiesces TX while every
+   * owner is alive, which is the path that makes teardown safe; reaching the
+   * transport destructor with transfers still in flight means the caller tore
+   * libusb down first, and by then _ctx may already be freed — pumping it is
+   * the SIGSEGV this diagnostic exists to name. The transport is shared_ptr-
+   * owned, so it is not guaranteed the device drops the last reference; hence
+   * the drain attempt stays. */
+  if (!_tx_shutdown.load(std::memory_order_acquire) &&
+      _tx_inflight.load(std::memory_order_acquire) > 0)
+    _logger->error("USB transport destroyed with TX in flight — the owner "
+                   "should quiesce (IRtlDevice::Stop) and release the device "
+                   "BEFORE libusb_close/libusb_exit; see the teardown order in "
+                   "examples/common/DeviceSession.h");
+  quiesce_tx();
 }
 
 bool UsbTransport::write_bytes(uint16_t reg_num, const uint8_t *ptr, size_t n) {
@@ -646,20 +652,81 @@ void UsbTransport::transfer_callback(struct libusb_transfer *transfer) {
      * clear_halt storm — now that completions are actually reaped. */
     if (transfer->status == LIBUSB_TRANSFER_STALL)
       self->_tx_wedged.store(true, std::memory_order_relaxed);
-    self->_tx_failed.fetch_add(1, std::memory_order_relaxed);
-    self->_tx_last_rc.store(-transfer->status, std::memory_order_relaxed);
-    self->_tx_last_timeout.store(
-        transfer->status == LIBUSB_TRANSFER_TIMED_OUT,
-        std::memory_order_relaxed);
-    self->_logger->error("Failed to send packet, status: {}, actual length: {}",
-                         transfer->status, transfer->actual_length);
-    devourer::Ev(self->_logger->events(), "tx.fail")
-        .f("status", (long long)transfer->status)
-        .f("actual_len", transfer->actual_length)
-        .f("timeout", transfer->status == LIBUSB_TRANSFER_TIMED_OUT);
+    /* A CANCELLED completion is quiesce_tx doing its job, not a failure —
+     * counting it would show phantom drops at the end of every session. */
+    if (transfer->status != LIBUSB_TRANSFER_CANCELLED) {
+      self->_tx_failed.fetch_add(1, std::memory_order_relaxed);
+      self->_tx_last_rc.store(-transfer->status, std::memory_order_relaxed);
+      self->_tx_last_timeout.store(
+          transfer->status == LIBUSB_TRANSFER_TIMED_OUT,
+          std::memory_order_relaxed);
+      self->_logger->error(
+          "Failed to send packet, status: {}, actual length: {}",
+          transfer->status, transfer->actual_length);
+      devourer::Ev(self->_logger->events(), "tx.fail")
+          .f("status", (long long)transfer->status)
+          .f("actual_len", transfer->actual_length)
+          .f("timeout", transfer->status == LIBUSB_TRANSFER_TIMED_OUT);
+    }
   }
-  self->_tx_inflight.fetch_sub(1, std::memory_order_relaxed);
+  {
+    std::lock_guard<std::mutex> lk(self->_tx_mu);
+    auto &live = self->_tx_live;
+    auto it = std::find(live.begin(), live.end(), transfer);
+    if (it != live.end())
+      live.erase(it);
+  }
+  /* The payload is transport-owned (allocated in tx_async) — free it with the
+   * allocator that made it, never libusb's LIBUSB_TRANSFER_FREE_BUFFER: on
+   * Windows a separately-linked libusb frees onto a different CRT heap. */
+  std::free(transfer->buffer);
   libusb_free_transfer(transfer);
+  /* Last, so a quiesce_tx loop that sees _tx_inflight == 0 knows every buffer
+   * and transfer is already freed and nothing more will touch this object. */
+  self->_tx_inflight.fetch_sub(1, std::memory_order_release);
+}
+
+/* Cancel + drain, called while the caller's libusb context is still alive.
+ * See IRtlTransport::quiesce_tx for the contract. */
+void UsbTransport::quiesce_tx() {
+  if (_tx_shutdown.exchange(true, std::memory_order_acq_rel))
+    return; /* already quiesced (Stop() then the destructor) */
+
+  /* Snapshot, then cancel outside the lock — libusb_cancel_transfer can
+   * complete the transfer inline, re-entering transfer_callback, which takes
+   * the same mutex. Cancellation is asynchronous: SUCCESS means "unlink
+   * submitted", so the drain below is what actually establishes quiescence.
+   * NOT_FOUND means the transfer already completed — its callback owns the
+   * bookkeeping, so there is nothing to do here. */
+  std::vector<libusb_transfer *> pending;
+  {
+    std::lock_guard<std::mutex> lk(_tx_mu);
+    pending = _tx_live;
+  }
+  for (auto *t : pending)
+    libusb_cancel_transfer(t);
+
+  /* Drain. Generous deadline: an unlink normally retires in microseconds (or
+   * instantly with NO_DEVICE once the adapter is unplugged), and hanging
+   * teardown forever is worse than reporting the anomaly. */
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while (_tx_inflight.load(std::memory_order_acquire) > 0 &&
+         std::chrono::steady_clock::now() < deadline) {
+    struct timeval tv {0, 20000};
+    if (libusb_handle_events_timeout_completed(_ctx, &tv, nullptr) != 0)
+      break; /* context is gone or broken — nothing left to reap with */
+  }
+
+  const int residual = _tx_inflight.load(std::memory_order_acquire);
+  if (residual > 0) {
+    /* Proceeding means libusb_close will run with live transfers, which is
+     * undefined behaviour — so say so loudly rather than fail silently. */
+    _logger->error("TX quiesce timed out with {} transfer(s) still in flight — "
+                   "the USB close that follows is unsafe",
+                   residual);
+    devourer::Ev(_logger->events(), "tx.quiesce_timeout").f("inflight", residual);
+  }
 }
 
 bool UsbTransport::tx_async(uint8_t tx_ep, uint8_t *packet, size_t length,
@@ -673,6 +740,11 @@ bool UsbTransport::tx_async(uint8_t tx_ep, uint8_t *packet, size_t length,
    * fail, and TX collapses (issue #240). If the in-flight depth is already high
    * (a fast caller outrunning the air), block briefly to reap — bounded
    * backpressure that also caps latency. */
+  /* Refused before the pump below, so a late send can't re-enter libusb after
+   * teardown has begun. Counts as neither submitted nor failed: a frame handed
+   * to us after we were told to stop is not a drop. */
+  if (_tx_shutdown.load(std::memory_order_acquire))
+    return false;
   {
     struct timeval zero {0, 0};
     libusb_handle_events_timeout_completed(_ctx, &zero, nullptr);
@@ -691,6 +763,19 @@ bool UsbTransport::tx_async(uint8_t tx_ep, uint8_t *packet, size_t length,
     _logger->error("Failed to allocate transfer");
     return false;
   }
+
+  /* The URB outlives this call by definition (that is what "async" buys), so
+   * it cannot reference the caller's buffer: every caller so far builds its
+   * frame in a local that dies on return. Copy into a transport-owned block,
+   * freed in transfer_callback. One memcpy per frame is far below the
+   * libusb_alloc_transfer above it and the kernel's own copy at submit. */
+  auto *payload = static_cast<uint8_t *>(std::malloc(length));
+  if (!payload) {
+    _logger->error("Failed to allocate TX payload ({} bytes)", length);
+    libusb_free_transfer(transfer);
+    return false;
+  }
+  std::memcpy(payload, packet, length);
 
   /* Recover a bulk-OUT that a prior async TX wedged (TIMED_OUT / stall). Only
    * the first send used to clear_halt; a mid-stream stall (e.g. hardware NDP
@@ -745,7 +830,7 @@ bool UsbTransport::tx_async(uint8_t tx_ep, uint8_t *packet, size_t length,
    * Over-submission is bounded by the in-flight soft cap above, not by
    * dropping frames on a timer. `timeout_ms` is kept for the sync path. */
   (void)timeout_ms;
-  libusb_fill_bulk_transfer(transfer, _dev_handle, tx_ep, packet, length,
+  libusb_fill_bulk_transfer(transfer, _dev_handle, tx_ep, payload, length,
                             &UsbTransport::transfer_callback, (void *)this,
                             /*timeout=*/0);
   /* Upstream OOT (rtl8814a/usb/rtl8814au_xmit.c) sets URB_ZERO_PACKET on
@@ -758,12 +843,27 @@ bool UsbTransport::tx_async(uint8_t tx_ep, uint8_t *packet, size_t length,
   /* Count the submission here; async completion (incl. TIMED_OUT) is counted
    * in transfer_callback, a submit error just below. */
   _tx_submitted.fetch_add(1, std::memory_order_relaxed);
+  /* Register and count BEFORE submitting: the completion can be delivered from
+   * another thread's pump the instant the URB is queued, and it must find its
+   * own entry to remove. */
+  {
+    std::lock_guard<std::mutex> lk(_tx_mu);
+    _tx_live.push_back(transfer);
+  }
+  _tx_inflight.fetch_add(1, std::memory_order_relaxed);
   int rc = libusb_submit_transfer(transfer);
   if (rc == LIBUSB_SUCCESS) {
-    _tx_inflight.fetch_add(1, std::memory_order_relaxed);
     DVR_DEBUG(_logger, "Packet sent successfully, length: {}", length);
     return true;
   }
+  /* Never submitted, so no callback will run — undo the bookkeeping here. */
+  {
+    std::lock_guard<std::mutex> lk(_tx_mu);
+    auto it = std::find(_tx_live.begin(), _tx_live.end(), transfer);
+    if (it != _tx_live.end())
+      _tx_live.erase(it);
+  }
+  _tx_inflight.fetch_sub(1, std::memory_order_relaxed);
   _tx_failed.fetch_add(1, std::memory_order_relaxed);
   _tx_last_rc.store(rc, std::memory_order_relaxed);
   _tx_last_timeout.store(rc == LIBUSB_ERROR_TIMEOUT, std::memory_order_relaxed);
@@ -771,6 +871,7 @@ bool UsbTransport::tx_async(uint8_t tx_ep, uint8_t *packet, size_t length,
   devourer::Ev(_logger->events(), "tx.fail")
       .f("rc", rc)
       .f("timeout", rc == LIBUSB_ERROR_TIMEOUT);
+  std::free(payload);
   libusb_free_transfer(transfer);
   return false;
 }

--- a/src/UsbTransport.h
+++ b/src/UsbTransport.h
@@ -10,6 +10,8 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
+#include <vector>
 
 #include <libusb.h>
 
@@ -74,6 +76,7 @@ public:
                const std::function<bool()> &should_stop) override;
   int rx_raw(uint8_t *buf, int len, int timeout_ms) override;
   void clear_halt(uint8_t ep) override { libusb_clear_halt(_dev_handle, ep); }
+  void quiesce_tx() override;
 
   UsbLinkInfo usb_info() const override { return _info; }
   TxStats tx_stats() const override;
@@ -115,6 +118,19 @@ private:
    * before the device handle / context go away, and so a soft cap can throttle
    * over-submission. */
   std::atomic<int> _tx_inflight{0};
+
+  /* Submitted-but-not-yet-completed transfers, so quiesce_tx can cancel them
+   * by handle. transfer_callback removes its own entry, and it runs on
+   * whichever thread pumped the event — the submitting one, or another
+   * tx_async caller under DEVOURER_TX_THREADS. Never hold _tx_mu across a
+   * libusb_handle_events call: the callback re-enters and takes it. */
+  std::mutex _tx_mu;
+  std::vector<libusb_transfer *> _tx_live;
+
+  /* Latched by quiesce_tx. Refuses further submissions (and further event
+   * pumping) so nothing re-enters libusb once teardown has begun, and makes
+   * quiesce idempotent for the Stop()-then-destructor path. */
+  std::atomic<bool> _tx_shutdown{false};
 
   /* Allocate the async RX ring from kernel DMA memory (dev_mem_alloc) for a
    * zerocopy bulk-IN path; falls back to heap buffers per-URB when the alloc is

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -1804,7 +1804,14 @@ bool RtlJaguarDevice::NetDevOpen(SelectedChannel selectedChannel) {
   return true;
 }
 
+void RtlJaguarDevice::Stop() { _device.quiesce_tx(); }
+
 RtlJaguarDevice::~RtlJaguarDevice() {
+  /* First, before any member starts unwinding: the async bulk-OUT URBs point
+   * at transport-owned memory and complete on whichever thread pumps libusb,
+   * so nothing may be released while they are still live. Idempotent, so the
+   * usual Stop()-then-destroy path pays nothing here. */
+  _device.quiesce_tx();
   /* Safety net: if a CW tone is still armed (caller forgot StopCwTone), restore
    * the chip before teardown so it isn't left radiating a bare carrier. */
   StopCwTone();

--- a/src/jaguar1/RtlJaguarDevice.h
+++ b/src/jaguar1/RtlJaguarDevice.h
@@ -95,6 +95,12 @@ public:
    * once, then runs this on its own std::thread next to the TX loop. */
   void StartRxLoop(Action_ParsedRadioPacket packetProcessor) override;
   void StopRxLoop() override { should_stop = true; }
+  /* Jaguar1's send path is the only asynchronous one in the tree, so its
+   * Stop() is TX quiesce and nothing else: cancel and reap the outstanding
+   * bulk-OUT URBs while the caller's libusb context is still up. Deliberately
+   * NOT a card-disable power sequence — this family has never run one, and
+   * adding it here would be an unvalidated change of on-the-wire behaviour. */
+  void Stop() override;
   void SetMonitorChannel(SelectedChannel channel) override;
   /* Lean frequency-hop retune: switches the RF channel only, skipping the
    * per-rate TX-power loop, bandwidth post-set, and thermal pwrtrk tick that

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -40,6 +40,10 @@ RtlJaguar2Device::RtlJaguar2Device(RtlAdapter device, Logger_t logger,
       _macinit{device, logger, variant}, _fw{device, logger, variant} {}
 
 RtlJaguar2Device::~RtlJaguar2Device() {
+  /* Inert on this generation (its send path is synchronous), but the invariant
+   * belongs to every device: nothing gets released while a transfer the
+   * transport still owns is outstanding. */
+  _device.quiesce_tx();
   /* Safety net: restore the chip if a CW tone is still armed. */
   StopCwTone();
   stop_pwrtrack();

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -381,6 +381,10 @@ void RtlJaguar3Device::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
  * (exception path / caller that drops the device) — a joinable std::thread in
  * the destructor would otherwise std::terminate. Idempotent with Stop(). */
 RtlJaguar3Device::~RtlJaguar3Device() {
+  /* Inert on this generation (its send path is synchronous), but the invariant
+   * belongs to every device: nothing gets released while a transfer the
+   * transport still owns is outstanding. */
+  _device.quiesce_tx();
   /* Safety net: restore the chip if a CW tone is still armed (before the coex
    * thread is joined — StopCwTone serializes on _reg_mu with it). */
   StopCwTone();

--- a/src/kestrel/CLAUDE.md
+++ b/src/kestrel/CLAUDE.md
@@ -55,9 +55,15 @@ the halbb per-band LNA/TIA gain-error cache, without which 5 GHz is deaf), TX
 (mgmt injection — the OpenIPC video path via `streamtx`; legacy/HT/VHT/HE
 rates), channel/BW **5/10/20/40/80 MHz on both dies + 160 MHz on the 8852C**
 (the 8852B die has no 160 MHz — vendor bw_sup; caps report accordingly).
-40 MHz tunes to the block center (primary ±2); 80/160 MHz derive
-center/pri_ch from the channel plan (160 = an 8-wide block, center =
-block_start+14). **6 GHz TX tops out at 80 MHz**: the 6G 160 MHz TX does not
+40 MHz tunes to the block center (primary ±2); 80/160 MHz derive the center
+from the channel plan (160 = an 8-wide block, center = block_start+14).
+`halbb_ctrl_bw_ch`'s `pri_ch` argument is the primary **channel number**, not a
+sub-band index (vendor phl passes `rtw_chan_def::chan` through unchanged): the
+vendor derives the 0x4978[11:8] sub-band index from `pri_ch` vs `central_ch`,
+indexes the 2.4 GHz CCK SCO threshold tables with `pri_ch - 1`, and places the
+NBI spur notch from it. All three are RX-side — feeding it an index costs CCK
+reception and all >20 MHz reception while TX is unaffected, so an SDR duty
+check cannot see it (`tests/kestrel_prich_onair.sh`). **6 GHz TX tops out at 80 MHz**: the 6G 160 MHz TX does not
 radiate on the C8852C (the RF synth locks and RX-160 works, but the 6G+160
 TX-enable path is un-ported — B210-confirmed 0% duty vs 45% at 6G-80 / 40% at
 5G-160; a MAC TXAGC-max / RF-TX-path gap, not a chip limit — the vendor

--- a/src/kestrel/HalKestrel.cpp
+++ b/src/kestrel/HalKestrel.cpp
@@ -2145,30 +2145,26 @@ bool HalKestrel::set_channel(uint8_t channel, ChannelWidth_t bw,
   const uint8_t band_type = (band == 6) ? 2 : (channel <= 14 ? 0 : 1);
   const bool is_2g = (band_type == 0);
   /* The RF synth tunes to the bandwidth-block CENTER; `channel` is the primary
-   * 20. For 40 MHz: offset UPPER(2) => primary is the upper 20 (center = ch-2,
-   * pri_ch=2); otherwise LOWER (center = ch+2, pri_ch=1). `pri_ch` is the BB
-   * primary-sub index (0x49C4[11:8]); 20 MHz uses 0. */
+   * 20, and it is also what halbb wants as its `pri_ch`: the primary CHANNEL
+   * NUMBER, not a sub-band index (vendor phl hands it rtw_chan_def::chan
+   * unchanged). halbb_ctrl_bw_ch derives the 0x4978[11:8] sub-band index
+   * itself by comparing pri_ch against central_ch, indexes the 2.4 GHz CCK SCO
+   * threshold tables with pri_ch-1, and places the NBI spur notch from it — so
+   * passing an index here reads those tables out of bounds at 20 MHz (index
+   * -1) and mis-derives the sub-band everywhere else.
+   * For 40 MHz: offset UPPER(2) => the primary is the upper 20 (center =
+   * ch-2); otherwise LOWER (center = ch+2). */
   uint8_t center = channel;
-  uint8_t pri_ch = 0;
   if (bw == CHANNEL_WIDTH_40) {
-    if (offset == 2) {
-      center = static_cast<uint8_t>(channel - 2);
-      pri_ch = 2;
-    } else {
-      center = static_cast<uint8_t>(channel + 2);
-      pri_ch = 1;
-    }
+    center = static_cast<uint8_t>(offset == 2 ? channel - 2 : channel + 2);
   } else if (bw == CHANNEL_WIDTH_80) {
-    /* 80 MHz block is fixed by the channel plan: the primary's position
-     * (pri_ch 1..4) and the block center derive from the channel number. The
-     * grid origin differs by band — 5 GHz aligns on the 36 + 16k grid
-     * ({36..48}->center 42, ...); 6 GHz aligns on the 1 + 16k grid
-     * ({1..13}->center 7, {17..29}->23, ...). block_start = ch - ((ch-o)/4 %
-     * 4)*4, o = grid origin. */
+    /* The 80 MHz block is fixed by the channel plan. The grid origin differs
+     * by band — 5 GHz aligns on the 36 + 16k grid ({36..48}->center 42, ...);
+     * 6 GHz aligns on the 1 + 16k grid ({1..13}->center 7, {17..29}->23, ...).
+     * block_start = ch - ((ch-o)/4 % 4)*4, o = grid origin. */
     const int o = (band_type == 2) ? 1 : 36;
     const int bs = channel - (((channel - o) / 4) % 4) * 4;
     center = static_cast<uint8_t>(bs + 6);
-    pri_ch = static_cast<uint8_t>((channel - bs) / 4 + 1);
   } else if (bw == CHANNEL_WIDTH_160) {
     if (_variant != ChipVariant::C8852C) {
       /* The 8852B die tops out at 80 MHz (rtl8852b_halinit.c bw_sup has no
@@ -2179,11 +2175,10 @@ bool HalKestrel::set_channel(uint8_t channel, ChannelWidth_t bw,
     }
     /* 160 MHz spans 8 20-MHz sub-channels; same grid-origin idea as 80 MHz but
      * modulo 8. block_start = ch - ((ch-o)/4 % 8)*4; center = bs+14 (middle of
-     * bs..bs+28); pri_ch 1..8. 5 GHz: {36..64}->center 50; 6 GHz: {1..29}->15. */
+     * bs..bs+28). 5 GHz: {36..64}->center 50; 6 GHz: {1..29}->15. */
     const int o = (band_type == 2) ? 1 : 36;
     const int bs = channel - (((channel - o) / 4) % 8) * 4;
     center = static_cast<uint8_t>(bs + 14);
-    pri_ch = static_cast<uint8_t>((channel - bs) / 4 + 1);
     /* 6 GHz 160 MHz TX does not radiate on the C8852C: the RF synth locks
      * (RF18 6G+160, LCK 0xb7[8]=0) and RX-160 works, but the 6G+160 TX-enable
      * path is un-ported — SDR-confirmed 0% duty vs 45% at 6G-80 / 40% at
@@ -2218,7 +2213,7 @@ bool HalKestrel::set_channel(uint8_t channel, ChannelWidth_t bw,
   /* Full vendor per-channel BB config (halbb_ctrl_bw_ch -> per-chip backend),
    * both chips: per-band gain-error, hidden/normal efuse RX gain, band
    * mode-sel, SCO comp, BW/RXBB/ADC, CCK enable. */
-  vnd_bb_ctrl_bw_ch(pri_ch, center, bw, band_type);
+  vnd_bb_ctrl_bw_ch(channel, center, bw, band_type);
   /* Vendored halrf IQK, both chips. The 0xbff8 one-shot-done poll depends on
    * the NCTL micro-engine, which vnd_rf_iqk loads lazily on first call
    * (kestrel_halrf_rfk_init — also LCK/RCK, the SI reset and the efuse trim).

--- a/src/kestrel/RtlKestrelDevice.cpp
+++ b/src/kestrel/RtlKestrelDevice.cpp
@@ -77,6 +77,10 @@ RtlKestrelDevice::RtlKestrelDevice(RtlAdapter device, Logger_t logger,
 }
 
 RtlKestrelDevice::~RtlKestrelDevice() {
+  /* Inert on this generation (its send path is synchronous), but the invariant
+   * belongs to every device: nothing gets released while a transfer the
+   * transport still owns is outstanding. */
+  _device.quiesce_tx();
   _rx_stop = true;
   stop_wp_drain();
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -404,6 +404,18 @@ quiesce must still return, and a `tx.quiesce_timeout` event in the log says it
 never drained. `BUILD=<dir>` points at another tree, which is how a fix is
 shown to fix something rather than asserted to.
 
+### `kestrel_prich_onair.sh`: Kestrel per-channel BB programming
+
+Counts delivered frames across the configurations that the vendored
+`halbb_ctrl_bw_ch` treats differently — 2.4 GHz CCK (its SCO threshold tables),
+20 MHz OFDM as the control, and RX at 40/80 MHz (the primary sub-band index).
+`KESTREL_TX=1` swaps the roles to check the transmit side, and `REF_ONLY=1`
+takes the Kestrel out of the path entirely, which is the first thing to run
+when a wide-bandwidth cell scores zero — the emitter's own channel width comes
+from `DEVOURER_HOP_BW`, not from the `/40` in `DEVOURER_TX_RATE` (that only
+fills the descriptor field), and getting that wrong zeroes a cell for reasons
+that have nothing to do with the DUT.
+
 ## Supported DUTs
 
 Listed in `SUPPORTED_DUTS` at the top of `regress.py`. Extend the dict

--- a/tests/README.md
+++ b/tests/README.md
@@ -381,6 +381,29 @@ compare curves only on the rising edge). Bench-measured on an 8812AU→8822BU
 pair at MCS7/20 MHz: **+3.0 dB LDPC gain at the 10%-delivery crossing**, and
 in the saturation regime LDPC delivered ~80% where BCC delivered 0–19%.
 
+### `tx_teardown_asan.sh` / `teardown_gen_sanity.sh`: lifetime bugs on real hardware
+
+A sanitizer only sees what runs, and the interesting lifetime bugs live in the
+device/libusb teardown, which no headless test reaches. Both scripts want an
+ASan build:
+
+```bash
+cmake -S . -B build-asan -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DDEVOURER_SANITIZE=address && cmake --build build-asan -j
+sudo -v && tests/tx_teardown_asan.sh            # Jaguar1 DUT, max-duty TX
+sudo -v && tests/teardown_gen_sanity.sh         # every plugged generation
+```
+
+`tx_teardown_asan.sh` floods at `DEVOURER_TX_GAP_US=0` and kills the demo
+mid-stream (`SIG=INT` for the other signal), because a saturated async TX queue
+at exit is the condition that exposes teardown ordering — a gap-2000 run drains
+between frames and looks clean either way. It also covers the aggregation URB
+(`DEVOURER_TX_USB_AGG`) and, given a hub with per-port power switching
+(`WEDGE_HUB`/`WEDGE_PORT`, uhubctl `ppps`), a real VBUS cut mid-flood: the
+quiesce must still return, and a `tx.quiesce_timeout` event in the log says it
+never drained. `BUILD=<dir>` points at another tree, which is how a fix is
+shown to fix something rather than asserted to.
+
 ## Supported DUTs
 
 Listed in `SUPPORTED_DUTS` at the top of `regress.py`. Extend the dict

--- a/tests/kestrel_prich_onair.sh
+++ b/tests/kestrel_prich_onair.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Does the Kestrel receive what it should, on the channels where the halbb
+# `pri_ch` argument actually changes what the baseband is programmed with?
+#
+# halbb_ctrl_bw_ch takes the primary CHANNEL NUMBER. From it the vendor derives
+# the 0x4978[11:8] primary-sub-band index, the 2.4 GHz CCK SCO thresholds
+# (indexed pri_ch-1) and the NBI spur-notch placement. Each cell counts
+# canonical-SA frames delivered between the Kestrel and a reference adapter:
+#
+#   cck6         1M CCK on ch6, RX 20 — the SCO threshold tables, RX side
+#   ofdm36       6M on ch36, RX 20     — 5 GHz control (no index involved)
+#   ofdm6        6M on ch6, RX 20      — 2.4 GHz OFDM, to separate a CCK-only
+#                                        fault from a whole-band one
+#   ofdm36-bw40  6M on ch36, RX 40     — the sub-band index: the frame occupies
+#   ofdm36-bw80  6M on ch36, RX 80       only the primary 20, so a receiver that
+#                                        thinks the primary is elsewhere in the
+#                                        block decodes nothing
+#
+# The 20 MHz OFDM cells are the controls: pri_ch reaches no table there, so they
+# must not move. Run against two builds and compare.
+#
+#   BUILD=/path/to/before tests/kestrel_prich_onair.sh   # Kestrel receives
+#   KESTREL_TX=1 RX_PID=0x012d tests/kestrel_prich_onair.sh  # Kestrel transmits
+#   REF_ONLY=1   RX_PID=0xc812 tests/kestrel_prich_onair.sh  # bench control
+#
+# REF_ONLY takes the Kestrel out of the path entirely — worth running before
+# reading anything into a zero, since a wide-PPDU cell scores zero for plenty
+# of reasons that have nothing to do with the chip under test.
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD="${BUILD:-$ROOT/build}"
+
+RX_VID="${RX_VID:-0x35bc}"; RX_PID="${RX_PID:-0x0101}"   # Kestrel 8852C
+TX_VID="${TX_VID:-0x2357}"; TX_PID="${TX_PID:-0x0120}"   # RTL8821AU
+TX_PWR="${TX_PWR-}"           # optional flat TX index/dBm; unset = efuse default
+SECS="${SECS:-12}"
+OUT="${OUT:-/tmp/devourer-kestrel-prich}"
+
+for b in rxdemo txdemo; do
+    [ -x "$BUILD/$b" ] || { echo "no $b in $BUILD"; exit 1; }
+done
+plugged() { lsusb -d "$(printf '%04x:%04x' "$1" "$2")" >/dev/null 2>&1; }
+plugged "$RX_VID" "$RX_PID" || { echo "SKIP: Kestrel $RX_VID:$RX_PID not plugged"; exit 77; }
+plugged "$TX_VID" "$TX_PID" || { echo "SKIP: TX $TX_VID:$TX_PID not plugged"; exit 77; }
+
+mkdir -p "$OUT"
+
+cleanup() {
+    sudo pkill -x txdemo 2>/dev/null || true
+    sudo pkill -x rxdemo 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+unbind() {
+    local want="${1#0x}" d p i
+    for d in /sys/bus/usb/devices/*/idProduct; do
+        p=$(cat "$d" 2>/dev/null) || continue
+        [ "$p" = "$want" ] || continue
+        for i in "$(dirname "$d")":*; do
+            [ -e "$i/driver" ] || continue
+            sudo sh -c "echo '$(basename "$i")' > '$i/driver/unbind'" 2>/dev/null || true
+        done
+    done
+}
+
+# KESTREL_TX=1 flips the roles: the Kestrel transmits and the reference adapter
+# receives, so the same channel configurations are checked from the TX side —
+# where the primary sub-band decides which 20 MHz of the block a 20 MHz PPDU
+# actually goes out on.
+if [ -n "${KESTREL_TX:-}" ]; then
+    _t_vid="$RX_VID"; _t_pid="$RX_PID"
+    RX_VID="$TX_VID"; RX_PID="$TX_PID"
+    TX_VID="$_t_vid"; TX_PID="$_t_pid"
+fi
+
+# $1 label, $2 channel, $3 TX rate spec, $4 RX bandwidth, $5 channel offset,
+# $6 TX-side chip bandwidth. NB the rate spec's /40 only fills the descriptor
+# field — the transmitter's own channel width comes from DEVOURER_HOP_BW, so a
+# cell that wants a real wide PPDU has to set both.
+cell() {
+    local label="$1" ch="$2" rate="$3" bw="$4" off="${5:-0}" txbw="${6:-}"
+    local rxlog="$OUT/$label.rx.log" txlog="$OUT/$label.tx.log"
+    unbind "$RX_PID"; unbind "$TX_PID"
+
+    sudo env DEVOURER_VID="$RX_VID" DEVOURER_PID="$RX_PID" \
+        DEVOURER_CHANNEL="$ch" DEVOURER_BW="$bw" DEVOURER_CHOFFSET="$off" \
+        DEVOURER_LOG_LEVEL=warn \
+        "$BUILD/rxdemo" >"$rxlog" 2>&1 &
+    local rx=$!
+    sleep 6   # Kestrel bring-up (tables + RFK) before the emitter starts
+
+    sudo env DEVOURER_VID="$TX_VID" DEVOURER_PID="$TX_PID" \
+        DEVOURER_CHANNEL="$ch" ${rate:+DEVOURER_TX_RATE="$rate"} \
+        ${txbw:+DEVOURER_HOP_BW="$txbw"} ${txbw:+DEVOURER_HOP_OFFSET="$off"} \
+        ${TX_PWR:+DEVOURER_TX_PWR="$TX_PWR"} DEVOURER_TX_GAP_US=2000 \
+        DEVOURER_LOG_LEVEL=warn \
+        "$BUILD/txdemo" >"$txlog" 2>&1 &
+    local tx=$!
+    sleep "$SECS"
+
+    sudo pkill -TERM -x txdemo 2>/dev/null || true; wait "$tx" 2>/dev/null || true
+    sudo pkill -TERM -x rxdemo 2>/dev/null || true; wait "$rx" 2>/dev/null || true
+
+    local hits sent
+    hits=$(grep -c '"ev":"rx.txhit"' "$rxlog" 2>/dev/null || true)
+    sent=$(grep -o '"submitted":[0-9]*' "$txlog" | tail -1 | cut -d: -f2)
+    printf '%-10s ch%-4s %-12s bw%-3s  hits=%-6s tx=%s\n' \
+        "$label" "$ch" "$rate" "$bw" "${hits:-0}" "${sent:-?}"
+    sleep 2
+}
+
+if [ -n "${REF_ONLY:-}" ]; then
+    # Neither side is the Kestrel: the reference pair alone, to establish that
+    # a real 40/80 MHz PPDU is decodable on this bench at all before reading
+    # anything into a Kestrel cell that scores zero.
+    echo "== reference pair only, wide PPDUs (build $BUILD) =="
+    cell ref-ht40-36 36 MCS7/40 40 1 40
+    cell ref-vht80-36 36 VHT1SS_MCS3/80 80 1 80
+elif [ -n "${KESTREL_TX:-}" ]; then
+    echo "== Kestrel TX vs pri_ch programming (build $BUILD) =="
+    # The width comes from the rate spec, so these put the Kestrel itself into
+    # the 40/80 MHz configuration; the reference receiver follows.
+    cell tx-ht20-36 36 MCS7     20
+    cell tx-ht40-36 36 MCS7/40  40 1 40
+    cell tx-vht80-36 36 VHT1SS_MCS3/80 80 1 80
+else
+    echo "== Kestrel RX vs pri_ch programming (build $BUILD, TX_PWR=${TX_PWR:-default}) =="
+    cell cck6    6  1M  20
+    cell ofdm6   6  ""  20
+    cell ofdm36  36 ""  20
+    cell ofdm36-bw40 36 "" 40 1
+    cell ofdm36-bw80 36 "" 80 1
+fi

--- a/tests/teardown_gen_sanity.sh
+++ b/tests/teardown_gen_sanity.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Does every plugged generation still init and tear down cleanly?
+#
+# The TX-quiesce call the Jaguar1 teardown needs is made by every device's
+# destructor. On the generations whose send path is synchronous it should be
+# inert — this run is what says "inert", not "assumed inert": each adapter gets
+# a short RX session and a short TX session under ASan, killed with SIGTERM,
+# and both must exit 0 with no sanitizer report.
+#
+# Build:  cmake -S . -B build-asan -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+#               -DDEVOURER_SANITIZE=address && cmake --build build-asan -j
+# Run:    sudo -v && tests/teardown_gen_sanity.sh
+#
+# DUTS overrides the adapter list: "label:vid:pid,label:vid:pid".
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD="${BUILD:-$ROOT/build-asan}"
+CHANNEL="${CHANNEL:-6}"
+RUN_SECS="${RUN_SECS:-6}"
+OUT="${OUT:-/tmp/devourer-gen-sanity}"
+
+# One per generation; skipped when not plugged.
+DUTS="${DUTS:-J1-8821AU:0x2357:0x0120,\
+J2-8822BU:0x2357:0x012d,\
+J3-8812CU:0x0bda:0xc812,\
+J3-8812EU:0x0bda:0xa81a,\
+KESTREL:0x35bc:0x0101}"
+
+mkdir -p "$OUT"; rm -f "$OUT"/*.log "$OUT"/asan.* 2>/dev/null || true
+
+cleanup() {
+    sudo pkill -x txdemo 2>/dev/null || true
+    sudo pkill -x rxdemo 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# rtw88/rtw89 claim every Realtek dongle at enumeration; unbind the interface
+# (a module removal doesn't survive the next re-enumeration).
+unbind() {
+    local want="${1#0x}" d p i
+    for d in /sys/bus/usb/devices/*/idProduct; do
+        p=$(cat "$d" 2>/dev/null) || continue
+        [ "$p" = "$want" ] || continue
+        for i in "$(dirname "$d")":*; do
+            [ -e "$i/driver" ] || continue
+            sudo sh -c "echo '$(basename "$i")' > '$i/driver/unbind'" 2>/dev/null || true
+        done
+    done
+}
+
+pass=0; fail=0; skip=0
+
+run_one() {
+    local label="$1" vid="$2" pid="$3" demo="$4"
+    local log="$OUT/${label}-${demo}.log" rc
+    unbind "$pid"
+    sudo env \
+        ASAN_OPTIONS="abort_on_error=1:detect_leaks=0:log_path=$OUT/asan.$label.$demo" \
+        DEVOURER_VID="$vid" DEVOURER_PID="$pid" DEVOURER_CHANNEL="$CHANNEL" \
+        DEVOURER_LOG_LEVEL=info \
+        "$BUILD/$demo" >"$log" 2>&1 &
+    local bg=$!
+    sleep "$RUN_SECS"
+    sudo pkill -TERM -x "$demo" 2>/dev/null || true
+    wait "$bg"; rc=$?
+    if ls "$OUT/asan.$label.$demo".* >/dev/null 2>&1; then
+        echo "FAIL $label $demo: sanitizer report"
+        sudo head -12 "$OUT/asan.$label.$demo".*
+        fail=$((fail + 1))
+    elif [ "$rc" -ne 0 ]; then
+        echo "FAIL $label $demo: exit $rc"
+        tail -4 "$log"
+        fail=$((fail + 1))
+    else
+        echo "ok   $label $demo: clean exit"
+        pass=$((pass + 1))
+    fi
+    sleep 2
+}
+
+echo "== per-generation init/teardown under ASan (ch$CHANNEL) =="
+IFS=',' read -r -a duts <<< "$DUTS"
+for entry in "${duts[@]}"; do
+    IFS=':' read -r label vid pid <<< "$entry"
+    if ! lsusb -d "$(printf '%04x:%04x' "$vid" "$pid")" >/dev/null 2>&1; then
+        echo "skip $label ($vid:$pid not plugged)"
+        skip=$((skip + 1)); continue
+    fi
+    run_one "$label" "$vid" "$pid" rxdemo
+    run_one "$label" "$vid" "$pid" txdemo
+done
+
+echo
+echo "== $pass passed, $fail failed, $skip skipped (logs in $OUT) =="
+[ "$fail" -eq 0 ]

--- a/tests/tx_quiesce_selftest.cpp
+++ b/tests/tx_quiesce_selftest.cpp
@@ -1,0 +1,147 @@
+/* Headless guard for the TX quiesce seam (IRtlTransport::quiesce_tx,
+ * RtlAdapter::quiesce_tx).
+ *
+ * What this covers: that the quiesce call reaches the transport through the
+ * adapter, that a transport which has been quiesced refuses further sends and
+ * the refusal is visible to the caller as `send_packet() == false`, that the
+ * call is idempotent, and that the interface default is inert (the shape the
+ * synchronous transports rely on).
+ *
+ * What it does NOT cover: UsbTransport's implementation — cancelling live
+ * URBs, draining completions and owning the payload buffer. That needs a real
+ * libusb handle, so it is validated on hardware under ASan (the max-duty
+ * gap-0 teardown run), not here. This test exists so the wiring around it
+ * cannot be quietly removed. */
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "RtlAdapter.h"
+
+static int failures = 0;
+
+#define CHECK(cond)                                                            \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);     \
+      failures++;                                                              \
+    }                                                                          \
+  } while (0)
+
+namespace {
+
+/* Models the asynchronous half of a USB transport: a send is accepted while
+ * running and refused once quiesced, and quiesce is what drains. */
+class FakeAsyncTransport final : public devourer::IRtlTransport {
+public:
+  int accepted = 0;
+  int refused = 0;
+  int quiesce_calls = 0;
+  int inflight = 0;
+
+  bool is_usb() const override { return true; }
+  uint8_t read8(uint16_t) override { return 0; }
+  uint16_t read16(uint16_t) override { return 0; }
+  uint32_t read32(uint16_t) override { return 0; }
+  bool write8(uint16_t, uint8_t) override { return true; }
+  bool write16(uint16_t, uint16_t) override { return true; }
+  bool write32(uint16_t, uint32_t) override { return true; }
+  bool write_bytes(uint16_t, const uint8_t *, size_t) override { return true; }
+
+  bool tx_async(uint8_t, uint8_t *, size_t, unsigned) override {
+    if (_shutdown) {
+      ++refused;
+      return false;
+    }
+    ++accepted;
+    ++inflight;
+    return true;
+  }
+  int tx_sync(uint8_t, uint8_t *, size_t len, int) override {
+    return static_cast<int>(len);
+  }
+  void rx_loop(int, int, const std::function<void(const uint8_t *, int)> &,
+               const std::function<bool()> &) override {}
+
+  void quiesce_tx() override {
+    ++quiesce_calls;
+    if (_shutdown)
+      return; /* idempotent: the real one latches a flag the same way */
+    _shutdown = true;
+    inflight = 0;
+  }
+
+private:
+  bool _shutdown = false;
+};
+
+/* A transport whose TX is synchronous has nothing outstanding, so it inherits
+ * the interface's no-op — the property the HalMAC generations depend on. */
+class SyncOnlyTransport final : public devourer::IRtlTransport {
+public:
+  bool is_usb() const override { return false; }
+  uint8_t read8(uint16_t) override { return 0; }
+  uint16_t read16(uint16_t) override { return 0; }
+  uint32_t read32(uint16_t) override { return 0; }
+  bool write8(uint16_t, uint8_t) override { return true; }
+  bool write16(uint16_t, uint16_t) override { return true; }
+  bool write32(uint16_t, uint32_t) override { return true; }
+  bool write_bytes(uint16_t, const uint8_t *, size_t) override { return true; }
+  bool tx_async(uint8_t, uint8_t *, size_t len, unsigned) override {
+    return tx_sync(0, nullptr, len, 0) > 0;
+  }
+  int tx_sync(uint8_t, uint8_t *, size_t len, int) override {
+    return static_cast<int>(len);
+  }
+  void rx_loop(int, int, const std::function<void(const uint8_t *, int)> &,
+               const std::function<bool()> &) override {}
+};
+
+} /* namespace */
+
+int main() {
+  auto logger = std::make_shared<Logger>();
+  std::vector<uint8_t> frame(64, 0xA5);
+
+  {
+    auto fake = std::make_shared<FakeAsyncTransport>();
+    RtlAdapter adapter(fake, logger);
+
+    CHECK(adapter.send_packet(frame.data(), frame.size()));
+    CHECK(adapter.send_packet(frame.data(), frame.size()));
+    CHECK(fake->accepted == 2);
+    CHECK(fake->inflight == 2);
+
+    adapter.quiesce_tx();
+    CHECK(fake->quiesce_calls == 1);
+    CHECK(fake->inflight == 0);
+
+    /* Post-quiesce sends are refused, not queued: teardown has begun and
+     * nothing may re-enter the bus layer. */
+    CHECK(!adapter.send_packet(frame.data(), frame.size()));
+    CHECK(fake->refused == 1);
+    CHECK(fake->accepted == 2);
+
+    /* Stop() then the device destructor both quiesce — the second must be a
+     * no-op rather than a second cancel/drain pass. */
+    adapter.quiesce_tx();
+    CHECK(fake->quiesce_calls == 2);
+    CHECK(fake->inflight == 0);
+  }
+
+  {
+    auto sync = std::make_shared<SyncOnlyTransport>();
+    RtlAdapter adapter(sync, logger);
+    CHECK(adapter.send_packet(frame.data(), frame.size()));
+    adapter.quiesce_tx(); /* default no-op — must not disturb the transport */
+    CHECK(adapter.send_packet(frame.data(), frame.size()));
+  }
+
+  if (failures != 0) {
+    std::fprintf(stderr, "tx_quiesce_selftest: %d failure(s)\n", failures);
+    return 1;
+  }
+  std::printf("tx_quiesce_selftest: OK\n");
+  return 0;
+}

--- a/tests/tx_teardown_asan.sh
+++ b/tests/tx_teardown_asan.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Does a max-duty TX session tear down cleanly when it is killed mid-flight?
+#
+# Jaguar1 is the only generation whose send path is asynchronous: send_packet
+# submits a bulk-OUT URB and returns, so at a high frame rate there are always
+# transfers outstanding. Two things have to hold at exit, and neither is
+# observable at low duty (where the queue drains between frames — which is why
+# a gap-2000 run has always looked fine):
+#
+#   1. the URB may not reference memory the caller has already freed;
+#   2. the device — and with it those URBs — must die BEFORE libusb does.
+#
+# This drives an ASan build of txdemo at DEVOURER_TX_GAP_US=0, kills it with
+# SIGTERM mid-stream, and asserts a clean exit with no sanitizer report. The
+# gap-2000 and aggregation variants are run too: the first is the case that
+# always worked (a regression check), the second exercises the multi-frame
+# aggregation URB, which builds a differently-sized buffer.
+#
+# Build first (any Jaguar1 adapter; the DUT defaults to the 8821AU):
+#   cmake -S . -B build-asan -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+#         -DDEVOURER_SANITIZE=address && cmake --build build-asan -j
+# Run:
+#   sudo -v && tests/tx_teardown_asan.sh
+#   TX_VID=0x0bda TX_PID=0x8813 REPS=3 tests/tx_teardown_asan.sh   # 8814AU
+#
+# BUILD=<dir> points at a different (e.g. pre-fix) tree, which is how the
+# defect is demonstrated rather than merely asserted away.
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+BUILD="${BUILD:-$ROOT/build-asan}"
+TX_VID="${TX_VID:-0x2357}"
+TX_PID="${TX_PID:-0x0120}"   # Archer T2U Plus — RTL8821AU (Jaguar1)
+CHANNEL="${CHANNEL:-6}"
+TX_RATE="${TX_RATE:-MCS7}"
+RUN_SECS="${RUN_SECS:-8}"
+REPS="${REPS:-3}"
+OUT="${OUT:-/tmp/devourer-tx-teardown}"
+
+TXDEMO="$BUILD/txdemo"
+[ -x "$TXDEMO" ] || { echo "no txdemo at $TXDEMO — build it first"; exit 1; }
+lsusb -d "$(printf '%04x:%04x' "$TX_VID" "$TX_PID")" >/dev/null 2>&1 || {
+    echo "SKIP: TX adapter $TX_VID:$TX_PID not plugged"; exit 77; }
+
+mkdir -p "$OUT"
+rm -f "$OUT"/*.log "$OUT"/asan.* 2>/dev/null || true
+
+cleanup() {
+    sudo pkill -x txdemo 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# The in-tree rtw88 modules claim every Realtek dongle at enumeration. Unbind
+# the interface rather than rmmod: a module removal does not survive the next
+# re-enumeration, and it de-inits the chip on the way out.
+unbind() {
+    local want="${TX_PID#0x}" d p i
+    for d in /sys/bus/usb/devices/*/idProduct; do
+        p=$(cat "$d" 2>/dev/null) || continue
+        [ "$p" = "$want" ] || continue
+        for i in "$(dirname "$d")":*; do
+            [ -e "$i/driver" ] || continue
+            sudo sh -c "echo '$(basename "$i")' > '$i/driver/unbind'" 2>/dev/null || true
+        done
+    done
+}
+
+fail=0
+pass=0
+SIG="${SIG:-TERM}"
+
+# One kill-during-TX cell. $1 = label, remaining args = extra env assignments.
+cell() {
+    local label="$1"; shift
+    local rep log rc
+    for rep in $(seq 1 "$REPS"); do
+        log="$OUT/${label}-${rep}.log"
+        unbind
+        # ASAN_OPTIONS: abort_on_error makes a sanitizer finding a distinct
+        # exit status instead of a silently-appended report; the log prefix
+        # keeps the report out of the demo's own stderr stream.
+        sudo env \
+            ASAN_OPTIONS="abort_on_error=1:detect_leaks=0:log_path=$OUT/asan.$label.$rep" \
+            DEVOURER_VID="$TX_VID" DEVOURER_PID="$TX_PID" \
+            DEVOURER_CHANNEL="$CHANNEL" DEVOURER_TX_RATE="$TX_RATE" \
+            DEVOURER_LOG_LEVEL=info \
+            "$@" \
+            "$TXDEMO" >"$log" 2>&1 &
+        local pid=$!
+        sleep "$RUN_SECS"
+        # Signal the demo itself, not sudo: its handler is what breaks the TX
+        # loop and runs the ordered teardown under test.
+        sudo pkill "-$SIG" -x txdemo 2>/dev/null || true
+        wait "$pid"; rc=$?
+        local frames
+        frames=$(grep -c '"ev":"tx' "$log" 2>/dev/null || echo 0)
+        local asan_report=""
+        asan_report=$(ls "$OUT/asan.$label.$rep".* 2>/dev/null | head -1 || true)
+        if [ -n "$asan_report" ]; then
+            echo "FAIL $label rep$rep: sanitizer report ($asan_report)"
+            head -20 "$asan_report"
+            fail=$((fail + 1))
+        elif [ "$rc" -ne 0 ]; then
+            echo "FAIL $label rep$rep: exit $rc (SIGSEGV=139, SIGABRT=134)"
+            tail -5 "$log"
+            fail=$((fail + 1))
+        else
+            echo "ok   $label rep$rep: clean exit, ${frames} tx events"
+            pass=$((pass + 1))
+        fi
+        sleep 2   # let the adapter settle before the next claim
+    done
+}
+
+echo "== txdemo teardown under ASan =="
+echo "   build   $BUILD"
+echo "   adapter $TX_VID:$TX_PID  ch$CHANNEL  $TX_RATE"
+echo
+
+# The reported crash: queue saturated at the moment of the signal.
+cell gap0        DEVOURER_TX_GAP_US=0
+# Multi-frame aggregation URB — a different buffer size and lifetime.
+cell gap0-agg    DEVOURER_TX_GAP_US=0 DEVOURER_TX_USB_AGG=3
+# The case that always exited cleanly: nothing outstanding at the signal.
+cell gap2000     DEVOURER_TX_GAP_US=2000
+
+# The wedge path: the adapter vanishes while URBs are outstanding, so the
+# cancel-and-drain has to complete against a device that will never answer.
+# Needs a hub with per-port power switching (uhubctl `ppps`) — an
+# authorized-toggle is not a real unplug. WEDGE_HUB/WEDGE_PORT name the port
+# the DUT is on (uhubctl with no args lists them).
+if [ -n "${WEDGE_HUB:-}" ] && [ -n "${WEDGE_PORT:-}" ]; then
+    log="$OUT/wedge.log"
+    unbind
+    sudo env \
+        ASAN_OPTIONS="abort_on_error=1:detect_leaks=0:log_path=$OUT/asan.wedge" \
+        DEVOURER_VID="$TX_VID" DEVOURER_PID="$TX_PID" \
+        DEVOURER_CHANNEL="$CHANNEL" DEVOURER_TX_RATE="$TX_RATE" \
+        DEVOURER_LOG_LEVEL=info DEVOURER_TX_GAP_US=0 \
+        "$TXDEMO" >"$log" 2>&1 &
+    wedge_pid=$!
+    sleep "$RUN_SECS"
+    sudo uhubctl -l "$WEDGE_HUB" -p "$WEDGE_PORT" -a off >/dev/null 2>&1
+    # Give the demo a bounded window to notice and exit. A quiesce that cannot
+    # drain must still return (it logs tx.quiesce_timeout), so a hang here is
+    # itself the failure.
+    waited=0
+    while kill -0 "$wedge_pid" 2>/dev/null && [ "$waited" -lt 20 ]; do
+        sleep 1; waited=$((waited + 1))
+    done
+    if kill -0 "$wedge_pid" 2>/dev/null; then
+        echo "FAIL wedge: still running ${waited}s after the adapter lost power"
+        sudo pkill -x txdemo 2>/dev/null || true
+        fail=$((fail + 1))
+    elif ls "$OUT/asan.wedge".* >/dev/null 2>&1; then
+        echo "FAIL wedge: sanitizer report"
+        sudo head -20 "$OUT/asan.wedge".*
+        fail=$((fail + 1))
+    else
+        wait "$wedge_pid" 2>/dev/null; rc=$?
+        echo "ok   wedge: exited ${waited}s after power cut (rc=$rc)"
+        grep -q '"ev":"tx.quiesce_timeout"' "$log" &&
+            echo "     note: quiesce hit its deadline (drain never completed)"
+        pass=$((pass + 1))
+    fi
+    sudo uhubctl -l "$WEDGE_HUB" -p "$WEDGE_PORT" -a on >/dev/null 2>&1
+    sleep 3
+fi
+
+echo
+echo "== $pass passed, $fail failed (logs in $OUT) =="
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Two bugs that a sanitizer build found in the same session. They are independent
— separate commits — but they share the reason nobody had seen them: neither is
reachable from `ctest`, and one of them is invisible to the measurement we
normally trust.

## 1. TX teardown — fixes #281

`txdemo` segfaults inside libusb on teardown when killed during max-duty TX on
a Jaguar1 adapter, and exits cleanly at `DEVOURER_TX_GAP_US=2000`. Two defects
hid behind that one signature.

**The crash is a teardown-order bug.** `~UsbTransport` pumped
`libusb_handle_events` whenever transfers were in flight, but the demos
destroyed their `IRtlDevice` at end of `main` — after `libusb_release_interface`
/ `close` / `exit` — so the pump ran on a context libusb had already freed. Only
reachable with URBs outstanding at exit, i.e. exactly gap 0. `EepromManager`
appears in the backtrace only because it holds an `RtlAdapter` by value and is
declared first, so it drops the last transport reference; reordering members
would move the frame, not fix anything.

```
SEGV on unknown address 0x14 ... /usr/lib/libusb-1.0.so.0
  #3 devourer::UsbTransport::~UsbTransport()   UsbTransport.cpp:269
  #11 RtlJaguarDevice::~RtlJaguarDevice()      RtlJaguarDevice.cpp:1823
  #15 main                                     examples/tx/main.cpp:2061
```

**The second defect:** `RtlJaguarDevice::send_packet`/`send_packets` built the
URB in a local `std::vector` and handed `.data()` to a fire-and-forget
`libusb_submit_transfer`. libusb requires that buffer to outlive the transfer.
Linux usbfs copies the payload at submit, so it is invisible there — but it is a
real bug on the backends that keep the caller's pointer.

Fixed at the transport seam:

- **`IRtlTransport::quiesce_tx()`** — cancels every outstanding transfer, reaps
  the completions, refuses further sends; bounded by a deadline that reports
  `tx.quiesce_timeout` rather than hanging teardown. Called from
  `IRtlDevice::Stop()` and from every device destructor, i.e. while all owners
  are alive. Jaguar1 gains a `Stop()` override for it — TX quiesce only,
  deliberately **not** a card-disable power sequence, which this family has
  never run.
- **`tx_async` copies the payload** into a transport-owned buffer freed in the
  callback. Symmetric alloc/free rather than `LIBUSB_TRANSFER_FREE_BUFFER`,
  which would cross CRT heaps on Windows.
- **`examples/common/DeviceSession.h`** owns device → interface → handle →
  context and unwinds in that order; every demo adopts it, which also fixes the
  resources their early returns leaked.

Jaguar1-over-USB is the only asynchronous submitter in the tree, so the other
generations are unaffected — their quiesce finds nothing in flight.

**Validation** (RTL8821AU, ASan build): 4/6 cells crash before, **9/9 clean
after** — including SIGINT, the aggregation URB, and a real VBUS cut mid-flood
(NO_DEVICE completions, prompt quiesce, adapter re-enumerates). On-air
throughput unchanged (49.9/39.2 → 49.8/39.2 Mbps at 2.4/5 GHz); `regress.py`
green on ch6 and ch36; all generations clean under ASan.

## 2. Kestrel RX — fixes #343

The Kestrel receiver was dead in two whole regimes: **no CCK at all on 2.4 GHz,
and nothing above 20 MHz**. 20 MHz OFDM was fine on both bands and TX was fine
at every width, which is why it survived — the 40/80 MHz validation rested on
SDR transmit duty, and a duty measurement cannot see a broken receiver.

`HalKestrel::set_channel` passed `halbb_ctrl_bw_ch` a primary sub-band *index*
where the vendor wants the primary *channel number* (phl hands it
`rtw_chan_def::chan` unchanged). Inside, `pri_ch` is used three ways, all
receive-side: it indexes the 2.4 GHz CCK SCO threshold tables at `pri_ch - 1`,
it is compared against `central_ch` to derive the `0x4978[11:8]` sub-band index,
and it places the NBI spur notch. At 20 MHz the index is 0, so the CCK path
reads that table at `-1` — the stack-buffer-underflow that surfaced all of this.

| cell | before | after |
|---|---|---|
| CCK 1M @ ch6, RX 20 MHz | **0** | 57 |
| OFDM 6M @ ch6, RX 20 MHz | 56 | 56 ← control |
| OFDM 6M @ ch36, RX 20 MHz | 57 | 57 ← control |
| OFDM 6M @ ch36, **RX 40 MHz** | **0** | 57 |
| OFDM 6M @ ch36, **RX 80 MHz** | **0** | 57 |
| Kestrel **TX** 20/40/80 → ref RX | 38 | 38 |

RTL8832CU against an RTL8821AU emitter, hits over 12 s, each figure reproduced
twice. The 8852B backend has the identical function, so that die is affected the
same way — untested here for want of a plugged one.

## Tooling

`DEVOURER_SANITIZE=address|address+undefined|thread` builds the library, demos
and selftests instrumented (vendored halbb/halrf exempted from UBSan; MSVC
restricted to its ASan and made to error rather than silently degrade), plus a
`build-sanitizers` CI job running `ctest` under ASan+UBSan.

The bugs this class produces need a real device, so the hardware harnesses carry
the weight: `tests/tx_teardown_asan.sh`, `tests/teardown_gen_sanity.sh`,
`tests/kestrel_prich_onair.sh`. All three take `BUILD=<dir>`, which is how each
before/after table above was produced. One new headless test,
`tx_quiesce_seam`, guards the wiring; `ctest` is 47/47 under ASan+UBSan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
