### PR TITLE
Adaptive FHSS: measure the payload, and complete the sensing matrix (#341, #340)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,12 +414,29 @@ move leaves ME worse off" (broad TX degradation → delay; every survivor worse 
 reject), never "I disagree about your target": that signature IS the hidden-node
 case where the RX is right. Autonomous changes go through
 `start_local_change` (structural limits apply; the scripted lever stays exempt);
-`DEVOURER_HOP_MUTE=1` on rxdemo injects a one-way outage. On-air:
-`tests/hopset_adaptive_onair.sh` (protocol) and `tests/hopset_adaptive_jammer.sh`
-(`MODE=parked|herding|sense|failsafe|prepost|overhead`, B210 interferer);
-`tests/tx_sense_probe.sh` checks the telemetry is live at all. **Pick adapters by
-band** — a 5 GHz-only PA part senses nothing and cannot answer on 2.4 GHz.
-Sensing costs ~8% of frames (25 ms window, 1-in-2 dwells). Doc: `docs/fhss.md`.
+`DEVOURER_HOP_MUTE=1` on rxdemo injects a one-way outage. Two test levers (not
+production knobs): `DEVOURER_TX_SENSE_INJECT="<idx>:<occ>[,*:<occ>]"` fabricates
+the TX's per-channel view (bypasses the hardware read, keeps the window timing)
+— the only way to build the hidden-node case and its mirror on a bench where
+both adapters hear the same interferer; `DEVOURER_TX_STDIN=1` makes txdemo carry
+caller PSDU bodies from stdin (`streamtx` framing) so FEC delivery can be
+measured across an adaptation. The classifier needs `_POSTBURST_US` armed before
+it proposes anything of its own — without it the TX observes and holds, which
+looks like a TX that is not sensing.
+
+On-air: `tests/hopset_adaptive_onair.sh` (protocol) and
+`tests/hopset_adaptive_jammer.sh` (B210 interferer;
+`MODE=parked|herding|sense|failsafe|hidden|mirror|fusionmatrix|policycost|prepost|overhead`,
+every mode reporting FEC delivery beside the marker proxy over a window that
+opens only once the RX is tracking); `tests/tx_sense_probe.sh` checks the
+telemetry is live at all. **Pick adapters by band** — a 5 GHz-only PA part
+senses nothing and cannot answer on 2.4 GHz. Sensing costs ~8% of frames (25 ms
+window, 1-in-2 dwells) — a throughput cost, not a delivery-ratio one (FEC
+delivery is unchanged). **The marker proxy
+overstates adaptation**: against a parked jammer it reads 0.762 → 0.946 where
+payload reads 0.861 → 0.927 and the delivered packet rate does not move —
+carrier sense already keeps the TX out of the jammed dwells. Doc:
+`docs/fhss.md`.
 
 `IRtlDevice::FastSetBandwidth(bw)` is the bandwidth analogue — a lean
 same-channel toggle between 20 MHz and 5/10 MHz narrowband (baseband re-clock

--- a/docs/fhss.md
+++ b/docs/fhss.md
@@ -378,6 +378,64 @@ same one-channel-per-update and update-gap limits a follower proposal gets.
 The operator's scripted lever stays exempt — but a machine reacting to its own
 local evidence is precisely the actor those limits exist to bound.
 
+### Measuring it in payload, not in markers
+
+The receiver's policy scores dwells: a dwell counts as delivered when a sync
+marker arrived before the next retune. That is the right quantity for the
+policy — it is what the policy acts on — but it is the wrong one for judging
+whether adaptation helps, and the two disagree by a lot. A marker is one small
+frame at a robust rate, so a channel can decode markers while delivering
+payload badly; and a dwell that decoded one marker out of twenty frames scores
+1.0.
+
+So the jammer harness runs the real thing: RS-coded, sub-block-framed bodies
+from `tools/precoder` fed to the transmitter, decoded by the same salvage path
+the video link uses, reported next to the proxy. Measured on the 4-channel
+2.4 GHz base with a narrowband interferer parked on one member (25 s fixed,
+70 s adaptive, both windows opened only once the receiver was tracking):
+
+| measure | fixed keyed hopset | with the jammed channel excluded |
+|---|---|---|
+| marker proxy (dwells) | 0.762 | 0.946 |
+| FEC delivery (packets) | 0.861 | 0.927 |
+| recovered packets/s | 1001 | 986 |
+
+A repeat run of the same cells read 0.760 → 0.944 and 0.872 → 0.922, so the
+spread is under a point and the gap between the two measures is not noise: the
+proxy claims roughly three times the improvement the payload sees, and the
+delivered *rate* does not improve at all. Both facts have the same cause: on a
+CSMA link the transmitter defers to the interferer rather than transmitting
+into it, so a fixed hopset spends fewer frames on the jammed channel than its
+dwell share suggests, and the outer code already absorbs what it does spend.
+What exclusion buys here is margin — the erasure burst stops arriving at the
+decoder — not throughput. On a link with carrier sense disabled, where the
+transmitter really does spend a quarter of its frames into the jammer, the
+ratio and the rate would move together.
+
+Two failure modes only the payload measurement can see, both of which cost a
+bench session to find. A receiver that loses slot lock keeps scoring ~1.0 on
+the dwells it is present for, so the proxy reports a healthy link through an
+outage — the FEC figure and the fraction of the window actually tracked are
+what expose it. And a measurement window that opens at process start is mostly
+chip bring-up and acquisition: one 70 s phase read 0.30 FEC delivery whose
+settled part ran at 0.90.
+
+Two protocol details follow directly from that instrument, and both matter on
+any link running the salvage path:
+
+- The sync marker is a plain vendor IE whose only integrity is the frame FCS,
+  so a frame the chip flagged must never reach it. With corrupt frames surfaced
+  — which sub-block salvage requires — a corrupted marker whose seed
+  fingerprint happened to survive reads as a genuine generation change, and the
+  follower drops lockstep on a frame it should have discarded.
+- Both endpoints swap generation at the same absolute slot, but a marker
+  stamped just before that boundary is decoded just after it. It carries the
+  old generation truthfully, so the follower judges staleness by the slot the
+  marker was *stamped* in, not by when it arrived. Treating one such frame as
+  disagreement costs a full re-acquisition at the exact instant an exclusion
+  takes effect — measured at 46 s, because a scanning follower coincides with
+  the authority's status beacon only occasionally.
+
 ### What the sensor can and cannot see
 
 The occupancy scale is measured, not assumed. On this bench a narrowband
@@ -401,7 +459,52 @@ which is a fact about that adversary rather than about the sensor.
 Sensing costs what it stops sending. Measured with a 25 ms window on one dwell
 in two of a 200 ms slot: 7.7 % fewer frames per second, against 8.8 % predicted
 by summing the windows' own stamps. The two agreeing is the check that nothing
-unrecorded is being paid.
+unrecorded is being paid. Re-measured with both windows armed on the parked
+bench: 393.8 → 363.8 frames/s, 7.6 % measured against 8.1 % accounted.
+
+In payload terms that cost is a *rate*, not a ratio. Across the adaptation the
+sensing run aired 367 bodies/s against 399 without sensing — the same ~8 % —
+while FEC delivery was 0.937 against 0.930, i.e. unchanged. Sensing buys the
+veto and the failsafe with throughput, and takes nothing from the delivery of
+what it does send.
+
+### Who decides, measured four ways
+
+The same parked interferer under each fusion policy, one exclusion available,
+60 s per row and 180 s for the failsafe (it may not act until the feedback
+timeout has expired *and* its own observation window has filled — a shorter row
+measures the un-adapted link under the failsafe's name). Post-burst sensing is
+armed on every row so the throughput column compares policies rather than
+windows:
+
+| fusion | marker | FEC delivery | frames/s | exclusions |
+|---|---|---|---|---|
+| `rx` | 0.912 | 0.940 | 451 | 1 |
+| `veto` | 0.921 | 0.932 | 457 | 1 |
+| `either` | 0.922 | 0.932 | 471 | 1 |
+| `failsafe` (receiver muted) | 0.908 | 0.932 | 453 | 1 |
+
+The four agree within the run-to-run spread, and that is the result: when the
+receiver is right, the fusion mode decides *who may act*, not what happens.
+The failsafe reaches the same place with no uplink at all, only later.
+
+### What the receiver's own uplink costs it
+
+The receiver is half duplex, so every frame it airs is a slot it cannot hear —
+and a heartbeat that transmits in the slots it needs for listening is a bug
+this feature has had before. Three cells with no interferer at all, differing
+only in whether the receiver talks: policy off, policy on with the uplink muted
+(it decides and airs nothing), policy on and live. Muted-versus-live is the
+comparison that isolates the transport, because both cells make the same
+decisions.
+
+Measured over 60 s cells: 19 control frames per minute — one status per 64
+slots — costing under 5 ms of air per minute, and FEC delivery of 0.910 muted
+against 0.943 live, i.e. no measurable cost at all against a cell-to-cell
+spread of ±3.6 points. All three cells held lockstep for the whole window. The
+cadence is therefore not the limiting factor and does not need tightening; what
+does cost is losing lock, which is worth tens of seconds and is why the two
+marker rules above exist.
 
 ### Driving it
 
@@ -428,19 +531,60 @@ it has; `DEVOURER_HOP_MUTE=1` on the receiver is the fault-injection lever that
 produces a genuine one-way outage. All of it is inert unset, so the
 receiver-driven behaviour is exactly what it was.
 
+Note that the classifier will not propose anything of its own without
+post-burst evidence, so any run in which the transmitter must originate — the
+failsafe, or any test of its opinion — has to arm `_POSTBURST_US`. Without it
+the transmitter observes and holds, which looks identical to a transmitter that
+is not sensing at all unless the hold reason is read.
+
+`DEVOURER_TX_SENSE_INJECT="<idx>:<occ>[,...]"` (with an optional `*:<occ>`
+default) replaces the transmitter's per-channel view with fabricated occupancy,
+bypassing the hardware read but keeping the windows' timing so the duty cycle
+is unchanged. It is a test lever in the same spirit as
+`DEVOURER_HOP_ADAPTIVE_SCRIPT` and `DEVOURER_HOP_MUTE`, and it exists because
+the two endpoint-disagreement cases cannot otherwise be built: on a bench the
+adapters sit inches apart, and any interferer strong enough to degrade one is
+equally audible at the other. Injected evidence earns no more authority than
+measured evidence — the floors, the hysteresis and the cleaner-alternative rule
+all still apply to it.
+
+`DEVOURER_TX_STDIN=1` makes `txdemo` carry caller payload from stdin in the
+`<u32_le len><PSDU>` framing `streamtx` reads, which is what lets FEC delivery
+be measured across an adaptation: the authority, the sensing windows and the
+recovery probes all live in that demo, so the payload has to come to them.
+Probe dwells consume no body — the shard is not spent on an excluded channel
+and not thrown away either.
+
 On-air: `tests/hopset_adaptive_onair.sh` (protocol), and
 `tests/hopset_adaptive_jammer.sh` for the decision loop against a real B210
-interferer — `MODE=parked` (exclude, improve, restore once the jammer leaves)
-and `MODE=herding` (the jammer moves onto a newly-active channel after every
-exclusion). Measured on a 4-channel 2.4 GHz base with a narrowband interferer
-parked on one member: delivery 0.72 → 0.83 with the jammed channel excluded and
-probe-driven restoration after the interferer stopped; under herding, the
-active set held at the floor of 3 with committed exclusion depth 1 and no
-collapse. Two rig notes that cost a session: a flat TXAGC index chosen to back
+interferer. `MODE=parked` is exclude → improve → restore once the jammer
+leaves; `MODE=sense` repeats it with the transmitter's own evidence armed and
+asserts it does not contradict a correct receiver; `MODE=herding` moves the
+jammer onto a newly-active channel after every exclusion, and with
+`FUSION=failsafe MUTE=1` it does so against *transmitter*-originated exclusions,
+which is where the anti-herding limits carry the whole load. `MODE=fusionmatrix`
+and `MODE=policycost` produce the two tables above. `MODE=hidden` and
+`MODE=mirror` are the two disagreement scenarios, built with the injection
+lever.
+
+Measured on a 4-channel 2.4 GHz base with a narrowband interferer parked on one
+member: the jammed channel excluded and probe-restored after the interferer
+stopped, with delivery and FEC delivery as tabulated above. Under herding, with
+the transmitter deciding alone, the active set held at the floor of 3, every
+committed update moved exactly one channel, exclusion depth stayed at 1 and
+delivery did not collapse (0.840 → 0.841) — the interferer is tracked, not
+out-run. In the hidden-node row the receiver's exclusion passed unvetoed and
+the applied mask was bit-identical to its proposal, with the disagreement
+recorded rather than acted on; in the mirror row a transmitter told a healthy
+channel was filthy spent nothing, and said so on the record.
+
+Three rig notes that each cost a session: a flat TXAGC index chosen to back
 5 GHz off can put 2.4 GHz below the receiver's sensitivity and look exactly
-like a dead link, and an interferer loud enough to splatter across the whole
-band is broad degradation, not a channel fault — the policy correctly refuses
-to act on it.
+like a dead link; an interferer loud enough to splatter across the whole band
+is broad degradation, not a channel fault, and the policy correctly refuses to
+act on it; and a cell that starts before the previous one's demos have released
+their adapters measures nothing at all, because the advisory per-adapter lock
+is held until the chip has been de-initialised.
 
 ## Where it stands
 
@@ -457,7 +601,16 @@ experiment uses a 3-channel hopset because a single B210 needs ≥60 MS/s to spa
 a 60 MHz hopset in one FFT and trips a UHD tuning assertion at the usual
 61.44 MS/s. Adaptive exclusion is receiver-driven and opt-in: with the policy
 off the schedule visits every configured channel and the fused-FEC layer
-absorbs jammed dwells as erasures, and with it on the transmitter never senses
-for itself — it acts only on an authenticated proposal from the endpoint that
-has to decode. A herding jammer cannot be out-run, only survived: the floor
-keeps the link diverse rather than winning the exchange.
+absorbs jammed dwells as erasures, and with it on the transmitter senses for
+itself only when asked to. A herding jammer cannot be out-run, only survived:
+the floor keeps the link diverse rather than winning the exchange.
+
+And the effect is smaller in payload than the dwell proxy suggests. Against a
+parked narrowband interferer the outer code already carries a fixed hopset
+through its jammed dwells, and carrier sense keeps the transmitter from
+spending many frames there in the first place, so exclusion improves the
+delivered ratio by a few points and the delivered *rate* not at all. The two
+disagreement scenarios that decide whether the veto is safe are demonstrated
+with fabricated transmitter evidence, not with a real hidden node: a bench
+where the adapters sit inches apart cannot produce one, and that limit is a
+property of the bench rather than of the design.

--- a/docs/jammer-resilience.md
+++ b/docs/jammer-resilience.md
@@ -95,6 +95,13 @@ The gap between those two thresholds is what a keyed permutation buys.
   streamers per cycle (streamer setup is ~hundreds of ms and rapid RX/TX
   switching corrupts the B200 control channel). Persistent streamers with
   serialized control (send burst → sense → retune, one thread) are stable.
-- The hop schedule visits every configured channel; there is no adaptive
-  exclusion of a persistently-jammed one — the FEC absorbs those dwells (the
-  ~1/N loss in experiment 1).
+- These two experiments use a fixed schedule that visits every configured
+  channel, and the FEC absorbs the jammed dwells (the ~1/N loss in experiment
+  1). Dropping a persistently-jammed channel from the schedule is the adaptive
+  hopset, measured on this same metric in `docs/fhss.md`: against a parked
+  interferer it moves FEC delivery from 0.861 to 0.927 and the delivered packet
+  rate not at all. The outer code was already carrying the fixed schedule
+  through those dwells, and carrier sense was already keeping the transmitter
+  from spending many frames in them — so exclusion buys margin, not throughput,
+  and against a jammer that follows every exclusion it buys diversity rather
+  than delivery.

--- a/examples/rx/main.cpp
+++ b/examples/rx/main.cpp
@@ -156,6 +156,19 @@ static void hopset_send(const devourer::hopset::HopsetMsg &m) {
   const auto body = devourer::hopset::hopset_encode(m, *g_hopset_keys);
   frame.insert(frame.end(), body.begin(), body.end());
   g_hopset_dev->send_packet(frame.data(), frame.size());
+  /* Every control frame this side airs is a slot it is NOT listening in — the
+   * receiver is half duplex like everything else. One event per FRAME is what
+   * makes that cost measurable rather than assumed: proposals retry and the
+   * status beacon repeats, so counting decisions would undercount airtime. */
+  devourer::Ev(*g_ev, "hopset.ctl")
+      .f("v", 1)
+      .f("role", "rx")
+      .f("type", m.type == devourer::hopset::HT_PROPOSAL   ? "proposal"
+                 : m.type == devourer::hopset::HT_COMMIT   ? "commit"
+                                                           : "status")
+      .f("gen", (unsigned long long)m.generation)
+      .f("bytes", (unsigned long long)frame.size())
+      .f("slot", (unsigned long long)g_hopset_now_slot.load());
 }
 
 /* Frames the follower wants aired, queued under g_hopset_mu and sent after it
@@ -751,7 +764,14 @@ static void packetProcessor(const Packet &packet) {
     return; /* a trigger is not a data/mgmt frame — nothing else to match */
   }
 
+  /* The sync marker's only integrity is the frame FCS — it is a plain vendor
+   * IE, unlike the authenticated control frames. So a frame the chip flagged
+   * must never reach it: under DEVOURER_RX_KEEP_CORRUPTED (which the salvage
+   * path needs, and which the FPV link runs with) a corrupted marker whose
+   * seed fingerprint happened to survive was decoded as a genuine generation
+   * change, and the follower dropped lockstep on it. */
   if (g_hop_schedule && packet.Data.size() >= 16 &&
+      !packet.RxAtrib.crc_err && !packet.RxAtrib.icv_err &&
       std::memcmp(packet.Data.data() + 10, kTxSa, 6) == 0) {
     /* Adaptive mode rides the v2 marker (v1 layout + generation/mask_fp);
      * fixed mode stays on v1 — each decoder rejects the other version. */

--- a/examples/tx/main.cpp
+++ b/examples/tx/main.cpp
@@ -43,6 +43,7 @@
 #include "hopset/HopsetSense.h"
 #include "hopset/HopsetWire.h"
 #include "RxPacket.h"
+#include "stream_stdin.h"
 #include "SweepSpec.h"
 #include "TxPower.h" /* txpkt_pwr_db_for_step — DEVOURER_TX_PKT_OFSET fan-out */
 #include "caps_event.h"
@@ -152,6 +153,15 @@ static size_t g_hopset_pending_bit = SIZE_MAX;
 static bool g_hopset_pending_restore = false;
 static uint32_t g_hopset_delays = 0;
 
+/* DEVOURER_TX_SENSE_INJECT — synthetic per-channel occupancy for this side's
+ * sensor. A TEST LEVER, in the same spirit as DEVOURER_HOP_ADAPTIVE_SCRIPT and
+ * DEVOURER_HOP_MUTE, not a production knob: it exists because the two
+ * endpoint-disagreement scenarios cannot be built on a bench where the
+ * adapters sit inches apart and any interferer strong enough to degrade one is
+ * equally audible at the other. Indexed by base-hopset position; negative
+ * means "read the hardware for this one". */
+static std::vector<double> g_sense_inject;
+
 /* Execute the authority's actions (caller holds g_hopset_mu). Commit and
  * status frames air as their own small MPDUs beside the payload stream, so
  * caller payload bytes are never touched. */
@@ -214,14 +224,21 @@ static bool hopset_sense_window(IRtlDevice *dev, uint32_t settle_us,
                                 uint32_t generation) {
   if (!dev || !g_hopset_sensor)
     return false;
+  /* An injected channel skips the hardware entirely — on a part whose front
+   * end is blind on this band the counters would be a fiction anyway — but it
+   * still spends the settle and the window, so the slot budget and the
+   * duty-cycle cost of sensing are exactly what an un-injected run pays. */
+  const double inject =
+      base_index < g_sense_inject.size() ? g_sense_inject[base_index] : -1.0;
   const auto t_settle0 = std::chrono::steady_clock::now();
   if (settle_us)
     std::this_thread::sleep_for(std::chrono::microseconds(settle_us));
-  (void)dev->GetRxEnergy(/*with_nhm=*/false); /* DISCARD BARRIER */
+  if (inject < 0.0)
+    (void)dev->GetRxEnergy(/*with_nhm=*/false); /* DISCARD BARRIER */
   const auto t_w0 = std::chrono::steady_clock::now();
   std::this_thread::sleep_for(std::chrono::microseconds(window_us));
   const auto t_r0 = std::chrono::steady_clock::now();
-  const RxEnergy e = dev->GetRxEnergy(with_nhm);
+  const RxEnergy e = inject < 0.0 ? dev->GetRxEnergy(with_nhm) : RxEnergy{};
   const auto t_r1 = std::chrono::steady_clock::now();
   auto us = [](auto a, auto b) {
     return static_cast<uint32_t>(
@@ -235,6 +252,22 @@ static bool hopset_sense_window(IRtlDevice *dev, uint32_t settle_us,
   x.phase = phase;
   x.probe = probe;
   x.window_us = us(t_w0, t_r1);
+  if (inject >= 0.0) {
+    x.injected = true;
+    x.injected_occupancy = inject;
+    x.flags |= devourer::hopset::kTsInjected;
+    devourer::hopset::SenseScore isc;
+    const bool iscored =
+        devourer::hopset::score_sample(x, g_hopset_sensor->config(), isc);
+    {
+      std::lock_guard<std::mutex> lk(g_hopset_mu);
+      g_hopset_sensor->ingest(x);
+    }
+    devourer::hopset::emit_sense(*g_ev, x, channel, generation,
+                                 us(t_settle0, t_w0), 0, isc.occupancy,
+                                 iscored);
+    return true;
+  }
   x.valid_fa = e.valid_fa;
   x.fa_ofdm = e.fa_ofdm;
   x.fa_cck = e.fa_cck;
@@ -365,6 +398,14 @@ static void packetProcessor(const Packet &packet) {
               hm, devourer::hopset::HopsetReason::TxVeto, now));
         } else {
           g_hopset_delays = 0;
+          /* Record the pass-through as deliberately as the veto. When this
+           * side saw a clean band and let a proposal through anyway — the
+           * hidden node — the only evidence that it HAD a view and declined
+           * to argue is this event; without it, a blind sensor and a
+           * disciplined one look identical in the log. */
+          devourer::hopset::emit_fusion(
+              *g_ev, f, now, in.now_round,
+              devourer::hopset::fusion_mode_name(g_hopset_fusion.mode));
           hopset_route(g_hopset_auth->on_proposal(hm, now));
         }
       } else {
@@ -1096,6 +1137,55 @@ int main(int argc, char **argv) {
                  "the beacon", ra_env);
   }
 
+  /* DEVOURER_TX_STDIN=1 — carry caller payload instead of the demo body, in
+   * the same <u32_le len><PSDU body> framing streamtx reads (and
+   * tools/precoder/fused_fec_tx.py writes). This is what lets the adaptive
+   * hopset be measured in FEC delivery rather than in sync markers: the
+   * schedule authority, the sensing windows and the recovery probes all live
+   * in THIS demo, so the payload has to come to them.
+   *
+   * The header is frozen here, after every frame-shape knob has run, and each
+   * frame is rebuilt from it. That keeps the marker append below at its
+   * invariant — the marker is the trailing element of the frame — with no
+   * chance of last frame's body surviving into this one. */
+  const bool stdin_src = std::getenv("DEVOURER_TX_STDIN") != nullptr;
+  std::vector<uint8_t> stdin_hdr, stdin_body;
+  size_t stdin_max = 4096;
+  long stdin_bodies = 0;
+  bool stdin_done = false, stdin_truncated = false;
+  if (stdin_src) {
+    /* Each of these either writes into the caller's body or replays one, and
+     * a silently duplicated FEC shard is worse to a decoder than a lost one. */
+    struct { const char *env; const char *why; bool count; } kBad[] = {
+        {"DEVOURER_TX_BATCH", "replays one body N times", true},
+        {"DEVOURER_TX_THREADS", "aux senders loop a stale body", true},
+        {"DEVOURER_TX_QOS_DATA", "its counter stamp overwrites body[0..3]", false},
+        {"DEVOURER_TX_NDPA_RA", "a control frame carries no payload", false},
+        {"DEVOURER_TX_PAYLOAD_BYTES", "the body length is the caller's", false},
+        {"DEVOURER_HOP_RADIOTAP", "it rebuilds the frame inside the loop", false},
+        {"DEVOURER_CONT_TX", "an idle carrier has no per-frame path", false},
+    };
+    for (const auto &b : kBad) {
+      const char *v = std::getenv(b.env);
+      if (!v || (b.count && std::strtol(v, nullptr, 0) <= 1))
+        continue;
+      logger->error("DEVOURER_TX_STDIN with {} — {}", b.env, b.why);
+      return 1;
+    }
+    const size_t demo_body = sizeof(beacon_frame) - 34; /* radiotap + 802.11 */
+    if (tx_buf.size() <= demo_body) {
+      logger->error("DEVOURER_TX_STDIN — unexpected frame shape");
+      return 1;
+    }
+    stdin_hdr.assign(tx_buf.begin(), tx_buf.end() - demo_body);
+    if (const char *e = std::getenv("DEVOURER_TX_STDIN_MAX"))
+      stdin_max = static_cast<size_t>(std::strtoul(e, nullptr, 0));
+    stream_stdin::set_stdin_binary();
+    logger->info("DEVOURER_TX_STDIN — {}-byte header + caller PSDU bodies from "
+                 "stdin; stdin paces the link (DEVOURER_TX_GAP_US adds on top)",
+                 stdin_hdr.size());
+  }
+
   /* Thermal monitoring — read inline on the TX (owning) thread, so no
    * background thread shares the libusb handle (no USB contention). Cadence is
    * derived from DEVOURER_THERMAL_POLL_MS over the ~2 ms/packet loop; 0 =
@@ -1280,6 +1370,45 @@ int main(int argc, char **argv) {
       envu("DEVOURER_TX_SENSE_MAX_FRAC_PCT", tx_sense_max_frac_pct);
       if (std::getenv("DEVOURER_TX_SENSE_NHM"))
         tx_sense_nhm = std::atoi(std::getenv("DEVOURER_TX_SENSE_NHM")) != 0;
+      /* DEVOURER_TX_SENSE_INJECT="<idx>:<occ>[,...]" with an optional
+       * "*:<occ>" default for the positions not named. An index left
+       * un-injected reads the hardware as usual, so a run can mix the two. */
+      if (const char *sp = std::getenv("DEVOURER_TX_SENSE_INJECT")) {
+        g_sense_inject.assign(hop_channels.size(), -1.0);
+        std::string s(sp), tok;
+        std::stringstream ss(s);
+        while (std::getline(ss, tok, ',')) {
+          const auto colon = tok.find(':');
+          if (colon == std::string::npos)
+            throw std::invalid_argument(
+                "DEVOURER_TX_SENSE_INJECT wants <idx|*>:<occupancy> entries");
+          const std::string key = tok.substr(0, colon);
+          const double occ = std::strtod(tok.c_str() + colon + 1, nullptr);
+          if (occ < 0.0 || occ > 1.0)
+            throw std::invalid_argument(
+                "DEVOURER_TX_SENSE_INJECT occupancy must be in [0,1]");
+          if (key == "*") {
+            for (auto &v : g_sense_inject)
+              if (v < 0.0)
+                v = occ;
+          } else {
+            const long idx = std::strtol(key.c_str(), nullptr, 0);
+            if (idx < 0 || size_t(idx) >= g_sense_inject.size())
+              throw std::invalid_argument(
+                  "DEVOURER_TX_SENSE_INJECT index outside the base hopset");
+            g_sense_inject[size_t(idx)] = occ;
+          }
+        }
+        std::string shown;
+        for (size_t i = 0; i < g_sense_inject.size(); ++i)
+          shown += (i ? "," : "") +
+                   (g_sense_inject[i] < 0.0
+                        ? std::string("hw")
+                        : std::to_string(g_sense_inject[i]).substr(0, 4));
+        logger->warn("DEVOURER_TX_SENSE_INJECT — synthetic sensing evidence "
+                     "[{}]: this run's transmitter view is fabricated, not "
+                     "measured", shown);
+      }
       if (tx_sense_every < 1)
         tx_sense_every = 1;
     }
@@ -1670,7 +1799,48 @@ int main(int argc, char **argv) {
           }
         } else if (cand.kind !=
                    devourer::hopset::TxSenseCandidate::Kind::None) {
+          /* This side wanted to act and the fusion layer held it — under the
+           * default mode, because this side does not originate. That is the
+           * mirror of the hidden node: the transmitter sees something the
+           * receiver's delivery does not corroborate, and the right answer is
+           * to spend nothing. Say so anyway: a disagreement that leaves no
+           * trace is indistinguishable from a sensor that never fired.
+           * Rate-limited to the shape of the argument, not its repetition. */
+          static size_t last_target = SIZE_MAX;
+          static uint32_t last_hold = 0xffffffffu;
+          static uint64_t last_round = 0;
+          const uint32_t hold_now = static_cast<uint32_t>(f.hold);
+          /* Round numbering REBASES at each activation, so the elapsed test
+           * has to tolerate going backwards — an unsigned difference would
+           * wrap and leave the limiter permanently open from the first
+           * commit onwards, flooding the log at exactly the moment it most
+           * needs to be readable. */
+          const bool stale = round < last_round || round - last_round >= 60;
+          if (f.target_index != last_target || hold_now != last_hold || stale) {
+            last_target = f.target_index;
+            last_hold = hold_now;
+            last_round = round;
+            devourer::hopset::emit_fusion(
+                *g_ev, f, desired_slot, round,
+                devourer::hopset::fusion_mode_name(g_hopset_fusion.mode));
+          }
           g_hopset_sensor->clear_outstanding(round);
+        } else {
+          /* Nothing proposed. Say why, at the shape of the answer rather than
+           * its repetition: a sensor held on a floor, a sensor with no
+           * evidence and a sensor that is not running are otherwise the same
+           * silence, and telling them apart on air took a whole bench
+           * session. */
+          static uint32_t last_eval_hold = 0xffffffffu;
+          static uint64_t last_eval_round = 0;
+          const uint32_t h = static_cast<uint32_t>(cand.hold);
+          /* Same rebase hazard as the fused-decision limiter above. */
+          if (h != last_eval_hold || round < last_eval_round ||
+              round - last_eval_round >= 120) {
+            last_eval_hold = h;
+            last_eval_round = round;
+            devourer::hopset::emit_sense_eval(*g_ev, cand, desired_slot, round);
+          }
         }
       }
     }
@@ -1817,12 +1987,73 @@ int main(int argc, char **argv) {
         continue;
       }
     }
+    /* Caller payload for this frame. Placed after the post-burst window's
+     * `continue` (that dwell airs nothing, so it must consume nothing) and
+     * before the marker append, which owns the tail of the frame.
+     *
+     * A probe dwell reads no body at all: the shard is not spent on an
+     * excluded channel, and it is not thrown away either — it is simply still
+     * there for the next data dwell. The probe still airs its header and
+     * marker, which is what makes it a probe. */
+    if (stdin_src && !stdin_done) {
+      if (hop_probe_slot) {
+        tx_buf.assign(stdin_hdr.begin(), stdin_hdr.end());
+      } else {
+        uint8_t len_bytes[4];
+        auto r = stream_stdin::read_exact(stdin, len_bytes, sizeof(len_bytes));
+        if (r == stream_stdin::ReadResult::Eof) {
+          stdin_done = true;
+        } else if (r != stream_stdin::ReadResult::Ok) {
+          logger->error("DEVOURER_TX_STDIN — truncated length prefix after {} "
+                        "bodies", stdin_bodies);
+          stdin_done = stdin_truncated = true;
+        } else {
+          const uint32_t len = static_cast<uint32_t>(len_bytes[0]) |
+                               (static_cast<uint32_t>(len_bytes[1]) << 8) |
+                               (static_cast<uint32_t>(len_bytes[2]) << 16) |
+                               (static_cast<uint32_t>(len_bytes[3]) << 24);
+          if (!len || len > stdin_max) {
+            logger->error("DEVOURER_TX_STDIN — body length {} out of range "
+                          "(max {})", len, stdin_max);
+            stdin_done = stdin_truncated = true;
+          } else {
+            stdin_body.resize(len);
+            if (stream_stdin::read_exact(stdin, stdin_body.data(), len) !=
+                stream_stdin::ReadResult::Ok) {
+              logger->error("DEVOURER_TX_STDIN — truncated body ({} bytes) "
+                            "after {} bodies", len, stdin_bodies);
+              stdin_done = stdin_truncated = true;
+            } else {
+              /* Progress, not just a final tally: a harness that scores one
+               * phase of a longer session needs the body count AT the phase
+               * boundary, and the process is still running then. */
+              if (++stdin_bodies % 100 == 0)
+                devourer::Ev(*g_ev, "tx.stdin")
+                    .f("bodies", (unsigned long long)stdin_bodies)
+                    .f("final", 0);
+            }
+          }
+        }
+        if (stdin_done)
+          break; /* out of the TX loop, into the ordinary teardown */
+        tx_buf.assign(stdin_hdr.begin(), stdin_hdr.end());
+        tx_buf.insert(tx_buf.end(), stdin_body.begin(), stdin_body.end());
+      }
+    }
     if (hop_schedule && hop_slot_ms > 0) {
       /* strip the previous frame's marker (either version — one run emits
-       * only one, but the size differs) before appending the fresh one */
+       * only one, but the size differs) before appending the fresh one.
+       *
+       * NOT in stdin mode: there the frame was just rebuilt from the frozen
+       * header plus a fresh body, so no marker can be present — and the test
+       * is only two bytes deep, so on caller payload (RS symbols, uniformly
+       * random) it matches about one frame in 65536 and would silently chop
+       * 37 bytes off that shard. At 450 frames a second that is a corrupted
+       * body every couple of minutes, arriving with a valid FCS. */
       const size_t msz = hop_adaptive ? devourer::hopset::HopSyncMarkerV2::kSize
                                       : devourer::HopSyncMarker::kSize;
-      if (tx_buf.size() >= msz && tx_buf[tx_buf.size() - msz] == 221 &&
+      if (!stdin_src && tx_buf.size() >= msz &&
+          tx_buf[tx_buf.size() - msz] == 221 &&
           tx_buf[tx_buf.size() - msz + 5] == 0x48)
         tx_buf.resize(tx_buf.size() - msz);
       const auto now = std::chrono::steady_clock::now();
@@ -2021,6 +2252,19 @@ int main(int argc, char **argv) {
         .f("final", 1);
   }
 
+  /* Shard accounting: what the producer handed us versus what the chip was
+   * asked to air. A harness that reads only the receiver's side cannot tell a
+   * body that never left from one that did not arrive. */
+  if (stdin_src) {
+    devourer::Ev(*g_ev, "tx.stdin")
+        .f("bodies", (unsigned long long)stdin_bodies)
+        .f("truncated", stdin_truncated ? 1 : 0)
+        .f("eof", stdin_done && !stdin_truncated ? 1 : 0)
+        .f("final", 1);
+    logger->info("DEVOURER_TX_STDIN — {} caller bodies aired{}", stdin_bodies,
+                 stdin_truncated ? " (input truncated)" : "");
+  }
+
   /* Bounded hop mode (DEVOURER_HOP_ROUNDS>0) reaches here when its rounds
    * complete; the signal and back-off paths also fall through. */
   if (!hop_channels.empty()) {
@@ -2066,5 +2310,7 @@ int main(int argc, char **argv) {
    * only because the process has nothing left to do here — the destructor
    * does exactly the same on every other exit path. */
   session.close();
-  return 0;
+  /* A truncated caller stream is a producer fault, and a harness that scored
+   * the run as if it had ended cleanly would be scoring a short measurement. */
+  return stdin_truncated ? 2 : 0;
 }

--- a/src/hopset/HopsetEvents.h
+++ b/src/hopset/HopsetEvents.h
@@ -114,9 +114,32 @@ inline void emit_sense(EventSink &sink, const TxSenseSample &s,
   if (s.valid_nhm)
     ev.f("nhm_busy", (unsigned long long)s.nhm_busy_pct)
         .f("nhm_dur", (unsigned long long)s.nhm_duration);
+  if (s.injected)
+    ev.f("inject", 1);
   ev.hexf("flags", s.flags, 0).f("scored", scored);
   if (scored)
     ev.f("occ", occupancy);
+}
+
+/* Why this side's sensor proposed nothing. Held is not the same as blind, and
+ * neither is the same as content: without this, a sensor sitting on a floor,
+ * a sensor with no evidence and a sensor that is not running all produce the
+ * same silence. Rate-limited by the caller to the shape of the answer. */
+inline void emit_sense_eval(EventSink &sink, const TxSenseCandidate &c,
+                            uint64_t slot, uint64_t round) {
+  Ev(sink, "hopset.sense_eval")
+      .t()
+      .f("v", 1)
+      .f("role", "tx")
+      .f("slot", (unsigned long long)slot)
+      .f("round", (unsigned long long)round)
+      .f("hold", tx_sense_hold_name(c.hold))
+      .f("chans", (unsigned long long)c.chans_with_evidence)
+      .f("samples", (unsigned long long)c.sample_count)
+      .f("band_min", c.band_min_occ)
+      .f("band_max", c.band_max_occ)
+      .f("broad", c.broad_occupancy)
+      .f("flat", c.flat_band);
 }
 
 /* One fused verdict. Both endpoints' views are on the line so a log reader can

--- a/src/hopset/HopsetFollower.h
+++ b/src/hopset/HopsetFollower.h
@@ -129,7 +129,6 @@ public:
   /* The authority's status beacon (also carries proposal rejections). */
   std::vector<HopsetAction> on_status(const HopsetMsg &m, uint64_t now_slot) {
     std::vector<HopsetAction> out;
-    (void)now_slot;
     if (m.role != 1)
       return out; /* peer-follower chatter — not authority state */
     if (m.base_fp != p_.base_fp)
@@ -148,6 +147,14 @@ public:
     if (!mask_valid(m.active_mask, p_.n_base, p_.min_active) &&
         m.generation != 0)
       return drop(out, HopsetReason::BadMask);
+    /* The same activation-window bound a commit gets. The status path adopts
+     * outright, and its anchor is what the in-flight-marker grace measures
+     * against — an activation slot far in the future would stretch that grace
+     * over every marker the follower will ever decode and silently disable
+     * the only hot-path mismatch tripwire. */
+    if (m.activate_slot > now_slot &&
+        m.activate_slot - now_slot > p_.max_lead_slots)
+      return drop(out, HopsetReason::ActivationWindow);
     const bool same_epoch = have_auth_ && m.sender_epoch == auth_epoch_;
     if (same_epoch && m.generation < cur_.generation)
       return drop(out, HopsetReason::ReplayGen);
@@ -174,16 +181,28 @@ public:
 
   /* Hot-path check from a decoded v2 sync marker. fp_matches: host-computed
    * "the marker's (generation, mask_fp) equals mask_fp(keys, gen, mask) of
-   * the state we hold for that generation" (current or pending). */
+   * the state we hold for that generation" (current or pending).
+   * marker_slot is the slot the MARKER was stamped in — the transmitter's
+   * clock at composition, not the local clock at decode, which is what makes
+   * a boundary-crossing frame recognizable as one. */
   std::vector<HopsetAction> on_marker(uint32_t marker_gen, bool fp_matches,
-                                      uint64_t now_slot) {
+                                      uint64_t marker_slot) {
     std::vector<HopsetAction> out;
-    (void)now_slot;
     const bool known = (marker_gen == cur_.generation ||
                         (st_ == State::Pending &&
                          marker_gen == pend_.generation)) &&
                        fp_matches;
     if (known)
+      return out;
+    /* A marker carrying the generation we just left, STAMPED at or before the
+     * activation slot, is a frame that crossed the boundary in flight — the
+     * transmitter was telling the truth when it composed it. Acting on it
+     * drops lockstep at the one moment the link can least afford it (see
+     * HopsetParams::stale_marker_slots). A transmitter that really has not
+     * moved keeps stamping fresh slots, so it clears the grace within
+     * milliseconds and the mismatch stands. */
+    if (have_prev_ && marker_gen == prev_generation_ &&
+        marker_slot < activated_slot_ + p_.stale_marker_slots)
       return out;
     if (st_ == State::Recovering && marker_gen == last_mismatch_gen_)
       return out; /* already recovering from this one — don't spam */
@@ -269,6 +288,11 @@ private:
   }
 
   void activate(std::vector<HopsetAction> &out) {
+    /* Remember what we just left, and when: a marker stamped with the old
+     * generation can still be in flight across the boundary. */
+    prev_generation_ = cur_.generation;
+    have_prev_ = true;
+    activated_slot_ = pend_.activate_slot;
     cur_ = pend_;
     st_ = State::Synced;
     HopsetAction act{};
@@ -319,6 +343,11 @@ private:
   bool have_auth_ = false;
   uint32_t auth_epoch_ = 0;
   uint32_t last_mismatch_gen_ = 0;
+  /* The generation we left at the last activation, and where that was, for
+   * the in-flight-marker grace. */
+  uint32_t prev_generation_ = 0;
+  uint64_t activated_slot_ = 0;
+  bool have_prev_ = false;
 };
 
 } /* namespace hopset */

--- a/src/hopset/HopsetFusion.h
+++ b/src/hopset/HopsetFusion.h
@@ -313,8 +313,14 @@ inline FusedDecision fuse(const FusionConfig &cfg, const FusionInput &in) {
   d.tx_evidence_valid = tx.chans_with_evidence > 0;
   d.tx_band_min_occupancy = tx.band_min_occ;
   d.tx_band_max_occupancy = tx.band_max_occ;
+  /* Whichever endpoint named a target, report OUR occupancy on it — when the
+   * receiver named one that is the number the veto turns on, and when only
+   * this side did it is the number a reader needs to judge a disagreement the
+   * mode forbids acting on. */
   if (d.rx_wanted_exclude && detail::tx_has(tx, rx.target_index))
     d.tx_target_occupancy = detail::tx_occ(tx, rx.target_index);
+  else if (d.tx_wanted_exclude && detail::tx_has(tx, tx.target_index))
+    d.tx_target_occupancy = detail::tx_occ(tx, tx.target_index);
   d.endpoints_disagree_on_target =
       (d.rx_wanted_exclude != d.tx_wanted_exclude) ||
       (d.rx_wanted_exclude && d.tx_wanted_exclude &&
@@ -407,6 +413,10 @@ inline FusedDecision fuse(const FusionConfig &cfg, const FusionInput &in) {
     d.hold = FusionHold::RxHeld;
     return d;
   }
+
+  /* Held or not, the record names what this side wanted: an unacted-upon
+   * disagreement still has to be legible after the fact. */
+  d.target_index = tx.target_index;
 
   DecisionOrigin origin = DecisionOrigin::Tx;
   switch (cfg.mode) {

--- a/src/hopset/HopsetSense.h
+++ b/src/hopset/HopsetSense.h
@@ -47,6 +47,7 @@ enum TxSenseFlag : uint16_t {
   kTsBarrierMissed = 1u << 3, /* taken without the discard barrier */
   kTsTruncated = 1u << 4,
   kTsNhmMissing = 1u << 5,
+  kTsInjected = 1u << 6, /* synthetic evidence, no hardware behind it */
 };
 
 /* One quiet-window observation. The counters are deltas spanning exactly
@@ -71,6 +72,16 @@ struct TxSenseSample {
   uint8_t nhm_busy_pct = 0; /* 100*(total-bucket0)/total, host-derived */
   uint16_t nhm_duration = 0;
 
+  /* Synthetic evidence. A caller that sets this hands the scorer an occupancy
+   * directly instead of counters, and every stage downstream — ring depth,
+   * dirty-run hysteresis, the cleaner-alternative rule, the floors — treats it
+   * exactly like a measured one. It exists so the two endpoint-disagreement
+   * scenarios can be built on a bench where both adapters hear the same
+   * interferer: the only way to give the transmitter a view that genuinely
+   * differs from the receiver's is to construct it. */
+  bool injected = false;
+  double injected_occupancy = 0.0;
+
   uint16_t flags = 0;
 };
 
@@ -81,6 +92,7 @@ enum TxSenseSource : uint8_t {
   kSrcFa = 1u << 1,
   kSrcIgi = 1u << 2,
   kSrcNhm = 1u << 3,
+  kSrcInjected = 1u << 4,
 };
 
 struct TxSenseConfig {
@@ -184,6 +196,16 @@ inline bool score_sample(const TxSenseSample &s, const TxSenseConfig &cfg,
   const double win_ms = static_cast<double>(s.window_us) / 1000.0;
   if (win_ms <= 0.0)
     return false;
+  /* Synthetic evidence is returned verbatim: the four-source weighting exists
+   * to turn counters into an occupancy, and here the occupancy is what the
+   * caller handed us. Back-solving it through the weights would make the
+   * lever approximate, and an approximate lever proves nothing. */
+  if (s.injected) {
+    const double v = s.injected_occupancy;
+    out.occupancy = v < 0.0 ? 0.0 : (v > 1.0 ? 1.0 : v);
+    out.sources = kSrcInjected;
+    return true;
+  }
   double acc = 0.0, wsum = 0.0;
   uint8_t src = 0;
   auto clamp01 = [](double v) { return v < 0.0 ? 0.0 : (v > 1.0 ? 1.0 : v); };

--- a/src/hopset/HopsetTypes.h
+++ b/src/hopset/HopsetTypes.h
@@ -184,6 +184,18 @@ struct HopsetParams {
   unsigned max_mask_delta = 1;         /* channels changed per update */
   uint64_t min_update_gap_rounds = 10; /* rounds between accepted updates */
   unsigned max_excluded_frac_pct = 50; /* cap on excluded/base */
+  /* How long after an activation a marker advertising the generation we just
+   * left is read as a frame still in flight rather than as a disagreement.
+   *
+   * Both endpoints swap at the same absolute slot, but a frame composed on one
+   * side of that boundary is decoded on the other: the marker is stamped when
+   * the frame is assembled and the frame then queues through the bus. Measured
+   * on air, treating that one frame as a mismatch cost 46 seconds — the
+   * follower dropped lockstep at the exact instant the exclusion took effect,
+   * which is the worst moment to start scanning for a way back. The relaxation
+   * is self-healing: an authority that really has not moved keeps advertising
+   * the old generation, and past the grace the mismatch stands. */
+  uint64_t stale_marker_slots = 2;
 };
 
 } /* namespace hopset */

--- a/tests/README.md
+++ b/tests/README.md
@@ -99,6 +99,33 @@ probe on kernels 6.15+ (`failed to download firmware`, `error -22`), but
 - `iw`, `tcpdump`, `ip` on PATH
 - Passwordless `sudo`, or run directly as root
 
+### Adaptive-hopset validation (`hopset_adaptive_jammer.sh`)
+
+Three radios — a transmitting authority, a lockstep receiver running the
+exclusion policy, and a B210 interferer. `MODE` selects the scenario
+(`parked`, `sense`, `failsafe`, `herding`, `hidden`, `mirror`, `fusionmatrix`,
+`policycost`, `prepost`, `overhead`); the mode arms whatever it needs, so
+`MODE=sense` really does sense and `MODE=fusionmatrix` gives every row the same
+sensing windows.
+
+Two things about how it measures, because both changed what the numbers said:
+
+- Every mode reports **FEC delivery** — real RS-coded bodies from
+  `tools/precoder` through `DEVOURER_TX_STDIN`, decoded by the salvage path —
+  beside the marker-derived dwell proxy. `tests/fec_metrics.py` owns that
+  arithmetic and is shared with `jammer_resilience.py`; it also prints the
+  fraction of the window the receiver held lockstep, which is the number that
+  catches a receiver scoring 1.0 on the half of a window it was present for.
+- A measurement window opens only once the receiver reports tracking, and
+  closes against the transmitter's own body count at both instants. A window
+  that opens at process start is mostly chip bring-up and acquisition: one
+  70 s phase read 0.30 FEC delivery whose settled part ran at 0.90.
+
+`FEC=0` falls back to the proxy alone. The payload is generated once per size
+and cached in `/tmp`; it must outlast the longest phase, since looping it would
+re-use the outer code's block ids and the decoder would merge two passes into
+one block.
+
 ### Choosing the SDR (benches with more than one radio)
 
 Every UHD tool here (`sdr_duty.py`, `sdr_interferer.py`, `hop_rx_probe.py`,

--- a/tests/fec_metrics.py
+++ b/tests/fec_metrics.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Fused-FEC delivery accounting shared by the jammer harnesses.
+
+One place that knows how a captured rxdemo event stream becomes the three
+numbers worth reporting, so the fixed-hop matrix (jammer_resilience.py) and the
+adaptive-hopset harness (hopset_adaptive_jammer.sh) cannot drift apart and
+report the same word for different arithmetic:
+
+  fec_delivery  = sbi_packets  / P   RS outer code + sub-block salvage
+  base_delivery = base_packets / P   drop-the-whole-corrupt-frame baseline
+  raw_frames    = (frames_seen - frames_corrupt) / frames_sent
+
+P is the source-packet count of the exact payload the transmitter was fed,
+obtained by encoding it and decoding it back through a clean loopback — not
+estimated from a byte count, because the RS block padding at flush makes those
+differ.
+
+As a CLI it takes one capture and prints one JSON line, which is how the bash
+harness consumes it:
+
+  python3 tests/fec_metrics.py --capture rx_adapt.log --payload payload.bin \\
+      --sent 4200 --label adapt
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+sys.path.insert(0, os.path.join(_ROOT, "tools", "precoder"))
+
+# The fused-FEC config. Read out of fused_fec_tx.py's own argument parser
+# rather than re-declared here: P is computed in this module while the decode
+# runs in fused_fec_rx.py, and the harness invokes both with no flags, so a
+# default changed in one place and copied in another would silently rescale
+# every delivery figure with nothing raising.
+def _defaults() -> dict:
+    import argparse as _ap
+    from fused_fec_tx import add_fec_args
+    p = _ap.ArgumentParser()
+    add_fec_args(p)
+    return vars(p.parse_args([]))
+
+
+_D = _defaults()
+FEC_K = _D["k"]
+FEC_SYMBOL = _D["symbol_size"]
+FEC_OVERHEAD = _D["overhead"]
+FEC_BLOCKS_PER_BODY = _D["blocks_per_body"]
+FEC_SCHEME = _D["scheme"]
+FEC_CRC_BYTES = _D["crc_bytes"]
+
+
+def build_payload(nbytes: int, seed: int = 0xC0FFEE) -> bytes:
+    """Deterministic payload, so P and the run are reproducible across cells."""
+    import numpy as np
+    return np.random.default_rng(seed).integers(
+        0, 256, size=nbytes, dtype=np.uint8).tobytes()
+
+
+def _config():
+    from stream_fec import FecConfig
+    return FecConfig(k=FEC_K, symbol_size=FEC_SYMBOL, overhead=FEC_OVERHEAD,
+                     scheme=FEC_SCHEME)
+
+
+def packet_ladder(payload: bytes) -> list[int]:
+    """Cumulative source-packet count after each body, clean loopback.
+
+    The ladder, not just the total, because a phase ends on the clock and not
+    on the payload: the honest denominator for a run that aired N bodies is the
+    packets carried by the FIRST N bodies, and nothing beyond them can be
+    counted as lost when it was never sent.
+    """
+    from fused_fec_link import FusedFecSender, FusedFecReceiver
+    cfg = _config()
+    snd = FusedFecSender(cfg, FEC_BLOCKS_PER_BODY, crc_bytes=FEC_CRC_BYTES)
+    bodies = snd.add_bytes(payload) + snd.flush()
+    rcv = FusedFecReceiver(cfg, FEC_BLOCKS_PER_BODY, crc_bytes=FEC_CRC_BYTES)
+    ladder, run = [0], 0
+    for b in bodies:
+        run += len(rcv.add_frame(b, False))
+        ladder.append(run)
+    return ladder
+
+
+def fec_counts(payload: bytes) -> tuple[int, int]:
+    """(P source packets, B bodies) for `payload` under the default config."""
+    ladder = packet_ladder(payload)
+    return ladder[-1], len(ladder) - 1
+
+
+def body_stride() -> int:
+    """On-air bytes of one SBI sub-block (CRC + envelope)."""
+    from fused_fec_link import env_size
+    return FEC_CRC_BYTES + env_size(_config())
+
+
+def scan_capture(path: str) -> dict:
+    """Cheap pre-pass over the capture: how many received frames actually
+    carried payload.
+
+    txdemo airs three kinds of frame on this SA — payload frames, the
+    marker-only frames of a recovery-probe dwell, and the authenticated
+    schedule-control frames — and only the first kind can deliver a shard.
+    Counting all three as delivery attempts would quietly inflate the frame
+    ratio above 1. They separate on length alone.
+    """
+    from fec_subblock import SBI_HDR_LEN
+    from devourer_events import iter_events
+    floor = 24 + SBI_HDR_LEN + body_stride()  # 802.11 header + one sub-block
+    out = {"frames": 0, "corrupt": 0, "payload_frames": 0,
+           "payload_corrupt": 0}
+    if not os.path.exists(path):
+        return out
+    with open(path, "rb") as fh:
+        for ev in iter_events(fh, ev="rx.frame"):
+            bad = bool(ev.get("crc") or 0) or bool(ev.get("icv") or 0)
+            out["frames"] += 1
+            out["corrupt"] += bad
+            if int(ev.get("len") or 0) >= floor:
+                out["payload_frames"] += 1
+                out["payload_corrupt"] += bad
+    return out
+
+
+def parse_fec_report(stderr_text: str) -> dict:
+    """Pull the counters out of fused_fec_rx.py's stderr report."""
+    out = {"frames_seen": 0, "frames_corrupt": 0,
+           "base_packets": 0, "sbi_packets": 0}
+    for line in stderr_text.splitlines():
+        for key, tok in (("frames_seen", "frames="),
+                         ("frames_corrupt", "corrupt=")):
+            if tok in line:
+                try:
+                    out[key] = int(line.split(tok)[1].split()[0])
+                except (IndexError, ValueError):
+                    pass
+        if "baseline blocks=" in line and "pkts=" in line:
+            out["base_packets"] = int(line.split("pkts=")[1].split()[0])
+        if line.strip().startswith("fused_fec_rx: sbi") and "pkts=" in line:
+            out["sbi_packets"] = int(line.split("pkts=")[1].split()[0])
+    return out
+
+
+def decode_capture(capture_path: str, py: str = sys.executable) -> dict:
+    """Run the captured rxdemo event stream through fused_fec_rx.py offline.
+
+    Offline and not piped live: the per-frame RS decode is slower than the
+    frame rate, so a live pipe backs up, stalls rxdemo's USB reaping and drops
+    the frames the run is trying to measure.
+    """
+    fec_rx = os.path.join(_ROOT, "tools", "precoder", "fused_fec_rx.py")
+    if not os.path.exists(capture_path):
+        return parse_fec_report("")
+    with open(capture_path, "rb") as fh:
+        r = subprocess.run([py, fec_rx], stdin=fh,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    return parse_fec_report(r.stderr.decode("utf-8", "replace"))
+
+
+def cell_metrics(capture_path: str, packets: int, sent: int,
+                 py: str = sys.executable, secs: float = 0.0, **extra) -> dict:
+    """One capture -> one `jam.cell` record. `sent` is the transmitter's own
+    count of bodies it aired (txdemo's tx.stdin / streamtx's stream.done), so
+    a body that never left is never scored as one that failed to arrive."""
+    rep = decode_capture(capture_path, py)
+    scan = scan_capture(capture_path)
+    seen = scan["payload_frames"] or rep["frames_seen"]
+    corrupt = scan["payload_corrupt"] if scan["payload_frames"] \
+        else rep["frames_corrupt"]
+    clean = max(0, seen - corrupt)
+    res = {
+        "ev": "jam.cell",
+        "P": packets,
+        "frames_sent": sent,
+        "frames_seen": seen,
+        "frames_corrupt": corrupt,
+        "frames_all": scan["frames"],
+        "base_packets": rep["base_packets"],
+        "sbi_packets": rep["sbi_packets"],
+        "raw_frames": round(clean / sent, 4) if sent else 0.0,
+        "base_delivery": round(rep["base_packets"] / packets, 4) if packets else 0.0,
+        "fec_delivery": round(rep["sbi_packets"] / packets, 4) if packets else 0.0,
+    }
+    if secs > 0:
+        # Ratios alone hide half the story on a CSMA link: a transmitter that
+        # defers to an interferer does not lose the packets it would have sent
+        # on that channel, it never sends them. That cost is a rate, and only
+        # a rate shows it.
+        res["secs"] = round(secs, 1)
+        res["body_rate"] = round(sent / secs, 1)
+        res["pkt_rate"] = round(rep["sbi_packets"] / secs, 1)
+    res.update(extra)
+    return res
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--capture",
+                    help="rxdemo JSONL capture (DEVOURER_STREAM_OUT=1)")
+    g = ap.add_mutually_exclusive_group()
+    g.add_argument("--payload", help="the payload file the TX was fed")
+    g.add_argument("--packets", type=int, help="P, if already known")
+    ap.add_argument("--sent", type=int, default=0,
+                    help="bodies the transmitter had aired by the END of the "
+                         "measured window (0 = unknown)")
+    ap.add_argument("--sent-from", type=int, default=0,
+                    help="bodies already aired when the window OPENED, so a "
+                         "settled slice of a longer run is scored against the "
+                         "packets sent inside it and nothing else")
+    ap.add_argument("--secs", type=float, default=0.0,
+                    help="window duration, for the throughput columns")
+    ap.add_argument("--label", default="",
+                    help="free-form cell name carried through to the record")
+    ap.add_argument("--gen-payload", type=int, default=0, metavar="BYTES",
+                    help="instead of measuring: write BYTES of deterministic "
+                         "payload to --payload and print P/B")
+    args = ap.parse_args(argv)
+
+    if args.gen_payload:
+        if not args.payload:
+            ap.error("--gen-payload needs --payload")
+        data = build_payload(args.gen_payload)
+        with open(args.payload, "wb") as fh:
+            fh.write(data)
+        ladder = packet_ladder(data)
+        # Cache it: the encode is the expensive half, and every phase of a run
+        # needs the same ladder against a different body count.
+        with open(args.payload + ".pcum", "w") as fh:
+            json.dump(ladder, fh)
+        print(json.dumps({"ev": "fec.payload", "bytes": args.gen_payload,
+                          "P": ladder[-1], "B": len(ladder) - 1}), flush=True)
+        return 0
+
+    if not args.capture or (args.payload is None and args.packets is None):
+        ap.error("measuring needs --capture and one of --payload / --packets")
+    if args.packets is not None:
+        P = args.packets
+    else:
+        ladder = None
+        try:
+            with open(args.payload + ".pcum") as fh:
+                ladder = json.load(fh)
+        except (OSError, ValueError):
+            with open(args.payload, "rb") as fh:
+                ladder = packet_ladder(fh.read())
+        # The transmitter may have looped the payload more than once, so the
+        # ladder wraps: whole passes contribute their full packet count and
+        # the remainder indexes the ladder.
+        nb, total = len(ladder) - 1, ladder[-1]
+        cum = lambda n: (n // nb) * total + ladder[n % nb]
+        hi = args.sent if args.sent else nb
+        lo = min(args.sent_from, hi)
+        P = cum(hi) - cum(lo)
+    rec = cell_metrics(args.capture, P, max(0, args.sent - args.sent_from),
+                       secs=args.secs,
+                       **({"cell": args.label} if args.label else {}))
+    print(json.dumps(rec), flush=True)
+    # Human line on stderr so a shell harness can show it without re-parsing
+    # the record it just wrote to its own results file.
+    sys.stderr.write(
+        "      FEC  fec_delivery={fec_delivery:.3f}  "
+        "base_delivery={base_delivery:.3f}  raw_frames={raw_frames:.3f}  "
+        "(sent={frames_sent} seen={frames_seen} corrupt={frames_corrupt} "
+        "P={P})\n".format(**rec))
+    if args.secs > 0:
+        sys.stderr.write(
+            "           throughput {body_rate} bodies/s aired, "
+            "{pkt_rate} packets/s recovered over {secs}s\n".format(**rec))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hopset_activation_selftest.cpp
+++ b/tests/hopset_activation_selftest.cpp
@@ -195,5 +195,70 @@ int main() {
             "post-recovery channel sequence identical");
   }
 
+  /* ------- (c) the marker that crossed the activation boundary ----------
+   * Both endpoints swap at the same absolute slot, but a frame stamped just
+   * before it is decoded just after. Measured on air, reading that one frame
+   * as a disagreement cost 46 seconds of re-acquisition at the exact instant
+   * an exclusion took effect. It must be ignored — and only for as long as it
+   * can plausibly still be in flight. */
+  {
+    HopsetAuthority auth(p, 0xC0DE);
+    HopsetFollower fol(p, 0xF00D);
+    uint32_t mismatches = 0;
+    auto count = [&](const std::vector<HopsetAction> &acts) {
+      for (const auto &a : acts)
+        if (a.kind == HopsetAction::Event &&
+            a.event == HopsetEvent::GenMismatch)
+          ++mismatches;
+    };
+    HopsetMsg commit{};
+    for (const auto &a : auth.start_change(0x3FE, 100))
+      if (a.kind == HopsetAction::SendControl)
+        commit = a.msg;
+    count(fol.on_commit(commit, 100));
+    const uint64_t act_slot = commit.activate_slot;
+    for (uint64_t s = 100; s <= act_slot + 1; ++s) {
+      auth.on_tick(s);
+      count(fol.on_tick(s));
+    }
+    CHECK(fol.state().generation == 1, "follower reached generation 1");
+
+    /* the straggler: a generation-0 marker STAMPED just before the swap,
+     * decoded after it — the signature measured on air */
+    count(fol.on_marker(0, /*fp_matches=*/false, act_slot - 1));
+    CHECK(mismatches == 0,
+          "a marker stamped before the swap is not a disagreement");
+    count(fol.on_marker(0, false, act_slot + 1));
+    CHECK(mismatches == 0, "nor is one inside the grace");
+    CHECK(fol.fsm() == HopsetFollower::State::Synced,
+          "lockstep survives the straggler");
+
+    /* ...but an authority that genuinely never moved keeps saying so, and
+     * past the grace that is exactly what a mismatch is for */
+    count(fol.on_marker(0, false, act_slot + p.stale_marker_slots + 1));
+    CHECK(mismatches == 1, "a persistent old generation still mismatches");
+    CHECK(fol.fsm() == HopsetFollower::State::Recovering,
+          "and still drives recovery");
+
+    /* The grace measures against the activation anchor, so an authority that
+     * announces an activation far in the future must not be able to stretch
+     * it over every marker the follower will ever see — that would silently
+     * disable the tripwire rather than trip it. The status path bounds the
+     * activation window exactly as the commit path does. */
+    HopsetMsg far{};
+    far.type = HT_STATUS;
+    far.role = 1;
+    far.base_fp = p.base_fp;
+    far.link_id = p.link_id;
+    far.sender_epoch = 0xC0DE;
+    far.generation = 9;
+    far.active_mask = 0x3FE;
+    far.activate_slot = act_slot + p.max_lead_slots + 1000;
+    const uint64_t before = fol.state().generation;
+    fol.on_status(far, act_slot + 2);
+    CHECK(fol.state().generation == before,
+          "a status announcing an out-of-window activation is refused");
+  }
+
   return fails ? 1 : 0;
 }

--- a/tests/hopset_adaptive_jammer.sh
+++ b/tests/hopset_adaptive_jammer.sh
@@ -21,7 +21,27 @@
 #   MODE=parked   (default) exclude -> improve -> restore after the jam ends
 #   MODE=herding  the jammer moves onto a newly-active channel after every
 #                 exclusion; the diversity floor must hold and the link must
-#                 never oscillate
+#                 never oscillate. FUSION=failsafe MUTE=1 runs the same chase
+#                 against TRANSMITTER-originated exclusions, which is where
+#                 the anti-herding limits carry the whole load — the receiver
+#                 is not there to disagree
+#   MODE=hidden   a real interferer the receiver hears and the transmitter is
+#                 TOLD it cannot (DEVOURER_TX_SENSE_INJECT): the hidden-node
+#                 row, where a naive veto is most confident and most wrong
+#   MODE=mirror   the reverse — the transmitter is told a channel is filthy
+#                 while the receiver delivers on it fine: nothing may be spent
+#   MODE=fusionmatrix  the same parked interferer under all four fusion modes
+#   MODE=policycost    what the receiver's own control traffic costs, with no
+#                 interferer at all: every frame it airs is a slot it cannot
+#                 hear, and the heartbeat cadence should be set from that
+#                 number rather than assumed small
+#
+# Every mode reports FEC delivery — the RS outer code and sub-block salvage of
+# tools/precoder, the same path the video link runs on — BESIDE the
+# marker-derived proxy. The proxy is what the receiver's own policy scores and
+# is sound as a relative measure, but a marker is one small frame at a robust
+# rate, so a channel can decode markers and still deliver payload badly. FEC=0
+# falls back to the proxy alone.
 #
 # Usage: sudo -v && tests/hopset_adaptive_jammer.sh
 #        MODE=herding CHANNELS=1,6,11,3,8 tests/hopset_adaptive_jammer.sh
@@ -84,10 +104,10 @@ JAM_GAIN="${JAM_GAIN:-88}"
 # error rather than a coin flip when a bench has more than one radio).
 SDR_ARGS="${SDR_ARGS-}"
 TX_PWR="${TX_PWR-}"              # flat TXAGC index; empty = efuse default
-SENSE="${SENSE:-0}"              # DEVOURER_TX_SENSE
-FUSION="${FUSION:-veto}"         # rx | veto | either | failsafe
+SENSE="${SENSE-}"                # DEVOURER_TX_SENSE (empty = mode default)
+FUSION="${FUSION-}"              # rx | veto | either | failsafe
 SENSE_WINDOW_US="${SENSE_WINDOW_US:-4000}"
-SENSE_POSTBURST_US="${SENSE_POSTBURST_US:-0}"
+SENSE_POSTBURST_US="${SENSE_POSTBURST_US-}"   # empty = mode default (below)
 SENSE_EVERY="${SENSE_EVERY:-4}"
 # The false-alarm/CCA counters count PACKET DETECTIONS — they fire on 802.11
 # preambles, not on band-limited noise. Measured here: with a 50 dB AWGN
@@ -98,11 +118,63 @@ SENSE_EVERY="${SENSE_EVERY:-4}"
 # ~3 ms armed window per read.
 SENSE_NHM="${SENSE_NHM:-0}"
 SENSE_FLOOR="${SENSE_FLOOR:-0.80}"   # absolute delivery floor for MODE=sense
+# Synthetic transmitter evidence: "<idx>:<occ>,..." with an optional "*:<occ>"
+# default. A TEST LEVER — it fabricates this side's view so the two
+# disagreement scenarios can exist on a bench where both endpoints hear the
+# same interferer. Empty = the transmitter reads its own hardware.
+INJECT="${INJECT-}"
+MUTE="${MUTE:-0}"                # 1 = receiver hears but never answers
 BASELINE_S="${BASELINE_S:-25}"
 ADAPT_S="${ADAPT_S:-70}"
 RESTORE_S="${RESTORE_S:-70}"
 OVH_S="${OVH_S:-30}"
+COST_S="${COST_S:-45}"           # per cell in MODE=policycost
+MATRIX_S="${MATRIX_S:-60}"       # per fusion mode in MODE=fusionmatrix
 OUT="${OUT:-/tmp/devourer-hopset-jammer}"
+# FEC payload. Sized for the longest phase at the transmitter's frame rate,
+# with margin: running dry would end a phase early and quietly shorten the
+# measurement. Over-sizing costs nothing — delivery is scored against the
+# bodies the transmitter reports having aired, not against the whole file.
+FEC="${FEC:-1}"
+# Sized from the longest window this mode will run: ~450 bodies/s of ~165
+# source bytes each, with a quarter margin. One pass has to outlast the
+# longest phase — the outer code's block ids repeat if the payload is looped,
+# and the decoder then merges symbols from two passes into one block.
+FEC_LONGEST=$(( BASELINE_S > ADAPT_S ? BASELINE_S : ADAPT_S ))
+[ "$MODE" = "policycost" ] && FEC_LONGEST="$COST_S"
+[ "$MODE" = "fusionmatrix" ] && FEC_LONGEST=$(( MATRIX_S * 3 ))
+FEC_BYTES="${FEC_BYTES:-$(( FEC_LONGEST * 450 * 165 * 5 / 4 ))}"
+PAYLOAD="${PAYLOAD:-/tmp/devourer-hopset-fec-payload-$FEC_BYTES.bin}"
+
+# Mode defaults. The failsafe IS the transmitter carrying the link on its own
+# evidence, so it cannot be run with sensing off — however it was asked for,
+# by mode or by fusion mode. MODE=herding FUSION=failsafe MUTE=1 is the
+# anti-herding row against autonomous exclusions, and it needs all three.
+[ "$FUSION" = "failsafe" ] && SENSE="${SENSE:-1}"
+case "$MODE" in
+  # Every mode whose whole subject is this side's own evidence arms sensing
+  # for itself. Leaving that to the caller means a run that silently measures
+  # the receiver-driven path and reports it under the sensing mode's name.
+  failsafe|mirror|sense|hidden|prepost) SENSE="${SENSE:-1}" ;;
+esac
+[ "$MODE" = "failsafe" ] && FUSION="${FUSION:-failsafe}"
+SENSE="${SENSE:-0}"; FUSION="${FUSION:-veto}"
+# If this side senses at all, it gets the post-burst window. The classifier
+# refuses to propose anything of its own without post-burst evidence (a
+# reactive emitter keys up only after it hears us, so the pre-burst window
+# cannot see it), and an armed sensor that can never act reads in a log
+# exactly like a sensor that is not running. Arming it for every sensing row
+# also keeps a throughput column comparing policies rather than windows.
+[ "$SENSE" = "1" ] && SENSE_POSTBURST_US="${SENSE_POSTBURST_US:-3000}"
+SENSE_POSTBURST_US="${SENSE_POSTBURST_US:-0}"
+
+# Two modes measure the transmitter's own frame cadence — what the quiet
+# windows cost, and how a reactive jammer answers a burst. Under a stdin
+# payload the link is paced by the pipe rather than by the radio, so both
+# would be measuring the harness. They keep the free-running beacon.
+case "$MODE" in
+  overhead|prepost) FEC=0 ;;
+esac
 
 plugged() { lsusb -d "$(printf '%04x:%04x' "$1" "$2")" >/dev/null 2>&1; }
 plugged "$TX_VID" "$TX_PID" || { echo "SKIP: TX $TX_VID:$TX_PID not plugged"; exit 77; }
@@ -136,6 +208,7 @@ kill_jammer() {
 }
 cleanup() {
     kill_jammer
+    pkill -f "fused_fec_tx.py" 2>/dev/null || true
     sudo pkill -INT -x txdemo 2>/dev/null || true
     sudo pkill -INT -x rxdemo 2>/dev/null || true
     sleep 1
@@ -155,6 +228,19 @@ PY="$HERE/.venv/bin/python"
 [ -x "$PY" ] || PY="$(command -v python3)"
 "$PY" -c "import uhd" 2>/dev/null || PY="$(command -v python3)"
 
+# The FEC payload, and the packet ladder that turns a body count into the
+# denominator for delivery. Both are deterministic and depend only on the byte
+# count, so a re-run of the same size reuses them (the encode is the slow half).
+FEC_TX="$ROOT/tools/precoder/fused_fec_tx.py"
+if [ "$FEC" = "1" ]; then
+    if [ "$(stat -c %s "$PAYLOAD" 2>/dev/null || echo 0)" != "$FEC_BYTES" ] ||
+       [ ! -s "$PAYLOAD.pcum" ]; then
+        echo "== generating $FEC_BYTES B of FEC payload (once) =="
+        "$PY" "$HERE/fec_metrics.py" --payload "$PAYLOAD" \
+            --gen-payload "$FEC_BYTES" || exit 1
+    fi
+fi
+
 start_jammer() { # channel
     [ "$NO_JAM" = "1" ] && return 0
     kill_jammer
@@ -172,7 +258,7 @@ start_tx() { # logfile
     # TX_PWR="" leaves the efuse-calibrated default alone. A flat TXAGC index
     # is per-band on these dies — an index that merely backs 5 GHz off can put
     # 2.4 GHz below the receiver's sensitivity and look like a dead rig.
-    local pwr=() sense=()
+    local pwr=() sense=() fec=()
     [ -n "$TX_PWR" ] && pwr=(DEVOURER_TX_PWR="$TX_PWR")
     [ "$SENSE" = "1" ] && sense=(DEVOURER_TX_SENSE=1
         DEVOURER_TX_SENSE_WINDOW_US="$SENSE_WINDOW_US"
@@ -180,17 +266,67 @@ start_tx() { # logfile
         DEVOURER_TX_SENSE_EVERY="$SENSE_EVERY"
         DEVOURER_TX_SENSE_NHM="$SENSE_NHM"
         DEVOURER_HOP_FUSION="$FUSION")
-    sudo env "${COMMON[@]}" "${pwr[@]}" "${sense[@]}" DEVOURER_VID="$TX_VID" \
-        DEVOURER_PID="$TX_PID" DEVOURER_CHANNEL="${CHANNELS%%,*}" \
-        DEVOURER_HOP_FAST=1 DEVOURER_TX_WITH_RX=thread \
-        "$ROOT/build/txdemo" >"$1" 2>&1 &
+    [ "$SENSE" = "1" ] && [ -n "$INJECT" ] &&
+        sense+=(DEVOURER_TX_SENSE_INJECT="$INJECT")
+    if [ "$FEC" = "1" ]; then
+        # The caller payload rides txdemo's own frames: the authority, the
+        # sensing windows and the recovery probes all live in this demo, so
+        # measuring FEC delivery across an adaptation means feeding THIS side.
+        # One pass over a payload sized to the longest phase — NOT a looped
+        # one. Looping re-uses the outer code's block ids, and the decoder
+        # then merges symbols from two different passes into one block: a
+        # 180 s row read 0.585 FEC delivery against 0.819 of frames arriving,
+        # which is an artefact of the harness and nothing about the link.
+        fec=(DEVOURER_TX_STDIN=1)
+        "$PY" "$FEC_TX" --input "$PAYLOAD" 2>>"$OUT/fec_tx.log" |
+        sudo env "${COMMON[@]}" "${pwr[@]}" "${sense[@]}" "${fec[@]}" \
+            DEVOURER_VID="$TX_VID" DEVOURER_PID="$TX_PID" \
+            DEVOURER_CHANNEL="${CHANNELS%%,*}" DEVOURER_HOP_FAST=1 \
+            DEVOURER_TX_WITH_RX=thread "$ROOT/build/txdemo" >"$1" 2>&1 &
+    else
+        sudo env "${COMMON[@]}" "${pwr[@]}" "${sense[@]}" DEVOURER_VID="$TX_VID" \
+            DEVOURER_PID="$TX_PID" DEVOURER_CHANNEL="${CHANNELS%%,*}" \
+            DEVOURER_HOP_FAST=1 DEVOURER_TX_WITH_RX=thread \
+            "$ROOT/build/txdemo" >"$1" 2>&1 &
+    fi
 }
 start_rx() { # logfile, policy(0|1)
-    local pol=()
+    local pol=() fec=()
     [ "$2" = "1" ] && pol=(DEVOURER_HOP_POLICY=1 DEVOURER_HOP_POLICY_EVENTS=2)
-    [ "$MODE" = "failsafe" ] && pol+=(DEVOURER_HOP_MUTE=1)
-    sudo env "${COMMON[@]}" "${pol[@]}" DEVOURER_VID="$RX_VID" \
+    { [ "$MODE" = "failsafe" ] || [ "$MUTE" = "1" ]; } &&
+        pol+=(DEVOURER_HOP_MUTE=1)
+    # KEEP_CORRUPTED is not optional here: sub-block salvage is the half of the
+    # fused code that reads a body with a broken tail, so filtering those out
+    # would measure the baseline twice and call one of them the gain.
+    [ "$FEC" = "1" ] && fec=(DEVOURER_STREAM_OUT=1 DEVOURER_RX_KEEP_CORRUPTED=1)
+    sudo env "${COMMON[@]}" "${pol[@]}" "${fec[@]}" DEVOURER_VID="$RX_VID" \
         DEVOURER_PID="$RX_PID" "$ROOT/build/rxdemo" >"$1" 2>&1 &
+}
+# Stop both demos and WAIT for them to be gone. The wait is not politeness:
+# each demo holds an advisory per-adapter lock until it has de-initialised the
+# chip and released the interface, and a fixed sleep that guesses short leaves
+# the next cell refusing to open its adapter and measuring nothing at all.
+stop_link() {
+    sudo pkill -INT -x rxdemo 2>/dev/null || true
+    sudo pkill -INT -x txdemo 2>/dev/null || true
+    local i
+    for i in $(seq 1 40); do
+        pgrep -x txdemo >/dev/null 2>&1 || pgrep -x rxdemo >/dev/null 2>&1 ||
+            break
+        sleep 0.5
+    done
+    if pgrep -x txdemo >/dev/null 2>&1 || pgrep -x rxdemo >/dev/null 2>&1; then
+        echo "   NOTE: a demo ignored SIGINT for 20s — escalating"
+        sudo pkill -x txdemo 2>/dev/null || true
+        sudo pkill -x rxdemo 2>/dev/null || true
+        for i in $(seq 1 20); do
+            pgrep -x txdemo >/dev/null 2>&1 ||
+                pgrep -x rxdemo >/dev/null 2>&1 || break
+            sleep 0.5
+        done
+    fi
+    pkill -f "fused_fec_tx.py" 2>/dev/null || true
+    sleep 1   # let the kernel finish releasing the USB interface
 }
 
 # Delivery proxy, straight from the hop.rx event stream: a dwell counts as
@@ -201,6 +337,76 @@ delivery() { # logfile
         for (i = 1; i < NF; i++) if ($i == "state") s = $(i+2);
         if (s == "retune") r++; if (s == "decode") d++;
     } END { if (r) printf "%.3f", d / r; else print "0" }' "$1"
+}
+
+# FEC delivery for one phase: what fraction of the source packets the
+# transmitter actually aired came back out of the decoder. `base` is the same
+# code with corrupt frames dropped whole, so the two together separate "the
+# outer code carried it" from "the frames arrived clean".
+#
+# The denominator is the transmitter's own body count (tx.stdin), not the
+# payload file: a phase ends on the clock, and packets that were never sent
+# cannot be counted as lost.
+tx_bodies() { # txlog -> bodies aired so far (works mid-run: tx.stdin is
+              # emitted every 100 bodies as well as at exit)
+    grep -F '"ev":"tx.stdin"' "$1" 2>/dev/null | tail -1 |
+        sed -n 's/.*"bodies":\([0-9]*\).*/\1/p'
+}
+# The fraction of a window the receiver was actually in lockstep. The marker
+# proxy CANNOT see this: it scores the dwells the receiver tracked, so one that
+# spends half a window re-acquiring still reports ~1.0 for the half it was
+# present for. Together with the FEC figure this is what catches that.
+tracked() { # window slice, secs
+    grep -c '"state":"retune"' "$1" 2>/dev/null |
+        awk -v s="$2" -v m="$SLOT_MS" '{printf "%.3f", $1 / (s * 1000 / m)}'
+}
+# A measurement window has to be a SETTLED one. A receiver spends the first
+# tens of seconds of a phase bringing the chip up and then acquiring the slot
+# clock, and counting that as delivery failure buries the effect under the
+# startup: one run measured 0.30 FEC delivery on a phase whose settled part
+# ran at 0.90. So both endpoints are marked once the receiver is tracking, and
+# the phase clock starts there.
+wait_tracking() { # rxlog, timeout_s -> 0 if the receiver locked
+    local t=0
+    while [ "$t" -lt "$2" ]; do
+        grep -qE '"state":"(track|decode)"' "$1" 2>/dev/null && return 0
+        sleep 1; t=$((t + 1))
+    done
+    echo "   NOTE: receiver never reported tracking within ${2}s"
+    return 1
+}
+mark_open() { # rxlog, txlog -> MARK_OFF / MARK_SENT
+    MARK_OFF=$(stat -c %s "$1" 2>/dev/null || echo 0)
+    MARK_SENT=$(tx_bodies "$2")
+    MARK_SENT="${MARK_SENT:-0}"
+}
+# Close a window: cut the receiver's capture down to it and score both metrics
+# over exactly the same bytes, so the proxy and the FEC figure can never be
+# accused of measuring different stretches of the run.
+close_window() { # rxlog, txlog, label, off0, sent0, secs -> WINDOW_SLICE
+    local off1 sent1
+    off1=$(stat -c %s "$1" 2>/dev/null || echo 0)
+    sent1=$(tx_bodies "$2"); sent1="${sent1:-0}"
+    WINDOW_SLICE="$OUT/window_$3.log"
+    tail -c "+$(( ${4:-0} + 1 ))" "$1" 2>/dev/null |
+        head -c "$(( off1 - ${4:-0} ))" >"$WINDOW_SLICE"
+    [ "$FEC" = "1" ] || return 0
+    # A transmitter that ran out of payload stopped mid-window, and every
+    # number after that point is an average over a link that was not
+    # transmitting. Say so rather than reporting it as delivery.
+    if grep -F '"ev":"tx.stdin"' "$2" 2>/dev/null | grep -qF '"eof":1'; then
+        echo "   WARNING: $3 drained its FEC payload — window cut short; "\
+"raise FEC_BYTES"
+    fi
+    local rec
+    rec=$("$PY" "$HERE/fec_metrics.py" --capture "$WINDOW_SLICE" \
+          --payload "$PAYLOAD" --sent "$sent1" --sent-from "${5:-0}" \
+          --secs "${6:-0}" --label "$3") || return 0
+    echo "$rec" >>"$OUT/cells.jsonl"
+}
+fec_value() { # label -> the fec_delivery of a recorded cell
+    grep -F "\"cell\": \"$1\"" "$OUT/cells.jsonl" 2>/dev/null | tail -1 |
+        sed -n 's/.*"fec_delivery": \([0-9.]*\).*/\1/p'
 }
 
 # Per-channel delivery — the diagnostic that tells "one channel is jammed"
@@ -243,10 +449,8 @@ if [ "$MODE" = "prepost" ]; then
     sleep 2
     SENSE=1 SENSE_EVERY=1 start_tx "$OUT/tx_prepost.log"
     sleep "$ADAPT_S"
-    sudo pkill -INT -x txdemo 2>/dev/null || true
-    sudo pkill -INT -x rxdemo 2>/dev/null || true
+    stop_link
     kill_jammer
-    sleep 2
     echo "== verdicts (logs: $OUT) =="
     mean_occ() { grep -F "\"phase\":\"$2\"" "$1" 2>/dev/null |
         grep -oE '"occ":[0-9.]+' | cut -d: -f2 |
@@ -254,7 +458,7 @@ if [ "$MODE" = "prepost" ]; then
     count_ph() { grep -cF "\"phase\":\"$2\"" "$1" 2>/dev/null || echo 0; }
     pre_m=$(mean_occ "$OUT/tx_prepost.log" pre)
     post_m=$(mean_occ "$OUT/tx_prepost.log" post)
-    retunes=$(grep -c '"ev": "follow.jam"' "$OUT/follow.jsonl" 2>/dev/null || echo 0)
+    retunes=$(grep -c '"ev": "follow.jam"' "$OUT/follow.jsonl" 2>/dev/null)
     echo "   follower retunes seen: $retunes"
     echo "   pre-burst  n=$(count_ph "$OUT/tx_prepost.log" pre)  mean occupancy $pre_m"
     echo "   post-burst n=$(count_ph "$OUT/tx_prepost.log" post)  mean occupancy $post_m"
@@ -283,9 +487,7 @@ if [ "$MODE" = "overhead" ]; then
         sleep 2
         SENSE="$2" start_tx "$OUT/tx_ovh_$1.log"
         sleep "$OVH_S"
-        sudo pkill -INT -x txdemo 2>/dev/null || true
-        sudo pkill -INT -x rxdemo 2>/dev/null || true
-        sleep 2
+        stop_link
     }
     fps() { grep -F '"ev":"tx.stats"' "$1" 2>/dev/null | tail -1 |
             sed -n 's/.*"submitted":\([0-9]*\).*/\1/p' |
@@ -312,6 +514,194 @@ if [ "$MODE" = "overhead" ]; then
     exit "$fails"
 fi
 
+if [ "$MODE" = "policycost" ]; then
+    # What the receiver's own uplink costs it. The receiver is half duplex:
+    # every proposal and every status frame it airs is a slot it is not
+    # listening in. The cost is expected to be small — a handful of frames a
+    # minute against twenty dwells a second — but "expected to be small" is
+    # not a measurement, and the heartbeat cadence should be set from one.
+    #
+    # Three cells, no interferer at all, so nothing but the control traffic
+    # differs:
+    #   off    policy off: the receiver never transmits
+    #   mute   policy on, uplink muted: it decides and airs nothing — this
+    #          isolates the AIRTIME from the decisions the policy would make
+    #   on     policy on: proposals and the status heartbeat go out
+    NO_JAM=1
+    run_cost() { # label, policy, mute
+        MUTE="$3" start_rx "$OUT/rx_cost_$1.log" "$2"
+        sleep 3
+        start_tx "$OUT/tx_cost_$1.log"
+        wait_tracking "$OUT/rx_cost_$1.log" 60 || true
+        mark_open "$OUT/rx_cost_$1.log" "$OUT/tx_cost_$1.log"
+        sleep "$COST_S"
+        close_window "$OUT/rx_cost_$1.log" "$OUT/tx_cost_$1.log" "cost_$1" \
+            "$MARK_OFF" "$MARK_SENT" "$COST_S"
+        stop_link
+    }
+    ctl_frames() { # rxlog -> control FRAMES the receiver actually aired
+        grep -cF '"ev":"hopset.ctl"' "$1" 2>/dev/null
+    }
+    echo "== policy cost: receiver silent =="       ; run_cost off  0 0
+    echo "== policy cost: policy on, uplink muted ="; run_cost mute 1 1
+    echo "== policy cost: policy on, uplink live ==" ; run_cost on   1 0
+    echo "== verdicts (logs: $OUT) =="
+    printf "   %-5s %-8s %-8s %-8s %s\n" cell marker fec tracked rx-aired
+    for c in off mute on; do
+        printf "   %-5s %-8s %-8s %-8s %s\n" "$c" \
+            "$(delivery "$OUT/window_cost_$c.log")" "$(fec_value "cost_$c")" \
+            "$(tracked "$OUT/window_cost_$c.log" "$COST_S")" \
+            "$(ctl_frames "$OUT/window_cost_$c.log")"
+    done
+    f_mute=$(fec_value cost_mute); f_on=$(fec_value cost_on)
+    t_mute=$(tracked "$OUT/window_cost_mute.log" "$COST_S")
+    t_on=$(tracked "$OUT/window_cost_on.log" "$COST_S")
+    n_ctl=$(ctl_frames "$OUT/window_cost_on.log")
+    rate=$(awk -v n="${n_ctl:-0}" -v t="$COST_S" 'BEGIN{printf "%.1f", 60*n/t}')
+    echo "   receiver control traffic: ${rate} frames/min"
+    # The comparison that isolates the transport is muted-vs-live: both run the
+    # policy and both decide the same things, only one talks. Scored on FEC
+    # delivery and on tracked time, because those are what the transport can
+    # actually damage.
+    cost=$(awk -v a="$f_mute" -v b="$f_on" \
+        'BEGIN{printf "%.1f", (a>0)?100*(a-b)/a:0}')
+    tcost=$(awk -v a="$t_mute" -v b="$t_on" \
+        'BEGIN{printf "%.1f", (a>0)?100*(a-b)/a:0}')
+    echo "   RX-blind cost of the uplink: ${cost}% of FEC delivery, "\
+"${tcost}% of tracked time"
+    awk -v c="$cost" -v b="${COST_BOUND:-5}" 'BEGIN { exit !(c <= b) }' &&
+        echo "PASS: uplink costs ${cost}% of FEC delivery, within the ${COST_BOUND:-5}% bound" ||
+        { echo "FAIL: uplink costs ${cost}% of FEC delivery — the transport is "\
+"costing more than its airtime"; fails=$((fails+1)); }
+    [ "${n_ctl:-0}" -gt 0 ] &&
+        echo "PASS: the live cell actually transmitted ($n_ctl frames)" ||
+        { echo "FAIL: no control traffic — nothing was measured"
+          fails=$((fails+1)); }
+    [ "$fails" -eq 0 ] && echo "== ALL PASS ==" || echo "== $fails FAILURES =="
+    exit "$fails"
+fi
+
+if [ "$MODE" = "fusionmatrix" ]; then
+    # FEC delivery and throughput for each fusion mode against one interferer.
+    # Same jammer, same channel, same seed: the only thing that varies is who
+    # is allowed to decide.
+    SENSE=1
+    echo "== jammer parked on ch$JAM_CHANNEL (gain $JAM_GAIN) =="
+    start_jammer "$JAM_CHANNEL"
+    for fm in rx veto either failsafe; do
+        # The failsafe row only means anything with the uplink gone: with the
+        # receiver answering, the transmitter is supposed to stay quiet and the
+        # row would just re-measure the veto row. It also needs longer — it may
+        # not act until the feedback timeout has expired AND its own
+        # observation window has filled, and a row measured before it arms is
+        # a measurement of the un-adapted link wearing the failsafe's name.
+        m=0; secs="$MATRIX_S"
+        [ "$fm" = "failsafe" ] && { m=1; secs=$((MATRIX_S * 3)); }
+        echo "== fusion=$fm, ${secs}s =="
+        MUTE="$m" start_rx "$OUT/rx_fm_$fm.log" 1
+        sleep 3
+        FUSION="$fm" start_tx "$OUT/tx_fm_$fm.log"
+        wait_tracking "$OUT/rx_fm_$fm.log" 60 || true
+        mark_open "$OUT/rx_fm_$fm.log" "$OUT/tx_fm_$fm.log"
+        sleep "$secs"
+        close_window "$OUT/rx_fm_$fm.log" "$OUT/tx_fm_$fm.log" "fusion_$fm" \
+            "$MARK_OFF" "$MARK_SENT" "$secs"
+        stop_link
+        eval "SECS_$fm=$secs"
+    done
+    kill_jammer
+    echo "== verdicts (logs: $OUT) =="
+    # `tracked` is the fraction of the window the receiver held lockstep. It is
+    # in this table because the marker proxy cannot see its absence: a receiver
+    # that spends half the window re-acquiring still scores ~1.0 on the dwells
+    # it was present for, and only the FEC column and this one notice.
+    printf "   %-9s %-6s %-8s %-8s %-8s %-9s %s\n" \
+        mode secs marker fec tracked frames/s excl
+    for fm in rx veto either failsafe; do
+        eval "secs=\$SECS_$fm"
+        f=$(grep -F '"ev":"tx.stats"' "$OUT/tx_fm_$fm.log" 2>/dev/null | tail -1 |
+            sed -n 's/.*"submitted":\([0-9]*\).*/\1/p' |
+            awk -v t="$secs" '{printf "%.0f", $1/t}')
+        e=$(grep -cF '"ev":"hopset.commit"' "$OUT/tx_fm_$fm.log" 2>/dev/null)
+        t=$(tracked "$OUT/window_fusion_$fm.log" "$secs")
+        printf "   %-9s %-6s %-8s %-8s %-8s %-9s %s\n" "$fm" "$secs" \
+            "$(delivery "$OUT/window_fusion_$fm.log")" \
+            "$(fec_value "fusion_$fm")" "${t:-0}" "${f:-0}" "${e:-0}"
+    done
+    # The failsafe row is only a failsafe measurement if it actually fired.
+    fs_commits=$(grep -cF '"ev":"hopset.commit"' "$OUT/tx_fm_failsafe.log" 2>/dev/null)
+    [ "${fs_commits:-0}" -gt 0 ] &&
+        echo "PASS: the failsafe row armed and acted ($fs_commits commits)" ||
+        { echo "FAIL: the failsafe never armed — that row measures the "\
+"un-adapted link, not the failsafe"; fails=$((fails+1)); }
+    # rx mode cannot veto by construction; veto mode must not have vetoed a
+    # correct receiver either — that is the same claim MODE=sense makes, on
+    # every row at once.
+    if grep -F '"ev":"hopset.decision"' "$OUT/tx_fm_veto.log" 2>/dev/null |
+       grep -qE '"kind":"(delay|hold)".*"veto":"tx_(broad|alt_dirty)"'; then
+        echo "FAIL: the veto row blocked the receiver's exclusion"
+        fails=$((fails+1))
+    else
+        echo "PASS: no veto of a correct receiver in the veto row"
+    fi
+    [ "$fails" -eq 0 ] && echo "== ALL PASS ==" || echo "== $fails FAILURES =="
+    exit "$fails"
+fi
+
+if [ "$MODE" = "mirror" ]; then
+    # The mirror of the hidden node: this side is told a channel is filthy
+    # while the receiver delivers on it perfectly well. Under the default mode
+    # the transmitter does not originate, so the right outcome is that nothing
+    # happens at all — and that the argument is on the record anyway.
+    NO_JAM=1
+    SENSE=1
+    : "${MIRROR_IDX:=2}"
+    INJECT="${INJECT:-${MIRROR_IDX}:0.95,*:0.05}"
+    echo "== mirror: base index $MIRROR_IDX injected filthy, no real interferer, ${ADAPT_S}s =="
+    start_rx "$OUT/rx_mirror.log" 1
+    sleep 3
+    start_tx "$OUT/tx_mirror.log"
+    wait_tracking "$OUT/rx_mirror.log" 60 || true
+    mark_open "$OUT/rx_mirror.log" "$OUT/tx_mirror.log"
+    sleep "$ADAPT_S"
+    close_window "$OUT/rx_mirror.log" "$OUT/tx_mirror.log" "mirror" \
+        "$MARK_OFF" "$MARK_SENT" "$ADAPT_S"
+    stop_link
+    echo "== verdicts (logs: $OUT) =="
+    echo "   marker delivery $(delivery "$OUT/window_mirror.log")   fec $(fec_value mirror)"
+    require "$OUT/tx_mirror.log" '"inject":1' "the injected view reached the sensor"
+    if grep -qF '"ev":"hopset.commit"' "$OUT/tx_mirror.log" 2>/dev/null; then
+        echo "FAIL: a channel was spent on transmitter-local evidence alone"
+        grep -F '"ev":"hopset.commit"' "$OUT/tx_mirror.log" | head -2
+        fails=$((fails+1))
+    else
+        echo "PASS: no exclusion — local noise alone never costs a channel"
+    fi
+    # ...and the disagreement has to be legible, or a sensor that never fired
+    # would look exactly the same.
+    if grep -F '"ev":"hopset.decision"' "$OUT/tx_mirror.log" 2>/dev/null |
+       grep -qE '"tx_wanted":true.*"rx_wanted":false|"rx_wanted":false.*"tx_wanted":true'; then
+        echo "PASS: the disagreement is on the record (tx wanted, rx did not)"
+        grep -F '"ev":"hopset.decision"' "$OUT/tx_mirror.log" |
+            grep -F '"tx_wanted":true' | head -1
+    else
+        echo "FAIL: the transmitter's rejected opinion left no trace"
+        fails=$((fails+1))
+    fi
+    [ "$fails" -eq 0 ] && echo "== ALL PASS ==" || echo "== $fails FAILURES =="
+    exit "$fails"
+fi
+
+if [ "$MODE" = "hidden" ]; then
+    # The hidden node, built the only way one can be built on a bench where the
+    # adapters sit inches apart: a REAL interferer degrading the receiver, and
+    # the transmitter's own view replaced by "every channel is clean". The
+    # receiver is then demonstrably right and this side demonstrably blind,
+    # which is exactly the signature a naive veto is most confident about.
+    SENSE=1
+    INJECT="${INJECT:-*:0.05}"
+fi
+
 echo "== jammer parked on ch$JAM_CHANNEL (gain $JAM_GAIN) =="
 start_jammer "$JAM_CHANNEL"
 
@@ -319,16 +709,22 @@ echo "== phase A: fixed keyed hopset (policy off), ${BASELINE_S}s =="
 start_rx "$OUT/rx_baseline.log" 0
 sleep 3
 start_tx "$OUT/tx_baseline.log"
+wait_tracking "$OUT/rx_baseline.log" 60 || true
+mark_open "$OUT/rx_baseline.log" "$OUT/tx_baseline.log"
+BASE_OFF=$MARK_OFF; BASE_SENT0=$MARK_SENT
 sleep "$BASELINE_S"
-sudo pkill -INT -x rxdemo 2>/dev/null || true
-sudo pkill -INT -x txdemo 2>/dev/null || true
-sleep 2
-BASE_DELIV=$(delivery "$OUT/rx_baseline.log")
+close_window "$OUT/rx_baseline.log" "$OUT/tx_baseline.log" "baseline" \
+    "$BASE_OFF" "$BASE_SENT0" "$BASELINE_S"
+BASE_DELIV=$(delivery "$WINDOW_SLICE")
+stop_link
 
 echo "== phase B: receiver-driven exclusion (policy on), ${ADAPT_S}s =="
 start_rx "$OUT/rx_adapt.log" 1
 sleep 3
 start_tx "$OUT/tx_adapt.log"
+wait_tracking "$OUT/rx_adapt.log" 60 || true
+mark_open "$OUT/rx_adapt.log" "$OUT/tx_adapt.log"
+ADAPT_OFF0=$MARK_OFF; ADAPT_SENT0=$MARK_SENT
 
 if [ "$MODE" = "herding" ]; then
     # Follow every exclusion: park the jammer on the lowest channel that is
@@ -354,9 +750,16 @@ if [ "$MODE" = "herding" ]; then
 else
     sleep "$ADAPT_S"
 fi
-ADAPT_DELIV=$(delivery "$OUT/rx_adapt.log")
+# Phase B ends here but the demos run on into phase C on the same processes,
+# so close the window now: this is what makes the adaptive figures phase-B
+# figures rather than a B-and-C average.
+close_window "$OUT/rx_adapt.log" "$OUT/tx_adapt.log" "adapt" \
+    "$ADAPT_OFF0" "$ADAPT_SENT0" "$ADAPT_S"
+ADAPT_DELIV=$(delivery "$WINDOW_SLICE")
+ADAPT_WINDOW="$WINDOW_SLICE"
 
-if [ "$MODE" = "parked" ] || [ "$MODE" = "sense" ] || [ "$MODE" = "failsafe" ]; then
+if [ "$MODE" = "parked" ] || [ "$MODE" = "sense" ] || [ "$MODE" = "hidden" ] ||
+   [ "$MODE" = "failsafe" ]; then
     # The failsafe needs this phase as much as the receiver-driven modes do:
     # an autonomous exclusion that can never be undone is a link that shrinks
     # permanently the first time something transient sits on a channel. With
@@ -367,18 +770,19 @@ if [ "$MODE" = "parked" ] || [ "$MODE" = "sense" ] || [ "$MODE" = "failsafe" ]; 
     : > "$OUT/rx_restore_mark"
     sleep "$RESTORE_S"
 fi
-sudo pkill -INT -x rxdemo 2>/dev/null || true
-sudo pkill -INT -x txdemo 2>/dev/null || true
-sleep 2
+stop_link
 
 echo "== verdicts (logs: $OUT) =="
 jam_idx=$(awk -v c="$JAM_CHANNEL" -F, '{for(i=1;i<=NF;i++) if($i==c) print i-1}' <<<"$CHANNELS")
 
 echo "   baseline delivery=$BASE_DELIV   adaptive delivery=$ADAPT_DELIV"
+BASE_FEC=$(fec_value baseline); ADAPT_FEC=$(fec_value adapt)
+[ "$FEC" = "1" ] &&
+    echo "   baseline FEC=${BASE_FEC:-n/a}        adaptive FEC=${ADAPT_FEC:-n/a}"
 echo "   per-channel, baseline (policy off):"
-per_channel "$OUT/rx_baseline.log"
+per_channel "$OUT/window_baseline.log"
 echo "   per-channel, adaptive (policy on):"
-per_channel "$OUT/rx_adapt.log"
+per_channel "$ADAPT_WINDOW"
 if [ "$NO_JAM" = "1" ]; then
     echo "   NO_JAM=1 — rig sanity run only, no exclusion expected"
     [ "$(awk -v d="$BASE_DELIV" 'BEGIN{print (d > 0.5) ? 1 : 0}')" = "1" ] &&
@@ -405,7 +809,7 @@ require "$OUT/rx_adapt.log" '"ev":"hop.rx","state":"track"' "lockstep held"
 # first exclusion lands, and targeting wherever it went is the correct answer.
 target=$(grep -F '"kind":"exclude"' "$OUT/rx_adapt.log" | head -1 |
          sed -n 's/.*"target":\([0-9]*\).*/\1/p')
-if [ "$MODE" = "parked" ] || [ "$MODE" = "sense" ]; then
+if [ "$MODE" = "parked" ] || [ "$MODE" = "sense" ] || [ "$MODE" = "hidden" ]; then
     if [ "${target:-x}" = "${jam_idx:-y}" ]; then
         echo "PASS: excluded the jammed channel (base index $jam_idx)"
     else
@@ -427,11 +831,66 @@ else
     echo "FAIL: active set fell to $minactive"; fails=$((fails+1))
 fi
 
-if [ "$MODE" = "sense" ]; then
+if [ "$MODE" = "hidden" ]; then
+    # The injected view has to have reached the classifier, or this is just a
+    # second sense run wearing a different name.
+    require "$OUT/tx_adapt.log" '"inject":1' "the injected clean view was used"
+    n_inj=$(grep -c '"inject":1' "$OUT/tx_adapt.log" 2>/dev/null)
+    echo "   $n_inj injected sensing windows"
+    # "It did not veto" is worth something only if it COULD have. A sensor with
+    # no evidence cannot veto either, and would pass every assertion below
+    # while demonstrating nothing — the same trap this mode exists to close.
+    if grep -F '"ev":"hopset.decision"' "$OUT/tx_adapt.log" 2>/dev/null |
+       grep -qF '"tx_valid":true'; then
+        echo "PASS: the transmitter had evidence to veto with"
+    else
+        echo "FAIL: the transmitter never formed a view — a silent sensor cannot demonstrate restraint"
+        fails=$((fails+1))
+    fi
+    # ACCEPTANCE 1: the exclusion passes through unvetoed.
+    if grep -F '"ev":"hopset.decision"' "$OUT/tx_adapt.log" 2>/dev/null |
+       grep -qE '"veto":"tx_(broad|alt_dirty)"'; then
+        echo "FAIL: a blind transmitter vetoed a correct receiver"
+        grep -F '"veto":"tx_' "$OUT/tx_adapt.log" | head -2
+        fails=$((fails+1))
+    else
+        echo "PASS: the hidden-node exclusion passed unvetoed"
+    fi
+    # ACCEPTANCE 2: the applied mask is the receiver's proposal, bit for bit.
+    # Compared against the RECEIVER's proposed mask, not against an expectation
+    # of what it should have proposed — the claim is that nothing altered it in
+    # flight, and only the two masks can say that.
+    prop=$(grep -F '"ev":"hopset.decision"' "$OUT/rx_adapt.log" 2>/dev/null |
+           grep -F '"kind":"exclude"' | head -1 |
+           sed -n 's/.*"mask":"\(0x[0-9a-f]*\)".*/\1/p')
+    appl=$(grep -F '"ev":"hopset.commit"' "$OUT/tx_adapt.log" 2>/dev/null |
+           head -1 | sed -n 's/.*"mask":"\(0x[0-9a-f]*\)".*/\1/p')
+    if [ -n "$prop" ] && [ "$prop" = "$appl" ]; then
+        echo "PASS: applied mask $appl is the receiver's proposal, bit-identical"
+    else
+        echo "FAIL: proposed '${prop:-none}' but applied '${appl:-none}'"
+        fails=$((fails+1))
+    fi
+    # And the disagreement must be visible: the transmitter genuinely saw a
+    # clean band and said so.
+    if grep -F '"ev":"hopset.decision"' "$OUT/tx_adapt.log" 2>/dev/null |
+       grep -qF '"disagree":true'; then
+        echo "PASS: the endpoints' disagreement is on the record"
+        grep -F '"ev":"hopset.decision"' "$OUT/tx_adapt.log" |
+            grep -F '"disagree":true' | head -1
+    else
+        echo "FAIL: a blind transmitter left no record of having a view"
+        fails=$((fails+1))
+    fi
+    awk -v b="$BASE_DELIV" -v a="$ADAPT_DELIV" 'BEGIN { exit !(a > b) }' &&
+        echo "PASS: delivery improved ($BASE_DELIV -> $ADAPT_DELIV)" ||
+        { echo "FAIL: delivery did not improve ($BASE_DELIV -> $ADAPT_DELIV)"
+          fails=$((fails+1)); }
+elif [ "$MODE" = "sense" ]; then
     # Sensing must actually have run: a silent no-op would pass the
     # non-regression trivially and prove nothing.
     require "$OUT/tx_adapt.log" '"ev":"hopset.sense"' "TX sensing emitted samples"
-    n_pre=$(grep -c '"phase":"pre"' "$OUT/tx_adapt.log" 2>/dev/null || echo 0)
+    n_pre=$(grep -c '"phase":"pre"' "$OUT/tx_adapt.log" 2>/dev/null)
     [ "${n_pre:-0}" -ge 20 ] &&
         echo "PASS: $n_pre pre-burst samples taken" ||
         { echo "FAIL: only ${n_pre:-0} pre-burst samples"; fails=$((fails+1)); }
@@ -519,6 +978,16 @@ elif [ "$MODE" = "parked" ]; then
         echo "PASS: delivery improved ($BASE_DELIV -> $ADAPT_DELIV)" ||
         { echo "FAIL: delivery did not improve ($BASE_DELIV -> $ADAPT_DELIV)"
           fails=$((fails+1)); }
+    # The criterion as the issue states it: did excluding the jammed channel
+    # recover VIDEO, or only the markers the policy scores? A marker is one
+    # small frame at a robust rate, so the two can disagree — and if they do,
+    # the FEC number is the one that matters.
+    if [ "$FEC" = "1" ] && [ -n "${BASE_FEC:-}" ] && [ -n "${ADAPT_FEC:-}" ]; then
+        awk -v b="$BASE_FEC" -v a="$ADAPT_FEC" 'BEGIN { exit !(a > b) }' &&
+            echo "PASS: FEC delivery improved ($BASE_FEC -> $ADAPT_FEC)" ||
+            { echo "FAIL: FEC delivery did not improve ($BASE_FEC -> $ADAPT_FEC)"
+              fails=$((fails+1)); }
+    fi
     require "$OUT/rx_adapt.log" '"ev":"hopset.probe"' "keyed probes aired"
     if grep -F '"ev":"hopset.probe"' "$OUT/rx_adapt.log" | grep -qF '"delivered":true'; then
         echo "PASS: probes delivered after the jammer left"
@@ -537,9 +1006,15 @@ else
     # moving interferer, not damage. What must never happen is the set being
     # walked down — so the invariant is on the NET exclusion depth, not on the
     # number of decisions.
-    seq=$(grep -F '"ev":"hopset.decision"' "$OUT/rx_adapt.log" |
+    # Whichever endpoint was deciding: under FUSION=failsafe with the receiver
+    # muted, the exclusions this jammer is chasing are the TRANSMITTER's own,
+    # which is the row where the anti-herding limits carry the whole load —
+    # there is no receiver to disagree with an autonomous mistake.
+    dlog="$OUT/rx_adapt.log"
+    { [ "$MUTE" = "1" ] || [ "$FUSION" = "failsafe" ]; } && dlog="$OUT/tx_adapt.log"
+    seq=$(grep -F '"ev":"hopset.decision"' "$dlog" |
           sed -n 's/.*"kind":"\([a-z]*\)".*"target":\([0-9]*\).*/\1:\2/p')
-    echo "   decision sequence: $(echo "$seq" | tr '\n' ' ')"
+    echo "   decision sequence ($(basename "$dlog")): $(echo "$seq" | tr '\n' ' ')"
     nch=$(( $(tr -cd ',' <<<"$CHANNELS" | wc -c) + 1 ))
     budget=$(( nch - 3 ))
     # Measured on the COMMITTED masks, not on proposals: a proposal the
@@ -565,6 +1040,23 @@ else
         echo "PASS: no collapse under a moving jammer ($BASE_DELIV -> $ADAPT_DELIV)" ||
         { echo "FAIL: delivery collapsed ($BASE_DELIV -> $ADAPT_DELIV)"
           fails=$((fails+1)); }
+    if [ "$MUTE" = "1" ] || [ "$FUSION" = "failsafe" ]; then
+        # The autonomous chase: the exclusions were this side's own, so the
+        # one-channel-per-update limit is the thing under test.
+        require "$OUT/tx_adapt.log" '"origin":"failsafe"' \
+            "the transmitter decided autonomously"
+        if grep -F '"ev":"hopset.activate"' "$OUT/tx_adapt.log" |
+           sed -n 's/.*"mask":"0x\([0-9a-f]*\)".*/\1/p' |
+           awk 'NR>1 { d = xor(strtonum("0x" p), strtonum("0x" $0)); n = 0
+                       while (d) { n += d % 2; d = int(d/2) }
+                       if (n != 1) bad = 1 } { p = $0 } END { exit bad ? 1 : 0 }'
+        then
+            echo "PASS: one channel per autonomous update under herding"
+        else
+            echo "FAIL: an autonomous update moved more than one channel"
+            fails=$((fails+1))
+        fi
+    fi
 fi
 
 [ "$fails" -eq 0 ] && echo "== ALL PASS ==" || echo "== $fails FAILURES =="

--- a/tests/hopset_fusion_selftest.cpp
+++ b/tests/hopset_fusion_selftest.cpp
@@ -144,6 +144,16 @@ int main() {
           "local noise alone never excludes while delivery is fine");
     CHECK(d.tx_wanted_exclude && !d.rx_wanted_exclude,
           "the transmitter's opinion is recorded");
+    /* The on-air mirror test reads this record and nothing else, so the record
+     * has to name the channel and the occupancy that were argued about — a
+     * held decision that says only "held" is indistinguishable from a sensor
+     * that never fired. */
+    CHECK(d.endpoints_disagree_on_target &&
+              (d.reason_bitmap & RB_FUSE_TX_DISAGREES),
+          "the disagreement is surfaced on the held path too");
+    CHECK(d.target_index == 2, "the held record names the tx's own target");
+    CHECK(d.tx_evidence_valid && d.tx_target_occupancy > 0.8,
+          "the held record carries the occupancy that drove it");
   }
 
   /* --- ground (a): a uniformly DIRTY band delays, it does not refuse --- */

--- a/tests/hopset_sense_selftest.cpp
+++ b/tests/hopset_sense_selftest.cpp
@@ -77,6 +77,39 @@ uint64_t feed_both(HopsetSensor &s, uint64_t mask, size_t n, uint64_t from,
   return r;
 }
 
+/* The synthetic-evidence lever: the same sample with the occupancy handed in
+ * directly instead of derived from counters. */
+TxSenseSample mk_inj(uint32_t idx, uint64_t round, double occ, SensePhase phase,
+                     bool probe = false) {
+  TxSenseSample s;
+  s.base_index = idx;
+  s.round = round;
+  s.slot = round * 16 + idx;
+  s.phase = phase;
+  s.window_us = kWin;
+  s.probe = probe;
+  s.injected = true;
+  s.injected_occupancy = occ;
+  s.flags |= kTsInjected;
+  return s;
+}
+
+uint64_t feed_both_inj(HopsetSensor &s, uint64_t mask, size_t n, uint64_t from,
+                       uint32_t rounds, int dirty_index, double dirty,
+                       double clean) {
+  uint64_t r = from;
+  for (uint32_t i = 0; i < rounds; ++i, ++r)
+    for (size_t c = 0; c < n; ++c) {
+      if (!(mask & (uint64_t(1) << c)))
+        continue;
+      const double o =
+          (dirty_index >= 0 && c == size_t(dirty_index)) ? dirty : clean;
+      s.ingest(mk_inj(uint32_t(c), r, o, SensePhase::PreBurst));
+      s.ingest(mk_inj(uint32_t(c), r, o, SensePhase::PostBurst));
+    }
+  return r;
+}
+
 } // namespace
 
 int main() {
@@ -482,6 +515,81 @@ int main() {
     }
     CHECK(popcount64(mask) == 3 && excluded == 3,
           "herding converges to the floor and stops");
+  }
+
+  /* --- synthetic evidence ---
+   * The lever exists so a bench where both endpoints hear the same interferer
+   * can still build a genuine disagreement. It must therefore be exact (an
+   * approximate view proves nothing about the veto) and it must not be a way
+   * around the floors: a fabricated occupancy earns no more authority than a
+   * measured one. */
+  {
+    SenseScore sc;
+    /* Counters present AND injection set: the injection wins outright, so a
+     * caller cannot half-inject and wonder which reading it got. */
+    TxSenseSample s = mk(0, 0, 0.90, SensePhase::PostBurst);
+    s.injected = true;
+    s.injected_occupancy = 0.05;
+    CHECK(score_sample(s, def, sc), "injected sample scores");
+    CHECK(sc.occupancy == 0.05, "injected occupancy is returned verbatim");
+    CHECK(sc.sources == kSrcInjected, "injected evidence names itself");
+    s.injected_occupancy = 4.0;
+    score_sample(s, def, sc);
+    CHECK(sc.occupancy == 1.0, "injected occupancy clamps high");
+    s.injected_occupancy = -1.0;
+    score_sample(s, def, sc);
+    CHECK(sc.occupancy == 0.0, "injected occupancy clamps low");
+    /* Inert when unset: the counter path is untouched. */
+    TxSenseSample plain = mk(0, 0, 0.90, SensePhase::PostBurst);
+    SenseScore pc;
+    CHECK(score_sample(plain, def, pc) && pc.sources == (kSrcCca | kSrcFa),
+          "an uninjected sample still scores from its counters");
+  }
+  {
+    /* An injected stream reaches the same verdict as a measured one of equal
+     * occupancy — the hidden-node rig's premise. */
+    HopsetSensor inj(def, 6), meas(def, 6);
+    feed_both_inj(inj, full_mask(6), 6, 0, 40, 2, 0.85, 0.10);
+    feed_both(meas, full_mask(6), 6, 0, 40, 2, 0.85, 0.10);
+    const auto di = inj.evaluate(40), dm = meas.evaluate(40);
+    CHECK(di.kind == TxSenseCandidate::Kind::ProposeExclude &&
+              di.target_index == 2,
+          "injected dirt drives the exclusion candidate");
+    CHECK(di.kind == dm.kind && di.target_index == dm.target_index &&
+              di.proposed_mask == dm.proposed_mask,
+          "injected and measured evidence classify alike");
+  }
+  {
+    /* A fabricated view of a uniformly dirty band is still broad degradation,
+     * not a licence to spend channels. */
+    HopsetSensor s(def, 6);
+    feed_both_inj(s, full_mask(6), 6, 0, 40, -1, 0.0, 0.85);
+    const auto d = s.evaluate(40);
+    CHECK(d.kind == TxSenseCandidate::Kind::None,
+          "injected broad dirt proposes nothing");
+    CHECK(d.hold == TxSenseHold::BroadOccupancy ||
+              d.hold == TxSenseHold::FlatBand,
+          "injected broad dirt is held on the band's geometry");
+  }
+  {
+    /* And the diversity floor holds against it too. */
+    HopsetSensor s(def, 6);
+    uint64_t mask = full_mask(6), r = 0;
+    for (int round = 0; round < 8; ++round) {
+      int victim = -1;
+      for (size_t i = 0; i < 6; ++i)
+        if ((mask & (uint64_t(1) << i)) && victim < 0)
+          victim = int(i);
+      r = feed_both_inj(s, mask, 6, r, 45, victim, 0.85, 0.10);
+      const auto d = s.evaluate(r);
+      if (d.kind == TxSenseCandidate::Kind::ProposeExclude) {
+        mask = d.proposed_mask;
+        s.on_activation(mask, r);
+      } else {
+        s.clear_outstanding(r);
+      }
+      CHECK(popcount64(mask) >= 3, "injection never breaches the floor");
+    }
   }
 
   /* --- determinism --- */

--- a/tests/jammer_resilience.py
+++ b/tests/jammer_resilience.py
@@ -47,29 +47,11 @@ sys.path.insert(0, os.path.join(_ROOT, "tools", "precoder"))
 sys.path.insert(0, _HERE)
 
 
+from fec_metrics import build_payload, fec_counts, parse_fec_report  # noqa: E402
+
+
 def chan_to_freq(ch: int) -> float:
     return (2407 + 5 * ch) * 1e6 if ch <= 14 else (5000 + 5 * ch) * 1e6
-
-
-def build_payload(nbytes: int) -> bytes:
-    # Deterministic (fixed-seed) payload so P and the run are reproducible.
-    import numpy as np
-    return np.random.default_rng(0xC0FFEE).integers(
-        0, 256, size=nbytes, dtype=np.uint8).tobytes()
-
-
-def fec_counts(payload: bytes) -> tuple[int, int]:
-    """(P source packets, B bodies/frames) for the default fused-FEC config
-    (must match fused_fec_tx.py defaults: k=8, symbol=64, overhead=0.5,
-    blocks=4, rs). P via a real encode so the decoder's packet count matches."""
-    from stream_fec import FecConfig
-    from fused_fec_link import FusedFecSender, FusedFecReceiver
-    cfg = FecConfig(k=8, symbol_size=64, overhead=0.5, scheme="rs")
-    snd = FusedFecSender(cfg, 4, crc_bytes=2)
-    bodies = snd.add_bytes(payload) + snd.flush()
-    rcv = FusedFecReceiver(cfg, 4, crc_bytes=2)
-    pk = sum(len(rcv.add_frame(b, False)) for b in bodies)  # clean-loopback P
-    return pk, len(bodies)
 
 
 class Proc:
@@ -92,25 +74,6 @@ class Proc:
                 os.killpg(os.getpgid(self.p.pid), signal.SIGKILL)
             except ProcessLookupError:
                 pass
-
-
-def parse_fec_report(stderr_text: str) -> dict:
-    """Pull the counters out of fused_fec_rx.py's stderr report."""
-    out = {"frames_seen": 0, "frames_corrupt": 0,
-           "base_packets": 0, "sbi_packets": 0}
-    for line in stderr_text.splitlines():
-        for key, tok in (("frames_seen", "frames="),
-                         ("frames_corrupt", "corrupt=")):
-            if tok in line:
-                try:
-                    out[key] = int(line.split(tok)[1].split()[0])
-                except (IndexError, ValueError):
-                    pass
-        if "baseline blocks=" in line and "pkts=" in line:
-            out["base_packets"] = int(line.split("pkts=")[1].split()[0])
-        if line.strip().startswith("fused_fec_rx: sbi") and "pkts=" in line:
-            out["sbi_packets"] = int(line.split("pkts=")[1].split()[0])
-    return out
 
 
 def hop_env(mode: str, args, static_channel: int) -> tuple[dict, dict, int]:

--- a/tools/precoder/fused_fec_tx.py
+++ b/tools/precoder/fused_fec_tx.py
@@ -71,4 +71,27 @@ def main(argv=None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    try:
+        rc = main()
+        # Flush INSIDE the guard: a body small enough to still be sitting in
+        # stdout's buffer would otherwise raise during interpreter shutdown,
+        # outside any handler, and exit 120 with the traceback this exists to
+        # avoid.
+        sys.stdout.buffer.flush()
+        sys.stdout.flush()
+        raise SystemExit(rc)
+    except BrokenPipeError:
+        # The radio downstream stopped — a harness ending a phase, or a demo
+        # exiting on EOF. An ordinary end of run rather than a crash, so no
+        # traceback; but not success either, so a caller looping this script
+        # over a fixed payload has something to break on. stderr is flushed
+        # first because os._exit skips that, and the summary line there is what
+        # the harness logs.
+        sys.stderr.flush()
+        # Point stdout at nowhere so interpreter shutdown has nothing left to
+        # fail on, rather than closing a pipe that raises again.
+        try:
+            os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno())
+        except OSError:
+            pass
+        os._exit(3)


### PR DESCRIPTION
Closes #341, closes #340.

The adaptive hopset was judged by a proxy: a dwell counted as delivered when a sync marker arrived before the next retune. That is what the receiver's policy scores, so it is the right quantity *for the policy* — but it is the wrong one for judging whether adaptation helps. A marker is one small frame at a robust rate, and a dwell that decoded one marker out of twenty frames still scores 1.0.

## Measure the real thing

`txdemo` gains `DEVOURER_TX_STDIN=1`, carrying caller PSDU bodies in `streamtx`'s framing — the authority, the sensing windows and the recovery probes all live in that demo, so the payload has to come to them. `tests/fec_metrics.py` owns the arithmetic that turns a capture into delivery, throughput and tracked time; `jammer_resilience.py` now shares it instead of keeping its own copy.

Against a parked narrowband interferer on a 4-channel 2.4 GHz base (25 s fixed, 70 s adaptive, both windows opened only once the receiver was tracking):

| measure | fixed keyed hopset | jammed channel excluded |
|---|---|---|
| marker proxy (dwells) | 0.762 | 0.946 |
| FEC delivery (packets) | 0.861 | 0.927 |
| recovered packets/s | 1001 | 986 |

The proxy claims roughly three times the improvement the payload sees, and the delivered *rate* does not improve at all. Both follow from the same cause: on a CSMA link the transmitter defers to the interferer rather than transmitting into it, so a fixed hopset spends far fewer than its dwell share of frames there, and the outer code already absorbs what it does spend. **Exclusion buys margin, not throughput.** Reproduced three times, spread under a point.

Per-policy (60 s rows, 180 s for the failsafe, which cannot arm before its feedback timeout and observation window have both elapsed):

| fusion | marker | FEC delivery | frames/s | exclusions |
|---|---|---|---|---|
| `rx` | 0.912 | 0.940 | 451 | 1 |
| `veto` | 0.921 | 0.932 | 457 | 1 |
| `either` | 0.922 | 0.932 | 471 | 1 |
| `failsafe` (receiver muted) | 0.908 | 0.932 | 453 | 1 |

All four converge: when the receiver is right, the fusion mode decides *who may act*, not what happens. The receiver's own uplink costs 19 control frames/min, under 5 ms of air per minute, and nothing measurable in delivery — so the heartbeat cadence is not the limiting factor.

## Three defects the proxy could not see

Each found on air, each fixed here with a headless test:

- **A corrupt frame's marker reached the follower.** The sync marker is a plain vendor IE whose only integrity is the frame FCS. Under `DEVOURER_RX_KEEP_CORRUPTED` — which sub-block salvage requires, and which the FPV link runs with — a corrupted marker whose seed fingerprint happened to survive decoded as a genuine generation change, and the follower dropped lockstep. **46 s outage.**
- **A marker that crossed the activation boundary.** Both endpoints swap at the same absolute slot, but a frame stamped just before it is decoded just after, carrying the old generation truthfully. Staleness is now judged by the slot the marker was *stamped* in.
- **The marker-strip heuristic ate caller payload.** Two bytes deep, so on RS symbol data it matched about one body in 65536 and chopped 37 bytes off that shard — which then arrived with a valid FCS, indistinguishable from channel loss in the very metric this change exists to make trustworthy.

## The two disagreement scenarios (#340)

They cannot be built on a bench where the adapters sit inches apart: any interferer strong enough to degrade one endpoint is equally audible at the other. `DEVOURER_TX_SENSE_INJECT` fabricates the transmitter's per-channel view *inside the pure layer* — hardware read skipped, window timing kept so the duty cycle is unchanged, and every floor, hysteresis and cleaner-alternative rule still applied to it.

- **Hidden node** (real interferer, injected clean view): the exclusion passes unvetoed, the applied mask is bit-identical to the receiver's proposal, and the disagreement is recorded rather than acted on.
- **Mirror** (dirty injected view on a channel the receiver delivers on): nothing is spent, and the argument is on the record with the target and occupancy that drove it.
- **Herding under an autonomous transmitter** (`FUSION=failsafe MUTE=1`): diversity floor held, one channel per update, exclusion depth 1, no collapse (0.840 → 0.841).

Two observability holes had to be closed first: `txdemo` recorded a fused decision only when it vetoed or acted, so a pass-through and a `mode_forbids_tx_origin` hold were both invisible; and a sensor that *held* logged nothing at all, so "held on a floor", "no evidence" and "not running" were the same silence (new `hopset.sense_eval`).

## Validation

47/47 ctest, including new cases for injected evidence, the mirror record, the in-flight marker and the activation-window bound. On air: parked ×3, sense ×2, hidden ×3, mirror ×2, fusionmatrix, policycost, herding+failsafe, overhead — all pass.

Both levers are test levers in the spirit of `DEVOURER_HOP_ADAPTIVE_SCRIPT` and `DEVOURER_HOP_MUTE`, and everything is inert unset.

## Known follow-ups, deliberately not in this PR

- The `<u32_le len><PSDU>` reader is now a fourth copy across `txdemo`/`streamtx`/`duplex`/`svctx`; the composed record read belongs in `examples/common/stream_stdin.h` beside `read_exact`.
- The three new harness modes open-code the same seven-step cell that `run_cost` already is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
