### PR TITLE
VHT on 2.4 GHz: confirm 256-QAM on air, with the cold-cycle discipline it needs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,7 +231,10 @@ are parsed in each demo's own code. The ones needed daily:
 - `DEVOURER_TX_RATE=<rate>[/<bw>][/SGI][/LDPC][/STBC][/ER|/ER106][/DCM]` — TX
   mode for rate-less frames (`MCS7/40/SGI`, `VHT2SS_MCS3/80/LDPC`, `1M`...).
   Unset = 6M legacy. CCK rates are 2.4 GHz-only; `1M` buys ~9 dB link budget
-  over `6M`. `/ER`, `/ER106`, `/DCM` are HE-only (Kestrel): the HE ER SU
+  over `6M`. Rate resolution never reads the band, so `VHT*` rates air on
+  2.4 GHz too — the non-standard NitroQAM/TurboQAM extension, confirmed on the
+  dies whose `AdapterCaps.vht_2g4_ok` is set, peer-decode required and the
+  256-QAM MCS8/9 points still unmeasured (`docs/vht-on-2g4.md`). `/ER`, `/ER106`, `/DCM` are HE-only (Kestrel): the HE ER SU
   extended-range PPDU + dual-carrier modulation (`docs/he-extended-range.md`).
   The library itself is radiotap-driven — a frame carrying its own rate
   radiotap overrides the mode per-packet (ER SU = radiotap-HE FORMAT=EXT_SU).
@@ -605,7 +608,14 @@ generators, never the output files.
   After detaching a kernel driver, expect a cold re-init; `DEVOURER_SKIP_RESET`
   only helps when firmware state is intact.
 - **The chip retains state across soft re-init** — cold-bisect hardware
-  problems with a VBUS power-cycle, not a re-run.
+  problems with a VBUS power-cycle, not a re-run. This is not only a bring-up
+  concern: **high-order constellation TX degrades across warm re-inits**. After
+  a run of back-to-back sessions an 8812AU delivered 0% at MCS7 (64-QAM) while
+  16-QAM and below still worked, and a VBUS cycle restored it to 58% at the
+  same channel, power and gap. Nothing logs an error, RSSI and EVM look
+  healthy, and the result is indistinguishable from a link too weak to carry
+  the rate — so any rate-ceiling measurement must cold-cycle per cell or it
+  measures accumulated chip state. An `authorized` toggle does not clear it.
 - **MediaTek Android hosts cap bulk-IN reads at 16 KB**: some MTK xhci/usbfs
   stacks (Dimensity 810, Helio G99, MT6765) never complete a larger bulk-IN
   transfer — `LIBUSB_ERROR_TIMEOUT` forever, zero RX with a green init

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1134,6 +1134,17 @@ if(Python3_Interpreter_FOUND)
                 ${CMAKE_CURRENT_SOURCE_DIR}/tools/la_csi.py --selftest
     )
     set_tests_properties(la_csi_math PROPERTIES SKIP_RETURN_CODE 77)
+
+    # Headless guard for the 2.4 GHz-VHT waterfall's decode + crossing math
+    # (tests/nitroqam_waterfall.py). The DESC_RATE decode is what proves which
+    # modulation a frame actually arrived as, and a bench link that tops out
+    # below 256-QAM never produces a 256-QAM txhit, a legacy fallback, or a
+    # threshold crossing — so those paths need a headless case.
+    add_test(
+        NAME nitroqam_decode_math
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/nitroqam_waterfall.py --self-test
+    )
 endif()
 
 # --- selftest aggregate ----------------------------------------------------

--- a/docs/vht-on-2g4.md
+++ b/docs/vht-on-2g4.md
@@ -1,0 +1,139 @@
+# VHT on the 2.4 GHz band
+
+802.11ac (VHT) is a 5 GHz standard. Running a VHT PPDU in the 2.4 GHz band is a
+vendor extension — the thing marketed as **NitroQAM** or **TurboQAM** on
+"AC1300"-class adapters. Its selling point is the top of the VHT rate ladder:
+256-QAM at MCS8/MCS9, which standards-only 802.11n does not have.
+
+## Selecting it
+
+Nothing gates this. Rate resolution never reads the band, so a VHT rate on a
+2.4 GHz channel is accepted end to end — `DEVOURER_TX_RATE=VHT1SS_MCS8/20` on
+channel 6, or a radiotap VHT field on a per-packet basis. The receiver must be
+able to decode it; a standards-only 802.11n station sees nothing at all.
+
+## Read this first: cold-cycle or measure nothing
+
+**High-order constellation TX degrades across warm re-inits.** After a run of
+back-to-back devourer sessions on the same adapter, 64-QAM and up stop decoding
+entirely while 16-QAM and below keep working. There is no error anywhere: the
+transmitter reports every frame submitted, the receiver reports a strong RSSI
+and a clean EVM on the frames it does decode, and the result looks exactly like
+a link too weak to carry a denser constellation.
+
+Measured on an RTL8812AU, same channel, same power, same inter-frame gap, the
+only difference being a VBUS power cycle:
+
+| MCS7 (64-QAM 5/6) | delivery |
+| --- | --- |
+| warm (many prior sessions) | 0% |
+| after VBUS cold cycle | 58% |
+
+This is the general "chip retains state across soft re-init" trap in the root
+`CLAUDE.md`, and it is severe enough here to invert a conclusion. An
+`authorized` toggle is **not** sufficient — it re-enumerates without removing
+power. Use a real VBUS cycle (`REGRESS_VBUS_MAP` + uhubctl, hub ports with
+per-port power switching only). `tests/nitroqam_waterfall.sh` does this before
+every cell by default, on both ends.
+
+The degradation itself is an open bug, tracked with its own reproduction in
+`tests/warm_tx_degradation_repro.sh` — a deployed link cannot power-cycle its
+adapter, so it needs a software-only recovery path.
+
+## What is measured
+
+Injection on 2.4 GHz at 20 MHz, delivery counted from FCS-clean canonical-SA
+frames, and every sampled `rx.txhit` decoded back to a rate so the receiver
+confirms *which* modulation arrived. A frame commanded as VHT that decodes as
+HT is a fallback, not a pass.
+
+| Transmitter | Generation | Peer | Confirmed on 2.4 GHz |
+| --- | --- | --- | --- |
+| RTL8812AU | Jaguar1 | RTL8822BU | VHT 1SS up to **MCS8 (256-QAM)**; HT MCS7 |
+| RTL8822BU | Jaguar2 | RTL8814AU | VHT 1SS MCS0, 2SS MCS0 |
+| RTL8812CU | Jaguar3 | RTL8814AU | VHT 1SS MCS0, MCS4 |
+
+`AdapterCaps::vht_2g4_ok` records the VHT format as a transmit claim for those
+three dies. 256-QAM specifically is confirmed on the 8812A only — the other two
+were measured before the cold-cycle requirement was understood, so their
+ceiling is a floor on what they can do, not a limit.
+
+**VHT MCS9 is not a legal rate at 20 MHz for 1 or 2 spatial streams.** Asking
+for `VHT1SS_MCS9/20` gets an MCS8 PPDU: the run delivered 311 frames and every
+sampled one decoded as `vht1ss_mcs8`. That is correct hardware behaviour, and
+the harness's modulation gate is what caught it rather than reporting 311
+frames as an MCS9 pass. Exercising MCS9 at all requires 40 MHz.
+
+## Cross-check against the vendor driver
+
+Whether a high-MCS wall is ours or the rig's cannot be answered from delivery
+alone. `tests/nitroqam_kernel_ab.sh` runs devourer and the vendor driver
+(`reference/rtl8812au`, the OpenHD fork) on the **same dongle**, same channel,
+same rates, interleaved, judged by an AR9271 sniffer — a different vendor's
+radio sharing no silicon, firmware or driver code with either side.
+
+| rate | devourer | vendor 88XXau |
+| --- | --- | --- |
+| MCS5 (64-QAM 2/3) | 61.7% | 68.4% |
+| MCS7 (64-QAM 5/6) | 58.2% | 64.3% |
+
+devourer is on par with the vendor driver at the top of the HT ladder. There is
+no devourer-side high-MCS defect.
+
+Two traps that harness encodes, each of which produced a wrong answer first:
+
+- **The in-tree `rtw88` is not a usable control.** It accepts frames on a
+  monitor netdev and reports them injected while airing nothing the sniffer
+  decodes — it reads as a kernel-side failure at every rate. Use the vendor
+  driver from `reference/`.
+- **Do not run all of one side then all of the other.** Ambient 2.4 GHz moved
+  one side's delivery 2× between runs. Interleave per rate, and bracket every
+  cell with a robust-rate sanity cell so a wedged half is reported invalid
+  rather than as a zero.
+
+## What is still not measured
+
+- **2 spatial streams above MCS2.** Every 2SS rate above the low ladder reads
+  zero on this bench even cold, on both directions tried. Two dongles in near
+  field give the two streams too little spatial decorrelation; this is a rig
+  property and is not evidence about the chip.
+- **40 MHz, hence the headline 400 Mbps rate.** `rxdemo` with
+  `DEVOURER_BW=40` delivers zero on both Jaguar1 and Jaguar2 — including for a
+  20 MHz transmitter on the primary channel, at either primary-channel offset,
+  in both role directions. Re-tested after the cold-cycle fix and unchanged, so
+  it is a real receiver-side gap, not warm state. Note the existing 40 MHz TX
+  validation (`tests/jaguar2_tx_bw40.sh`) uses a *kernel* sniffer, so the
+  devourer 40 MHz receive path may never have been exercised.
+- **Link asymmetry.** 8812AU → 8822BU reaches MCS7 at 68%; the reverse
+  direction is dead at MCS7 even with both ends cold. Pick the direction
+  deliberately when measuring, and do not read a dead direction as a chip
+  limit.
+
+## Scope
+
+This is a close-range, strong-link throughput mode — the opposite direction
+from the low-rate narrowband work that long-range FPV links want. It costs SNR
+to buy PHY rate.
+
+There is no regulatory enforcement, and the 2.4 GHz regulatory limit tables
+have no VHT rows to clamp against: on Jaguar2/8822B the TXAGC walk bounds
+2.4 GHz VHT by the HT limit instead of letting the missing row fall through
+unclamped, but on Jaguar1 that fallthrough is not bounded. The caller owns
+compliance.
+
+## Harnesses
+
+- `tests/nitroqam_waterfall.sh` — delivery-versus-power sweep with the
+  modulation gate, cold-cycling both ends per cell. Its power axis defaults to
+  `SetTxPowerOffsetQdb` (`--pwr-mode offset`), which preserves the chip's
+  calibrated per-rate shape; the flat `DEVOURER_TX_PWR` index
+  (`--pwr-mode flat`) is not a neutral substitute.
+- `tests/nitroqam_kernel_ab.sh` — the devourer-vs-vendor control above.
+- `nitroqam_waterfall.py --self-test` — headless decode/crossing math, wired
+  into `ctest` as `nitroqam_decode_math`.
+
+An SDR duty-cycle comparison was tried as a transmitter-only substitute for a
+receiver and **does not work** on this bench at any payload from 1400 to 4000
+bytes: the host feed rather than the channel sets the occupancy, so every
+encoding reads the same duty. It was dropped rather than shipped as a harness
+that cannot return a valid answer.

--- a/examples/common/caps_event.h
+++ b/examples/common/caps_event.h
@@ -70,7 +70,8 @@ inline void emit_adapter_caps(EventSink &sink, IRtlDevice *dev) {
   /* FEC RX truth table (ldpc above is the TX side, TxCaps.ldpc_ok). */
   ev.f("ldpc_rx_ht", c.ldpc_rx_ht ? 1 : 0)
       .f("ldpc_rx_vht", c.ldpc_rx_vht ? 1 : 0)
-      .f("ldpc_rx_flag", c.ldpc_rx_flag ? 1 : 0);
+      .f("ldpc_rx_flag", c.ldpc_rx_flag ? 1 : 0)
+      .f("vht_2g4", c.vht_2g4_ok ? 1 : 0);
 
   ev.f("per_pkt_txpwr", c.per_packet_txpower ? 1 : 0)
       .f("per_pkt_txpwr_steps", c.per_pkt_txpwr_steps)

--- a/src/AdapterCaps.h
+++ b/src/AdapterCaps.h
@@ -138,6 +138,27 @@ struct AdapterCaps {
    * offsets 16/20 unparsed, and the Jaguar1 phy_status_rpt has no ldpc bit). */
   bool ldpc_rx_flag = false;
 
+  /* Bench-derived like the ldpc_rx_* trio above, and a TRANSMIT claim: the
+   * baseband emits a VHT PPDU that a peer decodes on the 2.4 GHz band.
+   * 802.11ac is a 5 GHz standard, so nothing guarantees a 2.4 GHz VHT frame
+   * works at all; devourer's TX path
+   * never reads the band when resolving a rate, which makes it *selectable*
+   * everywhere, and this flag is the separate question of whether it flies.
+   * False means unmeasured on that chip, not incapable.
+   *
+   * Scope: VHT *format* on 2.4 GHz. The 256-QAM points that motivate the
+   * extension (the "NitroQAM" / "TurboQAM" marketing) are confirmed on the
+   * 8812A only — VHT1SS_MCS8 at 20 MHz, decoded by an 8822BU peer. Measuring
+   * them needs a chip that has been VBUS cold-cycled: high-order constellation
+   * TX degrades across warm re-inits until 64-QAM and up stop decoding, which
+   * reads exactly like a link too weak to carry them (docs/vht-on-2g4.md).
+   * Note VHT MCS9 is not a legal rate at 20 MHz for 1-2 streams; hardware
+   * falls back to MCS8 there, so 40 MHz is required to exercise MCS9 at all.
+   *
+   * A standards-only 802.11n receiver decodes none of it either way: this is a
+   * strong-link, close-range mode, the opposite of a range mode. */
+  bool vht_2g4_ok = false;
+
   /* --- feature flags --- */
   /* Per-packet TX power: a per-frame power trim driven by radiotap
    * DBM_TX_POWER (dB delta vs the calibrated table / session base) or a

--- a/src/RadiotapBuilder.h
+++ b/src/RadiotapBuilder.h
@@ -35,7 +35,13 @@ std::vector<uint8_t> build_stream_radiotap(const TxMode& mode);
  *     ER / ER106 / DCM (HE rates only, Kestrel): HE ER SU extended-range PPDU
  *       (242-tone RU, MCS0-2 / 106-tone RU, MCS0) and dual-carrier modulation
  *       (MCS 0/1/3/4; excludes STBC). Out-of-spec combos are clamped (W log).
- * Empty or unrecognised falls back to 6M legacy. */
+ * Empty or unrecognised falls back to 6M legacy.
+ *
+ * The rate is resolved without reference to the band, so a VHT rate on a
+ * 2.4 GHz channel is accepted and aired — the non-standard vendor extension
+ * ("NitroQAM"/"TurboQAM"). It is bench-confirmed on the chips whose
+ * AdapterCaps.vht_2g4_ok is set; the peer must be able to decode it, since a
+ * standards-only 802.11n receiver sees nothing. See docs/vht-on-2g4.md. */
 TxMode parse_tx_mode_str(const std::string& spec);
 
 }  // namespace devourer

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -1751,6 +1751,9 @@ devourer::AdapterCaps RtlJaguarDevice::GetAdapterCaps() {
     c.ldpc_rx_ht = true;
     c.ldpc_rx_vht = true;
     c.ldpc_rx_flag = false;
+    /* Decodes 2.4 GHz VHT on the bench (it served as the ground station for
+     * the other dies' runs), but its own TX side is unmeasured there, and
+     * vht_2g4_ok is a transmit claim. */
     break;
   case CHIP_8821:
     c.chip_name = "RTL8821A";
@@ -1765,6 +1768,11 @@ devourer::AdapterCaps RtlJaguarDevice::GetAdapterCaps() {
     c.ldpc_rx_ht = true;
     c.ldpc_rx_vht = true;
     c.ldpc_rx_flag = true;
+    /* 8812AU on air, cold-cycled: VHT 1SS up to MCS8 — 256-QAM — on 2.4 GHz,
+     * every sampled frame decoded as the commanded VHT rate by an 8822BU peer.
+     * The 8811A is the 1T1R cut of the same die on the same path, unmeasured
+     * on its own. */
+    c.vht_2g4_ok = true;
     if (_eepromManager->version_id.RFType == RF_TYPE_1T1R) {
       c.chip_name = "RTL8811A";
       c.marketing_names = "RTL8811AU/RTL8811AR";

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -1158,6 +1158,12 @@ devourer::AdapterCaps RtlJaguar2Device::GetAdapterCaps() {
     c.marketing_names = "RTL8822BU/RTL8812BU";
     c.chip_id = 0x0a;
     c.variant = "C8822B";
+    /* 8822BU on air: VHT 1SS MCS0 and 2SS MCS0 on 2.4 GHz, every sampled frame
+     * decoded as the commanded VHT rate by an 8814AU peer. It is also the die
+     * whose TXAGC walk gives 2.4G VHT a real regulatory bound rather than the
+     * table's missing-row fallthrough (HalJaguar2::apply_tx_power). The 8821C
+     * above is unmeasured. */
+    c.vht_2g4_ok = true;
   }
   return c;
 }

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -1573,6 +1573,11 @@ devourer::AdapterCaps RtlJaguar3Device::GetAdapterCaps() {
     c.marketing_names = "RTL8812CU/RTL8822CU";
     c.chip_id = 0x13;
     c.variant = "C8822C";
+    /* 8812CU on air: VHT 1SS MCS0 and MCS4 on 2.4 GHz, every sampled frame
+     * decoded as the commanded VHT rate by an 8814AU peer. Not set for the
+     * 8822E above — its 2.4 GHz TX is undecodable under the vendor driver too
+     * (docs/8822e-quirks.md), which this flag would otherwise paper over. */
+    c.vht_2g4_ok = true;
   }
   return c;
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -408,6 +408,60 @@ compare curves only on the rising edge). Bench-measured on an 8812AU→8822BU
 pair at MCS7/20 MHz: **+3.0 dB LDPC gain at the 10%-delivery crossing**, and
 in the saturation regime LDPC delivered ~80% where BCC delivered 0–19%.
 
+### `nitroqam_waterfall.sh`: VHT on the 2.4 GHz band
+
+VHT is a 5 GHz standard; airing it on 2.4 GHz is the vendor extension marketed
+as NitroQAM/TurboQAM. Same waterfall method as `ldpc_waterfall.sh` plus a
+**modulation gate**: every sampled `rx.txhit` is decoded back to a rate, so a
+cell that delivers frames which arrive as HT is reported as a fallback rather
+than as a pass.
+
+```bash
+sudo tests/nitroqam_waterfall.sh --emit-vid 0x0bda --emit-pid 0x8812 \
+    --ground-vid 0x2357 --ground-pid 0x012d --channel 6 --bw 20
+python3 tests/nitroqam_waterfall.py report \
+    /tmp/devourer-nitroqam-waterfall/points.jsonl
+```
+
+The power axis defaults to `--pwr-mode offset` (`SetTxPowerOffsetQdb`, which
+preserves the calibrated per-rate shape). Do not substitute the flat
+`DEVOURER_TX_PWR` index: it forces both paths to one level and zeroes the
+per-rate diffs, and measurably degrades the link — the same pair that reaches
+MCS4 at calibrated power tops out at MCS1 under a flat index.
+
+`nitroqam_waterfall.py --self-test` is the headless half, wired into `ctest` as
+`nitroqam_decode_math`: it covers the DESC_RATE decode and threshold-crossing
+math that a bench link topping out below 256-QAM never reaches on air.
+
+**Cold-cycle or measure nothing.** The harness VBUS-cycles both ends before
+every cell (`REGRESS_VBUS_MAP` + uhubctl) because high-order constellation TX
+degrades across warm re-inits: the same 8812AU delivered 0% at MCS7 warm and
+58% cold, same channel/power/gap, with no error logged anywhere. Without it a
+rate ceiling measures accumulated chip state, not the link.
+
+Measured: VHT confirmed on 2.4 GHz from an 8812AU, 8822BU and 8812CU, and
+**256-QAM (VHT1SS_MCS8) confirmed on the 8812AU**, modulation-verified by an
+8822BU peer. Note VHT MCS9 is illegal at 20 MHz for 1-2 streams — hardware
+emits MCS8 and the modulation gate catches it. Full results:
+`docs/vht-on-2g4.md`.
+
+### `nitroqam_kernel_ab.sh`: devourer vs the vendor driver, same dongle
+
+The control that decides whether a delivery wall is ours or the rig's: runs
+devourer and the vendor driver from `reference/rtl8812au` on the same adapter,
+interleaved per rate, judged by an AR9271 sniffer (different vendor's radio, no
+shared silicon or code).
+
+```bash
+sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3" tests/nitroqam_kernel_ab.sh 6
+```
+
+Measured at the top of the HT ladder: devourer 58.2% vs vendor 64.3% at MCS7,
+61.7% vs 68.4% at MCS5 — on par, no devourer-side high-MCS defect. Do **not**
+substitute the in-tree `rtw88` for the vendor driver: it accepts frames on a
+monitor netdev and reports them injected while airing nothing decodable, which
+reads as a kernel-side failure at every rate.
+
 ### `tx_teardown_asan.sh` / `teardown_gen_sanity.sh`: lifetime bugs on real hardware
 
 A sanitizer only sees what runs, and the interesting lifetime bugs live in the

--- a/tests/devourer_events.py
+++ b/tests/devourer_events.py
@@ -70,3 +70,29 @@ def desc_rate_to_mcs(code):
     if 44 <= code <= 53:                  # DESC_RATEVHTSS1MCS0..9
         return ("vht", code - 44)
     return None
+
+
+def desc_rate_decode(code):
+    """rx.frame/rx.txhit `rate` -> ("cck"|"ofdm"|"ht"|"vht", mcs, nss).
+
+    The stream-aware companion to desc_rate_to_mcs(): it classifies the whole
+    DESC_RATE space instead of collapsing multi-stream rates to None, so a
+    consumer can prove *which* modulation flew — e.g. VHT2SS_MCS9 (0x3f) vs
+    HT MCS15 (0x1b), the 256-QAM-on-2.4GHz question.
+
+    For HT, mcs is the raw 0..31 index and nss = mcs // 8 + 1. For VHT, mcs is
+    0..9 within the stream section. Legacy rates report mcs as the index inside
+    their section and nss 1. Returns None for an unknown code."""
+    if code is None:
+        return None
+    if 0 <= code <= 3:                    # DESC_RATE1M..11M
+        return ("cck", code, 1)
+    if 4 <= code <= 11:                   # DESC_RATE6M..54M
+        return ("ofdm", code - 4, 1)
+    if 12 <= code <= 43:                  # DESC_RATEMCS0..MCS31
+        ht_mcs = code - 12
+        return ("ht", ht_mcs, ht_mcs // 8 + 1)
+    if 44 <= code <= 83:                  # DESC_RATEVHTSS1MCS0..VHTSS4MCS9
+        off = code - 44
+        return ("vht", off % 10, off // 10 + 1)
+    return None

--- a/tests/nitroqam_kernel_ab.sh
+++ b/tests/nitroqam_kernel_ab.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# devourer vs the vendor kernel driver on the SAME adapter, same channel, same
+# rates, judged by a THIRD-PARTY receiver — the control that decides whether a
+# high-MCS delivery wall is a property of the rig or a devourer TX defect.
+#
+# Delivery alone cannot tell those apart: a weak link and a transmitter that
+# mis-drives high-order constellations look identical from the receive side.
+# Running the vendor driver on the same dongle at the same MCS into the same
+# sniffer separates them. If the vendor lands MCS7 where devourer does not, it
+# is our bug.
+#
+# The sniffer is an AR9271 (ath9k_htc): a different vendor's 802.11n radio, so
+# it shares no silicon, firmware or driver code with either side under test.
+# 1x1 HT, so HT MCS0-7 only — deliberately, since the question is about the
+# constellation (16-QAM vs 64-QAM), not the stream count.
+#
+# Three methodology rules this harness enforces, each learned by getting a wrong
+# answer without it:
+#
+#  1. CONTROL DRIVER. The in-tree rtw88 accepts frames on a monitor netdev and
+#     reports them injected while airing nothing a sniffer decodes. It reads as
+#     a kernel-side failure at every rate and makes the comparison worthless.
+#     Use the vendor driver from reference/ (raw-injection capable), which is
+#     what devourer treats as ground truth anyway.
+#  2. COLD CYCLE BETWEEN DRIVERS. Swapping libusb <-> kernel driver on a warm
+#     chip leaves it wedged: an observed run had the vendor side accept 144k
+#     frames and deliver zero at every rate, right after a run where the same
+#     rate delivered fine. VBUS-cycle between halves (REGRESS_VBUS_MAP).
+#  3. INTERLEAVE AND SANITY-GATE. Ambient 2.4 GHz drifts enough to move one
+#     side's delivery 2x between runs, so all-A-then-all-B compares two
+#     different channels. Interleave per rate, and bracket every cell with a
+#     robust-rate sanity cell — a half whose sanity cell delivers nothing is
+#     reported INVALID, never as a zero result.
+#
+#   sudo REGRESS_VBUS_MAP="0bda:8812=4-2.3,2" tests/nitroqam_kernel_ab.sh 6
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+
+CH=${CH:-${1:-6}}
+DUT_VID=${DUT_VID:-0bda} DUT_PID=${DUT_PID:-8812}
+DUT_REF=${DUT_REF:-rtl8812au}
+DUT_KO=${DUT_KO:-88XXau_ohd.ko}
+DUT_MOD=${DUT_MOD:-88XXau_ohd}
+INTREE_DRV=${INTREE_DRV:-rtw88_8812au}
+SNIFF=${SNIFF:-wlp13s0u1u3}          # AR9271
+RATES=${RATES:-"4 5 6 7"}
+SANITY_RATE=${SANITY_RATE:-0}        # robust rate that must always deliver
+SECS=${SECS:-6}
+# Kernel-side body size. The monitor netdev's MTU caps radiotap + 802.11 header
+# + body at 1500, so the body must leave room for both. devourer is handed the
+# matching PSDU (body + the 24-byte 802.11 header) so both sides put the same
+# number of bits on air per frame.
+# Inter-frame gap for the devourer side. Exposed so the cold-cycle effect can
+# be separated from the feed rate: the original zero-delivery runs used 2000.
+TX_GAP_US=${TX_GAP_US:-0}
+PAYLOAD=${PAYLOAD:-1400}
+DOT11_HDR=24
+CANON=57:42:75:05:d6:00
+OUT=${OUT:-/tmp/devourer-nq-kernel-ab}
+
+mkdir -p "$OUT"
+RESULTS="$OUT/cells.tsv"
+: > "$RESULTS"
+command -v tcpdump >/dev/null || { echo "need tcpdump" >&2; exit 2; }
+[ -x "$ROOT/build/txdemo" ] || { echo "build first" >&2; exit 2; }
+
+DUT_IF=""
+cleanup() {
+  sudo pkill -f "tcpdump -i $SNIFF" 2>/dev/null
+  sudo pkill -x txdemo 2>/dev/null
+  sudo pkill -f kernel_tx_inject 2>/dev/null
+  wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+# --- sniffer ---------------------------------------------------------------
+[ -e "/sys/class/net/$SNIFF" ] || { echo "no sniffer iface $SNIFF" >&2; exit 2; }
+sudo ip link set "$SNIFF" down
+sudo iw dev "$SNIFF" set type monitor
+sudo ip link set "$SNIFF" up
+sudo iw dev "$SNIFF" set channel "$CH"
+sleep 1
+echo "sniffer $SNIFF ambient: $(sudo timeout 3 tcpdump -i "$SNIFF" -nn 2>/dev/null | wc -l) frames/3s on ch$CH"
+
+dut_usb() {
+  for d in /sys/bus/usb/devices/*/; do
+    [ "$(cat "$d/idVendor" 2>/dev/null)" = "$DUT_VID" ] || continue
+    [ "$(cat "$d/idProduct" 2>/dev/null)" = "$DUT_PID" ] || continue
+    basename "$d"; return 0
+  done
+  return 1
+}
+
+# Real VBUS cycle where the hub supports it; the authorized toggle is a weaker
+# fallback that does NOT clear chip state (docs/adapter-doctor.md).
+cold_cycle() {
+  local map=${REGRESS_VBUS_MAP:-} entry hubport
+  if [ -n "$map" ]; then
+    entry=$(tr ';' '\n' <<<"$map" | grep -i "^$DUT_VID:$DUT_PID=" | head -1) || true
+    if [ -n "${entry:-}" ]; then
+      hubport=${entry#*=}
+      sudo uhubctl -l "${hubport%,*}" -p "${hubport#*,}" -a cycle -d 3 >/dev/null 2>&1
+      sleep 12
+      return 0
+    fi
+  fi
+  local u; u=$(dut_usb) || return 1
+  echo 0 | sudo tee "/sys/bus/usb/devices/$u/authorized" >/dev/null
+  sleep 2
+  echo 1 | sudo tee "/sys/bus/usb/devices/$u/authorized" >/dev/null
+  sleep 6
+  return 0
+}
+
+build_vendor() {
+  local dir="$ROOT/reference/$DUT_REF"
+  [ -d "$dir/core" ] || {
+    echo "!! $dir not populated — git submodule update --init reference/$DUT_REF" >&2
+    return 1; }
+  [ -f "$dir/$DUT_KO" ] && return 0
+  echo "building $DUT_REF (first run, a few minutes) ..."
+  make -C "$dir" -j"$(nproc)" > "$OUT/vendor_build.log" 2>&1 || {
+    echo "!! vendor build failed — see $OUT/vendor_build.log" >&2; return 1; }
+  [ -f "$dir/$DUT_KO" ]
+}
+
+use_devourer() {
+  sudo rmmod "$DUT_MOD" 2>/dev/null
+  sudo modprobe -r "$INTREE_DRV" 2>/dev/null
+  cold_cycle
+  # rtw88 auto-probes on every enumeration; drop it again after the cycle.
+  sudo modprobe -r "$INTREE_DRV" 2>/dev/null
+}
+
+use_vendor() {
+  sudo modprobe -r "$INTREE_DRV" 2>/dev/null
+  cold_cycle
+  sudo modprobe -r "$INTREE_DRV" 2>/dev/null
+  sudo insmod "$ROOT/reference/$DUT_REF/$DUT_KO" 2>/dev/null || true
+  local u prev="" cur=""
+  u=$(dut_usb) || return 1
+  for _ in $(seq 30); do
+    cur=$(basename "$(ls -d /sys/bus/usb/devices/$u/*/net/* 2>/dev/null | head -1)" 2>/dev/null)
+    if [ -n "$cur" ] && [ "$cur" = "$prev" ] && [ -e "/sys/class/net/$cur" ]; then
+      DUT_IF="$cur"
+      sudo ip link set "$DUT_IF" down
+      sudo iw dev "$DUT_IF" set type monitor
+      sudo ip link set "$DUT_IF" up
+      sudo iw dev "$DUT_IF" set channel "$CH"
+      sleep 1
+      return 0
+    fi
+    prev="$cur"; sleep 1
+  done
+  return 1
+}
+
+# $1 = side (devourer|vendor), $2 = mcs. Echoes "sent<TAB>rx<TAB>rates".
+run_cell() {
+  # Declare before use: within a single `local a=$1 b="${a}"`, bash marks every
+  # name local first, so `${a}` there reads the (unset) variable, not $1.
+  local side="$1" mcs="$2"
+  local cap="$OUT/${side}_mcs${mcs}.txt" sent=0
+  sudo timeout $((SECS + 6)) tcpdump -i "$SNIFF" -nn -e \
+      "wlan addr2 $CANON" > "$cap" 2>/dev/null &
+  sleep 1
+  if [ "$side" = devourer ]; then
+    sudo env DEVOURER_VID="0x$DUT_VID" DEVOURER_PID="0x$DUT_PID" \
+      DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="MCS$mcs/20" \
+      DEVOURER_TX_PAYLOAD_BYTES="$((PAYLOAD + DOT11_HDR))" \
+      DEVOURER_TX_GAP_US="$TX_GAP_US" DEVOURER_LOG_LEVEL=warn \
+      timeout --signal=TERM $((SECS + 10)) "$ROOT/build/txdemo" \
+      > "$OUT/${side}_tx_mcs$mcs.jsonl" 2>"$OUT/${side}_tx_mcs$mcs.err"
+    sent=$(grep -o '"submitted":[0-9]*' "$OUT/${side}_tx_mcs$mcs.jsonl" |
+           tail -1 | cut -d: -f2)
+  else
+    sent=$(sudo timeout $((SECS + 6)) python3 "$HERE/kernel_tx_inject.py" \
+           "$DUT_IF" "$mcs" "$PAYLOAD" "$SECS" 2>/dev/null |
+           grep -oE "injected [0-9]+" | awk '{print $2}')
+  fi
+  sleep 2
+  local n rates
+  n=$(grep -c "$CANON" "$cap" 2>/dev/null || echo 0)
+  rates=$(grep -oE "MCS [0-9]+" "$cap" 2>/dev/null | sort | uniq -c |
+          tr -s ' ' | tr '\n' ' ')
+  printf '%s\t%s\t%s\t%s\t%s\n' "$side" "$mcs" "${sent:-0}" "$n" "${rates:-none}"
+}
+
+emit() {
+  local row=$1
+  # A cell that produced no row at all is a harness failure, not a zero result —
+  # say so rather than letting `read` leave the fields unset under `set -u`.
+  if [ -z "$row" ]; then
+    echo "  !! cell produced no result row (TX never started?) — INVALID" >&2
+    return 1
+  fi
+  local side mcs sent rx rates
+  IFS=$'\t' read -r side mcs sent rx rates <<<"$row"
+  local pct="n/a"
+  [ "${sent:-0}" -gt 0 ] 2>/dev/null && \
+    pct=$(awk -v r="$rx" -v s="$sent" 'BEGIN{printf "%.1f%%", 100*r/s}')
+  printf '  %-8s MCS%-2s sent=%-7s rx=%-7s %-8s %s\n' \
+      "$side" "$mcs" "$sent" "$rx" "$pct" "$rates"
+  printf '%s\n' "$row" >> "$RESULTS"
+}
+
+build_vendor || exit 1
+
+echo
+echo "== interleaved A/B, ch$CH, PSDU $((PAYLOAD + DOT11_HDR)) B, ${SECS}s/cell"
+for m in $SANITY_RATE $RATES; do
+  use_devourer  || { echo "  devourer half: DUT unavailable" >&2; exit 1; }
+  emit "$(run_cell devourer "$m")"
+  use_vendor    || { echo "  vendor half: no netdev — INVALID" >&2; exit 1; }
+  emit "$(run_cell vendor "$m")"
+done
+
+echo
+python3 - "$RESULTS" "$SANITY_RATE" <<'EOF'
+import sys
+rows = [l.rstrip("\n").split("\t") for l in open(sys.argv[1]) if l.strip()]
+sanity = sys.argv[2]
+by = {(s, m): (int(sent or 0), int(rx or 0)) for s, m, sent, rx, _ in rows}
+
+# A side whose robust sanity rate delivered nothing was not transmitting; its
+# zeros at every other rate mean nothing and must not be read as a result.
+bad = [s for s in ("devourer", "vendor")
+       if by.get((s, sanity), (0, 0))[1] == 0]
+if bad:
+    print("!! %s delivered nothing at the MCS%s sanity rate — that half was not "
+          "airing. Every zero it reported is INVALID, not a measurement. "
+          "Cold-cycle and rerun." % (" and ".join(bad), sanity))
+    raise SystemExit(1)
+
+print("%-6s %12s %12s   %s" % ("rate", "devourer", "vendor", "verdict"))
+for _, m, _, _, _ in rows:
+    pass
+seen = []
+for s, m, sent, rx, _ in rows:
+    if m not in seen:
+        seen.append(m)
+for m in seen:
+    d_sent, d_rx = by.get(("devourer", m), (0, 0))
+    v_sent, v_rx = by.get(("vendor", m), (0, 0))
+    d = 100.0 * d_rx / d_sent if d_sent else 0.0
+    v = 100.0 * v_rx / v_sent if v_sent else 0.0
+    if d_rx == 0 and v_rx == 0:
+        verdict = "both dead — rig limit, not a devourer defect"
+    elif d_rx == 0 and v_rx > 0:
+        verdict = "*** DEVOURER DEFECT: vendor delivers, devourer does not ***"
+    elif v_rx == 0 and d_rx > 0:
+        verdict = "devourer delivers, vendor does not"
+    else:
+        verdict = "both deliver"
+    print("MCS%-3s %11.1f%% %11.1f%%   %s" % (m, d, v, verdict))
+EOF
+echo
+echo "logs: $OUT"

--- a/tests/nitroqam_waterfall.py
+++ b/tests/nitroqam_waterfall.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Point extraction + analysis for nitroqam_waterfall.sh — 256-QAM VHT on the
+2.4 GHz band ("NitroQAM"/"TurboQAM") measured against the 11n 64-QAM ceiling.
+
+Two subcommands:
+
+  point   — called per cell by the .sh: slices the ground RX log by byte range,
+            counts delivered frames, and decodes the sampled rx.txhit rates to
+            prove *which* modulation actually flew. Emits one JSON line.
+
+  report  — reads the accumulated points.jsonl: per-encoding delivery-vs-index
+            curves, the interpolated dB gap at each threshold, and a per-cell
+            modulation verdict.
+
+The modulation verdict is the point of this harness. A cell can deliver frames
+while the chip quietly aired something other than what was commanded, and a
+delivery curve alone cannot tell the two apart. rx.txhit carries the decoded
+DESC_RATE, so every cell reports how many sampled frames matched the commanded
+(mode, mcs, nss) — a cell with delivery but no matching frames is a FALLBACK,
+not a pass.
+
+Note rx.txhit is sampled by rxdemo (first 10 canonical-SA frames, then every
+100th), so mod_total is a sample count, never the delivered count.
+"""
+import argparse
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from devourer_events import desc_rate_decode, parse_event  # noqa: E402
+
+
+def expected_modulation(enc: str):
+    """DEVOURER_TX_RATE spec -> ("ht"|"vht", mcs, nss), or None for a legacy
+    rate (nothing to prove — the gate only guards HT/VHT modulation)."""
+    tok = enc.split("/")[0].strip().upper()
+    m = re.fullmatch(r"VHT(\d)SS_MCS(\d)", tok)
+    if m:
+        return ("vht", int(m.group(2)), int(m.group(1)))
+    m = re.fullmatch(r"MCS(\d+)", tok)
+    if m:
+        mcs = int(m.group(1))
+        return ("ht", mcs, mcs // 8 + 1)
+    return None
+
+
+def cmd_point(args):
+    sent = failed = -1
+    with open(args.txlog, errors="replace") as f:
+        for line in f:
+            ev = parse_event(line, "tx.stats")
+            if ev is not None:
+                sent = int(ev.get("submitted", -1))
+                failed = int(ev.get("failed", 0))
+
+    with open(args.rxlog, "rb") as f:
+        f.seek(args.off0)
+        blob = f.read(args.off1 - args.off0).decode(errors="replace")
+
+    want = expected_modulation(args.enc)
+    delivered = mod_total = mod_match = 0
+    seen = defaultdict(int)
+    for line in blob.splitlines():
+        ev = parse_event(line)
+        if ev is None:
+            continue
+        if ev["ev"] == "rx.energy":
+            delivered += int(ev.get("frames") or 0)
+        elif ev["ev"] == "rx.txhit":
+            got = desc_rate_decode(ev.get("rate"))
+            if got is None:
+                continue
+            mod_total += 1
+            seen["%s%dss_mcs%d" % (got[0], got[2], got[1])] += 1
+            if want is not None and got == want:
+                mod_match += 1
+
+    print(json.dumps({
+        "enc": args.enc, "idx": args.idx, "sent": sent, "failed": failed,
+        "delivered": delivered, "want": list(want) if want else None,
+        "mod_total": mod_total, "mod_match": mod_match, "seen": dict(seen),
+    }))
+
+
+def crossing(curve, thr):
+    """First index (interpolated) where the delivery ratio rises through thr.
+    curve: sorted [(idx, ratio)]. Ported from ldpc_waterfall.py."""
+    prev_i = prev_r = None
+    for i, r in curve:
+        if prev_r is not None and prev_r < thr <= r:
+            return prev_i + (thr - prev_r) * (i - prev_i) / (r - prev_r)
+        prev_i, prev_r = i, r
+    return None
+
+
+def cmd_report(args):
+    curves = defaultdict(list)
+    fallback = []
+    for line in open(args.points, errors="replace"):
+        line = line.strip()
+        if not line:
+            continue
+        p = json.loads(line)
+        if p["sent"] <= 0:
+            print("! dropping enc=%s idx=%s: sent=%s (no final tx.stats — TX "
+                  "died?)" % (p["enc"], p["idx"], p["sent"]), file=sys.stderr)
+            continue
+        ratio = min(1.0, p["delivered"] / p["sent"])
+        curves[p["enc"]].append(p | {"ratio": ratio})
+        # A cell that delivered frames but whose sampled rates never matched
+        # the commanded modulation is airing something else.
+        if p["want"] and p["mod_total"] > 0 and p["mod_match"] == 0:
+            fallback.append(p)
+
+    for enc in sorted(curves):
+        pts = sorted(curves[enc], key=lambda p: p["idx"])
+        print("\n== %s" % enc)
+        print("  idx | sent  | delivered | ratio | modulation (matched/sampled)")
+        for p in pts:
+            bar = "#" * int(p["ratio"] * 30)
+            if p["mod_total"] == 0:
+                verdict = "no sample"
+            elif p["mod_match"] == p["mod_total"]:
+                verdict = "OK %d/%d" % (p["mod_match"], p["mod_total"])
+            elif p["mod_match"] == 0:
+                verdict = "FALLBACK 0/%d %s" % (p["mod_total"], p["seen"])
+            else:
+                verdict = "MIXED %d/%d %s" % (p["mod_match"], p["mod_total"],
+                                              p["seen"])
+            print("  %3d | %5d | %9d | %5.1f%% %-30s %s"
+                  % (p["idx"], p["sent"], p["delivered"], p["ratio"] * 100,
+                     bar, verdict))
+
+    if fallback:
+        print("\n!! %d cell(s) delivered frames but decoded as a DIFFERENT "
+              "modulation than commanded — their delivery is not evidence for "
+              "the commanded rate:" % len(fallback))
+        for p in fallback:
+            print("   enc=%s idx=%s want=%s seen=%s"
+                  % (p["enc"], p["idx"], p["want"], p["seen"]))
+
+    base = args.baseline
+    if base not in curves:
+        print("\n(no baseline encoding %r in the points — no dB gap readout)"
+              % base)
+        return
+    base_curve = [(p["idx"], p["ratio"])
+                  for p in sorted(curves[base], key=lambda p: p["idx"])]
+    thrs = [float(t) for t in args.thresholds.split(",")]
+    for enc in sorted(curves):
+        if enc == base:
+            continue
+        cand = [(p["idx"], p["ratio"])
+                for p in sorted(curves[enc], key=lambda p: p["idx"])]
+        print("\n== SNR premium: %s vs %s (step %.2f dB/idx)"
+              % (enc, base, args.step_qdb / 4.0))
+        for thr in thrs:
+            cb = crossing(base_curve, thr)
+            cc = crossing(cand, thr)
+            if cb is None or cc is None:
+                print("  @%.0f%% delivery: not bracketed (base=%s, cand=%s) — "
+                      "widen/lower the sweep" % (thr * 100, cb, cc))
+                continue
+            premium = (cc - cb) * args.step_qdb / 4.0
+            print("  @%.0f%% delivery: base idx %.1f vs cand idx %.1f -> "
+                  "%+.2f dB premium for %s"
+                  % (thr * 100, cb, cc, premium, enc))
+
+
+def self_test():
+    """Cover the decode + crossing math the on-air runs cannot reach.
+
+    A bench link that tops out at 16-QAM never produces a 256-QAM txhit, a
+    legacy-rate fallback, or a threshold crossing between two curves — so those
+    paths would otherwise ship unexercised."""
+    # DESC_RATE decode across every section, including the multi-stream VHT
+    # rates the 2-tuple desc_rate_to_mcs() deliberately drops.
+    cases = {
+        0x00: ("cck", 0, 1), 0x03: ("cck", 3, 1),
+        0x04: ("ofdm", 0, 1), 0x0b: ("ofdm", 7, 1),
+        0x0c: ("ht", 0, 1), 0x13: ("ht", 7, 1),
+        0x14: ("ht", 8, 2), 0x1b: ("ht", 15, 2),
+        0x2c: ("vht", 0, 1), 0x35: ("vht", 9, 1),
+        0x36: ("vht", 0, 2), 0x3f: ("vht", 9, 2),
+        0x40: ("vht", 0, 3), 0x53: ("vht", 9, 4),
+    }
+    for code, want in cases.items():
+        got = desc_rate_decode(code)
+        assert got == want, "desc_rate_decode(%#x) = %r, want %r" % (
+            code, got, want)
+    assert desc_rate_decode(None) is None
+    assert desc_rate_decode(0x54) is None, "past VHT4SS_MCS9 must not decode"
+
+    # The commanded-modulation parser the fallback verdict compares against.
+    assert expected_modulation("VHT2SS_MCS9/40") == ("vht", 9, 2)
+    assert expected_modulation("VHT1SS_MCS0") == ("vht", 0, 1)
+    assert expected_modulation("MCS15/40/SGI") == ("ht", 15, 2)
+    assert expected_modulation("MCS7/20") == ("ht", 7, 1)
+    assert expected_modulation("6M/20") is None, "legacy has nothing to prove"
+
+    # A commanded VHT2SS_MCS9 frame arriving as HT MCS15 is the fallback the
+    # whole harness exists to catch — the two must not compare equal.
+    assert desc_rate_decode(0x1b) != expected_modulation("VHT2SS_MCS9/40")
+    assert desc_rate_decode(0x3f) == expected_modulation("VHT2SS_MCS9/40")
+
+    # Threshold crossing: interpolates between bracketing points, and reports
+    # None rather than guessing when the sweep never reaches the threshold.
+    assert crossing([(0, 0.0), (10, 1.0)], 0.5) == 5.0
+    assert crossing([(0, 0.0), (4, 0.2), (8, 0.6)], 0.5) == 7.0
+    assert crossing([(0, 0.0), (10, 0.3)], 0.5) is None
+    assert crossing([], 0.5) is None
+    print("nitroqam_waterfall self-test: OK")
+
+
+def main():
+    if "--self-test" in sys.argv:
+        self_test()
+        return
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("point", help="extract one cell (called by the .sh)")
+    p.add_argument("txlog")
+    p.add_argument("rxlog")
+    p.add_argument("off0", type=int)
+    p.add_argument("off1", type=int)
+    p.add_argument("enc")
+    p.add_argument("idx", type=int)
+    p.set_defaults(func=cmd_point)
+
+    r = sub.add_parser("report", help="analyze points.jsonl")
+    r.add_argument("points")
+    r.add_argument("--baseline", default="MCS15/40/SGI",
+                   help="encoding the others are compared against")
+    r.add_argument("--step-qdb", type=float, default=2.0,
+                   help="qdB per TXAGC index (2 = 0.5 dB on Jaguar1/2, "
+                        "1 = 0.25 dB on Jaguar3)")
+    r.add_argument("--thresholds", default="0.1,0.5,0.9")
+    r.set_defaults(func=cmd_report)
+
+    args = ap.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/nitroqam_waterfall.sh
+++ b/tests/nitroqam_waterfall.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# 256-QAM VHT on the 2.4 GHz band ("NitroQAM"/"TurboQAM") — delivery-vs-TX-power
+# waterfall against the 11n 64-QAM ceiling at the same streams and bandwidth.
+#
+# VHT is an 802.11ac (5 GHz) PPDU; airing it on 2.4 GHz is a vendor extension,
+# not a standard mode. devourer's TX path never reads the band when resolving a
+# rate, so DEVOURER_TX_RATE=VHT2SS_MCS9/40 on channel 6 is already selectable —
+# this harness measures whether the baseband actually emits it, what a peer
+# decodes, and what the 256-QAM constellation costs in SNR over 64-QAM.
+#
+# Method mirrors ldpc_waterfall.sh: one long-lived ground rxdemo whose log is
+# sliced by byte offset per cell, the emitter stepping a flat TXAGC index
+# (DEVOURER_TX_PWR -> SetTxPowerIndexOverride, 0.5 dB/step on Jaguar1/2,
+# 0.25 dB on Jaguar3). Per cell: delivered = sum of rx.energy frames,
+# sent = the final tx.stats submitted.
+#
+# The extra gate: rx.txhit carries the decoded DESC_RATE, so each cell also
+# reports how many sampled frames decoded as the *commanded* modulation. A cell
+# that delivers frames which decode as HT is a fallback, not a 256-QAM pass.
+#
+# Bench notes (docs/bench-testing-near-field.md): sweep the noise-limited low
+# index regime. Two adapters ~30 cm apart saturate the RX front end at full
+# power — if index 0 already delivers ~100%, add attenuation or distance.
+#
+#   sudo tests/nitroqam_waterfall.sh --emit-vid 0x2357 --emit-pid 0x012d \
+#        --ground-vid 0x0bda --ground-pid 0xb812 --channel 6
+#
+# Output: $OUT/points.jsonl (one JSON per cell) + per-cell raw logs.
+# Analysis: python3 tests/nitroqam_waterfall.py report $OUT/points.jsonl
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+TXDEMO="$ROOT/build/txdemo"
+RXDEMO="$ROOT/build/rxdemo"
+
+EMIT_VID=0x0bda EMIT_PID="" GROUND_VID=0x0bda GROUND_PID=""
+CHANNEL=6 BW=40 ENCS=""
+# Power axis. PWR_MODE=offset steps DEVOURER_TX_PWR_OFFSET_QDB — a quarter-dB
+# shift of the chip's own efuse-calibrated per-rate table, shape preserved. That
+# is the right lever for a waterfall: the alternative, the flat DEVOURER_TX_PWR
+# index, forces both paths to one level and zeroes the per-rate diffs, which
+# measurably degrades the link (bench: a pair that reaches MCS4 at calibrated
+# power tops out at MCS1 under a flat index). PWR_MODE=flat keeps the index for
+# comparison against harnesses that use it; PWR_MODE=none pins the calibrated
+# default and sweeps nothing.
+PWR_MODE=offset
+PWR_START=-60 PWR_STOP=0 PWR_STEP=8 SECS=6
+# VBUS cold-cycle the emitter before every cell (REGRESS_VBUS_MAP, uhubctl).
+# This is not optional hygiene — the chip retains state across a warm re-init,
+# and a run of back-to-back devourer sessions progressively degrades high-order
+# constellation TX until 64-QAM and up stop decoding entirely, which reads
+# exactly like a link too weak to carry them. Measured on an 8812AU: MCS7
+# delivered 0% warm and 58% after a cold cycle, same power, same channel, same
+# gap. Leave this on unless the adapter's hub cannot switch VBUS.
+COLD=${COLD:-1}
+OUT=/tmp/devourer-nitroqam-waterfall
+
+BASELINE=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --emit-vid) EMIT_VID="$2"; shift 2 ;;
+    --emit-pid) EMIT_PID="$2"; shift 2 ;;
+    --ground-vid) GROUND_VID="$2"; shift 2 ;;
+    --ground-pid) GROUND_PID="$2"; shift 2 ;;
+    --channel) CHANNEL="$2"; shift 2 ;;
+    --bw) BW="$2"; shift 2 ;;
+    --encs) ENCS="$2"; shift 2 ;;
+    --baseline) BASELINE="$2"; shift 2 ;;
+    --pwr-mode) PWR_MODE="$2"; shift 2 ;;
+    --pwr-start) PWR_START="$2"; shift 2 ;;
+    --pwr-stop) PWR_STOP="$2"; shift 2 ;;
+    --pwr-step) PWR_STEP="$2"; shift 2 ;;
+    --secs) SECS="$2"; shift 2 ;;
+    --outdir) OUT="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$EMIT_PID" ] && [ -n "$GROUND_PID" ] || {
+  echo "need --emit-pid and --ground-pid" >&2; exit 2; }
+[ -x "$TXDEMO" ] && [ -x "$RXDEMO" ] || { echo "build first" >&2; exit 2; }
+[ "$CHANNEL" -le 14 ] || echo "warning: ch$CHANNEL is 5 GHz — VHT there is the" \
+  "standard mode, not the extension this harness is about" >&2
+
+# Default set: the two 256-QAM points against the 11n 64-QAM ceiling at the same
+# 2 streams and bandwidth. MCS15 is the highest standards-only 2SS rate, so the
+# horizontal shift between the curves is the price of the denser constellation.
+[ -n "$ENCS" ] || ENCS="MCS15/$BW/SGI,VHT2SS_MCS8/$BW,VHT2SS_MCS9/$BW"
+[ -n "$BASELINE" ] || BASELINE="MCS15/$BW/SGI"
+
+mkdir -p "$OUT"
+RXLOG="$OUT/ground.rx.jsonl"
+POINTS="$OUT/points.jsonl"
+: > "$POINTS"
+
+# Real VBUS cycle for the emitter, keyed by VID:PID in REGRESS_VBUS_MAP
+# ("VID:PID=hub,port;..."). The `authorized` toggle is deliberately NOT used as
+# a fallback here: it re-enumerates without removing power, so it does not clear
+# the chip state this exists to clear (docs/adapter-doctor.md).
+# $1=vid $2=pid. Both ends need this, not just the transmitter: a receiver that
+# has been through many warm sessions loses high-order decode the same way a
+# transmitter loses high-order modulation.
+cold_cycle() {
+  [ "$COLD" = 1 ] || return 0
+  local map=${REGRESS_VBUS_MAP:-} key entry hubport
+  [ -n "$map" ] || return 0
+  key=$(printf '%s:%s' "${1#0x}" "${2#0x}")
+  entry=$(tr ';' '\n' <<<"$map" | grep -i "^$key=" | head -1) || true
+  [ -n "${entry:-}" ] || return 0
+  hubport=${entry#*=}
+  sudo uhubctl -l "${hubport%,*}" -p "${hubport#*,}" -a cycle -d 3 >/dev/null 2>&1
+  sleep 12
+}
+
+RXPID=""
+cleanup() {
+  [ -n "$RXPID" ] && kill "$RXPID" 2>/dev/null
+  pkill -x txdemo 2>/dev/null
+  wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+cold_cycle "$GROUND_VID" "$GROUND_PID"
+
+# Ground RX up once for the whole sweep (bring-up is ~6 s; per-cell windows are
+# carved out of its log by byte offset). The canonical-SA filter keeps ambient
+# 2.4 GHz traffic — of which there is plenty — out of the delivery count.
+DEVOURER_VID="$GROUND_VID" DEVOURER_PID="$GROUND_PID" \
+DEVOURER_CHANNEL="$CHANNEL" DEVOURER_BW="$BW" \
+DEVOURER_RX_AGG_SA=canon DEVOURER_RX_ENERGY_MS=500 \
+DEVOURER_LINKHEALTH=1 DEVOURER_LOG_LEVEL=warn \
+"$RXDEMO" > "$RXLOG" 2>"$OUT/ground.rx.stderr" &
+RXPID=$!
+sleep 8
+kill -0 "$RXPID" 2>/dev/null || {
+  echo "ground RX died — see $OUT/ground.rx.stderr" >&2; exit 1; }
+
+IFS=',' read -ra ENC_ARR <<<"$ENCS"
+for ENC in "${ENC_ARR[@]}"; do
+  IDX="$PWR_START"
+  while [ "$IDX" -le "$PWR_STOP" ]; do
+    TAG="$(echo "$ENC" | tr '/' '-')_idx$IDX"
+    TXLOG="$OUT/tx_$TAG.jsonl"
+    echo "[$(date +%H:%M:%S)] cell enc=$ENC idx=$IDX ..."
+    cold_cycle "$EMIT_VID" "$EMIT_PID"
+    OFF0=$(stat -c%s "$RXLOG")
+    PWRENV=()
+    case "$PWR_MODE" in
+      offset) PWRENV=(DEVOURER_TX_PWR_OFFSET_QDB="$IDX") ;;
+      flat)   PWRENV=(DEVOURER_TX_PWR="$IDX") ;;
+      none)   ;;
+      *) echo "bad --pwr-mode: $PWR_MODE (offset|flat|none)" >&2; exit 2 ;;
+    esac
+    env DEVOURER_VID="$EMIT_VID" DEVOURER_PID="$EMIT_PID" \
+    DEVOURER_CHANNEL="$CHANNEL" DEVOURER_HOP_BW="$BW" \
+    DEVOURER_TX_RATE="$ENC" "${PWRENV[@]}" \
+    DEVOURER_TX_GAP_US=2000 DEVOURER_LOG_LEVEL=warn \
+    timeout --signal=TERM $((SECS + 12)) "$TXDEMO" \
+        > "$TXLOG" 2>"$OUT/tx_$TAG.stderr" &
+    TXPID=$!
+    # Let bring-up finish, then measure for SECS, then a graceful stop (the
+    # final tx.stats needs a clean SIGTERM exit, not SIGKILL).
+    sleep $((SECS + 6))
+    kill -TERM "$TXPID" 2>/dev/null
+    wait "$TXPID" 2>/dev/null
+    sleep 1
+    OFF1=$(stat -c%s "$RXLOG")
+    python3 "$HERE/nitroqam_waterfall.py" point \
+        "$TXLOG" "$RXLOG" "$OFF0" "$OFF1" "$ENC" "$IDX" >> "$POINTS"
+    tail -1 "$POINTS"
+    IDX=$((IDX + PWR_STEP))
+  done
+done
+
+echo
+echo "done — analyze: python3 tests/nitroqam_waterfall.py report $POINTS" \
+     "--baseline '$BASELINE'"
+python3 "$HERE/nitroqam_waterfall.py" report "$POINTS" --baseline "$BASELINE"

--- a/tests/warm_tx_degradation_repro.sh
+++ b/tests/warm_tx_degradation_repro.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Reproduce the warm-session TX degradation: repeated devourer init/teardown
+# cycles on one adapter progressively destroy high-order-constellation TX while
+# leaving the low rates untouched, and only a VBUS power cycle recovers it.
+#
+# This matters beyond the bench. A field deployment (FPV link, drone) cannot
+# power-cycle its adapter, so a long-running or restart-prone session silently
+# loses its top rates with nothing in any log to say so.
+#
+# The signature is what makes this diagnosable: it is NOT a wedge. The adapter
+# keeps enumerating, keeps accepting frames, keeps reporting every frame
+# submitted, and keeps delivering the robust rates at full rate. Only the dense
+# constellations stop decoding. That points at analog TX quality (calibration
+# state — IQK/LCK/DPK — or power/thermal tracking) rather than the datapath,
+# which would take the low rates down with it.
+#
+# Method: hold ONE ground receiver up for the whole run so the reference never
+# moves, then alternate {probe} and {N warm devourer sessions} on the DUT and
+# watch the probe decay. Two controls separate the candidate causes:
+#   - idle with no power cycle  -> if this recovers it, the cause is thermal
+#   - VBUS power cycle          -> known to recover it
+#
+#   sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
+#        tests/warm_tx_degradation_repro.sh
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+TXDEMO="$ROOT/build/txdemo"
+RXDEMO="$ROOT/build/rxdemo"
+
+DUT_VID=${DUT_VID:-0x0bda} DUT_PID=${DUT_PID:-0x8812}
+GND_VID=${GND_VID:-0x2357} GND_PID=${GND_PID:-0x012d}
+CH=${CH:-6}
+# The rate under test must be one the link carries comfortably when cold, or a
+# decay curve cannot be distinguished from a marginal link. MCS7 measured ~60%
+# cold on this pair. CTRL_RATE is the robust control that must keep working
+# throughout — it is what shows the adapter is still transmitting at all.
+RATE=${RATE:-MCS7/20}
+CTRL_RATE=${CTRL_RATE:-MCS1/20}
+WARM_PER_ROUND=${WARM_PER_ROUND:-3}
+ROUNDS=${ROUNDS:-4}
+SECS=${SECS:-5}
+IDLE_SECS=${IDLE_SECS:-60}
+OUT=${OUT:-/tmp/devourer-warm-degradation}
+
+mkdir -p "$OUT"
+RXLOG="$OUT/ground.rx.jsonl"
+: > "$OUT/results.tsv"
+
+RXPID=""
+cleanup() {
+  [ -n "$RXPID" ] && kill "$RXPID" 2>/dev/null
+  pkill -x txdemo 2>/dev/null
+  wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+cold_cycle() { # $1=vid $2=pid
+  local map=${REGRESS_VBUS_MAP:-} key entry hubport
+  [ -n "$map" ] || { echo "REGRESS_VBUS_MAP unset — cannot cold-cycle" >&2; return 1; }
+  key=$(printf '%s:%s' "${1#0x}" "${2#0x}")
+  entry=$(tr ';' '\n' <<<"$map" | grep -i "^$key=" | head -1) || true
+  [ -n "${entry:-}" ] || { echo "no VBUS map entry for $key" >&2; return 1; }
+  hubport=${entry#*=}
+  sudo uhubctl -l "${hubport%,*}" -p "${hubport#*,}" -a cycle -d 3 >/dev/null 2>&1
+  sleep 12
+}
+
+# One devourer TX session at $1, measured against the standing ground receiver.
+# Echoes "delivered/sent".
+probe() {
+  local rate=$1 tag=$2
+  local off0 off1 sent delivered
+  off0=$(stat -c%s "$RXLOG")
+  sudo env DEVOURER_VID="$DUT_VID" DEVOURER_PID="$DUT_PID" \
+    DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$rate" \
+    DEVOURER_TX_GAP_US=2000 DEVOURER_LOG_LEVEL=warn \
+    timeout --signal=TERM $((SECS + 12)) "$TXDEMO" \
+    > "$OUT/tx_$tag.jsonl" 2>"$OUT/tx_$tag.err" &
+  local p=$!
+  sleep $((SECS + 6))
+  kill -TERM "$p" 2>/dev/null; wait "$p" 2>/dev/null
+  sleep 1
+  off1=$(stat -c%s "$RXLOG")
+  sent=$(grep -o '"submitted":[0-9]*' "$OUT/tx_$tag.jsonl" | tail -1 | cut -d: -f2)
+  delivered=$(python3 - "$RXLOG" "$off0" "$off1" <<'EOF'
+import sys
+sys.path.insert(0, "tests")
+from devourer_events import parse_event
+f = open(sys.argv[1], "rb"); f.seek(int(sys.argv[2]))
+blob = f.read(int(sys.argv[3]) - int(sys.argv[2])).decode(errors="replace")
+n = 0
+for line in blob.splitlines():
+    ev = parse_event(line, "rx.energy")
+    if ev:
+        n += int(ev.get("frames") or 0)
+print(n)
+EOF
+)
+  printf '%s/%s' "${delivered:-0}" "${sent:-0}"
+}
+
+# A warm session: full devourer bring-up + TX + teardown, no power cycle. This
+# is the thing under test — exactly what a restart-prone deployment does.
+#
+# WARM_PWR / WARM_GAP let a run stress the session rather than just repeat it,
+# to find what aggravates the decay. Plain repetition costs a few points; the
+# catastrophic form (top rates at zero) was first seen after a long spell of
+# max-power and max-duty sessions, so those are the first suspects.
+warm_session() {
+  local extra=()
+  [ -n "${WARM_PWR:-}" ] && extra=(DEVOURER_TX_PWR="$WARM_PWR")
+  sudo env DEVOURER_VID="$DUT_VID" DEVOURER_PID="$DUT_PID" \
+    DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$RATE" "${extra[@]}" \
+    DEVOURER_TX_GAP_US="${WARM_GAP:-2000}" DEVOURER_LOG_LEVEL=warn \
+    timeout --signal=TERM 14 "$TXDEMO" >/dev/null 2>&1
+  sleep 1
+}
+
+report() { # $1=label $2=test-result $3=control-result
+  local pct
+  pct=$(python3 -c "
+d,s='$2'.split('/')
+print('%.1f%%' % (100*int(d)/int(s)) if int(s) else 'n/a')")
+  local cpct
+  cpct=$(python3 -c "
+d,s='$3'.split('/')
+print('%.1f%%' % (100*int(d)/int(s)) if int(s) else 'n/a')")
+  printf '  %-34s %s %-9s   %s %-9s\n' "$1" "$RATE" "$pct" "$CTRL_RATE" "$cpct"
+  printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$OUT/results.tsv"
+}
+
+echo "warm-session TX degradation repro"
+echo "  DUT $DUT_VID:$DUT_PID   ground $GND_VID:$GND_PID   ch$CH"
+echo "  test rate $RATE, control rate $CTRL_RATE, ${WARM_PER_ROUND} warm sessions/round"
+echo
+
+cold_cycle "$GND_VID" "$GND_PID" || exit 1
+DEVOURER_VID="$GND_VID" DEVOURER_PID="$GND_PID" DEVOURER_CHANNEL="$CH" \
+DEVOURER_RX_AGG_SA=canon DEVOURER_RX_ENERGY_MS=500 DEVOURER_LOG_LEVEL=warn \
+"$RXDEMO" > "$RXLOG" 2>"$OUT/ground.rx.stderr" &
+RXPID=$!
+sleep 9
+kill -0 "$RXPID" 2>/dev/null || { echo "ground RX died" >&2; exit 1; }
+
+printf '  %-34s %-14s   %s\n' "stage" "test rate" "control rate"
+cold_cycle "$DUT_VID" "$DUT_PID" || exit 1
+report "cold baseline" "$(probe "$RATE" cold)" "$(probe "$CTRL_RATE" cold_ctrl)"
+
+warm=0
+for r in $(seq 1 "$ROUNDS"); do
+  for _ in $(seq 1 "$WARM_PER_ROUND"); do warm_session; warm=$((warm + 1)); done
+  report "after $warm warm sessions" \
+      "$(probe "$RATE" "warm$warm")" "$(probe "$CTRL_RATE" "warm${warm}_ctrl")"
+done
+
+# Control 1: idle, no power cycle. Recovery here would mean thermal, and would
+# also mean a field deployment could recover by simply pausing.
+echo "  (idling ${IDLE_SECS}s with no power cycle ...)"
+sleep "$IDLE_SECS"
+report "after ${IDLE_SECS}s idle (no power cycle)" \
+    "$(probe "$RATE" idle)" "$(probe "$CTRL_RATE" idle_ctrl)"
+
+# Control 2: the known recovery.
+cold_cycle "$DUT_VID" "$DUT_PID" || exit 1
+report "after VBUS cold cycle" \
+    "$(probe "$RATE" recovered)" "$(probe "$CTRL_RATE" recovered_ctrl)"
+
+echo
+echo "results: $OUT/results.tsv"


### PR DESCRIPTION
Closes #331.

## What this delivers

**256-QAM VHT on the 2.4 GHz band, confirmed on air.** RTL8812AU TX into an
RTL8822BU peer, ch6/20 MHz: `VHT1SS_MCS8` (256-QAM 3/4) delivered with **every
sampled frame decoding as the commanded VHT rate**. The VHT format is also
confirmed from an RTL8822BU and an RTL8812CU.

Recorded as `AdapterCaps::vht_2g4_ok` — a *transmit* claim, set only for dies
actually measured on air, emitted in the `adapter.caps` event. Verified reading
1/1/1 on the three measured dies and 0 on the 8814A/8822E.

As #331 predicted, no library change was needed to *select* the rate: rate
resolution never reads the band. The work was proving it flies, and building a
harness that can tell "256-QAM aired" from "something aired".

## Two things that had to be right first

Both produced a confidently wrong answer before they were fixed, so they are the
substance of this PR rather than incidental.

**A delivery curve cannot say which modulation flew.** `nitroqam_waterfall.sh`
decodes every sampled `rx.txhit` rate and reports a delivering-but-mismatched
cell as a fallback. That is what caught **VHT MCS9 being an illegal rate at
20 MHz for 1–2 spatial streams** — hardware correctly emits MCS8 instead, and
311 delivered frames would otherwise have scored as an MCS9 pass. Exercising
MCS9 needs 40 MHz.

**High-order constellation TX degrades across warm re-inits.** Same 8812AU, same
channel, power and inter-frame gap — only a VBUS power cycle between them:

| MCS7 (64-QAM 5/6) | delivery |
| --- | --- |
| warm | **0%** |
| cold | **58%** |

Nothing logs an error; the low rates keep working at full ratio; RSSI and EVM
look healthy on the frames that do decode. It is indistinguishable from a link
too weak to carry the constellation — it produced an entire coherent-but-wrong
"rig SNR limit" conclusion (peaked power curve, same ceiling on empty ch14, same
ceiling on three receivers) before the vendor-driver control exposed it.

So the waterfall now cold-cycles **both ends** per cell by default, `CLAUDE.md`'s
hardware gotchas carry the trap, and `tests/warm_tx_degradation_repro.sh`
reproduces the decay with idle and cold-cycle controls. **The degradation itself
is a separate open bug — #348** — because a deployed link cannot power-cycle its
adapter in flight.

## The control that settles "is it ours?"

`tests/nitroqam_kernel_ab.sh` runs devourer and the vendor driver from
`reference/rtl8812au` on the **same dongle**, interleaved per rate, judged by an
AR9271 sniffer (different vendor's radio, no shared silicon, firmware or driver
code):

| rate | devourer | vendor 88XXau |
| --- | --- | --- |
| MCS5 (64-QAM 2/3) | 61.7% | 68.4% |
| MCS7 (64-QAM 5/6) | 58.2% | 64.3% |

devourer is on par with the vendor driver at the top of the HT ladder — no
devourer-side high-MCS defect. The harness encodes two traps: the in-tree
`rtw88` is **not** usable as a control (it reports frames injected while airing
nothing decodable), and all-A-then-all-B is invalid (ambient moved one side 2×
between runs, so cells are interleaved and sanity-gated).

## Honest limits

- **2 spatial streams above MCS2** read zero even cold — two dongles in near
  field give the streams too little spatial decorrelation. A rig property, not
  evidence about the chip.
- **40 MHz, hence the headline 400 Mbps rate, is not measured.** `rxdemo` with
  `DEVOURER_BW=40` delivers zero on both Jaguar1 and Jaguar2, including for a
  20 MHz transmitter on the primary channel, at either offset, in both
  directions. Re-tested cold and unchanged, so it is a real receiver-side gap.
  Worth noting the existing `jaguar2_tx_bw40.sh` validates 40 MHz TX with a
  *kernel* sniffer, so the devourer 40 MHz receive path may never have been
  exercised. Not addressed here.
- An SDR duty-cycle comparison was tried as a transmitter-only substitute for a
  receiver and **does not work** on this bench at any payload from 1400–4000 B
  (the host feed, not the channel, sets occupancy). It was dropped rather than
  shipped as a harness that cannot return a valid answer; `docs/vht-on-2g4.md`
  records the attempt so it is not rebuilt.

## Testing

`ctest` 48/48, including the new headless `nitroqam_decode_math` covering the
`desc_rate_decode()` branches and threshold-crossing math that a sub-256-QAM
bench link cannot reach on air. `desc_rate_to_mcs()` keeps its 2-tuple contract
for the existing `tools/precoder` callers.

All on-air numbers above are from this branch on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
