### PR TITLE
Jaguar1: power the chip down at teardown (mechanism open; thermal explanation retracted)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -612,17 +612,23 @@ generators, never the output files.
   only helps when firmware state is intact.
 - **The chip retains state across soft re-init** — cold-bisect hardware
   problems with a VBUS power-cycle, not a re-run.
-- **Chip temperature silently caps the usable modulation.** A hot 8812AU loses
-  the dense constellations first while the robust rates carry on: measured on
-  ch6/20 MHz, thermal meter 43 → 53 costs MCS7 (64-QAM) ~83% → ~71% delivery
-  with RSSI *flat*, i.e. no power is lost, only signal quality. Nothing logs an
-  error and the signature is indistinguishable from a link too weak to carry
-  the rate. Any rate-ceiling measurement must therefore control temperature —
-  VBUS-cycle per cell, and read the `thermal` event
-  (`DEVOURER_THERMAL_POLL_MS`) beside the delivery number.
-  `tests/warm_tx_degradation_repro.sh` is the reference method. Removing power
-  is what cools the part: on a chip left in ACT, 120 s of idle bought 4 thermal
-  units where a 12 s VBUS cycle bought 9.
+- **A single delivery probe is worth ±3 points, so small effects are not
+  findings.** Ten identical back-to-back MCS7/20 probes on an 8812AU (nothing
+  changed between them) gave sd 1.8 and a 5.7-point spread; the MCS1 control
+  over the same run held 98.0 ± 0.2. Anything under ~4 points needs repetition
+  before it means anything — several plausible-looking "decay curves" have
+  turned out to sit inside that band. `tests/probe_repeatability.sh` measures
+  the floor for a given pair; run it before believing a delivery difference.
+- **A hot 8812AU tends to lose the dense constellations while the robust rates
+  carry on**, and it is easy to over-read. Delivery does correlate with the
+  `thermal` meter within one probe sequence (39 → 45 costing MCS7 ~5 points,
+  control flat) — but a sweep that varied *only* cooling time, by powering the
+  chip down for 5–120 s before an otherwise identical probe, found delivery
+  scattered 63–83% with no relation to either off-time or temperature. So heat
+  is a real correlate and not a demonstrated cause. Read the `thermal` event
+  (`DEVOURER_THERMAL_POLL_MS`) beside any rate-ceiling number, VBUS-cycle per
+  cell, and repeat the cell — do not attribute a difference to temperature
+  without varying temperature independently.
 - **MediaTek Android hosts cap bulk-IN reads at 16 KB**: some MTK xhci/usbfs
   stacks (Dimensity 810, Helio G99, MT6765) never complete a larger bulk-IN
   transfer — `LIBUSB_ERROR_TIMEOUT` forever, zero RX with a green init

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -514,8 +514,11 @@ MAC-latched `tsfl` RX timestamp — on all generations, µs-grade
 (`docs/time-distribution.md`, measured vs NTP/PTP: `docs/timing-accuracy.md`).
 `StartBeacon` loads a beacon into the MAC's reserved page and the chip
 auto-transmits at each TBTT with the live TSF stamped at the TX instant — the
-sub-µs downlink. The chip beacons **autonomously**: a session that ends
-without a power-cycle must call `StopBeacon()` or the beacon keeps airing.
+sub-µs downlink. The chip beacons **autonomously**, so `StopBeacon()` is what
+stops it mid-session; a session that ends via `Stop()` or destruction powers the
+chip down and takes the beacon with it (Jaguar1/Jaguar3 — Jaguar2 has no
+teardown power-down yet, so there it keeps airing until the adapter is
+re-enumerated).
 `UpdateBeaconPayload` swaps the airing content in place (frame-atomic on air,
 TBTT-quantized latency); `PinBeaconTbtt` steers the TBTT to an absolute TSF
 instant without corrupting the clock (Jaguar1: offset 0 only — its TBTT is
@@ -608,14 +611,18 @@ generators, never the output files.
   After detaching a kernel driver, expect a cold re-init; `DEVOURER_SKIP_RESET`
   only helps when firmware state is intact.
 - **The chip retains state across soft re-init** — cold-bisect hardware
-  problems with a VBUS power-cycle, not a re-run. This is not only a bring-up
-  concern: **high-order constellation TX degrades across warm re-inits**. After
-  a run of back-to-back sessions an 8812AU delivered 0% at MCS7 (64-QAM) while
-  16-QAM and below still worked, and a VBUS cycle restored it to 58% at the
-  same channel, power and gap. Nothing logs an error, RSSI and EVM look
-  healthy, and the result is indistinguishable from a link too weak to carry
-  the rate — so any rate-ceiling measurement must cold-cycle per cell or it
-  measures accumulated chip state. An `authorized` toggle does not clear it.
+  problems with a VBUS power-cycle, not a re-run.
+- **Chip temperature silently caps the usable modulation.** A hot 8812AU loses
+  the dense constellations first while the robust rates carry on: measured on
+  ch6/20 MHz, thermal meter 43 → 53 costs MCS7 (64-QAM) ~83% → ~71% delivery
+  with RSSI *flat*, i.e. no power is lost, only signal quality. Nothing logs an
+  error and the signature is indistinguishable from a link too weak to carry
+  the rate. Any rate-ceiling measurement must therefore control temperature —
+  VBUS-cycle per cell, and read the `thermal` event
+  (`DEVOURER_THERMAL_POLL_MS`) beside the delivery number.
+  `tests/warm_tx_degradation_repro.sh` is the reference method. Removing power
+  is what cools the part: on a chip left in ACT, 120 s of idle bought 4 thermal
+  units where a 12 s VBUS cycle bought 9.
 - **MediaTek Android hosts cap bulk-IN reads at 16 KB**: some MTK xhci/usbfs
   stacks (Dimensity 810, Helio G99, MT6765) never complete a larger bulk-IN
   transfer — `LIBUSB_ERROR_TIMEOUT` forever, zero RX with a green init

--- a/docs/warm-tx-degradation.md
+++ b/docs/warm-tx-degradation.md
@@ -1,0 +1,110 @@
+# Warm-session TX degradation — chip temperature caps the modulation
+
+A devourer session used to leave a Jaguar1 chip powered up. Not just enumerated
+— in the ACT power state with the RF front end live, indefinitely, long after
+the process that brought it up had exited. Nothing else in the tree does this:
+Jaguar2 resets the chip at init and Jaguar3 has run a full card-disable at
+teardown for a long time.
+
+The consequence was a transmitter that quietly lost its dense constellations.
+
+## The signature
+
+Across back-to-back sessions on one RTL8812AU, ch6/20 MHz, constant TX config:
+
+| | MCS7 (64-QAM 5/6) | MCS1 control | thermal | RSSI |
+| --- | --- | --- | --- | --- |
+| cold baseline | 83.0% | 98.0% | 43 | 69 |
+| after 24 max-duty sessions | 71.3% | 98.0% | **53** | 69 |
+| 120 s idle, chip still powered | 70.8% | 98.3% | 49 | 69 |
+| after VBUS cold cycle | 79.2% | 97.7% | **44** | 69 |
+
+**RSSI never moves.** The transmitter is not losing power; it is losing signal
+quality, and the chip's own thermal meter tracks the loss one-for-one. The
+robust rates are untouched throughout, because they need far less margin.
+
+This is dangerous to diagnose because nothing reports an error: every frame is
+submitted, the receiver reports a strong RSSI and a clean EVM *on the frames it
+still decodes* (only the low-order ones), and the result is indistinguishable
+from a link too weak to carry the constellation. It produced one confident and
+completely wrong "rig SNR limit" conclusion before the mechanism was found.
+
+Note what the idle row says: **idling does not cool the part.** 120 s of no
+traffic bought 4 thermal units; a 12 s VBUS cycle bought 9. A chip held in ACT
+with its RF on keeps dissipating whether or not you are transmitting.
+
+## The fix
+
+`RtlJaguarDevice::Stop()` and the destructor now run
+`HalModule::rtw_hal_deinit()` — halt the MAC engines (`REG_CR`, `REG_RCR`) then
+the die's card-disable power sequence. Those sequence tables
+(`rtl8812_card_disable_flow` and the 8814A/8821A equivalents) had been carried
+in `hal/Hal88*PwrSeq.c` since the port began with nothing calling them.
+
+The chip now powers down whenever no session owns it, so it cools. Same repro,
+after the fix:
+
+| stage | before | after |
+| --- | --- | --- |
+| 60 s idle, **no** power cycle | thermal 48, MCS7 73.0% | thermal **40**, MCS7 **85.8%** |
+
+Before, no amount of idling recovered anything and only pulling VBUS helped.
+Now an ordinary gap between sessions restores the part completely, without
+touching the hardware.
+
+## What this does not fix
+
+**Continuous transmission still heats the chip.** Inside one uninterrupted
+high-duty session the part reaches thermal equilibrium and stays there —
+~80% → ~75% at MCS7 on this adapter. That is physics, not a defect, and it is
+the honest steady-state capability of a hot radio.
+
+There is deliberately **no in-flight recovery API**. Recovery requires the
+radio to stop transmitting long enough to cool, and the measurement says that
+is around a minute (60 s of powered-down idle moved thermal 47 → 40 and MCS7
+75% → 86%). A call that restores the rate by killing the link for a minute is
+not a recovery for an airborne link, so shipping one would be theatre. For a
+long flight the lever is thermal-aware operation instead: poll the meter with
+`DEVOURER_THERMAL_POLL_MS`, watch the `thermal` event's rising `delta`, and
+back off with `SetTxPowerOffsetQdb` or reduce duty before the constellation
+starts failing.
+
+**A killed process leaves the chip hot.** `SIGKILL` runs neither `Stop()` nor
+the destructor, so the chip stays powered and keeps heating until something
+opens it again. An init-side power-off was considered and rejected: it would
+run immediately before power-on and so buys no cooling time at all, while
+adding risk to a bring-up path that works. The real answer for an unattended
+deployment is a supervisor that does not `SIGKILL` its radio process.
+
+## Per-chip findings
+
+- **RTL8812AU** — where the effect is characterized. Thermal 43 → 53, MCS7
+  −12 points. The fix is validated here.
+- **RTL8814AU** — barely heats at the same duty (34 → 37) and shows no
+  degradation. It re-inits cleanly after the power-down; there was simply
+  nothing to recover. The effect scales with how hot the part actually gets.
+- **RTL8821AU** — re-inits cleanly after the power-down; not separately
+  characterized for the thermal curve.
+- **Jaguar2 (RTL8822BU)** — audited and **inconclusive**: its thermal meter did
+  not move (33–34) across the same run, and the link available for the test was
+  too marginal at MCS7 to resolve a small effect. No teardown power-down was
+  added there on the strength of a non-measurement; it remains the one
+  generation that leaves the chip powered at exit.
+
+## Reproducing
+
+```sh
+sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
+     tests/warm_tx_degradation_repro.sh
+```
+
+Holds one ground receiver up for the whole run so the reference never moves,
+then alternates probes with warm sessions, recording delivery at a test rate and
+a robust control rate alongside the chip thermal meter and the receiver's RSSI
+and EVM. `WARM_PWR=63 WARM_GAP=0` turns the warm sessions into max-power,
+max-duty heating. Two controls close it out: an idle with no power cycle, and a
+VBUS cycle.
+
+Reading it: falling delivery with **flat RSSI and rising thermal** is heat;
+falling delivery with **falling RSSI** would be a transmitter losing power,
+which is a different bug.

--- a/docs/warm-tx-degradation.md
+++ b/docs/warm-tx-degradation.md
@@ -1,4 +1,4 @@
-# Warm-session TX degradation — chip temperature caps the modulation
+# Warm-session TX degradation on Jaguar1
 
 A devourer session used to leave a Jaguar1 chip powered up. Not just enumerated
 — in the ACT power state with the RF front end live, indefinitely, long after
@@ -6,105 +6,113 @@ the process that brought it up had exited. Nothing else in the tree does this:
 Jaguar2 resets the chip at init and Jaguar3 has run a full card-disable at
 teardown for a long time.
 
-The consequence was a transmitter that quietly lost its dense constellations.
+Alongside that, high-rate delivery was observed to decay across back-to-back
+sessions and to recover only when power was removed. This document records what
+is measured, what was fixed, and — importantly — **which parts of the causal
+story did not survive testing**.
 
-## The signature
+## First: know your noise floor
 
-Across back-to-back sessions on one RTL8812AU, ch6/20 MHz, constant TX config:
+Ten identical back-to-back MCS7/20 probes on an RTL8812AU, nothing changed
+between them:
 
-| | MCS7 (64-QAM 5/6) | MCS1 control | thermal | RSSI |
-| --- | --- | --- | --- | --- |
-| cold baseline | 83.0% | 98.0% | 43 | 69 |
-| after 24 max-duty sessions | 71.3% | 98.0% | **53** | 69 |
-| 120 s idle, chip still powered | 70.8% | 98.3% | 49 | 69 |
-| after VBUS cold cycle | 79.2% | 97.7% | **44** | 69 |
+| | mean | sd | range |
+| --- | --- | --- | --- |
+| MCS7/20 | 67.3% | **1.8** | 65.0 – 70.7 |
+| MCS1/20 control | 98.0% | 0.2 | 97.5 – 98.3 |
 
-**RSSI never moves.** The transmitter is not losing power; it is losing signal
-quality, and the chip's own thermal meter tracks the loss one-for-one. The
-robust rates are untouched throughout, because they need far less margin.
+**A single probe is worth about ±3 points.** Any claimed effect smaller than
+~4 points is not detectable one-shot, and several plausible-looking "decay
+curves" in this investigation sat inside that band. `tests/probe_repeatability.sh`
+measures the floor for a given pair; run it before believing a delivery
+difference.
 
-This is dangerous to diagnose because nothing reports an error: every frame is
-submitted, the receiver reports a strong RSSI and a clean EVM *on the frames it
-still decodes* (only the low-order ones), and the result is indistinguishable
-from a link too weak to carry the constellation. It produced one confident and
-completely wrong "rig SNR limit" conclusion before the mechanism was found.
+## What is measured
 
-Note what the idle row says: **idling does not cool the part.** 120 s of no
-traffic bought 4 thermal units; a 12 s VBUS cycle bought 9. A chip held in ACT
-with its RF on keeps dissipating whether or not you are transmitting.
+The fix is that `Stop()` and the destructor now power the chip down. Its effect
+on an idle gap, same repro before and after:
+
+| stage | before fix | after fix |
+| --- | --- | --- |
+| 60 s idle, **no** power cycle | thermal 48, MCS7 73.0% | thermal 40, MCS7 **85.8%** |
+
+That is ~13 points, around 7 sd — comfortably real. Before the fix no amount of
+idling recovered anything and only pulling VBUS helped; afterwards an ordinary
+gap between sessions restores the part.
+
+Delivery also correlates with the chip's thermal meter *within* one probe
+sequence: across the ten repeats above, thermal climbed 39 → 45 while MCS7 fell
+70.7% → 65.7%, with the control flat and RSSI unchanged (so nothing is losing
+transmit *power* — only quality).
+
+## What did NOT survive testing
+
+**"It is thermal" is not proven, and two experiments argue against it.**
+
+Every recovery that works removes power, and removing power does two things at
+once: it resets chip state *and* it lets the die cool. No power-cycle experiment
+can separate them. Two attempts to separate them failed to support cooling:
+
+- **Off-time sweep** (`tests/thermal_offtime_sweep.sh`) — degrade the part, then
+  power it down for 5/15/30/60/120 s before an otherwise identical probe. The
+  reset is bit-identical in every arm; only cooling time varies. Temperature
+  fell cleanly with off-time (47 → 40), but delivery scattered 63–83% with **no
+  relationship to off-time or temperature** — the best result came from the
+  *shortest* off-time and the *hottest* chip.
+- **Within a single uninterrupted session**
+  (`tests/thermal_causation_probe.sh`) — 240 s of continuous max-duty TX, one
+  bring-up, no re-init, no state change. The thermal meter stayed **pinned**
+  while MCS7 delivery still drifted down ~10% and the MCS1 control held flat.
+
+So heat is a real correlate of delivery in some conditions and demonstrably not
+the driver in others. The mechanism behind the recovery-on-power-removal is
+**open**. Do not cite this document as evidence that the effect is thermal.
 
 ## The fix
 
-`RtlJaguarDevice::Stop()` and the destructor now run
+`RtlJaguarDevice::Stop()` and the destructor run
 `HalModule::rtw_hal_deinit()` — halt the MAC engines (`REG_CR`, `REG_RCR`) then
-the die's card-disable power sequence. Those sequence tables
-(`rtl8812_card_disable_flow` and the 8814A/8821A equivalents) had been carried
-in `hal/Hal88*PwrSeq.c` since the port began with nothing calling them.
+the die's card-disable power sequence, through the same `HalPwrSeqCmdParsing`
+and the same three-way chip dispatch `InitPowerOn` already uses. The sequence
+tables (`rtl8812_card_disable_flow` and the 8814A/8821A equivalents) had been
+carried in `hal/Hal88*PwrSeq.c` since the port began with nothing calling them.
 
-The chip now powers down whenever no session owns it, so it cools. Same repro,
-after the fix:
+It is justified on its own terms regardless of the mechanism question: leaving a
+radio powered and transmitting-capable after its owning process has exited is
+wrong, it is what every other generation already avoids, and it is what makes an
+autonomously-airing beacon stop at session end.
 
-| stage | before | after |
-| --- | --- | --- |
-| 60 s idle, **no** power cycle | thermal 48, MCS7 73.0% | thermal **40**, MCS7 **85.8%** |
+## What it does not fix
 
-Before, no amount of idling recovered anything and only pulling VBUS helped.
-Now an ordinary gap between sessions restores the part completely, without
-touching the hardware.
+- **Continuous transmission.** Inside one uninterrupted high-duty session the
+  part still drifts down; power-down at teardown cannot help a session that
+  never ends.
+- **`SIGKILL`.** Neither `Stop()` nor the destructor runs, so the chip stays
+  powered. An init-side power-off was considered and rejected: it would run
+  immediately before power-on, buying nothing, while adding risk to a bring-up
+  path that works.
+- **There is no in-flight recovery API.** Until the mechanism is understood
+  there is nothing principled to implement, and a call that restored the rate by
+  dropping the link would not be a recovery for an airborne link anyway.
 
-## What this does not fix
+## Per-chip
 
-**Continuous transmission still heats the chip.** Inside one uninterrupted
-high-duty session the part reaches thermal equilibrium and stays there —
-~80% → ~75% at MCS7 on this adapter. That is physics, not a defect, and it is
-the honest steady-state capability of a hot radio.
-
-There is deliberately **no in-flight recovery API**. Recovery requires the
-radio to stop transmitting long enough to cool, and the measurement says that
-is around a minute (60 s of powered-down idle moved thermal 47 → 40 and MCS7
-75% → 86%). A call that restores the rate by killing the link for a minute is
-not a recovery for an airborne link, so shipping one would be theatre. For a
-long flight the lever is thermal-aware operation instead: poll the meter with
-`DEVOURER_THERMAL_POLL_MS`, watch the `thermal` event's rising `delta`, and
-back off with `SetTxPowerOffsetQdb` or reduce duty before the constellation
-starts failing.
-
-**A killed process leaves the chip hot.** `SIGKILL` runs neither `Stop()` nor
-the destructor, so the chip stays powered and keeps heating until something
-opens it again. An init-side power-off was considered and rejected: it would
-run immediately before power-on and so buys no cooling time at all, while
-adding risk to a bring-up path that works. The real answer for an unattended
-deployment is a supervisor that does not `SIGKILL` its radio process.
-
-## Per-chip findings
-
-- **RTL8812AU** — where the effect is characterized. Thermal 43 → 53, MCS7
-  −12 points. The fix is validated here.
+- **RTL8812AU** — where the effect is characterized and the fix validated.
 - **RTL8814AU** — barely heats at the same duty (34 → 37) and shows no
-  degradation. It re-inits cleanly after the power-down; there was simply
-  nothing to recover. The effect scales with how hot the part actually gets.
-- **RTL8821AU** — re-inits cleanly after the power-down; not separately
-  characterized for the thermal curve.
-- **Jaguar2 (RTL8822BU)** — audited and **inconclusive**: its thermal meter did
-  not move (33–34) across the same run, and the link available for the test was
-  too marginal at MCS7 to resolve a small effect. No teardown power-down was
-  added there on the strength of a non-measurement; it remains the one
-  generation that leaves the chip powered at exit.
+  degradation; re-inits cleanly after the power-down.
+- **RTL8821AU** — re-inits cleanly; not separately characterized.
+- **Jaguar2 (RTL8822BU)** — audited, inconclusive: thermal did not move and the
+  available link was too marginal at MCS7 to resolve a small effect. No teardown
+  power-down added there on the strength of a non-measurement.
 
-## Reproducing
+## Harnesses
 
-```sh
-sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
-     tests/warm_tx_degradation_repro.sh
-```
+| script | question it answers |
+| --- | --- |
+| `probe_repeatability.sh` | how big must an effect be to be real on this pair? |
+| `warm_tx_degradation_repro.sh` | does delivery decay across sessions, and what do the sensors say? |
+| `thermal_offtime_sweep.sh` | is the recovery cooling, or the state reset? |
+| `thermal_causation_probe.sh` | does delivery track temperature with nothing else changing? |
 
-Holds one ground receiver up for the whole run so the reference never moves,
-then alternates probes with warm sessions, recording delivery at a test rate and
-a robust control rate alongside the chip thermal meter and the receiver's RSSI
-and EVM. `WARM_PWR=63 WARM_GAP=0` turns the warm sessions into max-power,
-max-duty heating. Two controls close it out: an idle with no power cycle, and a
-VBUS cycle.
-
-Reading it: falling delivery with **flat RSSI and rising thermal** is heat;
-falling delivery with **falling RSSI** would be a transmitter losing power,
-which is a different bug.
+Reading the repro: falling delivery with **flat RSSI** means signal quality, not
+transmit power. Falling RSSI would be a different bug.

--- a/src/jaguar1/CLAUDE.md
+++ b/src/jaguar1/CLAUDE.md
@@ -37,6 +37,22 @@ methods), `RadioManagementModule` (channel/BW/TX power, up to 4 RF paths),
   8814A decodes LDPC but reports no per-frame flag (`ldpc_rx_flag=0`,
   `RxAtrib.ldpc` reads 0).
 
+## Teardown
+
+`RtlJaguarDevice::Stop()` and the destructor run `HalModule::rtw_hal_deinit()`:
+halt the MAC engines (`REG_CR`, `REG_RCR`), then the die's card-disable power
+sequence via the existing `HalPwrSeqCmdParsing` (`rtl8812_card_disable_flow` /
+`rtl8814A_` / `rtl8821A_`, dispatched exactly like `InitPowerOn` dispatches the
+enable flows). Both call sites are best-effort — a chip already off the bus
+makes the writes fail, which is fine on a teardown path.
+
+This is not tidiness. Left in ACT the chip keeps its RF front end live and never
+cools, and a hot die loses the dense constellations while the robust rates carry
+on — thermal 43 → 53 costs MCS7 ~12 points of delivery at flat RSSI
+(`docs/warm-tx-degradation.md`). It also means an autonomously-airing beacon
+stops when the session ends. `PowerOff()` clears `_macPwrCtrlOn` so a re-init on
+the same `HalModule` still runs the power-on sequence.
+
 ## TX power
 
 Every per-rate index funnels through one composer, `ComputeTxPowerIndex(path,

--- a/src/jaguar1/CLAUDE.md
+++ b/src/jaguar1/CLAUDE.md
@@ -46,12 +46,16 @@ sequence via the existing `HalPwrSeqCmdParsing` (`rtl8812_card_disable_flow` /
 enable flows). Both call sites are best-effort — a chip already off the bus
 makes the writes fail, which is fine on a teardown path.
 
-This is not tidiness. Left in ACT the chip keeps its RF front end live and never
-cools, and a hot die loses the dense constellations while the robust rates carry
-on — thermal 43 → 53 costs MCS7 ~12 points of delivery at flat RSSI
-(`docs/warm-tx-degradation.md`). It also means an autonomously-airing beacon
-stops when the session ends. `PowerOff()` clears `_macPwrCtrlOn` so a re-init on
-the same `HalModule` still runs the power-on sequence.
+This is not tidiness. Left in ACT the chip keeps its RF front end live
+indefinitely after the owning process exits — it never powers down and never
+cools. Measured consequence: after a run of sessions, a 60 s idle recovered MCS7
+delivery from 73.0% to 85.8% only once the teardown power-down existed; before
+it, idling recovered nothing. *Why* removing power helps is not established —
+a card-disable both resets chip state and lets the die cool, and an off-time
+sweep could not separate them (`docs/warm-tx-degradation.md`). It also means an
+autonomously-airing beacon stops when the session ends. `PowerOff()` clears
+`_macPwrCtrlOn` so a re-init on the same `HalModule` still runs the power-on
+sequence.
 
 ## TX power
 

--- a/src/jaguar1/HalModule.cpp
+++ b/src/jaguar1/HalModule.cpp
@@ -660,6 +660,45 @@ bool HalModule::rtl8812au_hal_init(uint8_t init_channel) {
   return true;
 }
 
+void HalModule::rtw_hal_deinit() {
+  _logger->info("Jaguar1: clean de-init (stop TRX + card-disable)");
+  /* Halt the MAC engines before pulling power out from under them, so the
+   * sequence isn't racing DMA that is still moving frames. Mirrors
+   * HalJaguar3::rtw_hal_deinit. */
+  _device.rtw_write16(REG_CR, 0x0000); /* clear MACTXEN/MACRXEN */
+  _device.rtw_write32(REG_RCR, 0x00000000); /* drop all RX — stop FIFO fill */
+  PowerOff();
+}
+
+bool HalModule::PowerOff() {
+  /* Same three-way dispatch as InitPowerOn — the ACT->CARDEMU->PDN sequence is
+   * as silicon-specific as the enable one. These tables have been carried in
+   * hal/Hal88*PwrSeq.c since the port began with nothing calling them. */
+  WLAN_PWR_CFG *disable_flow;
+  switch (_eepromManager->version_id.ICType) {
+#if defined(DEVOURER_HAVE_8814)
+  case CHIP_8814A:
+    disable_flow = rtl8814A_card_disable_flow;
+    break;
+#endif
+  case CHIP_8821:
+    disable_flow = rtl8821A_card_disable_flow;
+    break;
+  default:
+    disable_flow = rtl8812_card_disable_flow;
+    break;
+  }
+  const bool ok = HalPwrSeqCmdParsing(disable_flow);
+  if (!ok) {
+    _logger->warn("PowerOff: card-disable flow did not complete");
+  }
+  /* Either way the chip is no longer in the state InitPowerOn's early-out
+   * assumes, so clear the latch — otherwise a re-init on this same HalModule
+   * would skip the power-on sequence and bring up a half-powered chip. */
+  _macPwrCtrlOn = false;
+  return ok;
+}
+
 bool HalModule::InitPowerOn() {
   if (_macPwrCtrlOn) {
     return true;

--- a/src/jaguar1/HalModule.h
+++ b/src/jaguar1/HalModule.h
@@ -67,10 +67,20 @@ public:
             Logger_t logger, const devourer::DeviceConfig &cfg = {});
   bool rtw_hal_init(SelectedChannel selectedChannel);
   const devourer::FwBootStatus &GetFwBootStatus() const { return _fwBoot; }
+  /* Halt TRX and run the chip's card-disable power sequence, leaving it powered
+   * down but re-enumerable — the counterpart to rtw_hal_init, and what every
+   * other generation already does (HalJaguar2::power_off,
+   * HalJaguar3::rtw_hal_deinit). Without it a Jaguar1 chip stays in ACT with
+   * the RF front end live for as long as the adapter is plugged in, long after
+   * the session that brought it up has exited. Best-effort: a chip that has
+   * already left the bus makes these writes fail, which is fine. */
+  void rtw_hal_deinit();
 
 private:
   bool rtl8812au_hal_init(uint8_t init_channel);
   bool InitPowerOn();
+  /* Card-disable power sequence (ACT -> CARDEMU -> PDN) for the current die. */
+  bool PowerOff();
   bool InitLLTTable8812A(uint8_t txpktbuf_bndy);
   bool _LLTWrite_8812A(uint32_t address, uint32_t data);
   void _InitHardwareDropIncorrectBulkOut_8812A();

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -1856,7 +1856,25 @@ bool RtlJaguarDevice::NetDevOpen(SelectedChannel selectedChannel) {
   return true;
 }
 
-void RtlJaguarDevice::Stop() { _device.quiesce_tx(); }
+/* Clean shutdown — see IRtlDevice::Stop. Quiesce TX first so the de-init writes
+ * are not racing frames the transport still owns, then power the chip down.
+ *
+ * The power-down is the point: without it a Jaguar1 chip stays in ACT with its
+ * RF front end live for as long as the adapter is plugged in, heating across
+ * back-to-back sessions until the dense constellations stop decoding while the
+ * robust rates carry on. It also means a beacon loaded into the MAC's reserved
+ * page stops airing when the session ends instead of transmitting forever.
+ *
+ * Best-effort: a chip that already dropped off the bus makes the writes fail,
+ * which is fine on a teardown path. */
+void RtlJaguarDevice::Stop() {
+  _device.quiesce_tx();
+  try {
+    _halModule.rtw_hal_deinit();
+  } catch (...) {
+    _logger->info("Jaguar1: Stop() de-init writes failed (chip already gone?)");
+  }
+}
 
 RtlJaguarDevice::~RtlJaguarDevice() {
   /* First, before any member starts unwinding: the async bulk-OUT URBs point
@@ -1878,6 +1896,14 @@ RtlJaguarDevice::~RtlJaguarDevice() {
   _rxmask_stop.store(true);
   if (_rxmask_thread.joinable()) {
     _rxmask_thread.join();
+  }
+  /* Backstop for a caller that destroys without Stop(): power the chip down so
+   * it is not left in ACT heating itself indefinitely. After the thread joins,
+   * so nothing is still touching the chip. Harmless if Stop() already ran. */
+  try {
+    _halModule.rtw_hal_deinit();
+  } catch (...) {
+    /* Teardown path — a chip that already left the bus is not an error. */
   }
 }
 

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -1860,10 +1860,14 @@ bool RtlJaguarDevice::NetDevOpen(SelectedChannel selectedChannel) {
  * are not racing frames the transport still owns, then power the chip down.
  *
  * The power-down is the point: without it a Jaguar1 chip stays in ACT with its
- * RF front end live for as long as the adapter is plugged in, heating across
- * back-to-back sessions until the dense constellations stop decoding while the
- * robust rates carry on. It also means a beacon loaded into the MAC's reserved
- * page stops airing when the session ends instead of transmitting forever.
+ * RF front end live for as long as the adapter is plugged in, long after the
+ * owning process has exited — which is both wrong on its own terms and what
+ * every other generation already avoids. Measured consequence: a 60 s idle
+ * recovers MCS7 delivery from 73% to 86% only once this exists; before it,
+ * idling recovered nothing (docs/warm-tx-degradation.md, which also records why
+ * the *reason* removing power helps is still open). It also means a beacon
+ * loaded into the MAC's reserved page stops airing when the session ends
+ * instead of transmitting forever.
  *
  * Best-effort: a chip that already dropped off the bus makes the writes fail,
  * which is fine on a teardown path. */

--- a/tests/README.md
+++ b/tests/README.md
@@ -462,6 +462,25 @@ substitute the in-tree `rtw88` for the vendor driver: it accepts frames on a
 monitor netdev and reports them injected while airing nothing decodable, which
 reads as a kernel-side failure at every rate.
 
+### `warm_tx_degradation_repro.sh`: chip temperature vs usable modulation
+
+Holds one ground receiver up for a whole run so the reference never moves, then
+alternates probes with warm devourer sessions, recording delivery at a test rate
+and a robust control rate alongside the chip's thermal meter and the receiver's
+RSSI/EVM. Two controls close it: an idle with no power cycle, and a VBUS cycle.
+
+```bash
+sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
+     tests/warm_tx_degradation_repro.sh
+# WARM_PWR=63 WARM_GAP=0 makes the warm sessions max-power/max-duty heating
+```
+
+Reading it: falling delivery with **flat RSSI and rising thermal** is heat (a
+hot die loses the dense constellations first); falling delivery with **falling
+RSSI** would be a transmitter losing power, a different bug. Measured on an
+8812AU, thermal 43 → 53 costs MCS7 ~12 points at unchanged RSSI. Full results
+and the fix: `docs/warm-tx-degradation.md`.
+
 ### `tx_teardown_asan.sh` / `teardown_gen_sanity.sh`: lifetime bugs on real hardware
 
 A sanitizer only sees what runs, and the interesting lifetime bugs live in the

--- a/tests/README.md
+++ b/tests/README.md
@@ -462,24 +462,36 @@ substitute the in-tree `rtw88` for the vendor driver: it accepts frames on a
 monitor netdev and reports them injected while airing nothing decodable, which
 reads as a kernel-side failure at every rate.
 
-### `warm_tx_degradation_repro.sh`: chip temperature vs usable modulation
+### Warm-session TX degradation: four harnesses, and start with the first
 
-Holds one ground receiver up for a whole run so the reference never moves, then
-alternates probes with warm devourer sessions, recording delivery at a test rate
-and a robust control rate alongside the chip's thermal meter and the receiver's
-RSSI/EVM. Two controls close it: an idle with no power cycle, and a VBUS cycle.
+**`probe_repeatability.sh` — run this before believing any delivery
+difference.** N identical back-to-back probes with nothing changed between them,
+reporting the spread. On an 8812AU a single MCS7/20 probe has sd 1.8 and a
+5.7-point range (the MCS1 control: 98.0 ± 0.2), so **effects under ~4 points are
+not detectable one-shot**. Several plausible-looking decay curves in this
+investigation turned out to sit inside that band.
 
 ```bash
 sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
-     tests/warm_tx_degradation_repro.sh
-# WARM_PWR=63 WARM_GAP=0 makes the warm sessions max-power/max-duty heating
+     tests/probe_repeatability.sh
 ```
 
-Reading it: falling delivery with **flat RSSI and rising thermal** is heat (a
-hot die loses the dense constellations first); falling delivery with **falling
-RSSI** would be a transmitter losing power, a different bug. Measured on an
-8812AU, thermal 43 → 53 costs MCS7 ~12 points at unchanged RSSI. Full results
-and the fix: `docs/warm-tx-degradation.md`.
+`warm_tx_degradation_repro.sh` holds one ground receiver up for a whole run,
+then alternates probes with warm devourer sessions, recording delivery at a test
+and a control rate alongside the chip thermal meter and the receiver's RSSI/EVM.
+Two controls close it: an idle with no power cycle, and a VBUS cycle.
+`WARM_PWR=63 WARM_GAP=0` turns the warm sessions into max-power/max-duty
+heating.
+
+`thermal_offtime_sweep.sh` and `thermal_causation_probe.sh` exist to separate
+*cooling* from *state reset*, which no ordinary power-cycle experiment can do —
+the first varies only how long the chip stays powered down, the second measures
+delivery inside a single uninterrupted session where nothing but temperature can
+move. Both currently argue **against** a thermal explanation; the mechanism is
+open. Results and what did not survive testing: `docs/warm-tx-degradation.md`.
+
+Reading any of them: falling delivery with **flat RSSI** is signal quality;
+falling RSSI would be a transmitter losing power, a different bug.
 
 ### `tx_teardown_asan.sh` / `teardown_gen_sanity.sh`: lifetime bugs on real hardware
 

--- a/tests/probe_repeatability.sh
+++ b/tests/probe_repeatability.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# What is the run-to-run scatter of a single delivery probe, with NOTHING
+# changed between runs?
+#
+# This is the measurement that should have come first. Every conclusion drawn
+# from the warm-degradation work — the decay curve, the recovery, the thermal
+# correlation — is a difference of a few points between probes. None of it means
+# anything unless a probe repeated under identical conditions lands in a tighter
+# band than the effect being claimed.
+#
+# So: one ground receiver up for the whole run, one DUT, N identical probes
+# back to back, no power cycling, no config change, no re-tuning. Report the
+# spread. Any claimed effect smaller than this band is not a finding.
+#
+#   sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
+#        tests/probe_repeatability.sh
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+TXDEMO="$ROOT/build/txdemo"
+RXDEMO="$ROOT/build/rxdemo"
+
+DUT_VID=${DUT_VID:-0x0bda} DUT_PID=${DUT_PID:-0x8812}
+GND_VID=${GND_VID:-0x2357} GND_PID=${GND_PID:-0x012d}
+CH=${CH:-6}
+RATES=${RATES:-"MCS7/20 MCS1/20"}
+REPS=${REPS:-10}
+SECS=${SECS:-6}
+OUT=${OUT:-/tmp/devourer-probe-repeat}
+
+mkdir -p "$OUT"
+RXLOG="$OUT/ground.rx.jsonl"
+: > "$OUT/results.tsv"
+
+RXPID=""
+cleanup() {
+  [ -n "$RXPID" ] && kill "$RXPID" 2>/dev/null
+  pkill -x txdemo 2>/dev/null
+  wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+cold_cycle() {
+  local map=${REGRESS_VBUS_MAP:-} key entry hubport
+  [ -n "$map" ] || return 0
+  key=$(printf '%s:%s' "${1#0x}" "${2#0x}")
+  entry=$(tr ';' '\n' <<<"$map" | grep -i "^$key=" | head -1) || return 0
+  hubport=${entry#*=}
+  sudo uhubctl -l "${hubport%,*}" -p "${hubport#*,}" -a cycle -d 3 >/dev/null 2>&1
+  sleep 12
+}
+
+probe() { # $1=rate $2=tag -> "delivered sent thermal rssi"
+  local rate="$1" tag="$2" off0 off1 sent therm
+  off0=$(stat -c%s "$RXLOG")
+  sudo env DEVOURER_VID="$DUT_VID" DEVOURER_PID="$DUT_PID" \
+    DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$rate" \
+    DEVOURER_TX_GAP_US=2000 DEVOURER_THERMAL_POLL_MS=500 \
+    DEVOURER_LOG_LEVEL=warn \
+    timeout --signal=TERM $((SECS + 12)) "$TXDEMO" \
+    > "$OUT/tx_$tag.jsonl" 2>"$OUT/tx_$tag.err" &
+  local p=$!
+  sleep $((SECS + 6))
+  kill -TERM "$p" 2>/dev/null; wait "$p" 2>/dev/null
+  sleep 1
+  off1=$(stat -c%s "$RXLOG")
+  sent=$(grep -o '"submitted":[0-9]*' "$OUT/tx_$tag.jsonl" | tail -1 | cut -d: -f2)
+  therm=$(grep -o '"raw":[0-9]*' "$OUT/tx_$tag.jsonl" | tail -1 | cut -d: -f2)
+  python3 - "$RXLOG" "$off0" "$off1" "${sent:-0}" "${therm:-0}" <<'EOF'
+import sys
+sys.path.insert(0, "tests")
+from devourer_events import parse_event
+f = open(sys.argv[1], "rb"); f.seek(int(sys.argv[2]))
+blob = f.read(int(sys.argv[3]) - int(sys.argv[2])).decode(errors="replace")
+frames, rssi = 0, []
+for line in blob.splitlines():
+    ev = parse_event(line, "rx.energy")
+    if not ev:
+        continue
+    n = int(ev.get("frames") or 0)
+    frames += n
+    if n and ev.get("rssi_mean"):
+        rssi.append(ev["rssi_mean"])
+print("%d %s %s %.0f" % (frames, sys.argv[4], sys.argv[5],
+                         sum(rssi) / len(rssi) if rssi else 0))
+EOF
+}
+
+cold_cycle "$GND_VID" "$GND_PID"
+DEVOURER_VID="$GND_VID" DEVOURER_PID="$GND_PID" DEVOURER_CHANNEL="$CH" \
+DEVOURER_RX_AGG_SA=canon DEVOURER_RX_ENERGY_MS=500 DEVOURER_LOG_LEVEL=warn \
+"$RXDEMO" > "$RXLOG" 2>"$OUT/ground.rx.stderr" &
+RXPID=$!
+sleep 9
+kill -0 "$RXPID" 2>/dev/null || { echo "ground RX died" >&2; exit 1; }
+
+cold_cycle "$DUT_VID" "$DUT_PID"
+
+for RATE in $RATES; do
+  echo
+  echo "== $RATE, $REPS identical probes, nothing changed between them"
+  printf '  %-5s %-9s %-8s %-6s\n' "rep" "delivery" "thermal" "rssi"
+  for i in $(seq 1 "$REPS"); do
+    read -r d s th rs <<<"$(probe "$RATE" "${RATE//\//-}_$i")"
+    pct=$(python3 -c "print('%.1f' % (100*$d/$s) if $s else 0)")
+    printf '  %-5s %-9s %-8s %-6s\n' "$i" "$pct%" "$th" "$rs"
+    printf '%s\t%s\t%s\t%s\t%s\n' "$RATE" "$i" "$pct" "$th" "$rs" >> "$OUT/results.tsv"
+  done
+  python3 - "$OUT/results.tsv" "$RATE" <<'EOF'
+import sys, statistics as st
+rate = sys.argv[2]
+v = [float(l.split("\t")[2]) for l in open(sys.argv[1])
+     if l.split("\t")[0] == rate]
+if len(v) > 1:
+    sd = st.stdev(v)
+    print("  -> mean %.1f%%  sd %.1f  range %.1f-%.1f  spread %.1f points"
+          % (st.mean(v), sd, min(v), max(v), max(v) - min(v)))
+    print("     an effect smaller than ~%.0f points (2 sd) is not detectable "
+          "with a single probe" % (2 * sd))
+EOF
+done

--- a/tests/thermal_causation_probe.sh
+++ b/tests/thermal_causation_probe.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Does chip TEMPERATURE cause the high-rate delivery loss, or does chip STATE?
+#
+# The obvious experiments cannot tell those apart. A VBUS cycle resets state AND
+# cools the part. A card-disable at teardown resets state AND lets the part cool.
+# Anything that recovers delivery by removing power is consistent with both
+# stories, so none of it is proof.
+#
+# This is the discriminator: measure delivery WITHIN ONE UNINTERRUPTED SESSION.
+# One bring-up, one channel set, one calibration, one TX config, never torn down
+# and never re-inited. Across the run the only thing that changes is how hot the
+# die is. If delivery decays as the thermal meter climbs, temperature is doing
+# it, because nothing else moved.
+#
+# The control leg is the same session at a robust rate. Heating is identical;
+# if the decay were something time-dependent but not thermal (a leaking counter,
+# a drifting receiver, ambient), it would drag the control down too. A decay
+# that appears ONLY at the dense constellation is the thermal signature.
+#
+#   sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
+#        tests/thermal_causation_probe.sh
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+TXDEMO="$ROOT/build/txdemo"
+RXDEMO="$ROOT/build/rxdemo"
+
+DUT_VID=${DUT_VID:-0x0bda} DUT_PID=${DUT_PID:-0x8812}
+GND_VID=${GND_VID:-0x2357} GND_PID=${GND_PID:-0x012d}
+CH=${CH:-6}
+RATES=${RATES:-"MCS7/20 MCS1/20"}   # first = test (near the cliff), second = control
+SECS=${SECS:-240}                   # one continuous session per rate
+BIN=${BIN:-20}                      # seconds per reporting bin
+OUT=${OUT:-/tmp/devourer-thermal-causation}
+
+mkdir -p "$OUT"
+RXLOG="$OUT/ground.rx.jsonl"
+
+RXPID=""
+cleanup() {
+  [ -n "$RXPID" ] && kill "$RXPID" 2>/dev/null
+  pkill -x txdemo 2>/dev/null
+  wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+cold_cycle() { # $1=vid $2=pid
+  local map=${REGRESS_VBUS_MAP:-} key entry hubport
+  [ -n "$map" ] || { echo "REGRESS_VBUS_MAP unset" >&2; return 1; }
+  key=$(printf '%s:%s' "${1#0x}" "${2#0x}")
+  entry=$(tr ';' '\n' <<<"$map" | grep -i "^$key=" | head -1) || true
+  [ -n "${entry:-}" ] || { echo "no VBUS entry for $key" >&2; return 1; }
+  hubport=${entry#*=}
+  sudo uhubctl -l "${hubport%,*}" -p "${hubport#*,}" -a cycle -d 3 >/dev/null 2>&1
+  sleep 12
+}
+
+cold_cycle "$GND_VID" "$GND_PID" || exit 1
+DEVOURER_VID="$GND_VID" DEVOURER_PID="$GND_PID" DEVOURER_CHANNEL="$CH" \
+DEVOURER_RX_AGG_SA=canon DEVOURER_RX_ENERGY_MS=1000 DEVOURER_LOG_LEVEL=warn \
+"$RXDEMO" > "$RXLOG" 2>"$OUT/ground.rx.stderr" &
+RXPID=$!
+sleep 9
+kill -0 "$RXPID" 2>/dev/null || { echo "ground RX died" >&2; exit 1; }
+
+for RATE in $RATES; do
+  TAG="${RATE//\//-}"
+  echo
+  echo "== single uninterrupted session: $RATE, ${SECS}s, max duty, ch$CH"
+  echo "   (one bring-up, no re-init, no power cycle — only temperature moves)"
+  cold_cycle "$DUT_VID" "$DUT_PID" || exit 1
+  OFF0=$(stat -c%s "$RXLOG")
+  sudo env DEVOURER_VID="$DUT_VID" DEVOURER_PID="$DUT_PID" \
+    DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$RATE" \
+    DEVOURER_TX_GAP_US=0 DEVOURER_TX_PAYLOAD_BYTES=1024 \
+    DEVOURER_THERMAL_POLL_MS=1000 DEVOURER_LOG_LEVEL=warn \
+    timeout --signal=TERM $((SECS + 15)) "$TXDEMO" \
+    > "$OUT/tx_$TAG.jsonl" 2>"$OUT/tx_$TAG.err" &
+  TXP=$!
+  sleep $((SECS + 8))
+  kill -TERM "$TXP" 2>/dev/null; wait "$TXP" 2>/dev/null
+  sleep 1
+  OFF1=$(stat -c%s "$RXLOG")
+
+  python3 - "$RXLOG" "$OFF0" "$OFF1" "$OUT/tx_$TAG.jsonl" "$BIN" "$RATE" <<'EOF'
+import sys
+sys.path.insert(0, "tests")
+from devourer_events import parse_event
+
+rxlog, off0, off1, txlog, binsec, rate = sys.argv[1:7]
+binsec = int(binsec)
+
+f = open(rxlog, "rb"); f.seek(int(off0))
+blob = f.read(int(off1) - int(off0)).decode(errors="replace")
+
+# rx.energy carries a monotonic ms timestamp; bin delivered frames by it.
+bins, t0 = {}, None
+for line in blob.splitlines():
+    ev = parse_event(line, "rx.energy")
+    if not ev or ev.get("t") is None:
+        continue
+    t = int(ev["t"])
+    if t0 is None:
+        t0 = t
+    bins.setdefault((t - t0) // (binsec * 1000), [0, 0])
+    b = bins[(t - t0) // (binsec * 1000)]
+    b[0] += int(ev.get("frames") or 0)
+    b[1] += 1
+
+# Thermal samples, binned the same way off the TX session's own clock.
+th, n = {}, 0
+for line in open(txlog, errors="replace"):
+    ev = parse_event(line, "thermal")
+    if not ev:
+        continue
+    th.setdefault(n // binsec, []).append(int(ev.get("raw") or 0))
+    n += 1
+
+print("  %-10s %10s %10s   %s" % ("t(s)", "frames/s", "thermal", ""))
+ks = sorted(k for k in bins if bins[k][1] >= max(1, binsec // 2))
+base = None
+for k in ks:
+    fr, wins = bins[k]
+    rateps = fr / (wins * 1.0)          # rx.energy window = 1000 ms
+    t = th.get(k, [])
+    tm = sum(t) / len(t) if t else 0
+    if base is None and rateps > 0:
+        base = rateps
+    rel = (rateps / base * 100) if base else 0
+    bar = "#" * int(rel / 4)
+    print("  %-10d %10.0f %10.0f   %5.1f%% %s" % (k * binsec, rateps, tm, rel, bar))
+if base and ks:
+    last = bins[ks[-1]]
+    lastps = last[0] / last[1]
+    print("  -> %s: %.0f -> %.0f frames/s over %ds (%.1f%% of start)"
+          % (rate, base, lastps, ks[-1] * binsec, lastps / base * 100))
+EOF
+done

--- a/tests/thermal_offtime_sweep.sh
+++ b/tests/thermal_offtime_sweep.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Cooling, or state reset? Sweep how LONG the chip stays powered down.
+#
+# Every recovery observed so far removes power, and removing power does two
+# things at once: it resets chip state and it lets the die cool. No experiment
+# that simply power-cycles can tell those apart, which is why "it is thermal"
+# was not proven by any of them.
+#
+# This separates them. Degrade the part, then power it down for N seconds and
+# probe immediately on the way back up. The state reset is BIT-IDENTICAL for
+# every N — same VBUS cycle, same enumeration, same bring-up, same calibration.
+# The only thing that varies is how long the die had to cool.
+#
+#   delivery rises with N        -> cooling is doing the work (thermal)
+#   delivery flat across N       -> the reset is doing the work (state)
+#
+# Off-times are swept in a deliberately non-monotonic order so a slow drift in
+# the ambient channel cannot masquerade as the trend.
+#
+#   sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
+#        tests/thermal_offtime_sweep.sh
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+TXDEMO="$ROOT/build/txdemo"
+RXDEMO="$ROOT/build/rxdemo"
+
+DUT_VID=${DUT_VID:-0x0bda} DUT_PID=${DUT_PID:-0x8812}
+GND_VID=${GND_VID:-0x2357} GND_PID=${GND_PID:-0x012d}
+CH=${CH:-6}
+RATE=${RATE:-MCS7/20}
+CTRL=${CTRL:-MCS1/20}
+HEAT_SECS=${HEAT_SECS:-90}          # max-duty soak before each off-time
+OFF_TIMES=${OFF_TIMES:-"5 60 15 120 30"}   # non-monotonic on purpose
+SECS=${SECS:-6}
+OUT=${OUT:-/tmp/devourer-offtime-sweep}
+
+mkdir -p "$OUT"
+RXLOG="$OUT/ground.rx.jsonl"
+: > "$OUT/results.tsv"
+
+RXPID=""
+cleanup() {
+  [ -n "$RXPID" ] && kill "$RXPID" 2>/dev/null
+  pkill -x txdemo 2>/dev/null
+  wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+hubport_for() { # $1=vid $2=pid -> "hub port"
+  local map=${REGRESS_VBUS_MAP:-} key entry
+  key=$(printf '%s:%s' "${1#0x}" "${2#0x}")
+  entry=$(tr ';' '\n' <<<"$map" | grep -i "^$key=" | head -1) || return 1
+  local hp=${entry#*=}
+  printf '%s %s' "${hp%,*}" "${hp#*,}"
+}
+
+read -r DUT_HUB DUT_PORT <<<"$(hubport_for "$DUT_VID" "$DUT_PID")" || {
+  echo "no VBUS map entry for DUT" >&2; exit 1; }
+
+# Power the DUT off, hold for $1 seconds, power on. The hold is the variable
+# under test; everything else about the cycle is identical every time.
+power_off_for() {
+  sudo uhubctl -l "$DUT_HUB" -p "$DUT_PORT" -a off >/dev/null 2>&1
+  sleep "$1"
+  sudo uhubctl -l "$DUT_HUB" -p "$DUT_PORT" -a on >/dev/null 2>&1
+  sleep 8   # enumeration; identical for every arm
+}
+
+probe() { # $1=rate $2=tag -> "delivered/sent thermal"
+  local rate="$1" tag="$2" off0 off1 sent delivered therm
+  off0=$(stat -c%s "$RXLOG")
+  sudo env DEVOURER_VID="$DUT_VID" DEVOURER_PID="$DUT_PID" \
+    DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$rate" \
+    DEVOURER_TX_GAP_US=2000 DEVOURER_THERMAL_POLL_MS=500 \
+    DEVOURER_LOG_LEVEL=warn \
+    timeout --signal=TERM $((SECS + 12)) "$TXDEMO" \
+    > "$OUT/tx_$tag.jsonl" 2>"$OUT/tx_$tag.err" &
+  local p=$!
+  sleep $((SECS + 6))
+  kill -TERM "$p" 2>/dev/null; wait "$p" 2>/dev/null
+  sleep 1
+  off1=$(stat -c%s "$RXLOG")
+  sent=$(grep -o '"submitted":[0-9]*' "$OUT/tx_$tag.jsonl" | tail -1 | cut -d: -f2)
+  # FIRST thermal sample of the session — the coldest point, i.e. what the die
+  # actually cooled to during the off-time, before this probe reheats it.
+  therm=$(grep -o '"raw":[0-9]*' "$OUT/tx_$tag.jsonl" | head -1 | cut -d: -f2)
+  delivered=$(python3 - "$RXLOG" "$off0" "$off1" <<'EOF'
+import sys
+sys.path.insert(0, "tests")
+from devourer_events import parse_event
+f = open(sys.argv[1], "rb"); f.seek(int(sys.argv[2]))
+blob = f.read(int(sys.argv[3]) - int(sys.argv[2])).decode(errors="replace")
+print(sum(int(ev.get("frames") or 0)
+          for ev in (parse_event(l, "rx.energy") for l in blob.splitlines()) if ev))
+EOF
+)
+  printf '%s/%s %s' "${delivered:-0}" "${sent:-0}" "${therm:-0}"
+}
+
+heat() {
+  sudo env DEVOURER_VID="$DUT_VID" DEVOURER_PID="$DUT_PID" \
+    DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$RATE" DEVOURER_TX_PWR=63 \
+    DEVOURER_TX_GAP_US=0 DEVOURER_TX_PAYLOAD_BYTES=1024 \
+    DEVOURER_LOG_LEVEL=warn \
+    timeout --signal=TERM $((HEAT_SECS + 10)) "$TXDEMO" >/dev/null 2>&1 &
+  local p=$!
+  sleep "$HEAT_SECS"
+  kill -TERM "$p" 2>/dev/null; wait "$p" 2>/dev/null
+}
+
+# Ground station up once for the whole sweep — the reference must not move.
+sudo uhubctl -l "$(hubport_for "$GND_VID" "$GND_PID" | cut -d' ' -f1)" \
+     -p "$(hubport_for "$GND_VID" "$GND_PID" | cut -d' ' -f2)" \
+     -a cycle -d 3 >/dev/null 2>&1
+sleep 12
+DEVOURER_VID="$GND_VID" DEVOURER_PID="$GND_PID" DEVOURER_CHANNEL="$CH" \
+DEVOURER_RX_AGG_SA=canon DEVOURER_RX_ENERGY_MS=500 DEVOURER_LOG_LEVEL=warn \
+"$RXDEMO" > "$RXLOG" 2>"$OUT/ground.rx.stderr" &
+RXPID=$!
+sleep 9
+kill -0 "$RXPID" 2>/dev/null || { echo "ground RX died" >&2; exit 1; }
+
+echo "off-time sweep — identical reset every arm, only cooling time varies"
+echo "  DUT $DUT_VID:$DUT_PID  heat ${HEAT_SECS}s max-duty, then power off for N"
+echo
+printf '  %-10s %-10s %-10s %-8s\n' "off(s)" "$RATE" "$CTRL" "thermal"
+for N in $OFF_TIMES; do
+  heat
+  power_off_for "$N"
+  t=$(probe "$RATE" "off${N}")
+  c=$(probe "$CTRL" "off${N}_ctrl")
+  read -r t_ds t_th <<<"$t"
+  read -r c_ds _ <<<"$c"
+  pct=$(python3 -c "d,s='$t_ds'.split('/'); print('%.1f%%'%(100*int(d)/int(s)) if int(s) else 'n/a')")
+  cpct=$(python3 -c "d,s='$c_ds'.split('/'); print('%.1f%%'%(100*int(d)/int(s)) if int(s) else 'n/a')")
+  printf '  %-10s %-10s %-10s %-8s\n' "$N" "$pct" "$cpct" "$t_th"
+  printf '%s\t%s\t%s\n' "$N" "$t" "$c" >> "$OUT/results.tsv"
+done
+
+echo
+echo "read: delivery rising with off-time => cooling (thermal);"
+echo "      delivery flat across off-time => the reset, not the cooling."

--- a/tests/warm_tx_degradation_repro.sh
+++ b/tests/warm_tx_degradation_repro.sh
@@ -67,14 +67,25 @@ cold_cycle() { # $1=vid $2=pid
 }
 
 # One devourer TX session at $1, measured against the standing ground receiver.
-# Echoes "delivered/sent".
+# Echoes "delivered/sent thermal_raw rssi evm".
+#
+# The three extra channels are what separate the candidate mechanisms, and the
+# whole point of running this before changing any library code:
+#   thermal_raw  the chip's own RF 0x42 meter. The adapter is never powered
+#                down between sessions, so it never cools; a monotonic rise
+#                that falls after a VBUS cycle means heat, not latched state.
+#   rssi         falling RSSI means the transmitter is losing POWER; RSSI flat
+#                while the high rates die means it is losing signal QUALITY
+#                (EVM / phase noise) at unchanged power. Different fixes.
+#   evm          the receiver's own quality estimate, as a cross-check on rssi.
 probe() {
-  local rate=$1 tag=$2
-  local off0 off1 sent delivered
+  local rate="$1" tag="$2"
+  local off0 off1 sent delivered stats
   off0=$(stat -c%s "$RXLOG")
   sudo env DEVOURER_VID="$DUT_VID" DEVOURER_PID="$DUT_PID" \
     DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$rate" \
-    DEVOURER_TX_GAP_US=2000 DEVOURER_LOG_LEVEL=warn \
+    DEVOURER_TX_GAP_US=2000 DEVOURER_THERMAL_POLL_MS="${THERM_MS:-1000}" \
+    DEVOURER_LOG_LEVEL=warn \
     timeout --signal=TERM $((SECS + 12)) "$TXDEMO" \
     > "$OUT/tx_$tag.jsonl" 2>"$OUT/tx_$tag.err" &
   local p=$!
@@ -83,21 +94,38 @@ probe() {
   sleep 1
   off1=$(stat -c%s "$RXLOG")
   sent=$(grep -o '"submitted":[0-9]*' "$OUT/tx_$tag.jsonl" | tail -1 | cut -d: -f2)
-  delivered=$(python3 - "$RXLOG" "$off0" "$off1" <<'EOF'
+  # Last thermal reading of the session — the warmest point, i.e. the one that
+  # would matter if heat is the mechanism.
+  local therm
+  therm=$(grep -o '"raw":[0-9]*' "$OUT/tx_$tag.jsonl" | tail -1 | cut -d: -f2)
+  stats=$(python3 - "$RXLOG" "$off0" "$off1" <<'EOF'
 import sys
 sys.path.insert(0, "tests")
 from devourer_events import parse_event
 f = open(sys.argv[1], "rb"); f.seek(int(sys.argv[2]))
 blob = f.read(int(sys.argv[3]) - int(sys.argv[2])).decode(errors="replace")
-n = 0
+frames = 0
+rssi, evm = [], []
 for line in blob.splitlines():
     ev = parse_event(line, "rx.energy")
-    if ev:
-        n += int(ev.get("frames") or 0)
-print(n)
+    if not ev:
+        continue
+    n = int(ev.get("frames") or 0)
+    frames += n
+    # Average only over windows that actually carried frames — an empty window
+    # reports rssi/evm as 0 and would drag the mean toward zero.
+    if n:
+        if ev.get("rssi_mean"):
+            rssi.append(ev["rssi_mean"])
+        if ev.get("evm_mean"):
+            evm.append(ev["evm_mean"])
+mean = lambda a: (sum(a) / len(a)) if a else 0
+print("%d %.0f %.0f" % (frames, mean(rssi), mean(evm)))
 EOF
 )
-  printf '%s/%s' "${delivered:-0}" "${sent:-0}"
+  read -r delivered rssi evm <<<"$stats"
+  printf '%s/%s %s %s %s' "${delivered:-0}" "${sent:-0}" "${therm:-0}" \
+      "${rssi:-0}" "${evm:-0}"
 }
 
 # A warm session: full devourer bring-up + TX + teardown, no power cycle. This
@@ -117,17 +145,23 @@ warm_session() {
   sleep 1
 }
 
-report() { # $1=label $2=test-result $3=control-result
-  local pct
+# $1=label, $2/$3 = probe output for the test and control rate
+# ("delivered/sent thermal rssi evm").
+report() {
+  local label="$1" t="$2" c="$3"
+  local t_ds t_therm t_rssi t_evm c_ds
+  read -r t_ds t_therm t_rssi t_evm <<<"$t"
+  read -r c_ds _ _ _ <<<"$c"
+  local pct cpct
   pct=$(python3 -c "
-d,s='$2'.split('/')
+d,s='$t_ds'.split('/')
 print('%.1f%%' % (100*int(d)/int(s)) if int(s) else 'n/a')")
-  local cpct
   cpct=$(python3 -c "
-d,s='$3'.split('/')
+d,s='$c_ds'.split('/')
 print('%.1f%%' % (100*int(d)/int(s)) if int(s) else 'n/a')")
-  printf '  %-34s %s %-9s   %s %-9s\n' "$1" "$RATE" "$pct" "$CTRL_RATE" "$cpct"
-  printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$OUT/results.tsv"
+  printf '  %-32s %-8s %-8s  therm=%-3s rssi=%-3s evm=%s\n' \
+      "$label" "$pct" "$cpct" "$t_therm" "$t_rssi" "$t_evm"
+  printf '%s\t%s\t%s\n' "$label" "$t" "$c" >> "$OUT/results.tsv"
 }
 
 echo "warm-session TX degradation repro"
@@ -143,7 +177,7 @@ RXPID=$!
 sleep 9
 kill -0 "$RXPID" 2>/dev/null || { echo "ground RX died" >&2; exit 1; }
 
-printf '  %-34s %-14s   %s\n' "stage" "test rate" "control rate"
+printf '  %-32s %-8s %-8s  %s\n' "stage" "$RATE" "$CTRL_RATE" "chip/link sensors"
 cold_cycle "$DUT_VID" "$DUT_PID" || exit 1
 report "cold baseline" "$(probe "$RATE" cold)" "$(probe "$CTRL_RATE" cold_ctrl)"
 


### PR DESCRIPTION
Addresses the reproducible half of #348. **Note the title is now inaccurate** —
see "Mechanism: open" below; the fix stands, the explanation did not.

## What is fixed

A Jaguar1 session left the chip in the **ACT power state with the RF front end
live, indefinitely**, long after the owning process exited. Nothing else in the
tree does this: Jaguar2 resets at init, Jaguar3 has run a full card-disable at
teardown for a long time.

`Stop()` and the destructor now run `HalModule::rtw_hal_deinit()` — halt the MAC
engines (`REG_CR`, `REG_RCR`), then the die's card-disable power sequence,
through the same `HalPwrSeqCmdParsing` and the same three-way chip dispatch
`InitPowerOn` already uses. The tables (`rtl8812_card_disable_flow` and the
8814A/8821A equivalents) had been sitting in `hal/Hal88*PwrSeq.c` since the port
began with nothing calling them.

**Measured effect** — same repro, before and after:

| stage | before | after |
| --- | --- | --- |
| 60 s idle, **no** power cycle | thermal 48, MCS7 73.0% | thermal 40, MCS7 **85.8%** |

~13 points, about 7 sd against the measured noise floor. Before the fix, no
amount of idling recovered anything and only pulling VBUS helped.

The change is also justified independently of any performance argument: leaving
a radio powered and transmitting-capable after its owning process has exited is
wrong, it is what every other generation already avoids, and it is what makes an
autonomously-airing beacon stop at session end.

## Mechanism: open (a correction)

An earlier revision of this PR claimed the cause was chip temperature. **That
was correlation across sessions presented as causation, and it is retracted.**
Every recovery that works removes power, and removing power resets chip state
*and* lets the die cool — no power-cycle experiment separates them. Two
harnesses added here try to, and both argue against cooling:

- **`thermal_offtime_sweep.sh`** — degrade, then power down for 5/15/30/60/120 s
  before an otherwise identical probe. Reset bit-identical in every arm; only
  cooling time varies. Temperature fell cleanly with off-time (47 → 40) but
  delivery scattered 63–83% with **no relation to off-time or temperature** —
  best result from the *shortest* off-time and the *hottest* chip.
- **`thermal_causation_probe.sh`** — delivery inside a single uninterrupted
  session (one bring-up, no re-init, no state change). Thermal stayed **pinned**
  through 240 s of max-duty TX while MCS7 drifted ~10% and the control held flat.

Heat remains a real correlate within one probe sequence (thermal 39 → 45 costing
~5 points, control flat, RSSI unchanged) and is demonstrably not the driver
above. The docs now say the mechanism is open rather than asserting it.

## Know the noise floor

**`probe_repeatability.sh`** is the measurement that should have come first: ten
identical back-to-back probes, nothing changed between them.

| | mean | sd | range |
| --- | --- | --- | --- |
| MCS7/20 | 67.3% | **1.8** | 65.0 – 70.7 |
| MCS1/20 control | 98.0% | 0.2 | 97.5 – 98.3 |

A single probe is worth ±3 points, so **effects under ~4 points are not
findings** — and several plausible-looking decay curves in this investigation sat
inside that band. This is now documented in `CLAUDE.md` as a bench rule.

## Behaviour change

A beacon in the MAC's reserved page now stops when the session ends instead of
airing until re-enumeration. Matches Jaguar3 and the vendor driver; `CLAUDE.md`
updated.

## Testing

- 8812AU, 8814AU, 8821AU each re-init cleanly across three consecutive sessions
  after the power-down.
- `teardown_gen_sanity.sh` 10/10 across every plugged generation.
- `tx_teardown_asan.sh` 6/6 including max-duty kills — the case that matters now
  that teardown writes registers while URBs may be in flight.
- `ctest` 48/48.

## Not included, deliberately

- **No in-flight recovery API.** Until the mechanism is understood there is
  nothing principled to implement.
- **No init-side power-off.** It runs immediately before power-on, so it buys
  nothing while adding risk to a working bring-up path.
- **Jaguar2 unchanged.** Audited and inconclusive — thermal did not move and the
  available link was too marginal at MCS7 to resolve a small effect. No
  measurement, no speculative change.

## Still open in #348

The severe form (MCS5/6/7 at 0% while MCS0–4 held ~88%) is unreproduced, the
mechanism is unresolved, and `SIGKILL` still leaves the chip powered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
