### PR TITLE
Qualify the receiver before believing a delivery number (#348 post-mortem; corrects two #349 measurements)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -631,16 +631,15 @@ generators, never the output files.
   before it means anything — several plausible-looking "decay curves" have
   turned out to sit inside that band. `tests/probe_repeatability.sh` measures
   the floor for a given pair; run it before believing a delivery difference.
-- **A hot 8812AU tends to lose the dense constellations while the robust rates
-  carry on**, and it is easy to over-read. Delivery does correlate with the
-  `thermal` meter within one probe sequence (39 → 45 costing MCS7 ~5 points,
-  control flat) — but a sweep that varied *only* cooling time, by powering the
-  chip down for 5–120 s before an otherwise identical probe, found delivery
-  scattered 63–83% with no relation to either off-time or temperature. So heat
-  is a real correlate and not a demonstrated cause. Read the `thermal` event
-  (`DEVOURER_THERMAL_POLL_MS`) beside any rate-ceiling number, VBUS-cycle per
-  cell, and repeat the cell — do not attribute a difference to temperature
-  without varying temperature independently.
+- **Do not attribute a rate ceiling to chip temperature without varying
+  temperature independently.** Delivery does correlate with the `thermal` meter
+  within a probe sequence, and that correlation is a trap: a sweep varying
+  *only* the power-off duration (identical reset every arm) found delivery
+  scattered 63–83% with no relation to off-time or temperature, and inside a
+  single uninterrupted session the meter stays pinned while delivery drifts.
+  Read the `thermal` event (`DEVOURER_THERMAL_POLL_MS`) beside a rate-ceiling
+  number by all means, but a power cycle changes chip state *and* temperature
+  together, so it can never separate them (`docs/warm-tx-degradation.md`).
 - **MediaTek Android hosts cap bulk-IN reads at 16 KB**: some MTK xhci/usbfs
   stacks (Dimensity 810, Helio G99, MT6765) never complete a larger bulk-IN
   transfer — `LIBUSB_ERROR_TIMEOUT` forever, zero RX with a green init

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -612,6 +612,18 @@ generators, never the output files.
   only helps when firmware state is intact.
 - **The chip retains state across soft re-init** — cold-bisect hardware
   problems with a VBUS power-cycle, not a re-run.
+- **Qualify the ground station before believing a delivery number.** Delivery is
+  a property of a *link*; a receiver whose modulation cliff sits at the rate
+  under test measures itself, not the transmitter, and swings between "fine" and
+  "zero" on a few dB of ambient while the robust rates stay pinned — which looks
+  exactly like a transmitter that degrades and recovers. Same TX, same channel,
+  minutes apart: a TP-Link Archer T3U (8822BU, **internal** antennas) ran
+  MCS3 97.8 / MCS4 98.3 / MCS5 79.1 / MCS6 49.0 / **MCS7 2.9**, while an
+  RTL8814AU (two **external** antennas) was flat at ~80% across the same ladder.
+  Both healthy — one just has less margin. `tests/ground_station_qualify.sh`
+  sweeps the ladder and refuses the pairing (exit 1) when the test rate is off
+  the flat part. Prefer external-antenna adapters as ground stations for
+  high-MCS work, and cross-check with a second, independent receiver.
 - **A single delivery probe is worth ±3 points, so small effects are not
   findings.** Ten identical back-to-back MCS7/20 probes on an 8812AU (nothing
   changed between them) gave sd 1.8 and a 5.7-point spread; the MCS1 control

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -612,17 +612,23 @@ generators, never the output files.
   only helps when firmware state is intact.
 - **The chip retains state across soft re-init** — cold-bisect hardware
   problems with a VBUS power-cycle, not a re-run.
-- **Chip temperature silently caps the usable modulation.** A hot 8812AU loses
-  the dense constellations first while the robust rates carry on: measured on
-  ch6/20 MHz, thermal meter 43 → 53 costs MCS7 (64-QAM) ~83% → ~71% delivery
-  with RSSI *flat*, i.e. no power is lost, only signal quality. Nothing logs an
-  error and the signature is indistinguishable from a link too weak to carry
-  the rate. Any rate-ceiling measurement must therefore control temperature —
-  VBUS-cycle per cell, and read the `thermal` event
-  (`DEVOURER_THERMAL_POLL_MS`) beside the delivery number.
-  `tests/warm_tx_degradation_repro.sh` is the reference method. Removing power
-  is what cools the part: on a chip left in ACT, 120 s of idle bought 4 thermal
-  units where a 12 s VBUS cycle bought 9.
+- **A single delivery probe is worth ±3 points, so small effects are not
+  findings.** Ten identical back-to-back MCS7/20 probes on an 8812AU (nothing
+  changed between them) gave sd 1.8 and a 5.7-point spread; the MCS1 control
+  over the same run held 98.0 ± 0.2. Anything under ~4 points needs repetition
+  before it means anything — several plausible-looking "decay curves" have
+  turned out to sit inside that band. `tests/probe_repeatability.sh` measures
+  the floor for a given pair; run it before believing a delivery difference.
+- **A hot 8812AU tends to lose the dense constellations while the robust rates
+  carry on**, and it is easy to over-read. Delivery does correlate with the
+  `thermal` meter within one probe sequence (39 → 45 costing MCS7 ~5 points,
+  control flat) — but a sweep that varied *only* cooling time, by powering the
+  chip down for 5–120 s before an otherwise identical probe, found delivery
+  scattered 63–83% with no relation to either off-time or temperature. So heat
+  is a real correlate and not a demonstrated cause. Read the `thermal` event
+  (`DEVOURER_THERMAL_POLL_MS`) beside any rate-ceiling number, VBUS-cycle per
+  cell, and repeat the cell — do not attribute a difference to temperature
+  without varying temperature independently.
 - **MediaTek Android hosts cap bulk-IN reads at 16 KB**: some MTK xhci/usbfs
   stacks (Dimensity 810, Helio G99, MT6765) never complete a larger bulk-IN
   transfer — `LIBUSB_ERROR_TIMEOUT` forever, zero RX with a green init

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -514,8 +514,11 @@ MAC-latched `tsfl` RX timestamp — on all generations, µs-grade
 (`docs/time-distribution.md`, measured vs NTP/PTP: `docs/timing-accuracy.md`).
 `StartBeacon` loads a beacon into the MAC's reserved page and the chip
 auto-transmits at each TBTT with the live TSF stamped at the TX instant — the
-sub-µs downlink. The chip beacons **autonomously**: a session that ends
-without a power-cycle must call `StopBeacon()` or the beacon keeps airing.
+sub-µs downlink. The chip beacons **autonomously**, so `StopBeacon()` is what
+stops it mid-session; a session that ends via `Stop()` or destruction powers the
+chip down and takes the beacon with it (Jaguar1/Jaguar3 — Jaguar2 has no
+teardown power-down yet, so there it keeps airing until the adapter is
+re-enumerated).
 `UpdateBeaconPayload` swaps the airing content in place (frame-atomic on air,
 TBTT-quantized latency); `PinBeaconTbtt` steers the TBTT to an absolute TSF
 instant without corrupting the clock (Jaguar1: offset 0 only — its TBTT is
@@ -608,14 +611,18 @@ generators, never the output files.
   After detaching a kernel driver, expect a cold re-init; `DEVOURER_SKIP_RESET`
   only helps when firmware state is intact.
 - **The chip retains state across soft re-init** — cold-bisect hardware
-  problems with a VBUS power-cycle, not a re-run. This is not only a bring-up
-  concern: **high-order constellation TX degrades across warm re-inits**. After
-  a run of back-to-back sessions an 8812AU delivered 0% at MCS7 (64-QAM) while
-  16-QAM and below still worked, and a VBUS cycle restored it to 58% at the
-  same channel, power and gap. Nothing logs an error, RSSI and EVM look
-  healthy, and the result is indistinguishable from a link too weak to carry
-  the rate — so any rate-ceiling measurement must cold-cycle per cell or it
-  measures accumulated chip state. An `authorized` toggle does not clear it.
+  problems with a VBUS power-cycle, not a re-run.
+- **Chip temperature silently caps the usable modulation.** A hot 8812AU loses
+  the dense constellations first while the robust rates carry on: measured on
+  ch6/20 MHz, thermal meter 43 → 53 costs MCS7 (64-QAM) ~83% → ~71% delivery
+  with RSSI *flat*, i.e. no power is lost, only signal quality. Nothing logs an
+  error and the signature is indistinguishable from a link too weak to carry
+  the rate. Any rate-ceiling measurement must therefore control temperature —
+  VBUS-cycle per cell, and read the `thermal` event
+  (`DEVOURER_THERMAL_POLL_MS`) beside the delivery number.
+  `tests/warm_tx_degradation_repro.sh` is the reference method. Removing power
+  is what cools the part: on a chip left in ACT, 120 s of idle bought 4 thermal
+  units where a 12 s VBUS cycle bought 9.
 - **MediaTek Android hosts cap bulk-IN reads at 16 KB**: some MTK xhci/usbfs
   stacks (Dimensity 810, Helio G99, MT6765) never complete a larger bulk-IN
   transfer — `LIBUSB_ERROR_TIMEOUT` forever, zero RX with a green init

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -705,6 +705,16 @@ add_executable(doctor
 target_include_directories(doctor PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/examples/common)
 target_link_libraries(doctor PUBLIC devourer PRIVATE PkgConfig::libusb)
 
+# chipstate — read a chip's registers without touching it: no USB reset, no
+# bring-up, no calibration. The only way to inspect the state a previous
+# session left behind, since every other entry point reconfigures the chip on
+# the way in and destroys exactly that evidence.
+add_executable(chipstate
+    examples/chipstate/main.cpp
+)
+target_include_directories(chipstate PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/examples/common)
+target_link_libraries(chipstate PUBLIC devourer PRIVATE PkgConfig::libusb)
+
 # Headless regression guard for the binary-stdin framing shared by the two
 # stream demos above (examples/common/stream_stdin.h). No libusb, no radio — just the
 # set_stdin_binary() + read_exact() path, so a text-mode regression (e.g. the

--- a/docs/vht-on-2g4.md
+++ b/docs/vht-on-2g4.md
@@ -12,7 +12,24 @@ Nothing gates this. Rate resolution never reads the band, so a VHT rate on a
 channel 6, or a radiotap VHT field on a per-packet basis. The receiver must be
 able to decode it; a standards-only 802.11n station sees nothing at all.
 
-## Read this first: cold-cycle or measure nothing
+## Read this first: qualify the receiver, or measure the receiver
+
+Delivery is a property of a *link*. A ground station whose modulation cliff sits
+at the rate under test reports its own limits, not the transmitter's — and it
+swings between "fine" and "zero" on a few dB of ambient while the robust rates
+stay pinned. Two RTL8822BU adapters, identical silicon and identical code, same
+transmitter and channel, differing only in antennas:
+
+| ground (both 8822BU) | MCS1 | MCS4 | MCS5 | MCS6 | MCS7 |
+| --- | --- | --- | --- | --- | --- |
+| TP-Link Archer T3U — **internal** antennas | 98.1 | 97.1 | 79.1 | 49.0 | **2.9** |
+| Comfast CF-924AC V2 — **two external** | 95.8 | 95.8 | 95.7 | 94.4 | **95.9** |
+
+Run `tests/ground_station_qualify.sh` before trusting any number here; it refuses
+the pairing when the test rate is off the flat part of the ladder. Every figure
+below was taken through a qualified receiver.
+
+## Cold-cycle too
 
 **High-order constellation TX degrades across warm re-inits.** After a run of
 back-to-back devourer sessions on the same adapter, 64-QAM and up stop decoding
@@ -47,16 +64,25 @@ frames, and every sampled `rx.txhit` decoded back to a rate so the receiver
 confirms *which* modulation arrived. A frame commanded as VHT that decodes as
 HT is a fallback, not a pass.
 
+Measured from an RTL8812AU into a qualified CF-924AC (external antennas):
+
+| rate | delivery | modulation verified |
+| --- | --- | --- |
+| VHT 1SS MCS8 — **256-QAM** | **77.1%** | 37/37 decoded as `vht1ss_mcs8` |
+| VHT 2SS MCS0 | 95.3% | 54/54 |
+| VHT 2SS MCS4 | 90.8% | 43/43 |
+| VHT 2SS MCS7 | 15.5% | 7/7 |
+| VHT 2SS MCS8 — 256-QAM, 2 streams | 0.6% | not reached |
+
 | Transmitter | Generation | Peer | Confirmed on 2.4 GHz |
 | --- | --- | --- | --- |
-| RTL8812AU | Jaguar1 | RTL8822BU | VHT 1SS up to **MCS8 (256-QAM)**; HT MCS7 |
+| RTL8812AU | Jaguar1 | CF-924AC (8822BU) | VHT 1SS to **MCS8 (256-QAM)**, 2SS to MCS7 |
 | RTL8822BU | Jaguar2 | RTL8814AU | VHT 1SS MCS0, 2SS MCS0 |
 | RTL8812CU | Jaguar3 | RTL8814AU | VHT 1SS MCS0, MCS4 |
 
 `AdapterCaps::vht_2g4_ok` records the VHT format as a transmit claim for those
-three dies. 256-QAM specifically is confirmed on the 8812A only — the other two
-were measured before the cold-cycle requirement was understood, so their
-ceiling is a floor on what they can do, not a limit.
+three dies. The Jaguar2/Jaguar3 rows are floors, not limits — they were measured
+through an unqualified receiver and have not been re-run.
 
 **VHT MCS9 is not a legal rate at 20 MHz for 1 or 2 spatial streams.** Asking
 for `VHT1SS_MCS9/20` gets an MCS8 PPDU: the run delivered 311 frames and every
@@ -93,15 +119,16 @@ Two traps that harness encodes, each of which produced a wrong answer first:
 
 ## What is still not measured
 
-- **2 spatial streams above MCS2.** Every 2SS rate above the low ladder reads
-  zero on this bench even cold, on both directions tried. Two dongles in near
-  field give the two streams too little spatial decorrelation; this is a rig
-  property and is not evidence about the chip.
+- **256-QAM on 2 spatial streams** (`VHT2SS_MCS8`) reads 0.6% where 2SS MCS7
+  reaches 15.5% — the ladder is rolling off, so this is the link running out of
+  margin rather than anything specific to the mode. It is the one genuine
+  remaining gap to the 2×2 headline.
 - **40 MHz, hence the headline 400 Mbps rate.** `rxdemo` with
   `DEVOURER_BW=40` delivers zero on both Jaguar1 and Jaguar2 — including for a
   20 MHz transmitter on the primary channel, at either primary-channel offset,
-  in both role directions. Re-tested after the cold-cycle fix and unchanged, so
-  it is a real receiver-side gap, not warm state. Note the existing 40 MHz TX
+  in both role directions, and including the most robust 40 MHz rate (MCS0/40).
+  Re-tested on a **qualified** receiver and still zero, so this is a real
+  receiver-side gap and not a margin artifact. Note the existing 40 MHz TX
   validation (`tests/jaguar2_tx_bw40.sh`) uses a *kernel* sniffer, so the
   devourer 40 MHz receive path may never have been exercised.
 - **Link asymmetry.** 8812AU → 8822BU reaches MCS7 at 68%; the reverse

--- a/docs/warm-tx-degradation.md
+++ b/docs/warm-tx-degradation.md
@@ -1,0 +1,110 @@
+# Warm-session TX degradation — chip temperature caps the modulation
+
+A devourer session used to leave a Jaguar1 chip powered up. Not just enumerated
+— in the ACT power state with the RF front end live, indefinitely, long after
+the process that brought it up had exited. Nothing else in the tree does this:
+Jaguar2 resets the chip at init and Jaguar3 has run a full card-disable at
+teardown for a long time.
+
+The consequence was a transmitter that quietly lost its dense constellations.
+
+## The signature
+
+Across back-to-back sessions on one RTL8812AU, ch6/20 MHz, constant TX config:
+
+| | MCS7 (64-QAM 5/6) | MCS1 control | thermal | RSSI |
+| --- | --- | --- | --- | --- |
+| cold baseline | 83.0% | 98.0% | 43 | 69 |
+| after 24 max-duty sessions | 71.3% | 98.0% | **53** | 69 |
+| 120 s idle, chip still powered | 70.8% | 98.3% | 49 | 69 |
+| after VBUS cold cycle | 79.2% | 97.7% | **44** | 69 |
+
+**RSSI never moves.** The transmitter is not losing power; it is losing signal
+quality, and the chip's own thermal meter tracks the loss one-for-one. The
+robust rates are untouched throughout, because they need far less margin.
+
+This is dangerous to diagnose because nothing reports an error: every frame is
+submitted, the receiver reports a strong RSSI and a clean EVM *on the frames it
+still decodes* (only the low-order ones), and the result is indistinguishable
+from a link too weak to carry the constellation. It produced one confident and
+completely wrong "rig SNR limit" conclusion before the mechanism was found.
+
+Note what the idle row says: **idling does not cool the part.** 120 s of no
+traffic bought 4 thermal units; a 12 s VBUS cycle bought 9. A chip held in ACT
+with its RF on keeps dissipating whether or not you are transmitting.
+
+## The fix
+
+`RtlJaguarDevice::Stop()` and the destructor now run
+`HalModule::rtw_hal_deinit()` — halt the MAC engines (`REG_CR`, `REG_RCR`) then
+the die's card-disable power sequence. Those sequence tables
+(`rtl8812_card_disable_flow` and the 8814A/8821A equivalents) had been carried
+in `hal/Hal88*PwrSeq.c` since the port began with nothing calling them.
+
+The chip now powers down whenever no session owns it, so it cools. Same repro,
+after the fix:
+
+| stage | before | after |
+| --- | --- | --- |
+| 60 s idle, **no** power cycle | thermal 48, MCS7 73.0% | thermal **40**, MCS7 **85.8%** |
+
+Before, no amount of idling recovered anything and only pulling VBUS helped.
+Now an ordinary gap between sessions restores the part completely, without
+touching the hardware.
+
+## What this does not fix
+
+**Continuous transmission still heats the chip.** Inside one uninterrupted
+high-duty session the part reaches thermal equilibrium and stays there —
+~80% → ~75% at MCS7 on this adapter. That is physics, not a defect, and it is
+the honest steady-state capability of a hot radio.
+
+There is deliberately **no in-flight recovery API**. Recovery requires the
+radio to stop transmitting long enough to cool, and the measurement says that
+is around a minute (60 s of powered-down idle moved thermal 47 → 40 and MCS7
+75% → 86%). A call that restores the rate by killing the link for a minute is
+not a recovery for an airborne link, so shipping one would be theatre. For a
+long flight the lever is thermal-aware operation instead: poll the meter with
+`DEVOURER_THERMAL_POLL_MS`, watch the `thermal` event's rising `delta`, and
+back off with `SetTxPowerOffsetQdb` or reduce duty before the constellation
+starts failing.
+
+**A killed process leaves the chip hot.** `SIGKILL` runs neither `Stop()` nor
+the destructor, so the chip stays powered and keeps heating until something
+opens it again. An init-side power-off was considered and rejected: it would
+run immediately before power-on and so buys no cooling time at all, while
+adding risk to a bring-up path that works. The real answer for an unattended
+deployment is a supervisor that does not `SIGKILL` its radio process.
+
+## Per-chip findings
+
+- **RTL8812AU** — where the effect is characterized. Thermal 43 → 53, MCS7
+  −12 points. The fix is validated here.
+- **RTL8814AU** — barely heats at the same duty (34 → 37) and shows no
+  degradation. It re-inits cleanly after the power-down; there was simply
+  nothing to recover. The effect scales with how hot the part actually gets.
+- **RTL8821AU** — re-inits cleanly after the power-down; not separately
+  characterized for the thermal curve.
+- **Jaguar2 (RTL8822BU)** — audited and **inconclusive**: its thermal meter did
+  not move (33–34) across the same run, and the link available for the test was
+  too marginal at MCS7 to resolve a small effect. No teardown power-down was
+  added there on the strength of a non-measurement; it remains the one
+  generation that leaves the chip powered at exit.
+
+## Reproducing
+
+```sh
+sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
+     tests/warm_tx_degradation_repro.sh
+```
+
+Holds one ground receiver up for the whole run so the reference never moves,
+then alternates probes with warm sessions, recording delivery at a test rate and
+a robust control rate alongside the chip thermal meter and the receiver's RSSI
+and EVM. `WARM_PWR=63 WARM_GAP=0` turns the warm sessions into max-power,
+max-duty heating. Two controls close it out: an idle with no power cycle, and a
+VBUS cycle.
+
+Reading it: falling delivery with **flat RSSI and rising thermal** is heat;
+falling delivery with **falling RSSI** would be a transmitter losing power,
+which is a different bug.

--- a/docs/warm-tx-degradation.md
+++ b/docs/warm-tx-degradation.md
@@ -1,118 +1,114 @@
-# Warm-session TX degradation on Jaguar1
+# The "warm TX degradation" that wasn't — a measurement post-mortem
 
-A devourer session used to leave a Jaguar1 chip powered up. Not just enumerated
-— in the ACT power state with the RF front end live, indefinitely, long after
-the process that brought it up had exited. Nothing else in the tree does this:
-Jaguar2 resets the chip at init and Jaguar3 has run a full card-disable at
-teardown for a long time.
+A field report described an RTL8812AU whose 64-QAM rates died across repeated
+sessions while the robust rates stayed perfect, recovering only on a USB power
+cycle. Investigating it produced, in order: a latched-chip-state root cause, a
+thermal root cause, a band-switching root cause, and a degraded-adapter root
+cause. **All four were wrong, and all four had the same origin.**
 
-Alongside that, high-rate delivery was observed to decay across back-to-back
-sessions and to recover only when power was removed. This document records what
-is measured, what was fixed, and — importantly — **which parts of the causal
-story did not survive testing**.
+The ground station was a TP-Link Archer T3U — an RTL8822BU with *internal*
+antennas. Its modulation cliff sits inside the 64-QAM rates, so it could not
+measure what it was being asked to measure.
 
-## First: know your noise floor
+## The measurement that ends it
 
-Ten identical back-to-back MCS7/20 probes on an RTL8812AU, nothing changed
-between them:
+Two RTL8822BU adapters. Identical silicon, identical code path, same
+transmitter, same channel, minutes apart. The only difference is antennas:
 
-| | mean | sd | range |
-| --- | --- | --- | --- |
-| MCS7/20 | 67.3% | **1.8** | 65.0 – 70.7 |
-| MCS1/20 control | 98.0% | 0.2 | 97.5 – 98.3 |
+| ground station | MCS1 | MCS3 | MCS4 | MCS5 | MCS6 | MCS7 |
+| --- | --- | --- | --- | --- | --- | --- |
+| Archer T3U — **internal** | 98.1 | 97.8 | 98.3 | 79.1 | 49.0 | **2.9** |
+| Comfast CF-924AC V2 — **two external** | 95.8 | 95.4 | 95.8 | 95.7 | 94.4 | **95.9** |
 
-**A single probe is worth about ±3 points.** Any claimed effect smaller than
-~4 points is not detectable one-shot, and several plausible-looking "decay
-curves" in this investigation sat inside that band. `tests/probe_repeatability.sh`
-measures the floor for a given pair; run it before believing a delivery
-difference.
+One is a textbook waterfall rolling off through 64-QAM. The other is flat with
+margin to spare. Both adapters are healthy.
 
-## What is measured
+## Why a marginal receiver imitates a degrading transmitter
 
-The fix is that `Stop()` and the destructor now power the chip down. Its effect
-on an idle gap, same repro before and after:
+A receiver perched on its cliff swings between "fine" and "zero" on a few dB of
+ambient, while the rates below the cliff stay pinned at ~98%. That is precisely
+the reported symptom: high-order modulation dies, low rates unaffected,
+apparently recovering at random.
 
-| stage | before fix | after fix |
-| --- | --- | --- |
-| 60 s idle, **no** power cycle | thermal 48, MCS7 73.0% | thermal 40, MCS7 **85.8%** |
+Earlier in one session that same T3U delivered MCS7 at 68%; later, 0.6%. The
+cliff never moved — the operating point did (co-channel ambient rose from ~19 to
+~58 frames/3 s). Power-cycling appeared to "fix" it only because a cycle takes
+long enough for conditions to drift back.
 
-That is ~13 points, around 7 sd — comfortably real. Before the fix no amount of
-idling recovered anything and only pulling VBUS helped; afterwards an ordinary
-gap between sessions restores the part.
+## What each wrong answer was, and what killed it
 
-Delivery also correlates with the chip's thermal meter *within* one probe
-sequence: across the ten repeats above, thermal climbed 39 → 45 while MCS7 fell
-70.7% → 65.7%, with the control flat and RSSI unchanged (so nothing is losing
-transmit *power* — only quality).
+- **Latched chip state.** Refuted by reading the registers: the BB TX-swing is
+  rewritten unconditionally at every init by `phy_SetBBSwingByBand_8812A`.
+- **Thermal.** Refuted by `tests/thermal_offtime_sweep.sh` — vary only the
+  power-off duration, keeping the reset identical, and delivery does not follow
+  temperature (best result came from the *shortest* off-time and the *hottest*
+  chip). Also by `tests/thermal_causation_probe.sh`: inside one uninterrupted
+  session the thermal meter is pinned while delivery still drifts.
+- **A transmitter defect from band switching.** A stressor matrix did reproduce
+  a 32-point collapse — but judged by an AR9271 sniffer the same stressor moved
+  decoded MCS7 from 3721 to 3915 frames, i.e. not at all. The transmitter also
+  matched the vendor driver (62.5% vs 69.8%).
+- **A degraded 8822BU.** The vendor driver failed on it identically, which
+  looked conclusive — but a link-budget shortfall predicts exactly that too. TX
+  power moved nothing (front end already near-field saturated at RSSI 67) and
+  both RX chains read healthy. Then the CF-924AC settled it.
 
-## What did NOT survive testing
+## Rules this produced
 
-**"It is thermal" is not proven, and two experiments argue against it.**
+1. **Qualify the receiver before believing a delivery number.**
+   `tests/ground_station_qualify.sh` sweeps the ladder and refuses the pairing
+   (exit 1) when the test rate is off the flat part. Prefer external-antenna
+   adapters as ground stations for high-MCS work.
+2. **Measure the noise floor first.** `tests/probe_repeatability.sh` — a single
+   MCS7/20 probe here has sd 1.8 and a 5.7-point spread, so effects under ~4
+   points are not findings. Several convincing "decay curves" sat inside it.
+3. **Corroborate with an independent receiver** before attributing a delivery
+   change to either end. An AR9271 and the `reference/` vendor drivers were on
+   this bench the whole time; either would have caught this on day one.
+4. **A control that fails under two drivers does not prove hardware damage.**
+   Run the vendor driver on the *receive* side too (`tests/rx_vendor_ab.sh`),
+   and check the physical setup — antennas, placement, gain.
+5. **Never attribute causation to an intervention that changes two variables.**
+   Removing power both resets chip state and cools the die; no amount of
+   power-cycling separates them.
 
-Every recovery that works removes power, and removing power does two things at
-once: it resets chip state *and* it lets the die cool. No power-cycle experiment
-can separate them. Two attempts to separate them failed to support cooling:
+## The one code change that survived
 
-- **Off-time sweep** (`tests/thermal_offtime_sweep.sh`) — degrade the part, then
-  power it down for 5/15/30/60/120 s before an otherwise identical probe. The
-  reset is bit-identical in every arm; only cooling time varies. Temperature
-  fell cleanly with off-time (47 → 40), but delivery scattered 63–83% with **no
-  relationship to off-time or temperature** — the best result came from the
-  *shortest* off-time and the *hottest* chip.
-- **Within a single uninterrupted session**
-  (`tests/thermal_causation_probe.sh`) — 240 s of continuous max-duty TX, one
-  bring-up, no re-init, no state change. The thermal meter stayed **pinned**
-  while MCS7 delivery still drifted down ~10% and the MCS1 control held flat.
+Jaguar1 was the only generation that neither reset the chip at init nor
+de-initialised it at teardown, so a session left the chip in ACT with its RF
+front end live indefinitely after the owning process exited — and an
+autonomously-airing beacon kept transmitting.
 
-So heat is a real correlate of delivery in some conditions and demonstrably not
-the driver in others. The mechanism behind the recovery-on-power-removal is
-**open**. Do not cite this document as evidence that the effect is thermal.
+`RtlJaguarDevice::Stop()` and the destructor now run
+`HalModule::rtw_hal_deinit()`: halt the MAC engines, then the die's card-disable
+power sequence, using tables that had sat in `hal/Hal88*PwrSeq.c` since the port
+began with nothing calling them.
 
-## The fix
+**It carries no performance claim.** The delivery recovery an earlier revision
+cited was measured through the unqualified T3U. The change stands on the
+architecture alone: every other generation already does this, and it makes a
+stray beacon stop. `tuning.teardown_power_down=0`
+(`DEVOURER_TEARDOWN_POWER_DOWN=0`) disables it, which post-mortems need — a
+powered-down chip answers every register read with the CARDEMU fill.
 
-`RtlJaguarDevice::Stop()` and the destructor run
-`HalModule::rtw_hal_deinit()` — halt the MAC engines (`REG_CR`, `REG_RCR`) then
-the die's card-disable power sequence, through the same `HalPwrSeqCmdParsing`
-and the same three-way chip dispatch `InitPowerOn` already uses. The sequence
-tables (`rtl8812_card_disable_flow` and the 8814A/8821A equivalents) had been
-carried in `hal/Hal88*PwrSeq.c` since the port began with nothing calling them.
+## Is the original report real?
 
-It is justified on its own terms regardless of the mechanism question: leaving a
-radio powered and transmitting-capable after its owning process has exited is
-wrong, it is what every other generation already avoids, and it is what makes an
-autonomously-airing beacon stop at session end.
-
-## What it does not fix
-
-- **Continuous transmission.** Inside one uninterrupted high-duty session the
-  part still drifts down; power-down at teardown cannot help a session that
-  never ends.
-- **`SIGKILL`.** Neither `Stop()` nor the destructor runs, so the chip stays
-  powered. An init-side power-off was considered and rejected: it would run
-  immediately before power-on, buying nothing, while adding risk to a bring-up
-  path that works.
-- **There is no in-flight recovery API.** Until the mechanism is understood
-  there is nothing principled to implement, and a call that restored the rate by
-  dropping the link would not be a recovery for an airborne link anyway.
-
-## Per-chip
-
-- **RTL8812AU** — where the effect is characterized and the fix validated.
-- **RTL8814AU** — barely heats at the same duty (34 → 37) and shows no
-  degradation; re-inits cleanly after the power-down.
-- **RTL8821AU** — re-inits cleanly; not separately characterized.
-- **Jaguar2 (RTL8822BU)** — audited, inconclusive: thermal did not move and the
-  available link was too marginal at MCS7 to resolve a small effect. No teardown
-  power-down added there on the strength of a non-measurement.
+Unknown, and deliberately left open. Every measurement taken here was through an
+instrument that could not support the conclusion, so nothing gathered so far is
+evidence either way. A re-report is worth taking seriously if it comes from a rig
+where the ground station passes rule 1, a second receiver corroborates, and the
+noise floor is established.
 
 ## Harnesses
 
-| script | question it answers |
+| script | question |
 | --- | --- |
-| `probe_repeatability.sh` | how big must an effect be to be real on this pair? |
-| `warm_tx_degradation_repro.sh` | does delivery decay across sessions, and what do the sensors say? |
-| `thermal_offtime_sweep.sh` | is the recovery cooling, or the state reset? |
+| `ground_station_qualify.sh` | can this receiver measure this rate at all? |
+| `probe_repeatability.sh` | how big must an effect be to be real here? |
+| `rx_vendor_ab.sh` | is a bad receiver our code, or the hardware? |
+| `band_stressor_sniffer.sh` | does a stressor hurt the transmitter, judged independently? |
+| `ground_rx_degradation.sh` | which end of the link is losing? |
+| `severe_form_hunt.sh` | which stressor, if any, reproduces the collapse? |
+| `thermal_offtime_sweep.sh` | cooling, or state reset? |
 | `thermal_causation_probe.sh` | does delivery track temperature with nothing else changing? |
-
-Reading the repro: falling delivery with **flat RSSI** means signal quality, not
-transmit power. Falling RSSI would be a different bug.
+| `examples/chipstate` | what state did the last session leave, read without disturbing it? |

--- a/docs/warm-tx-degradation.md
+++ b/docs/warm-tx-degradation.md
@@ -1,4 +1,4 @@
-# Warm-session TX degradation — chip temperature caps the modulation
+# Warm-session TX degradation on Jaguar1
 
 A devourer session used to leave a Jaguar1 chip powered up. Not just enumerated
 — in the ACT power state with the RF front end live, indefinitely, long after
@@ -6,105 +6,113 @@ the process that brought it up had exited. Nothing else in the tree does this:
 Jaguar2 resets the chip at init and Jaguar3 has run a full card-disable at
 teardown for a long time.
 
-The consequence was a transmitter that quietly lost its dense constellations.
+Alongside that, high-rate delivery was observed to decay across back-to-back
+sessions and to recover only when power was removed. This document records what
+is measured, what was fixed, and — importantly — **which parts of the causal
+story did not survive testing**.
 
-## The signature
+## First: know your noise floor
 
-Across back-to-back sessions on one RTL8812AU, ch6/20 MHz, constant TX config:
+Ten identical back-to-back MCS7/20 probes on an RTL8812AU, nothing changed
+between them:
 
-| | MCS7 (64-QAM 5/6) | MCS1 control | thermal | RSSI |
-| --- | --- | --- | --- | --- |
-| cold baseline | 83.0% | 98.0% | 43 | 69 |
-| after 24 max-duty sessions | 71.3% | 98.0% | **53** | 69 |
-| 120 s idle, chip still powered | 70.8% | 98.3% | 49 | 69 |
-| after VBUS cold cycle | 79.2% | 97.7% | **44** | 69 |
+| | mean | sd | range |
+| --- | --- | --- | --- |
+| MCS7/20 | 67.3% | **1.8** | 65.0 – 70.7 |
+| MCS1/20 control | 98.0% | 0.2 | 97.5 – 98.3 |
 
-**RSSI never moves.** The transmitter is not losing power; it is losing signal
-quality, and the chip's own thermal meter tracks the loss one-for-one. The
-robust rates are untouched throughout, because they need far less margin.
+**A single probe is worth about ±3 points.** Any claimed effect smaller than
+~4 points is not detectable one-shot, and several plausible-looking "decay
+curves" in this investigation sat inside that band. `tests/probe_repeatability.sh`
+measures the floor for a given pair; run it before believing a delivery
+difference.
 
-This is dangerous to diagnose because nothing reports an error: every frame is
-submitted, the receiver reports a strong RSSI and a clean EVM *on the frames it
-still decodes* (only the low-order ones), and the result is indistinguishable
-from a link too weak to carry the constellation. It produced one confident and
-completely wrong "rig SNR limit" conclusion before the mechanism was found.
+## What is measured
 
-Note what the idle row says: **idling does not cool the part.** 120 s of no
-traffic bought 4 thermal units; a 12 s VBUS cycle bought 9. A chip held in ACT
-with its RF on keeps dissipating whether or not you are transmitting.
+The fix is that `Stop()` and the destructor now power the chip down. Its effect
+on an idle gap, same repro before and after:
+
+| stage | before fix | after fix |
+| --- | --- | --- |
+| 60 s idle, **no** power cycle | thermal 48, MCS7 73.0% | thermal 40, MCS7 **85.8%** |
+
+That is ~13 points, around 7 sd — comfortably real. Before the fix no amount of
+idling recovered anything and only pulling VBUS helped; afterwards an ordinary
+gap between sessions restores the part.
+
+Delivery also correlates with the chip's thermal meter *within* one probe
+sequence: across the ten repeats above, thermal climbed 39 → 45 while MCS7 fell
+70.7% → 65.7%, with the control flat and RSSI unchanged (so nothing is losing
+transmit *power* — only quality).
+
+## What did NOT survive testing
+
+**"It is thermal" is not proven, and two experiments argue against it.**
+
+Every recovery that works removes power, and removing power does two things at
+once: it resets chip state *and* it lets the die cool. No power-cycle experiment
+can separate them. Two attempts to separate them failed to support cooling:
+
+- **Off-time sweep** (`tests/thermal_offtime_sweep.sh`) — degrade the part, then
+  power it down for 5/15/30/60/120 s before an otherwise identical probe. The
+  reset is bit-identical in every arm; only cooling time varies. Temperature
+  fell cleanly with off-time (47 → 40), but delivery scattered 63–83% with **no
+  relationship to off-time or temperature** — the best result came from the
+  *shortest* off-time and the *hottest* chip.
+- **Within a single uninterrupted session**
+  (`tests/thermal_causation_probe.sh`) — 240 s of continuous max-duty TX, one
+  bring-up, no re-init, no state change. The thermal meter stayed **pinned**
+  while MCS7 delivery still drifted down ~10% and the MCS1 control held flat.
+
+So heat is a real correlate of delivery in some conditions and demonstrably not
+the driver in others. The mechanism behind the recovery-on-power-removal is
+**open**. Do not cite this document as evidence that the effect is thermal.
 
 ## The fix
 
-`RtlJaguarDevice::Stop()` and the destructor now run
+`RtlJaguarDevice::Stop()` and the destructor run
 `HalModule::rtw_hal_deinit()` — halt the MAC engines (`REG_CR`, `REG_RCR`) then
-the die's card-disable power sequence. Those sequence tables
-(`rtl8812_card_disable_flow` and the 8814A/8821A equivalents) had been carried
-in `hal/Hal88*PwrSeq.c` since the port began with nothing calling them.
+the die's card-disable power sequence, through the same `HalPwrSeqCmdParsing`
+and the same three-way chip dispatch `InitPowerOn` already uses. The sequence
+tables (`rtl8812_card_disable_flow` and the 8814A/8821A equivalents) had been
+carried in `hal/Hal88*PwrSeq.c` since the port began with nothing calling them.
 
-The chip now powers down whenever no session owns it, so it cools. Same repro,
-after the fix:
+It is justified on its own terms regardless of the mechanism question: leaving a
+radio powered and transmitting-capable after its owning process has exited is
+wrong, it is what every other generation already avoids, and it is what makes an
+autonomously-airing beacon stop at session end.
 
-| stage | before | after |
-| --- | --- | --- |
-| 60 s idle, **no** power cycle | thermal 48, MCS7 73.0% | thermal **40**, MCS7 **85.8%** |
+## What it does not fix
 
-Before, no amount of idling recovered anything and only pulling VBUS helped.
-Now an ordinary gap between sessions restores the part completely, without
-touching the hardware.
+- **Continuous transmission.** Inside one uninterrupted high-duty session the
+  part still drifts down; power-down at teardown cannot help a session that
+  never ends.
+- **`SIGKILL`.** Neither `Stop()` nor the destructor runs, so the chip stays
+  powered. An init-side power-off was considered and rejected: it would run
+  immediately before power-on, buying nothing, while adding risk to a bring-up
+  path that works.
+- **There is no in-flight recovery API.** Until the mechanism is understood
+  there is nothing principled to implement, and a call that restored the rate by
+  dropping the link would not be a recovery for an airborne link anyway.
 
-## What this does not fix
+## Per-chip
 
-**Continuous transmission still heats the chip.** Inside one uninterrupted
-high-duty session the part reaches thermal equilibrium and stays there —
-~80% → ~75% at MCS7 on this adapter. That is physics, not a defect, and it is
-the honest steady-state capability of a hot radio.
-
-There is deliberately **no in-flight recovery API**. Recovery requires the
-radio to stop transmitting long enough to cool, and the measurement says that
-is around a minute (60 s of powered-down idle moved thermal 47 → 40 and MCS7
-75% → 86%). A call that restores the rate by killing the link for a minute is
-not a recovery for an airborne link, so shipping one would be theatre. For a
-long flight the lever is thermal-aware operation instead: poll the meter with
-`DEVOURER_THERMAL_POLL_MS`, watch the `thermal` event's rising `delta`, and
-back off with `SetTxPowerOffsetQdb` or reduce duty before the constellation
-starts failing.
-
-**A killed process leaves the chip hot.** `SIGKILL` runs neither `Stop()` nor
-the destructor, so the chip stays powered and keeps heating until something
-opens it again. An init-side power-off was considered and rejected: it would
-run immediately before power-on and so buys no cooling time at all, while
-adding risk to a bring-up path that works. The real answer for an unattended
-deployment is a supervisor that does not `SIGKILL` its radio process.
-
-## Per-chip findings
-
-- **RTL8812AU** — where the effect is characterized. Thermal 43 → 53, MCS7
-  −12 points. The fix is validated here.
+- **RTL8812AU** — where the effect is characterized and the fix validated.
 - **RTL8814AU** — barely heats at the same duty (34 → 37) and shows no
-  degradation. It re-inits cleanly after the power-down; there was simply
-  nothing to recover. The effect scales with how hot the part actually gets.
-- **RTL8821AU** — re-inits cleanly after the power-down; not separately
-  characterized for the thermal curve.
-- **Jaguar2 (RTL8822BU)** — audited and **inconclusive**: its thermal meter did
-  not move (33–34) across the same run, and the link available for the test was
-  too marginal at MCS7 to resolve a small effect. No teardown power-down was
-  added there on the strength of a non-measurement; it remains the one
-  generation that leaves the chip powered at exit.
+  degradation; re-inits cleanly after the power-down.
+- **RTL8821AU** — re-inits cleanly; not separately characterized.
+- **Jaguar2 (RTL8822BU)** — audited, inconclusive: thermal did not move and the
+  available link was too marginal at MCS7 to resolve a small effect. No teardown
+  power-down added there on the strength of a non-measurement.
 
-## Reproducing
+## Harnesses
 
-```sh
-sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
-     tests/warm_tx_degradation_repro.sh
-```
+| script | question it answers |
+| --- | --- |
+| `probe_repeatability.sh` | how big must an effect be to be real on this pair? |
+| `warm_tx_degradation_repro.sh` | does delivery decay across sessions, and what do the sensors say? |
+| `thermal_offtime_sweep.sh` | is the recovery cooling, or the state reset? |
+| `thermal_causation_probe.sh` | does delivery track temperature with nothing else changing? |
 
-Holds one ground receiver up for the whole run so the reference never moves,
-then alternates probes with warm sessions, recording delivery at a test rate and
-a robust control rate alongside the chip thermal meter and the receiver's RSSI
-and EVM. `WARM_PWR=63 WARM_GAP=0` turns the warm sessions into max-power,
-max-duty heating. Two controls close it out: an idle with no power cycle, and a
-VBUS cycle.
-
-Reading it: falling delivery with **flat RSSI and rising thermal** is heat;
-falling delivery with **falling RSSI** would be a transmitter losing power,
-which is a different bug.
+Reading the repro: falling delivery with **flat RSSI** means signal quality, not
+transmit power. Falling RSSI would be a different bug.

--- a/examples/chipstate/main.cpp
+++ b/examples/chipstate/main.cpp
@@ -1,0 +1,157 @@
+/* chipstate — read a chip's registers WITHOUT touching it.
+ *
+ * Every other entry point into this driver reconfigures the chip on the way in:
+ * `claim_interface_then_reset` re-enumerates it, `Init`/`InitWrite` re-run the
+ * power sequence, reload the BB/RF/MAC tables and re-calibrate. That is exactly
+ * what you must not do when the question is "what state did the previous
+ * session leave this chip in?" — the act of looking destroys the evidence.
+ *
+ * So this tool: open, claim, DO NOT reset, construct the device (chip identity
+ * resolves from SYS_CFG2 at construction, no bring-up needed), dump, exit. The
+ * output is the DEVOURER_DUMP_CANARY format, so two dumps diff directly:
+ *
+ *   sudo build/chipstate --pid 0x8812 > degraded.canary
+ *   # ... VBUS power-cycle the adapter ...
+ *   sudo build/chipstate --pid 0x8812 > healthy.canary
+ *   python3 tests/canary_diff.py degraded.canary healthy.canary --strict
+ *
+ * Reading a powered-down chip returns garbage or fails — that is a real answer
+ * about the chip, not a tool error, so it is reported rather than hidden.
+ *
+ * Note --init: it runs a normal bring-up before dumping, which is what you want
+ * for a healthy-reference dump on a chip that has just been power-cycled and is
+ * therefore not configured at all.
+ */
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+
+#if __has_include(<libusb.h>)
+#include <libusb.h>
+#else
+#include <libusb-1.0/libusb.h>
+#endif
+
+#include "DeviceSession.h"
+#include "IRtlDevice.h"
+#include "UsbOpen.h"
+#include "WiFiDriver.h"
+#include "logger.h"
+#include "SignalStop.h"
+
+namespace {
+
+/* Same list the other demos' open loop iterates; --pid narrows to one. */
+const uint16_t kRealtekPids[] = {0x8812, 0x8813, 0x881a, 0x0811, 0xa811,
+                                 0x0820, 0x0821, 0x8822, 0x0120, 0x012d,
+                                 0xb82c, 0xc811, 0xc812, 0xa81a};
+
+struct Args {
+  uint16_t vid = 0x0bda;
+  int pid = -1;
+  int channel = 6;
+  bool init = false;
+};
+
+void usage() {
+  std::fprintf(stderr,
+               "usage: chipstate [--vid 0xNNNN] [--pid 0xNNNN] [--init] "
+               "[--channel N]\n"
+               "  default: attach read-only, no USB reset, no bring-up.\n"
+               "  --init : run a full bring-up first (for a healthy reference\n"
+               "           dump on a freshly power-cycled adapter).\n");
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  Args a;
+  for (int i = 1; i < argc; ++i) {
+    const char *v = (i + 1 < argc) ? argv[i + 1] : nullptr;
+    if (!std::strcmp(argv[i], "--vid") && v) {
+      a.vid = static_cast<uint16_t>(std::strtol(v, nullptr, 0));
+      ++i;
+    } else if (!std::strcmp(argv[i], "--pid") && v) {
+      a.pid = static_cast<int>(std::strtol(v, nullptr, 0));
+      ++i;
+    } else if (!std::strcmp(argv[i], "--channel") && v) {
+      a.channel = static_cast<int>(std::strtol(v, nullptr, 0));
+      ++i;
+    } else if (!std::strcmp(argv[i], "--init")) {
+      a.init = true;
+    } else {
+      usage();
+      return 2;
+    }
+  }
+
+  auto logger = std::make_shared<Logger>();
+  install_devourer_signal_handlers();
+  devourer::DeviceSession session{logger};
+
+  libusb_context *ctx = nullptr;
+  if (libusb_init(&ctx) < 0) {
+    logger->error("libusb_init failed");
+    return 3;
+  }
+  session.adopt_context(ctx);
+
+  libusb_device_handle *handle = nullptr;
+  if (a.pid >= 0) {
+    handle = libusb_open_device_with_vid_pid(ctx, a.vid,
+                                             static_cast<uint16_t>(a.pid));
+  } else {
+    for (uint16_t pid : kRealtekPids) {
+      handle = libusb_open_device_with_vid_pid(ctx, a.vid, pid);
+      if (handle)
+        break;
+    }
+  }
+  if (!handle) {
+    logger->error("no adapter found (vid {:04x})", a.vid);
+    return 3;
+  }
+
+  /* do_reset=false is the whole point: a USB reset re-runs the chip's own boot
+   * and would wipe the state we came to read. Only --init opts into disturbing
+   * the chip, and even then the reset stays off so the bring-up starts from
+   * whatever the chip currently holds. */
+  std::shared_ptr<devourer::UsbDeviceLock> lock;
+  if (devourer::claim_interface_then_reset(
+          handle, devourer::find_wifi_interface(handle), logger,
+          /*do_reset=*/false, lock) != 0) {
+    session.adopt_handle(handle);
+    return 3;
+  }
+  session.adopt_handle(handle);
+  session.adopt_lock(lock);
+
+  devourer::DeviceConfig cfg;
+  /* Leave the chip exactly as found. Without this the device destructor runs
+   * the card-disable sequence on the way out, so the tool would power down the
+   * very state it exists to inspect — one look and the evidence is gone. */
+  cfg.tuning.teardown_power_down = false;
+  WiFiDriver driver(logger);
+  std::unique_ptr<IRtlDevice> owned = driver.CreateRtlDevice(handle, ctx, lock, cfg);
+  if (!owned) {
+    logger->error("CreateRtlDevice failed (chip support not built?)");
+    return 3;
+  }
+  session.adopt_device(std::move(owned));
+  IRtlDevice *const dev = session.device();
+
+  if (a.init) {
+    logger->info("chipstate: --init, running a full bring-up before the dump");
+    dev->InitWrite(SelectedChannel{.Channel = static_cast<uint8_t>(a.channel),
+                                   .ChannelOffset = 0,
+                                   .ChannelWidth = CHANNEL_WIDTH_20});
+  } else {
+    logger->info("chipstate: read-only attach (no USB reset, no bring-up) — "
+                 "the chip is being read exactly as the last session left it");
+  }
+
+  dev->DumpChipState();
+  return 0;
+}

--- a/examples/common/env_config.cpp
+++ b/examples/common/env_config.cpp
@@ -124,6 +124,9 @@ devourer::DeviceConfig devourer_config_from_env() {
   }
 
   /* ---- tuning ---- */
+  /* Defaults ON, so this reads the negation: only an explicit 0 disables it. */
+  if (const char *e = env_str("DEVOURER_TEARDOWN_POWER_DOWN"))
+    cfg.tuning.teardown_power_down = (std::atoi(e) != 0);
   cfg.tuning.skip_iqk = env_flag("DEVOURER_SKIP_IQK");
   cfg.tuning.force_iqk = env_flag("DEVOURER_FORCE_IQK");
   cfg.tuning.disable_iqk = env_flag("DEVOURER_DISABLE_IQK");

--- a/src/DeviceConfig.h
+++ b/src/DeviceConfig.h
@@ -327,6 +327,17 @@ struct DeviceConfig {
      * kernel eFEM pin-mux so the DPDT follows TX/RX in hardware (both RX chains
      * live); the others are the pre-fix static routes. See docs/8822e-quirks.md. */
     Dpdt8822eMode dpdt_8822e = Dpdt8822eMode::EfemPinmux;
+
+    /* env: DEVOURER_TEARDOWN_POWER_DOWN=0|1 — Jaguar1: run the die's
+     * card-disable power sequence at Stop()/destruction (default on), instead
+     * of leaving the chip in ACT with its RF front end live indefinitely.
+     *
+     * Turning it OFF is what a post-mortem needs: a powered-down chip answers
+     * every register read with the CARDEMU fill (0xEA...), so the state a
+     * session left behind is only inspectable (examples/chipstate) while the
+     * chip is still up. It is also the A/B lever for measuring what the
+     * power-down is actually worth. */
+    bool teardown_power_down = true;
   } tuning;
 
   /* ---- Diagnostics output --------------------------------------------- */

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -559,6 +559,22 @@ public:
    * Init/InitWrite). On Jaguar1 a failed FW boot does not abort bring-up —
    * this is the only place the failure is visible to a caller. */
   virtual devourer::FwBootStatus GetFwBootStatus() { return {}; }
+
+  /* Dump the chip's canary register set (BB / MAC / per-path RF) to the
+   * diagnostic plane. Reads only — no writes, no calibration, no bring-up.
+   *
+   * The point is that it is callable on a device that has NOT been Init'ed, so
+   * a chip left in whatever state a previous session abandoned it in can be
+   * inspected AS IT IS. Every other path into this driver reconfigures the chip
+   * on the way in, which destroys exactly the evidence a state bug leaves
+   * behind. Pair it with an open that skips libusb_reset_device
+   * (claim_interface_then_reset's `do_reset=false`) — a USB reset re-runs the
+   * chip's own boot and is just as destructive.
+   *
+   * Output format matches DEVOURER_DUMP_CANARY, so two dumps diff directly with
+   * tests/canary_diff.py. Reading a powered-down chip yields garbage or throws;
+   * interpreting that is the caller's job. No-op where unsupported (default). */
+  virtual void DumpChipState() {}
 };
 
 #endif /* IRTL_DEVICE_H */

--- a/src/jaguar1/CLAUDE.md
+++ b/src/jaguar1/CLAUDE.md
@@ -46,16 +46,14 @@ sequence via the existing `HalPwrSeqCmdParsing` (`rtl8812_card_disable_flow` /
 enable flows). Both call sites are best-effort — a chip already off the bus
 makes the writes fail, which is fine on a teardown path.
 
-This is not tidiness. Left in ACT the chip keeps its RF front end live
-indefinitely after the owning process exits — it never powers down and never
-cools. Measured consequence: after a run of sessions, a 60 s idle recovered MCS7
-delivery from 73.0% to 85.8% only once the teardown power-down existed; before
-it, idling recovered nothing. *Why* removing power helps is not established —
-a card-disable both resets chip state and lets the die cool, and an off-time
-sweep could not separate them (`docs/warm-tx-degradation.md`). It also means an
-autonomously-airing beacon stops when the session ends. `PowerOff()` clears
-`_macPwrCtrlOn` so a re-init on the same `HalModule` still runs the power-on
-sequence.
+This is not tidiness: left in ACT the chip keeps its RF front end live
+indefinitely after the owning process exits, and an autonomously-airing beacon
+keeps transmitting. Justified on those grounds alone — **no performance claim is
+attached**, and the delivery recovery an earlier revision cited came from a
+ground station too marginal to support it (`docs/warm-tx-degradation.md`).
+`PowerOff()` clears `_macPwrCtrlOn` so a re-init on the same `HalModule` still
+runs the power-on sequence; `tuning.teardown_power_down=0` disables it, which a
+post-mortem needs since a powered-down chip reads back the CARDEMU fill.
 
 ## TX power
 

--- a/src/jaguar1/CLAUDE.md
+++ b/src/jaguar1/CLAUDE.md
@@ -37,6 +37,22 @@ methods), `RadioManagementModule` (channel/BW/TX power, up to 4 RF paths),
   8814A decodes LDPC but reports no per-frame flag (`ldpc_rx_flag=0`,
   `RxAtrib.ldpc` reads 0).
 
+## Teardown
+
+`RtlJaguarDevice::Stop()` and the destructor run `HalModule::rtw_hal_deinit()`:
+halt the MAC engines (`REG_CR`, `REG_RCR`), then the die's card-disable power
+sequence via the existing `HalPwrSeqCmdParsing` (`rtl8812_card_disable_flow` /
+`rtl8814A_` / `rtl8821A_`, dispatched exactly like `InitPowerOn` dispatches the
+enable flows). Both call sites are best-effort — a chip already off the bus
+makes the writes fail, which is fine on a teardown path.
+
+This is not tidiness. Left in ACT the chip keeps its RF front end live and never
+cools, and a hot die loses the dense constellations while the robust rates carry
+on — thermal 43 → 53 costs MCS7 ~12 points of delivery at flat RSSI
+(`docs/warm-tx-degradation.md`). It also means an autonomously-airing beacon
+stops when the session ends. `PowerOff()` clears `_macPwrCtrlOn` so a re-init on
+the same `HalModule` still runs the power-on sequence.
+
 ## TX power
 
 Every per-rate index funnels through one composer, `ComputeTxPowerIndex(path,

--- a/src/jaguar1/CLAUDE.md
+++ b/src/jaguar1/CLAUDE.md
@@ -46,12 +46,16 @@ sequence via the existing `HalPwrSeqCmdParsing` (`rtl8812_card_disable_flow` /
 enable flows). Both call sites are best-effort — a chip already off the bus
 makes the writes fail, which is fine on a teardown path.
 
-This is not tidiness. Left in ACT the chip keeps its RF front end live and never
-cools, and a hot die loses the dense constellations while the robust rates carry
-on — thermal 43 → 53 costs MCS7 ~12 points of delivery at flat RSSI
-(`docs/warm-tx-degradation.md`). It also means an autonomously-airing beacon
-stops when the session ends. `PowerOff()` clears `_macPwrCtrlOn` so a re-init on
-the same `HalModule` still runs the power-on sequence.
+This is not tidiness. Left in ACT the chip keeps its RF front end live
+indefinitely after the owning process exits — it never powers down and never
+cools. Measured consequence: after a run of sessions, a 60 s idle recovered MCS7
+delivery from 73.0% to 85.8% only once the teardown power-down existed; before
+it, idling recovered nothing. *Why* removing power helps is not established —
+a card-disable both resets chip state and lets the die cool, and an off-time
+sweep could not separate them (`docs/warm-tx-degradation.md`). It also means an
+autonomously-airing beacon stops when the session ends. `PowerOff()` clears
+`_macPwrCtrlOn` so a re-init on the same `HalModule` still runs the power-on
+sequence.
 
 ## TX power
 

--- a/src/jaguar1/HalModule.cpp
+++ b/src/jaguar1/HalModule.cpp
@@ -660,6 +660,45 @@ bool HalModule::rtl8812au_hal_init(uint8_t init_channel) {
   return true;
 }
 
+void HalModule::rtw_hal_deinit() {
+  _logger->info("Jaguar1: clean de-init (stop TRX + card-disable)");
+  /* Halt the MAC engines before pulling power out from under them, so the
+   * sequence isn't racing DMA that is still moving frames. Mirrors
+   * HalJaguar3::rtw_hal_deinit. */
+  _device.rtw_write16(REG_CR, 0x0000); /* clear MACTXEN/MACRXEN */
+  _device.rtw_write32(REG_RCR, 0x00000000); /* drop all RX — stop FIFO fill */
+  PowerOff();
+}
+
+bool HalModule::PowerOff() {
+  /* Same three-way dispatch as InitPowerOn — the ACT->CARDEMU->PDN sequence is
+   * as silicon-specific as the enable one. These tables have been carried in
+   * hal/Hal88*PwrSeq.c since the port began with nothing calling them. */
+  WLAN_PWR_CFG *disable_flow;
+  switch (_eepromManager->version_id.ICType) {
+#if defined(DEVOURER_HAVE_8814)
+  case CHIP_8814A:
+    disable_flow = rtl8814A_card_disable_flow;
+    break;
+#endif
+  case CHIP_8821:
+    disable_flow = rtl8821A_card_disable_flow;
+    break;
+  default:
+    disable_flow = rtl8812_card_disable_flow;
+    break;
+  }
+  const bool ok = HalPwrSeqCmdParsing(disable_flow);
+  if (!ok) {
+    _logger->warn("PowerOff: card-disable flow did not complete");
+  }
+  /* Either way the chip is no longer in the state InitPowerOn's early-out
+   * assumes, so clear the latch — otherwise a re-init on this same HalModule
+   * would skip the power-on sequence and bring up a half-powered chip. */
+  _macPwrCtrlOn = false;
+  return ok;
+}
+
 bool HalModule::InitPowerOn() {
   if (_macPwrCtrlOn) {
     return true;

--- a/src/jaguar1/HalModule.cpp
+++ b/src/jaguar1/HalModule.cpp
@@ -692,6 +692,19 @@ bool HalModule::PowerOff() {
   if (!ok) {
     _logger->warn("PowerOff: card-disable flow did not complete");
   }
+  /* Read back the state the sequence is supposed to have produced, rather than
+   * trusting its return value. The only polling step is the MAC-off wait in
+   * ACT->CARDEMU, so a sequence can "succeed" while the chip sits somewhere
+   * unintended — and a power-down that silently does nothing would make this
+   * whole teardown path inert. 0x0005 should show WL-suspend (BIT3) set and the
+   * MAC-off bit (BIT1) clear; REG_CR should read back with the MAC engines
+   * gone. Logged, not asserted: the next session's init already logs the same
+   * two registers, so the pair brackets the power state across a teardown. */
+  const uint8_t pwr_after = _device.rtw_read8(REG_SYS_CLKR + 1);
+  const uint16_t cr_after = _device.rtw_read16(REG_CR);
+  _logger->info("PowerOff: card-disable applied — 0x0005=0x{:02X} "
+                "REG_CR 0x100=0x{:04X} (seq {})",
+                pwr_after, cr_after, ok ? "ok" : "INCOMPLETE");
   /* Either way the chip is no longer in the state InitPowerOn's early-out
    * assumes, so clear the latch — otherwise a re-init on this same HalModule
    * would skip the power-on sequence and bring up a half-powered chip. */

--- a/src/jaguar1/HalModule.h
+++ b/src/jaguar1/HalModule.h
@@ -67,10 +67,20 @@ public:
             Logger_t logger, const devourer::DeviceConfig &cfg = {});
   bool rtw_hal_init(SelectedChannel selectedChannel);
   const devourer::FwBootStatus &GetFwBootStatus() const { return _fwBoot; }
+  /* Halt TRX and run the chip's card-disable power sequence, leaving it powered
+   * down but re-enumerable — the counterpart to rtw_hal_init, and what every
+   * other generation already does (HalJaguar2::power_off,
+   * HalJaguar3::rtw_hal_deinit). Without it a Jaguar1 chip stays in ACT with
+   * the RF front end live for as long as the adapter is plugged in, long after
+   * the session that brought it up has exited. Best-effort: a chip that has
+   * already left the bus makes these writes fail, which is fine. */
+  void rtw_hal_deinit();
 
 private:
   bool rtl8812au_hal_init(uint8_t init_channel);
   bool InitPowerOn();
+  /* Card-disable power sequence (ACT -> CARDEMU -> PDN) for the current die. */
+  bool PowerOff();
   bool InitLLTTable8812A(uint8_t txpktbuf_bndy);
   bool _LLTWrite_8812A(uint32_t address, uint32_t data);
   void _InitHardwareDropIncorrectBulkOut_8812A();

--- a/src/jaguar1/RadioManagementModule.cpp
+++ b/src/jaguar1/RadioManagementModule.cpp
@@ -722,6 +722,17 @@ void RadioManagementModule::DumpCanary() {
   static const uint16_t bb_pathB[] = {
       0xe1c, 0xe20, 0xe24, 0xe28, 0xe2c, 0xe30, 0xe34, 0xe38, 0xe3c,
       0xe40, 0xe50, 0xe54, 0xe10, 0xe14, 0xe90, 0xe94};
+  /* The TX IQ correction coefficients IQK writes via FillTxIqc. Two reasons
+   * they are worth their own list. They live on BB page C1 (0x82c[31]=1), so a
+   * plain read of the address returns whichever bank happens to be selected —
+   * they have to be read deliberately. And nothing in array_mp_8812a_phy_reg
+   * rewrites them, so unlike everything else here they are NOT re-established
+   * by a bring-up: whatever the last calibration left is what transmits. A bad
+   * value damages TX EVM, which kills the dense constellations while the robust
+   * rates ride through unharmed — and until now nothing in the tree could see
+   * them. */
+  static const uint16_t bb_pageC1_A[] = {0xcc4, 0xcc8, 0xccc, 0xcd4};
+  static const uint16_t bb_pageC1_B[] = {0xec4, 0xec8, 0xecc, 0xed4};
   static const uint16_t bb_pathC[] = {
       0x1820, 0x1824, 0x1828, 0x182c, 0x1830, 0x1834, 0x1838, 0x183c,
       0x1840, 0x181c, 0x1850};
@@ -732,7 +743,12 @@ void RadioManagementModule::DumpCanary() {
                                         0x102, 0x420, 0x4c8, 0x508,
                                         0x522, 0x550, 0x560, 0x610,
                                         0x614};
-  static const uint32_t rf_canary[] = {0x00, 0x05, 0x18, 0x42, 0x65, 0x8f};
+  /* 0x08 is the LOK source and 0x58 the LOK the IQK loads from it. Same
+   * reasoning as the TX IQC above: the RF table does not rewrite 0x58 and the
+   * IQK does not back it up, so it survives a bring-up. A wrong local-oscillator
+   * calibration is phase noise, which again hurts dense constellations first. */
+  static const uint32_t rf_canary[] = {0x00, 0x05, 0x08, 0x18,
+                                       0x42, 0x58, 0x65, 0x8f};
 
   const auto ictype = _eepromManager->version_id.ICType;
   const bool has_pathB = (ictype != CHIP_8821);
@@ -752,6 +768,19 @@ void RadioManagementModule::DumpCanary() {
       _logger->info("BB 0x{:04x} = 0x{:08X}", a, _device.rtw_read32(a));
     for (uint16_t a : bb_pathD)
       _logger->info("BB 0x{:04x} = 0x{:08X}", a, _device.rtw_read32(a));
+  }
+  /* Page-C1 reads. Selecting the bank is a write to 0x82c, so snapshot it and
+   * put it back — the dump must not change what the chip does, only what we
+   * can see of it. */
+  {
+    const uint32_t page_save = _device.rtw_read32(0x82c);
+    _device.phy_set_bb_reg(0x82c, 0x80000000, 0x1);
+    for (uint16_t a : bb_pageC1_A)
+      _logger->info("BBC1 0x{:03x} = 0x{:08X}", a, _device.rtw_read32(a));
+    if (has_pathB)
+      for (uint16_t a : bb_pageC1_B)
+        _logger->info("BBC1 0x{:03x} = 0x{:08X}", a, _device.rtw_read32(a));
+    _device.rtw_write32(0x82c, page_save);
   }
   for (uint16_t a : mac_canary)
     _logger->info("MAC 0x{:03x} = 0x{:08X}", a, _device.rtw_read32(a));

--- a/src/jaguar1/RadioManagementModule.h
+++ b/src/jaguar1/RadioManagementModule.h
@@ -280,6 +280,11 @@ public:
    * unconfigured BB). */
   int FastSwingOffsetSteps(int steps, bool apply_now = true);
 
+  /* Read-only dump of the canary register set (BB / MAC / per-path RF) to the
+   * diagnostic plane. Public because it is also the read-only inspection path
+   * for a chip that was never Init'ed — see IRtlDevice::DumpChipState. */
+  void DumpCanary();
+
 private:
   void rtw_hal_set_msr(uint8_t net_type);
   void hw_var_set_monitor();
@@ -305,7 +310,6 @@ private:
   void Set_HW_VAR_ENABLE_RX_BAR(bool val);
   void phy_SwChnl8812();
   void phy_SwChnl8812_fast(uint8_t channelToSW);
-  void DumpCanary();
   void phy_SwChnl8814A();
   bool phy_SwBand8812(uint8_t channelToSW);
   void phy_FixSpur_8812A(ChannelWidth_t Bandwidth, uint8_t Channel);

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -1856,7 +1856,25 @@ bool RtlJaguarDevice::NetDevOpen(SelectedChannel selectedChannel) {
   return true;
 }
 
-void RtlJaguarDevice::Stop() { _device.quiesce_tx(); }
+/* Clean shutdown — see IRtlDevice::Stop. Quiesce TX first so the de-init writes
+ * are not racing frames the transport still owns, then power the chip down.
+ *
+ * The power-down is the point: without it a Jaguar1 chip stays in ACT with its
+ * RF front end live for as long as the adapter is plugged in, heating across
+ * back-to-back sessions until the dense constellations stop decoding while the
+ * robust rates carry on. It also means a beacon loaded into the MAC's reserved
+ * page stops airing when the session ends instead of transmitting forever.
+ *
+ * Best-effort: a chip that already dropped off the bus makes the writes fail,
+ * which is fine on a teardown path. */
+void RtlJaguarDevice::Stop() {
+  _device.quiesce_tx();
+  try {
+    _halModule.rtw_hal_deinit();
+  } catch (...) {
+    _logger->info("Jaguar1: Stop() de-init writes failed (chip already gone?)");
+  }
+}
 
 RtlJaguarDevice::~RtlJaguarDevice() {
   /* First, before any member starts unwinding: the async bulk-OUT URBs point
@@ -1878,6 +1896,14 @@ RtlJaguarDevice::~RtlJaguarDevice() {
   _rxmask_stop.store(true);
   if (_rxmask_thread.joinable()) {
     _rxmask_thread.join();
+  }
+  /* Backstop for a caller that destroys without Stop(): power the chip down so
+   * it is not left in ACT heating itself indefinitely. After the thread joins,
+   * so nothing is still touching the chip. Harmless if Stop() already ran. */
+  try {
+    _halModule.rtw_hal_deinit();
+  } catch (...) {
+    /* Teardown path — a chip that already left the bus is not an error. */
   }
 }
 

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -1861,13 +1861,15 @@ bool RtlJaguarDevice::NetDevOpen(SelectedChannel selectedChannel) {
  *
  * The power-down is the point: without it a Jaguar1 chip stays in ACT with its
  * RF front end live for as long as the adapter is plugged in, long after the
- * owning process has exited — which is both wrong on its own terms and what
- * every other generation already avoids. Measured consequence: a 60 s idle
- * recovers MCS7 delivery from 73% to 86% only once this exists; before it,
- * idling recovered nothing (docs/warm-tx-degradation.md, which also records why
- * the *reason* removing power helps is still open). It also means a beacon
- * loaded into the MAC's reserved page stops airing when the session ends
- * instead of transmitting forever.
+ * owning process has exited. That is wrong on its own terms, it is what every
+ * other generation already avoids (HalJaguar2::power_off,
+ * HalJaguar3::rtw_hal_deinit), and it is what makes a beacon loaded into the
+ * MAC's reserved page stop airing when the session ends instead of
+ * transmitting indefinitely.
+ *
+ * No performance claim is attached. An earlier revision cited a delivery
+ * recovery here; that measurement came from a ground station too marginal to
+ * support it (docs/warm-tx-degradation.md).
  *
  * Best-effort: a chip that already dropped off the bus makes the writes fail,
  * which is fine on a teardown path. */

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -1860,10 +1860,14 @@ bool RtlJaguarDevice::NetDevOpen(SelectedChannel selectedChannel) {
  * are not racing frames the transport still owns, then power the chip down.
  *
  * The power-down is the point: without it a Jaguar1 chip stays in ACT with its
- * RF front end live for as long as the adapter is plugged in, heating across
- * back-to-back sessions until the dense constellations stop decoding while the
- * robust rates carry on. It also means a beacon loaded into the MAC's reserved
- * page stops airing when the session ends instead of transmitting forever.
+ * RF front end live for as long as the adapter is plugged in, long after the
+ * owning process has exited — which is both wrong on its own terms and what
+ * every other generation already avoids. Measured consequence: a 60 s idle
+ * recovers MCS7 delivery from 73% to 86% only once this exists; before it,
+ * idling recovered nothing (docs/warm-tx-degradation.md, which also records why
+ * the *reason* removing power helps is still open). It also means a beacon
+ * loaded into the MAC's reserved page stops airing when the session ends
+ * instead of transmitting forever.
  *
  * Best-effort: a chip that already dropped off the bus makes the writes fail,
  * which is fine on a teardown path. */

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -1873,6 +1873,11 @@ bool RtlJaguarDevice::NetDevOpen(SelectedChannel selectedChannel) {
  * which is fine on a teardown path. */
 void RtlJaguarDevice::Stop() {
   _device.quiesce_tx();
+  if (!_cfg.tuning.teardown_power_down) {
+    _logger->info("Jaguar1: Stop() leaving the chip powered "
+                  "(tuning.teardown_power_down=0)");
+    return;
+  }
   try {
     _halModule.rtw_hal_deinit();
   } catch (...) {
@@ -1902,12 +1907,14 @@ RtlJaguarDevice::~RtlJaguarDevice() {
     _rxmask_thread.join();
   }
   /* Backstop for a caller that destroys without Stop(): power the chip down so
-   * it is not left in ACT heating itself indefinitely. After the thread joins,
-   * so nothing is still touching the chip. Harmless if Stop() already ran. */
-  try {
-    _halModule.rtw_hal_deinit();
-  } catch (...) {
-    /* Teardown path — a chip that already left the bus is not an error. */
+   * it is not left in ACT indefinitely. After the thread joins, so nothing is
+   * still touching the chip. Harmless if Stop() already ran. */
+  if (_cfg.tuning.teardown_power_down) {
+    try {
+      _halModule.rtw_hal_deinit();
+    } catch (...) {
+      /* Teardown path — a chip that already left the bus is not an error. */
+    }
   }
 }
 

--- a/src/jaguar1/RtlJaguarDevice.h
+++ b/src/jaguar1/RtlJaguarDevice.h
@@ -227,6 +227,8 @@ public:
   devourer::FwBootStatus GetFwBootStatus() override {
     return _halModule.GetFwBootStatus();
   }
+  /* Read-only canary dump, safe to call without Init — see IRtlDevice. */
+  void DumpChipState() override { _radioManagement->DumpCanary(); }
 
   /* Runtime TX-mode default. send_packet honours a frame's own radiotap rate
    * fields per-packet; when a frame's radiotap carries no rate, this mode

--- a/tests/README.md
+++ b/tests/README.md
@@ -462,6 +462,31 @@ substitute the in-tree `rtw88` for the vendor driver: it accepts frames on a
 monitor netdev and reports them injected while airing nothing decodable, which
 reads as a kernel-side failure at every rate.
 
+### `ground_station_qualify.sh`: is your receiver fit to measure this rate?
+
+Run before trusting any delivery number, and before believing any story about a
+transmitter. Sweeps the rate ladder on the ground station and refuses the pairing
+(exit 1) when the test rate is off the flat part of the curve.
+
+```bash
+sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;0bda:8813=4-2.3,2" \
+     GND_VID=0x0bda GND_PID=0x8813 tests/ground_station_qualify.sh MCS7/20
+```
+
+A receiver sitting on its cliff at the test rate measures **itself**, not the
+transmitter, and swings between fine and zero on a few dB of ambient while the
+robust rates stay pinned — indistinguishable from a transmitter that degrades and
+recovers. Same TX, same channel, minutes apart:
+
+| ground | MCS3 | MCS4 | MCS5 | MCS6 | MCS7 |
+| --- | --- | --- | --- | --- | --- |
+| Archer T3U (8822BU, **internal** antennas) | 97.8 | 98.3 | 79.1 | 49.0 | **2.9** |
+| RTL8814AU (two **external** antennas) | 80.6 | 80.2 | 80.8 | 80.6 | **80.4** |
+
+Both adapters are healthy. Prefer external-antenna adapters as ground stations
+for high-MCS work, and cross-check against a second independent receiver
+(`rx_vendor_ab.sh` runs the vendor driver on the *receive* side).
+
 ### Warm-session TX degradation: four harnesses, and start with the first
 
 **`probe_repeatability.sh` — run this before believing any delivery

--- a/tests/README.md
+++ b/tests/README.md
@@ -462,6 +462,25 @@ substitute the in-tree `rtw88` for the vendor driver: it accepts frames on a
 monitor netdev and reports them injected while airing nothing decodable, which
 reads as a kernel-side failure at every rate.
 
+### `warm_tx_degradation_repro.sh`: chip temperature vs usable modulation
+
+Holds one ground receiver up for a whole run so the reference never moves, then
+alternates probes with warm devourer sessions, recording delivery at a test rate
+and a robust control rate alongside the chip's thermal meter and the receiver's
+RSSI/EVM. Two controls close it: an idle with no power cycle, and a VBUS cycle.
+
+```bash
+sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
+     tests/warm_tx_degradation_repro.sh
+# WARM_PWR=63 WARM_GAP=0 makes the warm sessions max-power/max-duty heating
+```
+
+Reading it: falling delivery with **flat RSSI and rising thermal** is heat (a
+hot die loses the dense constellations first); falling delivery with **falling
+RSSI** would be a transmitter losing power, a different bug. Measured on an
+8812AU, thermal 43 → 53 costs MCS7 ~12 points at unchanged RSSI. Full results
+and the fix: `docs/warm-tx-degradation.md`.
+
 ### `tx_teardown_asan.sh` / `teardown_gen_sanity.sh`: lifetime bugs on real hardware
 
 A sanitizer only sees what runs, and the interesting lifetime bugs live in the

--- a/tests/README.md
+++ b/tests/README.md
@@ -462,24 +462,36 @@ substitute the in-tree `rtw88` for the vendor driver: it accepts frames on a
 monitor netdev and reports them injected while airing nothing decodable, which
 reads as a kernel-side failure at every rate.
 
-### `warm_tx_degradation_repro.sh`: chip temperature vs usable modulation
+### Warm-session TX degradation: four harnesses, and start with the first
 
-Holds one ground receiver up for a whole run so the reference never moves, then
-alternates probes with warm devourer sessions, recording delivery at a test rate
-and a robust control rate alongside the chip's thermal meter and the receiver's
-RSSI/EVM. Two controls close it: an idle with no power cycle, and a VBUS cycle.
+**`probe_repeatability.sh` — run this before believing any delivery
+difference.** N identical back-to-back probes with nothing changed between them,
+reporting the spread. On an 8812AU a single MCS7/20 probe has sd 1.8 and a
+5.7-point range (the MCS1 control: 98.0 ± 0.2), so **effects under ~4 points are
+not detectable one-shot**. Several plausible-looking decay curves in this
+investigation turned out to sit inside that band.
 
 ```bash
 sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
-     tests/warm_tx_degradation_repro.sh
-# WARM_PWR=63 WARM_GAP=0 makes the warm sessions max-power/max-duty heating
+     tests/probe_repeatability.sh
 ```
 
-Reading it: falling delivery with **flat RSSI and rising thermal** is heat (a
-hot die loses the dense constellations first); falling delivery with **falling
-RSSI** would be a transmitter losing power, a different bug. Measured on an
-8812AU, thermal 43 → 53 costs MCS7 ~12 points at unchanged RSSI. Full results
-and the fix: `docs/warm-tx-degradation.md`.
+`warm_tx_degradation_repro.sh` holds one ground receiver up for a whole run,
+then alternates probes with warm devourer sessions, recording delivery at a test
+and a control rate alongside the chip thermal meter and the receiver's RSSI/EVM.
+Two controls close it: an idle with no power cycle, and a VBUS cycle.
+`WARM_PWR=63 WARM_GAP=0` turns the warm sessions into max-power/max-duty
+heating.
+
+`thermal_offtime_sweep.sh` and `thermal_causation_probe.sh` exist to separate
+*cooling* from *state reset*, which no ordinary power-cycle experiment can do —
+the first varies only how long the chip stays powered down, the second measures
+delivery inside a single uninterrupted session where nothing but temperature can
+move. Both currently argue **against** a thermal explanation; the mechanism is
+open. Results and what did not survive testing: `docs/warm-tx-degradation.md`.
+
+Reading any of them: falling delivery with **flat RSSI** is signal quality;
+falling RSSI would be a transmitter losing power, a different bug.
 
 ### `tx_teardown_asan.sh` / `teardown_gen_sanity.sh`: lifetime bugs on real hardware
 

--- a/tests/band_stressor_sniffer.sh
+++ b/tests/band_stressor_sniffer.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Does band switching actually degrade the TRANSMITTER? Judged by an independent
+# receiver, so the answer cannot be an artifact of the devourer link.
+#
+# The band-switch arm of the severe-form hunt showed MCS7 collapsing to 0% while
+# MCS1 held at 97%, measured over a devourer->devourer link. That looked like the
+# #348 severe form. It was not safe to believe: minutes later the same
+# transmitter delivered MCS7 at 62% to an AR9271 sniffer, and a fresh
+# power-cycled devourer receiver still read ~0%. Delivery is a property of the
+# whole link, and the original #348 report was measured the same way.
+#
+# So: measure the transmitter alone. The AR9271 (ath9k_htc) shares no silicon,
+# firmware or driver code with the DUT, and it is not being stressed. Anything it
+# still decodes was transmitted correctly.
+#
+#   sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3" tests/band_stressor_sniffer.sh
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+TXDEMO="$ROOT/build/txdemo"
+
+DUT_VID=${DUT_VID:-0bda} DUT_PID=${DUT_PID:-8812}
+SNIFF=${SNIFF:-wlp13s0u1u3}
+CH=${CH:-6}
+RATES=${RATES:-"7 4 1"}
+SESSIONS=${SESSIONS:-8}
+SECS=${SECS:-6}
+PAYLOAD=${PAYLOAD:-1400}
+CANON=57:42:75:05:d6:00
+OUT=${OUT:-/tmp/devourer-band-sniffer}
+mkdir -p "$OUT"
+
+cleanup() { sudo pkill -f "tcpdump -i $SNIFF" 2>/dev/null; sudo pkill -x txdemo 2>/dev/null; wait 2>/dev/null; }
+trap cleanup EXIT INT TERM
+
+[ -e "/sys/class/net/$SNIFF" ] || { echo "no sniffer $SNIFF" >&2; exit 2; }
+sudo ip link set "$SNIFF" down; sudo iw dev "$SNIFF" set type monitor
+sudo ip link set "$SNIFF" up;   sudo iw dev "$SNIFF" set channel "$CH"
+sleep 1
+
+cold_cycle() {
+  local map=${REGRESS_VBUS_MAP:-} entry hubport
+  entry=$(tr ';' '\n' <<<"$map" | grep -i "^$DUT_VID:$DUT_PID=" | head -1) || return 1
+  hubport=${entry#*=}
+  sudo uhubctl -l "${hubport%,*}" -p "${hubport#*,}" -a cycle -d 3 >/dev/null 2>&1
+  sleep 12
+}
+
+# Transmit at MCS $1 and count what the sniffer decodes, and at which rate.
+probe() {
+  local mcs="$1" tag="$2"
+  local cap="$OUT/${tag}.txt"
+  sudo timeout $((SECS + 6)) tcpdump -i "$SNIFF" -nn -e "wlan addr2 $CANON" \
+      > "$cap" 2>/dev/null &
+  sleep 1
+  local sent
+  sent=$(sudo env DEVOURER_VID="0x$DUT_VID" DEVOURER_PID="0x$DUT_PID" \
+    DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="MCS$mcs/20" \
+    DEVOURER_TX_PAYLOAD_BYTES="$PAYLOAD" DEVOURER_TX_GAP_US=2000 \
+    DEVOURER_TEARDOWN_POWER_DOWN=0 DEVOURER_LOG_LEVEL=warn \
+    timeout --signal=TERM $((SECS + 10)) "$TXDEMO" 2>/dev/null |
+    grep -o '"submitted":[0-9]*' | tail -1 | cut -d: -f2)
+  sleep 2
+  local n rates
+  n=$(grep -c "$CANON" "$cap" 2>/dev/null || echo 0)
+  rates=$(grep -oE "MCS [0-9]+" "$cap" 2>/dev/null | sort | uniq -c | tr -s ' ' | tr '\n' ' ')
+  printf '%s %s %s' "${sent:-0}" "$n" "${rates:-none}"
+}
+
+row() { # $1=label
+  local label="$1" m out sent rx rates
+  printf '  %-22s' "$label"
+  for m in $RATES; do
+    read -r sent rx rates <<<"$(probe "$m" "${label// /_}_mcs$m")"
+    printf ' MCS%-2s rx=%-6s' "$m" "$rx"
+  done
+  printf '\n'
+}
+
+echo "band-switch stressor, judged by $SNIFF (independent receiver)"
+echo "  sniffer ambient: $(sudo timeout 3 tcpdump -i "$SNIFF" -nn 2>/dev/null | wc -l) frames/3s"
+echo
+cold_cycle || { echo "cold cycle failed" >&2; exit 1; }
+row "before (cold)"
+
+echo "  (applying $SESSIONS band-switching sessions 2.4 <-> 5 GHz ...)"
+i=0
+while [ "$i" -lt "$SESSIONS" ]; do
+  c=$([ $((i % 2)) -eq 0 ] && echo 36 || echo "$CH")
+  sudo env DEVOURER_VID="0x$DUT_VID" DEVOURER_PID="0x$DUT_PID" \
+    DEVOURER_CHANNEL="$c" DEVOURER_TX_RATE="MCS7/20" DEVOURER_TX_GAP_US=0 \
+    DEVOURER_TEARDOWN_POWER_DOWN=0 DEVOURER_LOG_LEVEL=warn \
+    timeout --signal=TERM 14 "$TXDEMO" >/dev/null 2>&1
+  i=$((i + 1))
+done
+row "after band sessions"
+
+echo
+echo "a real transmitter defect shows the sniffer's high-MCS count collapsing."
+echo "unchanged counts mean the transmitter is fine and the earlier collapse was"
+echo "a property of the devourer receive link, not of TX."

--- a/tests/ground_rx_degradation.sh
+++ b/tests/ground_rx_degradation.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Is the high-rate delivery loss in the TRANSMITTER or the RECEIVER?
+#
+# Every measurement in this investigation so far reported "delivery", which is a
+# property of the whole link. When it fell, the transmitter got the blame — the
+# DUT was the thing being stressed and the thing being power-cycled. The ground
+# station was set up once and left running for the entire run.
+#
+# Then a vendor-driver A/B judged by a THIRD receiver (an AR9271 sniffer) showed
+# the very same "dead" transmitter delivering MCS7 at 62%, minutes after a run
+# had reported 0%. The only difference was which receiver was listening.
+#
+# So this isolates the receiver, by recovering it in increasing steps while the
+# transmitter is left completely alone:
+#
+#   1. fresh        - ground rxdemo just started
+#   2. aged         - after the ground has been running a while under load
+#   3. rx restart   - kill and restart the rxdemo PROCESS only (no power cycle):
+#                     separates accumulated software/driver state from chip state
+#   4. rx VBUS      - power-cycle the GROUND adapter (chip state)
+#   5. tx VBUS      - power-cycle the TRANSMITTER, ground left as-is: the control.
+#                     If this is what recovers delivery, the receiver is innocent.
+#
+# The robust control rate is measured at every step. A receiver losing high-order
+# demodulation shows the test rate collapsing while the control stays pinned.
+#
+#   sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
+#        tests/ground_rx_degradation.sh
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+TXDEMO="$ROOT/build/txdemo"
+RXDEMO="$ROOT/build/rxdemo"
+
+DUT_VID=${DUT_VID:-0x0bda} DUT_PID=${DUT_PID:-0x8812}
+GND_VID=${GND_VID:-0x2357} GND_PID=${GND_PID:-0x012d}
+CH=${CH:-6}
+RATE=${RATE:-MCS7/20}
+CTRL=${CTRL:-MCS1/20}
+AGE_SESSIONS=${AGE_SESSIONS:-8}   # load applied while the ground station ages
+PROBES=${PROBES:-3}
+SECS=${SECS:-5}
+OUT=${OUT:-/tmp/devourer-ground-rx}
+
+mkdir -p "$OUT"
+RXLOG="$OUT/ground.rx.jsonl"
+: > "$OUT/results.tsv"
+
+RXPID=""
+cleanup() {
+  [ -n "$RXPID" ] && kill "$RXPID" 2>/dev/null
+  pkill -x txdemo 2>/dev/null
+  wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+cold_cycle() {
+  local map=${REGRESS_VBUS_MAP:-} key entry hubport
+  [ -n "$map" ] || { echo "REGRESS_VBUS_MAP unset" >&2; return 1; }
+  key=$(printf '%s:%s' "${1#0x}" "${2#0x}")
+  entry=$(tr ';' '\n' <<<"$map" | grep -i "^$key=" | head -1) || true
+  [ -n "${entry:-}" ] || { echo "no VBUS entry for $key" >&2; return 1; }
+  hubport=${entry#*=}
+  sudo uhubctl -l "${hubport%,*}" -p "${hubport#*,}" -a cycle -d 3 >/dev/null 2>&1
+  sleep 12
+}
+
+start_ground() {
+  [ -n "$RXPID" ] && { kill "$RXPID" 2>/dev/null; wait "$RXPID" 2>/dev/null; }
+  DEVOURER_VID="$GND_VID" DEVOURER_PID="$GND_PID" DEVOURER_CHANNEL="$CH" \
+  DEVOURER_RX_AGG_SA=canon DEVOURER_RX_ENERGY_MS=500 DEVOURER_LOG_LEVEL=warn \
+  "$RXDEMO" >> "$RXLOG" 2>>"$OUT/ground.rx.stderr" &
+  RXPID=$!
+  sleep 9
+  kill -0 "$RXPID" 2>/dev/null || { echo "ground RX died" >&2; exit 1; }
+}
+
+measure() { # $1=rate $2=tag -> mean percent over PROBES
+  local rate="$1" tag="$2" i off0 off1 sent d sum=0 n=0
+  for i in $(seq 1 "$PROBES"); do
+    off0=$(stat -c%s "$RXLOG")
+    sudo env DEVOURER_VID="$DUT_VID" DEVOURER_PID="$DUT_PID" \
+      DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$rate" \
+      DEVOURER_TX_GAP_US=2000 DEVOURER_TEARDOWN_POWER_DOWN=0 \
+      DEVOURER_LOG_LEVEL=warn \
+      timeout --signal=TERM $((SECS + 12)) "$TXDEMO" \
+      > "$OUT/tx_${tag}_$i.jsonl" 2>/dev/null &
+    local p=$!
+    sleep $((SECS + 6))
+    kill -TERM "$p" 2>/dev/null; wait "$p" 2>/dev/null
+    sleep 1
+    off1=$(stat -c%s "$RXLOG")
+    sent=$(grep -o '"submitted":[0-9]*' "$OUT/tx_${tag}_$i.jsonl" | tail -1 | cut -d: -f2)
+    d=$(python3 - "$RXLOG" "$off0" "$off1" <<'EOF'
+import sys
+sys.path.insert(0, "tests")
+from devourer_events import parse_event
+f = open(sys.argv[1], "rb"); f.seek(int(sys.argv[2]))
+blob = f.read(int(sys.argv[3]) - int(sys.argv[2])).decode(errors="replace")
+print(sum(int(ev.get("frames") or 0)
+          for ev in (parse_event(l, "rx.energy") for l in blob.splitlines()) if ev))
+EOF
+)
+    if [ "${sent:-0}" -gt 0 ] 2>/dev/null; then
+      sum=$(python3 -c "print($sum + 100.0*$d/$sent)"); n=$((n + 1))
+    fi
+  done
+  python3 -c "print('%.1f' % ($sum/$n) if $n else 'nan')"
+}
+
+report() { printf '  %-24s %-9s %-9s\n' "$1" "$2" "$3"
+           printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$OUT/results.tsv"; }
+
+# Both ends cold, so step 1 is a genuine fresh baseline.
+cold_cycle "$GND_VID" "$GND_PID" || exit 1
+cold_cycle "$DUT_VID" "$DUT_PID" || exit 1
+start_ground
+
+echo "is the loss in the transmitter or the receiver?"
+echo "  transmitter is left untouched until the last step"
+echo
+printf '  %-24s %-9s %-9s\n' "step" "$RATE" "$CTRL"
+report "1 fresh ground" "$(measure "$RATE" fresh)" "$(measure "$CTRL" fresh_c)"
+
+echo "  (aging the ground station under $AGE_SESSIONS load sessions ...)"
+for _ in $(seq 1 "$AGE_SESSIONS"); do
+  sudo env DEVOURER_VID="$DUT_VID" DEVOURER_PID="$DUT_PID" \
+    DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$RATE" DEVOURER_TX_GAP_US=0 \
+    DEVOURER_TEARDOWN_POWER_DOWN=0 DEVOURER_LOG_LEVEL=warn \
+    timeout --signal=TERM 14 "$TXDEMO" >/dev/null 2>&1
+done
+report "2 aged ground" "$(measure "$RATE" aged)" "$(measure "$CTRL" aged_c)"
+
+start_ground   # process restart only — no power cycle
+report "3 rx process restart" "$(measure "$RATE" rxproc)" "$(measure "$CTRL" rxproc_c)"
+
+cold_cycle "$GND_VID" "$GND_PID" || exit 1
+start_ground
+report "4 rx VBUS cycle" "$(measure "$RATE" rxvbus)" "$(measure "$CTRL" rxvbus_c)"
+
+cold_cycle "$DUT_VID" "$DUT_PID" || exit 1
+report "5 tx VBUS cycle (control)" "$(measure "$RATE" txvbus)" "$(measure "$CTRL" txvbus_c)"
+
+echo
+echo "read: recovery at step 3 or 4 => the RECEIVER was the problem;"
+echo "      recovery only at step 5 => the transmitter was."
+echo "results: $OUT/results.tsv"

--- a/tests/ground_station_qualify.sh
+++ b/tests/ground_station_qualify.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Is this ground station fit to measure the rate you are about to measure?
+#
+# Run this BEFORE trusting any delivery number, and before believing any story
+# about a transmitter. A receiver whose modulation cliff sits at or below the
+# test rate does not measure the transmitter — it measures itself, and it does so
+# with enormous swings, because a few dB of ambient moves a cliff-edge rate
+# between "fine" and "zero" while leaving the robust rates untouched.
+#
+# That failure mode looks exactly like a transmitter that degrades and recovers,
+# and it cost this project an entire investigation. Measured here on the same
+# transmitter, same channel, minutes apart:
+#
+#   TP-Link Archer T3U (8822BU, INTERNAL antennas)
+#     MCS3 97.8  MCS4 98.3  MCS5 79.1  MCS6 49.0  MCS7 2.9   <- cliff inside 64-QAM
+#   RTL8814AU (two EXTERNAL antennas)
+#     MCS3 80.6  MCS4 80.2  MCS5 80.8  MCS6 80.6  MCS7 80.4  <- flat, margin to spare
+#
+# Both were healthy. The T3U simply has less antenna gain, so its cliff lands in
+# the middle of the rates under test. Earlier in the same session, with lower
+# ambient, that same T3U delivered MCS7 at 68% — the cliff had not moved, the
+# operating point had.
+#
+# A qualified ground station is FLAT from the test rate downwards. If delivery is
+# already rolling off at the test rate, raise the ground's margin (external
+# antennas, distance, orientation, a quieter channel) or measure a lower rate.
+#
+#   sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;0bda:8813=4-2.3,2" \
+#        GND_VID=0x0bda GND_PID=0x8813 tests/ground_station_qualify.sh MCS7/20
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TEST_RATE=${1:-MCS7/20}
+DUT_VID=${DUT_VID:-0x0bda} DUT_PID=${DUT_PID:-0x8812}
+GND_VID=${GND_VID:-0x0bda} GND_PID=${GND_PID:-0x8813}
+CH=${CH:-6}
+LADDER=${LADDER:-"MCS1/20 MCS3/20 MCS4/20 MCS5/20 MCS6/20 MCS7/20"}
+SECS=${SECS:-5}
+OUT=${OUT:-/tmp/devourer-ground-qualify}
+mkdir -p "$OUT"
+
+# The ladder must include the test rate, or the verdict is about nothing.
+case " $LADDER " in
+  *" $TEST_RATE "*) ;;
+  *) LADDER="$LADDER $TEST_RATE" ;;
+esac
+
+"$HERE/nitroqam_waterfall.sh" \
+    --emit-vid "$DUT_VID" --emit-pid "$DUT_PID" \
+    --ground-vid "$GND_VID" --ground-pid "$GND_PID" \
+    --channel "$CH" --bw 20 \
+    --encs "$(echo "$LADDER" | tr ' ' ',')" \
+    --baseline "${LADDER%% *}" \
+    --pwr-mode none --pwr-start 0 --pwr-stop 0 --secs "$SECS" \
+    --outdir "$OUT" 2>/dev/null | grep -E '^\{' > "$OUT/points.jsonl"
+
+python3 - "$OUT/points.jsonl" "$TEST_RATE" <<'EOF'
+import json, sys
+
+pts = {}
+for line in open(sys.argv[1]):
+    line = line.strip()
+    if not line:
+        continue
+    p = json.loads(line)
+    if p["sent"] > 0:
+        pts[p["enc"]] = 100.0 * p["delivered"] / p["sent"]
+test = sys.argv[2]
+
+if not pts:
+    print("no usable points — the link delivered nothing at any rate")
+    raise SystemExit(2)
+
+print("  ground-station rate ladder")
+for enc, v in pts.items():
+    print("    %-12s %5.1f%%  %s" % (enc, v, "#" * int(v / 4)))
+
+if test not in pts:
+    print("\n  test rate %s not measured — cannot qualify" % test)
+    raise SystemExit(2)
+
+# Flat means the test rate keeps up with the best robust rate below it. A cliff
+# shows as the test rate falling well short of what the same link does lower down.
+best = max(pts.values())
+at = pts[test]
+ratio = at / best if best else 0.0
+print()
+if ratio >= 0.85:
+    print("  QUALIFIED for %s: %.1f%% vs %.1f%% best on the ladder — flat, the "
+          "receiver has margin and delivery reflects the TRANSMITTER."
+          % (test, at, best))
+    raise SystemExit(0)
+print("  NOT QUALIFIED for %s: %.1f%% vs %.1f%% best on the ladder. This "
+      "receiver is on its cliff at the test rate, so delivery there measures "
+      "the RECEIVER, not the transmitter, and will swing hugely with ambient. "
+      "Use a ground station with more margin (external antennas, distance, "
+      "orientation, quieter channel) or measure a lower rate."
+      % (test, at, best))
+raise SystemExit(1)
+EOF

--- a/tests/probe_repeatability.sh
+++ b/tests/probe_repeatability.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# What is the run-to-run scatter of a single delivery probe, with NOTHING
+# changed between runs?
+#
+# This is the measurement that should have come first. Every conclusion drawn
+# from the warm-degradation work — the decay curve, the recovery, the thermal
+# correlation — is a difference of a few points between probes. None of it means
+# anything unless a probe repeated under identical conditions lands in a tighter
+# band than the effect being claimed.
+#
+# So: one ground receiver up for the whole run, one DUT, N identical probes
+# back to back, no power cycling, no config change, no re-tuning. Report the
+# spread. Any claimed effect smaller than this band is not a finding.
+#
+#   sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
+#        tests/probe_repeatability.sh
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+TXDEMO="$ROOT/build/txdemo"
+RXDEMO="$ROOT/build/rxdemo"
+
+DUT_VID=${DUT_VID:-0x0bda} DUT_PID=${DUT_PID:-0x8812}
+GND_VID=${GND_VID:-0x2357} GND_PID=${GND_PID:-0x012d}
+CH=${CH:-6}
+RATES=${RATES:-"MCS7/20 MCS1/20"}
+REPS=${REPS:-10}
+SECS=${SECS:-6}
+OUT=${OUT:-/tmp/devourer-probe-repeat}
+
+mkdir -p "$OUT"
+RXLOG="$OUT/ground.rx.jsonl"
+: > "$OUT/results.tsv"
+
+RXPID=""
+cleanup() {
+  [ -n "$RXPID" ] && kill "$RXPID" 2>/dev/null
+  pkill -x txdemo 2>/dev/null
+  wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+cold_cycle() {
+  local map=${REGRESS_VBUS_MAP:-} key entry hubport
+  [ -n "$map" ] || return 0
+  key=$(printf '%s:%s' "${1#0x}" "${2#0x}")
+  entry=$(tr ';' '\n' <<<"$map" | grep -i "^$key=" | head -1) || return 0
+  hubport=${entry#*=}
+  sudo uhubctl -l "${hubport%,*}" -p "${hubport#*,}" -a cycle -d 3 >/dev/null 2>&1
+  sleep 12
+}
+
+probe() { # $1=rate $2=tag -> "delivered sent thermal rssi"
+  local rate="$1" tag="$2" off0 off1 sent therm
+  off0=$(stat -c%s "$RXLOG")
+  sudo env DEVOURER_VID="$DUT_VID" DEVOURER_PID="$DUT_PID" \
+    DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$rate" \
+    DEVOURER_TX_GAP_US=2000 DEVOURER_THERMAL_POLL_MS=500 \
+    DEVOURER_LOG_LEVEL=warn \
+    timeout --signal=TERM $((SECS + 12)) "$TXDEMO" \
+    > "$OUT/tx_$tag.jsonl" 2>"$OUT/tx_$tag.err" &
+  local p=$!
+  sleep $((SECS + 6))
+  kill -TERM "$p" 2>/dev/null; wait "$p" 2>/dev/null
+  sleep 1
+  off1=$(stat -c%s "$RXLOG")
+  sent=$(grep -o '"submitted":[0-9]*' "$OUT/tx_$tag.jsonl" | tail -1 | cut -d: -f2)
+  therm=$(grep -o '"raw":[0-9]*' "$OUT/tx_$tag.jsonl" | tail -1 | cut -d: -f2)
+  python3 - "$RXLOG" "$off0" "$off1" "${sent:-0}" "${therm:-0}" <<'EOF'
+import sys
+sys.path.insert(0, "tests")
+from devourer_events import parse_event
+f = open(sys.argv[1], "rb"); f.seek(int(sys.argv[2]))
+blob = f.read(int(sys.argv[3]) - int(sys.argv[2])).decode(errors="replace")
+frames, rssi = 0, []
+for line in blob.splitlines():
+    ev = parse_event(line, "rx.energy")
+    if not ev:
+        continue
+    n = int(ev.get("frames") or 0)
+    frames += n
+    if n and ev.get("rssi_mean"):
+        rssi.append(ev["rssi_mean"])
+print("%d %s %s %.0f" % (frames, sys.argv[4], sys.argv[5],
+                         sum(rssi) / len(rssi) if rssi else 0))
+EOF
+}
+
+cold_cycle "$GND_VID" "$GND_PID"
+DEVOURER_VID="$GND_VID" DEVOURER_PID="$GND_PID" DEVOURER_CHANNEL="$CH" \
+DEVOURER_RX_AGG_SA=canon DEVOURER_RX_ENERGY_MS=500 DEVOURER_LOG_LEVEL=warn \
+"$RXDEMO" > "$RXLOG" 2>"$OUT/ground.rx.stderr" &
+RXPID=$!
+sleep 9
+kill -0 "$RXPID" 2>/dev/null || { echo "ground RX died" >&2; exit 1; }
+
+cold_cycle "$DUT_VID" "$DUT_PID"
+
+for RATE in $RATES; do
+  echo
+  echo "== $RATE, $REPS identical probes, nothing changed between them"
+  printf '  %-5s %-9s %-8s %-6s\n' "rep" "delivery" "thermal" "rssi"
+  for i in $(seq 1 "$REPS"); do
+    read -r d s th rs <<<"$(probe "$RATE" "${RATE//\//-}_$i")"
+    pct=$(python3 -c "print('%.1f' % (100*$d/$s) if $s else 0)")
+    printf '  %-5s %-9s %-8s %-6s\n' "$i" "$pct%" "$th" "$rs"
+    printf '%s\t%s\t%s\t%s\t%s\n' "$RATE" "$i" "$pct" "$th" "$rs" >> "$OUT/results.tsv"
+  done
+  python3 - "$OUT/results.tsv" "$RATE" <<'EOF'
+import sys, statistics as st
+rate = sys.argv[2]
+v = [float(l.split("\t")[2]) for l in open(sys.argv[1])
+     if l.split("\t")[0] == rate]
+if len(v) > 1:
+    sd = st.stdev(v)
+    print("  -> mean %.1f%%  sd %.1f  range %.1f-%.1f  spread %.1f points"
+          % (st.mean(v), sd, min(v), max(v), max(v) - min(v)))
+    print("     an effect smaller than ~%.0f points (2 sd) is not detectable "
+          "with a single probe" % (2 * sd))
+EOF
+done

--- a/tests/rx_vendor_ab.sh
+++ b/tests/rx_vendor_ab.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Is a receiver that cannot decode high-order rates broken in OUR code, or is the
+# adapter itself degraded? Same dongle, devourer vs the vendor kernel driver.
+#
+# Context: an 8822BU ground station decodes MCS1 at 98% and MCS7 at 0.4% from a
+# transmitter that an 8814AU ground decodes at 83% and an AR9271 sniffer at 62%.
+# So the transmitter is fine and this receiver is the broken end. That still
+# leaves two very different answers — a devourer RX bug, or a dying adapter —
+# and only the vendor driver on the same hardware separates them.
+#
+# The transmitter is held constant (devourer, fixed rate, fixed channel) and only
+# the RECEIVER's driver changes. Frames are counted by source address so both
+# sides count the same thing.
+#
+#   sudo REGRESS_VBUS_MAP="2357:012d=10,2;0bda:8812=3-2.3.4,3" tests/rx_vendor_ab.sh
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+TXDEMO="$ROOT/build/txdemo"
+RXDEMO="$ROOT/build/rxdemo"
+
+TX_VID=${TX_VID:-0x0bda} TX_PID=${TX_PID:-0x8812}
+RX_VID=${RX_VID:-2357}   RX_PID=${RX_PID:-012d}     # receiver under test, bare hex
+RX_REF=${RX_REF:-rtl88x2bu}
+RX_KO=${RX_KO:-88x2bu_ohd.ko}
+RX_MOD=${RX_MOD:-88x2bu_ohd}
+INTREE=${INTREE:-rtw88_8822bu}
+CH=${CH:-6}
+RATES=${RATES:-"MCS7/20 MCS1/20"}
+SECS=${SECS:-6}
+CANON=57:42:75:05:d6:00
+OUT=${OUT:-/tmp/devourer-rx-vendor-ab}
+mkdir -p "$OUT"
+
+RXPID=""
+cleanup() {
+  [ -n "$RXPID" ] && kill "$RXPID" 2>/dev/null
+  sudo pkill -x txdemo 2>/dev/null
+  sudo pkill -f "tcpdump -i" 2>/dev/null
+  wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+cold_cycle() { # $1=vid $2=pid, bare hex
+  local map=${REGRESS_VBUS_MAP:-} entry hubport
+  entry=$(tr ';' '\n' <<<"$map" | grep -i "^$1:$2=" | head -1) || return 1
+  hubport=${entry#*=}
+  sudo uhubctl -l "${hubport%,*}" -p "${hubport#*,}" -a cycle -d 3 >/dev/null 2>&1
+  sleep 12
+}
+
+rx_usb_node() {
+  for d in /sys/bus/usb/devices/*/; do
+    [ "$(cat "$d/idVendor" 2>/dev/null)" = "$RX_VID" ] || continue
+    [ "$(cat "$d/idProduct" 2>/dev/null)" = "$RX_PID" ] || continue
+    basename "$d"; return 0
+  done
+  return 1
+}
+
+# Transmit $1 for SECS while the caller is already listening. Echoes frames sent.
+transmit() {
+  local rate="$1"
+  local log="$OUT/tx_${rate//\//-}.jsonl"
+  # Explicit sleep-then-SIGTERM rather than letting `timeout` do the killing:
+  # the final tx.stats (the frames-sent denominator) is emitted on a clean
+  # SIGTERM, and a bring-up that runs long enough for `timeout` to fire first
+  # loses it — which silently turns a measured cell into a divide-by-zero.
+  sudo env DEVOURER_VID="$TX_VID" DEVOURER_PID="$TX_PID" \
+    DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$rate" \
+    DEVOURER_TX_GAP_US=2000 DEVOURER_TEARDOWN_POWER_DOWN=0 \
+    DEVOURER_LOG_LEVEL=warn \
+    timeout --signal=TERM $((SECS + 25)) "$TXDEMO" > "$log" 2>/dev/null &
+  local p=$!
+  sleep $((SECS + 8))
+  kill -TERM "$p" 2>/dev/null
+  wait "$p" 2>/dev/null
+  grep -o '"submitted":[0-9]*' "$log" | tail -1 | cut -d: -f2
+}
+
+# ---- leg A: receiver under devourer -----------------------------------------
+devourer_leg() {
+  local rate="$1" off0 off1 sent d
+  DEVOURER_VID="0x$RX_VID" DEVOURER_PID="0x$RX_PID" DEVOURER_CHANNEL="$CH" \
+  DEVOURER_RX_AGG_SA=canon DEVOURER_RX_ENERGY_MS=500 DEVOURER_LOG_LEVEL=warn \
+  "$RXDEMO" > "$OUT/dev_rx.jsonl" 2>/dev/null &
+  RXPID=$!
+  sleep 9
+  off0=$(stat -c%s "$OUT/dev_rx.jsonl")
+  sent=$(transmit "$rate")
+  sleep 1
+  off1=$(stat -c%s "$OUT/dev_rx.jsonl")
+  kill "$RXPID" 2>/dev/null; wait "$RXPID" 2>/dev/null; RXPID=""
+  d=$(python3 - "$OUT/dev_rx.jsonl" "$off0" "$off1" <<'EOF'
+import sys
+sys.path.insert(0, "tests")
+from devourer_events import parse_event
+f = open(sys.argv[1], "rb"); f.seek(int(sys.argv[2]))
+blob = f.read(int(sys.argv[3]) - int(sys.argv[2])).decode(errors="replace")
+print(sum(int(ev.get("frames") or 0)
+          for ev in (parse_event(l, "rx.energy") for l in blob.splitlines()) if ev))
+EOF
+)
+  printf '%s %s' "${d:-0}" "${sent:-0}"
+}
+
+# ---- leg B: same dongle under the vendor kernel driver ----------------------
+build_vendor() {
+  local dir="$ROOT/reference/$RX_REF"
+  [ -f "$dir/$RX_KO" ] && return 0
+  echo "  building $RX_REF (first run, a few minutes) ..."
+  make -C "$dir" -j"$(nproc)" > "$OUT/vendor_build.log" 2>&1 || {
+    echo "  !! vendor build failed — see $OUT/vendor_build.log" >&2
+    tail -12 "$OUT/vendor_build.log" >&2; return 1; }
+  [ -f "$dir/$RX_KO" ]
+}
+
+vendor_iface() {
+  local u prev="" cur=""
+  u=$(rx_usb_node) || return 1
+  for _ in $(seq 30); do
+    cur=$(basename "$(ls -d /sys/bus/usb/devices/$u/*/net/* 2>/dev/null | head -1)" 2>/dev/null)
+    [ -n "$cur" ] && [ "$cur" = "$prev" ] && [ -e "/sys/class/net/$cur" ] && {
+      printf '%s' "$cur"; return 0; }
+    prev="$cur"; sleep 1
+  done
+  return 1
+}
+
+vendor_leg() {
+  local rate="$1"
+  local iface sent n
+  local cap="$OUT/vendor_${rate//\//-}.txt"
+  iface=$(vendor_iface) || { echo "0 0"; return; }
+  sudo ip link set "$iface" down
+  sudo iw dev "$iface" set type monitor
+  sudo ip link set "$iface" up
+  sudo iw dev "$iface" set channel "$CH"
+  sleep 1
+  sudo timeout $((SECS + 14)) tcpdump -i "$iface" -nn -e "wlan addr2 $CANON" \
+      > "$cap" 2>/dev/null &
+  sleep 1
+  sent=$(transmit "$rate")
+  sleep 2
+  n=$(grep -c "$CANON" "$cap" 2>/dev/null || echo 0)
+  printf '%s %s' "${n:-0}" "${sent:-0}"
+}
+
+echo "receiver A/B — TX held constant (devourer 8812AU), only the RX driver changes"
+echo
+
+build_vendor || exit 1
+printf '  %-10s %-22s %-22s\n' "rate" "devourer RX" "vendor RX ($RX_MOD)"
+for RATE in $RATES; do
+  # devourer leg: kernel drivers off the dongle, chip cold.
+  sudo rmmod "$RX_MOD" 2>/dev/null
+  sudo modprobe -r "$INTREE" 2>/dev/null
+  cold_cycle "$RX_VID" "$RX_PID"
+  sudo modprobe -r "$INTREE" 2>/dev/null
+  read -r d_rx d_sent <<<"$(devourer_leg "$RATE")"
+
+  # vendor leg: same dongle, cold again so neither leg inherits the other.
+  sudo modprobe -r "$INTREE" 2>/dev/null
+  cold_cycle "$RX_VID" "$RX_PID"
+  sudo modprobe -r "$INTREE" 2>/dev/null
+  sudo insmod "$ROOT/reference/$RX_REF/$RX_KO" 2>/dev/null || true
+  read -r v_rx v_sent <<<"$(vendor_leg "$RATE")"
+  sudo rmmod "$RX_MOD" 2>/dev/null
+
+  d_pct=$(python3 -c "print('%.1f%%' % (100*$d_rx/$d_sent) if $d_sent else 'n/a')")
+  v_pct=$(python3 -c "print('%.1f%%' % (100*$v_rx/$v_sent) if $v_sent else 'n/a')")
+  printf '  %-10s %-22s %-22s\n' "$RATE" \
+      "$d_rx/$d_sent = $d_pct" "$v_rx/$v_sent = $v_pct"
+done
+
+echo
+echo "vendor decodes the high rate and devourer does not => devourer RX bug."
+echo "neither decodes it                                 => the adapter is degraded."

--- a/tests/severe_form_hunt.sh
+++ b/tests/severe_form_hunt.sh
@@ -133,13 +133,18 @@ stress_session() {
   sleep 1
 }
 
+start_ground() {
+  [ -n "$RXPID" ] && { kill "$RXPID" 2>/dev/null; wait "$RXPID" 2>/dev/null; }
+  DEVOURER_VID="$GND_VID" DEVOURER_PID="$GND_PID" DEVOURER_CHANNEL="$CH" \
+  DEVOURER_RX_AGG_SA=canon DEVOURER_RX_ENERGY_MS=500 DEVOURER_LOG_LEVEL=warn \
+  "$RXDEMO" >> "$RXLOG" 2>>"$OUT/ground.rx.stderr" &
+  RXPID=$!
+  sleep 9
+  kill -0 "$RXPID" 2>/dev/null || { echo "ground RX died" >&2; exit 1; }
+}
+
 cold_cycle "$GND_VID" "$GND_PID" || exit 1
-DEVOURER_VID="$GND_VID" DEVOURER_PID="$GND_PID" DEVOURER_CHANNEL="$CH" \
-DEVOURER_RX_AGG_SA=canon DEVOURER_RX_ENERGY_MS=500 DEVOURER_LOG_LEVEL=warn \
-"$RXDEMO" > "$RXLOG" 2>"$OUT/ground.rx.stderr" &
-RXPID=$!
-sleep 9
-kill -0 "$RXPID" 2>/dev/null || { echo "ground RX died" >&2; exit 1; }
+start_ground
 
 echo "severe-form hunt — $SESSIONS stressor sessions/arm, $PROBES probes/measurement"
 echo "  a hit is a >=20 point drop at $RATE with $CTRL intact (noise is ~+/-3)"
@@ -148,7 +153,16 @@ printf '  %-11s %-9s %-9s %-9s %-9s  %s\n' \
     "arm" "cold" "after" "delta" "ctrl" "verdict"
 
 for ARM in $ARMS; do
+  # Recover BOTH ends before every arm, and restart the ground process with
+  # them. Cycling only the DUT was a systematic flaw in the first version of
+  # this harness: the ground station stayed up across every arm, so anything
+  # that decayed on the receive side accumulated through the whole run and
+  # showed up as a per-arm delta. It produced a convincing 32-point "hit" that
+  # an independent receiver then refuted — the arms' own cold baselines had
+  # been sliding (62 -> 32 -> 1.2 -> 1.8) the entire time.
+  cold_cycle "$GND_VID" "$GND_PID" || exit 1
   cold_cycle "$DUT_VID" "$DUT_PID" || exit 1
+  start_ground
   before=$(measure "$RATE" "${ARM}_cold")
   RANDOM_SEQ=0
   for _ in $(seq 1 "$SESSIONS"); do
@@ -173,6 +187,44 @@ except ValueError:
       > "$OUT/${ARM}_after.canary" 2>&1
 done
 
+
+# --- drift canary ------------------------------------------------------------
+# Re-measure the very first arm's cold baseline at the END, both ends recovered
+# exactly as they were at the start. Nothing about the run should have changed
+# it. If it has, the reference moved underneath every arm and the per-arm deltas
+# above are differences between two different rigs, not stressor effects.
+#
+# This is not hypothetical: the run that "found" a 32-point band-switch collapse
+# had its arms' own cold baselines sliding 62 -> 32 -> 1.2 -> 1.8 -> 1.9 -> 0.7,
+# because the GROUND STATION's receiver was dying. An independent receiver later
+# showed the transmitter untouched, and the vendor driver failed on that ground
+# adapter exactly as devourer did — the adapter, not the code. Without this
+# check the run reports a confident, entirely wrong answer.
+cold_cycle "$GND_VID" "$GND_PID" || exit 1
+cold_cycle "$DUT_VID" "$DUT_PID" || exit 1
+start_ground
+first_arm=$(head -1 "$OUT/results.tsv" | cut -f1)
+first_cold=$(head -1 "$OUT/results.tsv" | cut -f2)
+final=$(measure "$RATE" drift_canary)
+echo
+python3 - "$first_arm" "$first_cold" "$final" <<'EOF'
+import sys
+arm, a, b = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    d = float(b) - float(a)
+except ValueError:
+    print("  drift canary: INVALID (%s -> %s)" % (a, b)); raise SystemExit(1)
+verdict = ("OK — the reference held" if abs(d) <= 4 else
+           "!! RUN INVALID: the reference moved %+.1f points during the run, "
+           "so every per-arm delta above is suspect. Check the GROUND station "
+           "(tests/rx_vendor_ab.sh) before believing any of it." % d)
+print("  drift canary: %s cold was %s, is now %s (%+.1f)  %s"
+      % (arm, a, b, d, verdict))
+raise SystemExit(0 if abs(d) <= 4 else 1)
+EOF
+canary_rc=$?
+
 echo
 echo "per-arm chip dumps: $OUT/*_after.canary"
 echo "results: $OUT/results.tsv"
+exit $canary_rc

--- a/tests/severe_form_hunt.sh
+++ b/tests/severe_form_hunt.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Hunt a deterministic reproduction of #348's SEVERE form: 64-QAM and up at 0%
+# delivery while 16-QAM and below stay perfect, recovered only by removing power.
+#
+# The mild form (~5-7 points across repeated identical sessions) is barely
+# outside this bench's noise — a single MCS7/20 probe has sd 1.8, so anything
+# under ~4 points is not a finding. The severe form is a >20-point collapse and
+# is unmistakable. Nothing has reproduced it since; the original sighting
+# followed a long session that, unlike the fixed-config repro, kept CHANGING the
+# radio: 2.4<->5 GHz bands, 20/40/80 bandwidths, flat max power indices, large
+# offsets, and 5 GHz tunes that never delivered.
+#
+# So each arm here adds exactly ONE of those stressors on top of the same
+# session loop, and every arm is measured the same way. That identifies the
+# responsible stressor rather than just eventually breaking the chip.
+#
+# Sessions run with DEVOURER_TEARDOWN_POWER_DOWN=0 on purpose: this is the
+# historical behaviour that produced the report, and it leaves the chip readable
+# afterwards so examples/chipstate can capture the degraded state.
+#
+#   sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
+#        tests/severe_form_hunt.sh
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+TXDEMO="$ROOT/build/txdemo"
+RXDEMO="$ROOT/build/rxdemo"
+
+DUT_VID=${DUT_VID:-0x0bda} DUT_PID=${DUT_PID:-0x8812}
+GND_VID=${GND_VID:-0x2357} GND_PID=${GND_PID:-0x012d}
+CH=${CH:-6}
+RATE=${RATE:-MCS7/20}
+CTRL=${CTRL:-MCS1/20}
+SESSIONS=${SESSIONS:-8}     # stressor sessions per arm
+PROBES=${PROBES:-3}         # repeats per measurement — must beat sd 1.8
+SECS=${SECS:-5}
+ARMS=${ARMS:-"baseline band bandwidth spur power failtune"}
+OUT=${OUT:-/tmp/devourer-severe-hunt}
+
+mkdir -p "$OUT"
+RXLOG="$OUT/ground.rx.jsonl"
+: > "$OUT/results.tsv"
+
+RXPID=""
+cleanup() {
+  [ -n "$RXPID" ] && kill "$RXPID" 2>/dev/null
+  pkill -x txdemo 2>/dev/null
+  wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+cold_cycle() {
+  local map=${REGRESS_VBUS_MAP:-} key entry hubport
+  [ -n "$map" ] || { echo "REGRESS_VBUS_MAP unset" >&2; return 1; }
+  key=$(printf '%s:%s' "${1#0x}" "${2#0x}")
+  entry=$(tr ';' '\n' <<<"$map" | grep -i "^$key=" | head -1) || true
+  [ -n "${entry:-}" ] || { echo "no VBUS entry for $key" >&2; return 1; }
+  hubport=${entry#*=}
+  sudo uhubctl -l "${hubport%,*}" -p "${hubport#*,}" -a cycle -d 3 >/dev/null 2>&1
+  sleep 12
+}
+
+# One measurement = PROBES repeats, reported as mean. Echoes "mean_pct".
+measure() {
+  local rate="$1" tag="$2" i off0 off1 sent d sum=0 n=0
+  for i in $(seq 1 "$PROBES"); do
+    off0=$(stat -c%s "$RXLOG")
+    sudo env DEVOURER_VID="$DUT_VID" DEVOURER_PID="$DUT_PID" \
+      DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$rate" \
+      DEVOURER_TX_GAP_US=2000 DEVOURER_TEARDOWN_POWER_DOWN=0 \
+      DEVOURER_LOG_LEVEL=warn \
+      timeout --signal=TERM $((SECS + 12)) "$TXDEMO" \
+      > "$OUT/tx_${tag}_$i.jsonl" 2>/dev/null &
+    local p=$!
+    sleep $((SECS + 6))
+    kill -TERM "$p" 2>/dev/null; wait "$p" 2>/dev/null
+    sleep 1
+    off1=$(stat -c%s "$RXLOG")
+    sent=$(grep -o '"submitted":[0-9]*' "$OUT/tx_${tag}_$i.jsonl" | tail -1 | cut -d: -f2)
+    d=$(python3 - "$RXLOG" "$off0" "$off1" <<'EOF'
+import sys
+sys.path.insert(0, "tests")
+from devourer_events import parse_event
+f = open(sys.argv[1], "rb"); f.seek(int(sys.argv[2]))
+blob = f.read(int(sys.argv[3]) - int(sys.argv[2])).decode(errors="replace")
+print(sum(int(ev.get("frames") or 0)
+          for ev in (parse_event(l, "rx.energy") for l in blob.splitlines()) if ev))
+EOF
+)
+    if [ "${sent:-0}" -gt 0 ] 2>/dev/null; then
+      sum=$(python3 -c "print($sum + 100.0*$d/$sent)"); n=$((n + 1))
+    fi
+  done
+  python3 -c "print('%.1f' % ($sum/$n) if $n else 'nan')"
+}
+
+# One stressor session. $1 = arm name. Each arm changes exactly one thing.
+stress_session() {
+  local arm="$1" e=()
+  case "$arm" in
+    baseline)   e=(DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$RATE") ;;
+    band)       # alternate 2.4 <-> 5 GHz: re-runs IQK, rewrites the LOK
+                if [ $((RANDOM_SEQ % 2)) -eq 0 ]; then
+                  e=(DEVOURER_CHANNEL=36 DEVOURER_TX_RATE="$RATE")
+                else
+                  e=(DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$RATE")
+                fi ;;
+    bandwidth)  if [ $((RANDOM_SEQ % 2)) -eq 0 ]; then
+                  e=(DEVOURER_CHANNEL="$CH" DEVOURER_HOP_BW=40 DEVOURER_TX_RATE=MCS7/40)
+                else
+                  e=(DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$RATE")
+                fi ;;
+    spur)       # ch13/14 arm the ADC-clock spur workaround (0x8ac/0x8c4)
+                if [ $((RANDOM_SEQ % 2)) -eq 0 ]; then
+                  e=(DEVOURER_CHANNEL=14 DEVOURER_TX_RATE=MCS4/20)
+                else
+                  e=(DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$RATE")
+                fi ;;
+    power)      if [ $((RANDOM_SEQ % 2)) -eq 0 ]; then
+                  e=(DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$RATE" DEVOURER_TX_PWR=63)
+                else
+                  e=(DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$RATE"
+                     DEVOURER_TX_PWR_OFFSET_QDB=48)
+                fi ;;
+    failtune)   # 5 GHz tunes that deliver nothing on this pair — the original
+                # session was full of them
+                e=(DEVOURER_CHANNEL=149 DEVOURER_TX_RATE="$RATE") ;;
+    *) echo "unknown arm $arm" >&2; return 1 ;;
+  esac
+  sudo env DEVOURER_VID="$DUT_VID" DEVOURER_PID="$DUT_PID" "${e[@]}" \
+    DEVOURER_TX_GAP_US=0 DEVOURER_TEARDOWN_POWER_DOWN=0 DEVOURER_LOG_LEVEL=warn \
+    timeout --signal=TERM 14 "$TXDEMO" >/dev/null 2>&1
+  sleep 1
+}
+
+cold_cycle "$GND_VID" "$GND_PID" || exit 1
+DEVOURER_VID="$GND_VID" DEVOURER_PID="$GND_PID" DEVOURER_CHANNEL="$CH" \
+DEVOURER_RX_AGG_SA=canon DEVOURER_RX_ENERGY_MS=500 DEVOURER_LOG_LEVEL=warn \
+"$RXDEMO" > "$RXLOG" 2>"$OUT/ground.rx.stderr" &
+RXPID=$!
+sleep 9
+kill -0 "$RXPID" 2>/dev/null || { echo "ground RX died" >&2; exit 1; }
+
+echo "severe-form hunt — $SESSIONS stressor sessions/arm, $PROBES probes/measurement"
+echo "  a hit is a >=20 point drop at $RATE with $CTRL intact (noise is ~+/-3)"
+echo
+printf '  %-11s %-9s %-9s %-9s %-9s  %s\n' \
+    "arm" "cold" "after" "delta" "ctrl" "verdict"
+
+for ARM in $ARMS; do
+  cold_cycle "$DUT_VID" "$DUT_PID" || exit 1
+  before=$(measure "$RATE" "${ARM}_cold")
+  RANDOM_SEQ=0
+  for _ in $(seq 1 "$SESSIONS"); do
+    stress_session "$ARM"
+    RANDOM_SEQ=$((RANDOM_SEQ + 1))
+  done
+  after=$(measure "$RATE" "${ARM}_after")
+  ctrl=$(measure "$CTRL" "${ARM}_ctrl")
+  read -r delta verdict <<<"$(python3 -c "
+b,a='$before','$after'
+try:
+    d=float(a)-float(b)
+    print('%+.1f' % d, 'HIT' if d<=-20 else ('mild' if d<=-4 else 'no effect'))
+except ValueError:
+    print('nan', 'INVALID')")"
+  printf '  %-11s %-9s %-9s %-9s %-9s  %s\n' \
+      "$ARM" "$before" "$after" "$delta" "$ctrl" "$verdict"
+  printf '%s\t%s\t%s\t%s\t%s\n' "$ARM" "$before" "$after" "$ctrl" "$verdict" \
+      >> "$OUT/results.tsv"
+  # Capture the chip state while it is still powered and still degraded.
+  sudo "$ROOT/build/chipstate" --pid "$DUT_PID" --vid "$DUT_VID" \
+      > "$OUT/${ARM}_after.canary" 2>&1
+done
+
+echo
+echo "per-arm chip dumps: $OUT/*_after.canary"
+echo "results: $OUT/results.tsv"

--- a/tests/thermal_causation_probe.sh
+++ b/tests/thermal_causation_probe.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Does chip TEMPERATURE cause the high-rate delivery loss, or does chip STATE?
+#
+# The obvious experiments cannot tell those apart. A VBUS cycle resets state AND
+# cools the part. A card-disable at teardown resets state AND lets the part cool.
+# Anything that recovers delivery by removing power is consistent with both
+# stories, so none of it is proof.
+#
+# This is the discriminator: measure delivery WITHIN ONE UNINTERRUPTED SESSION.
+# One bring-up, one channel set, one calibration, one TX config, never torn down
+# and never re-inited. Across the run the only thing that changes is how hot the
+# die is. If delivery decays as the thermal meter climbs, temperature is doing
+# it, because nothing else moved.
+#
+# The control leg is the same session at a robust rate. Heating is identical;
+# if the decay were something time-dependent but not thermal (a leaking counter,
+# a drifting receiver, ambient), it would drag the control down too. A decay
+# that appears ONLY at the dense constellation is the thermal signature.
+#
+#   sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
+#        tests/thermal_causation_probe.sh
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+TXDEMO="$ROOT/build/txdemo"
+RXDEMO="$ROOT/build/rxdemo"
+
+DUT_VID=${DUT_VID:-0x0bda} DUT_PID=${DUT_PID:-0x8812}
+GND_VID=${GND_VID:-0x2357} GND_PID=${GND_PID:-0x012d}
+CH=${CH:-6}
+RATES=${RATES:-"MCS7/20 MCS1/20"}   # first = test (near the cliff), second = control
+SECS=${SECS:-240}                   # one continuous session per rate
+BIN=${BIN:-20}                      # seconds per reporting bin
+OUT=${OUT:-/tmp/devourer-thermal-causation}
+
+mkdir -p "$OUT"
+RXLOG="$OUT/ground.rx.jsonl"
+
+RXPID=""
+cleanup() {
+  [ -n "$RXPID" ] && kill "$RXPID" 2>/dev/null
+  pkill -x txdemo 2>/dev/null
+  wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+cold_cycle() { # $1=vid $2=pid
+  local map=${REGRESS_VBUS_MAP:-} key entry hubport
+  [ -n "$map" ] || { echo "REGRESS_VBUS_MAP unset" >&2; return 1; }
+  key=$(printf '%s:%s' "${1#0x}" "${2#0x}")
+  entry=$(tr ';' '\n' <<<"$map" | grep -i "^$key=" | head -1) || true
+  [ -n "${entry:-}" ] || { echo "no VBUS entry for $key" >&2; return 1; }
+  hubport=${entry#*=}
+  sudo uhubctl -l "${hubport%,*}" -p "${hubport#*,}" -a cycle -d 3 >/dev/null 2>&1
+  sleep 12
+}
+
+cold_cycle "$GND_VID" "$GND_PID" || exit 1
+DEVOURER_VID="$GND_VID" DEVOURER_PID="$GND_PID" DEVOURER_CHANNEL="$CH" \
+DEVOURER_RX_AGG_SA=canon DEVOURER_RX_ENERGY_MS=1000 DEVOURER_LOG_LEVEL=warn \
+"$RXDEMO" > "$RXLOG" 2>"$OUT/ground.rx.stderr" &
+RXPID=$!
+sleep 9
+kill -0 "$RXPID" 2>/dev/null || { echo "ground RX died" >&2; exit 1; }
+
+for RATE in $RATES; do
+  TAG="${RATE//\//-}"
+  echo
+  echo "== single uninterrupted session: $RATE, ${SECS}s, max duty, ch$CH"
+  echo "   (one bring-up, no re-init, no power cycle — only temperature moves)"
+  cold_cycle "$DUT_VID" "$DUT_PID" || exit 1
+  OFF0=$(stat -c%s "$RXLOG")
+  sudo env DEVOURER_VID="$DUT_VID" DEVOURER_PID="$DUT_PID" \
+    DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$RATE" \
+    DEVOURER_TX_GAP_US=0 DEVOURER_TX_PAYLOAD_BYTES=1024 \
+    DEVOURER_THERMAL_POLL_MS=1000 DEVOURER_LOG_LEVEL=warn \
+    timeout --signal=TERM $((SECS + 15)) "$TXDEMO" \
+    > "$OUT/tx_$TAG.jsonl" 2>"$OUT/tx_$TAG.err" &
+  TXP=$!
+  sleep $((SECS + 8))
+  kill -TERM "$TXP" 2>/dev/null; wait "$TXP" 2>/dev/null
+  sleep 1
+  OFF1=$(stat -c%s "$RXLOG")
+
+  python3 - "$RXLOG" "$OFF0" "$OFF1" "$OUT/tx_$TAG.jsonl" "$BIN" "$RATE" <<'EOF'
+import sys
+sys.path.insert(0, "tests")
+from devourer_events import parse_event
+
+rxlog, off0, off1, txlog, binsec, rate = sys.argv[1:7]
+binsec = int(binsec)
+
+f = open(rxlog, "rb"); f.seek(int(off0))
+blob = f.read(int(off1) - int(off0)).decode(errors="replace")
+
+# rx.energy carries a monotonic ms timestamp; bin delivered frames by it.
+bins, t0 = {}, None
+for line in blob.splitlines():
+    ev = parse_event(line, "rx.energy")
+    if not ev or ev.get("t") is None:
+        continue
+    t = int(ev["t"])
+    if t0 is None:
+        t0 = t
+    bins.setdefault((t - t0) // (binsec * 1000), [0, 0])
+    b = bins[(t - t0) // (binsec * 1000)]
+    b[0] += int(ev.get("frames") or 0)
+    b[1] += 1
+
+# Thermal samples, binned the same way off the TX session's own clock.
+th, n = {}, 0
+for line in open(txlog, errors="replace"):
+    ev = parse_event(line, "thermal")
+    if not ev:
+        continue
+    th.setdefault(n // binsec, []).append(int(ev.get("raw") or 0))
+    n += 1
+
+print("  %-10s %10s %10s   %s" % ("t(s)", "frames/s", "thermal", ""))
+ks = sorted(k for k in bins if bins[k][1] >= max(1, binsec // 2))
+base = None
+for k in ks:
+    fr, wins = bins[k]
+    rateps = fr / (wins * 1.0)          # rx.energy window = 1000 ms
+    t = th.get(k, [])
+    tm = sum(t) / len(t) if t else 0
+    if base is None and rateps > 0:
+        base = rateps
+    rel = (rateps / base * 100) if base else 0
+    bar = "#" * int(rel / 4)
+    print("  %-10d %10.0f %10.0f   %5.1f%% %s" % (k * binsec, rateps, tm, rel, bar))
+if base and ks:
+    last = bins[ks[-1]]
+    lastps = last[0] / last[1]
+    print("  -> %s: %.0f -> %.0f frames/s over %ds (%.1f%% of start)"
+          % (rate, base, lastps, ks[-1] * binsec, lastps / base * 100))
+EOF
+done

--- a/tests/thermal_offtime_sweep.sh
+++ b/tests/thermal_offtime_sweep.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Cooling, or state reset? Sweep how LONG the chip stays powered down.
+#
+# Every recovery observed so far removes power, and removing power does two
+# things at once: it resets chip state and it lets the die cool. No experiment
+# that simply power-cycles can tell those apart, which is why "it is thermal"
+# was not proven by any of them.
+#
+# This separates them. Degrade the part, then power it down for N seconds and
+# probe immediately on the way back up. The state reset is BIT-IDENTICAL for
+# every N — same VBUS cycle, same enumeration, same bring-up, same calibration.
+# The only thing that varies is how long the die had to cool.
+#
+#   delivery rises with N        -> cooling is doing the work (thermal)
+#   delivery flat across N       -> the reset is doing the work (state)
+#
+# Off-times are swept in a deliberately non-monotonic order so a slow drift in
+# the ambient channel cannot masquerade as the trend.
+#
+#   sudo REGRESS_VBUS_MAP="0bda:8812=3-2.3.4,3;2357:012d=10,2" \
+#        tests/thermal_offtime_sweep.sh
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+TXDEMO="$ROOT/build/txdemo"
+RXDEMO="$ROOT/build/rxdemo"
+
+DUT_VID=${DUT_VID:-0x0bda} DUT_PID=${DUT_PID:-0x8812}
+GND_VID=${GND_VID:-0x2357} GND_PID=${GND_PID:-0x012d}
+CH=${CH:-6}
+RATE=${RATE:-MCS7/20}
+CTRL=${CTRL:-MCS1/20}
+HEAT_SECS=${HEAT_SECS:-90}          # max-duty soak before each off-time
+OFF_TIMES=${OFF_TIMES:-"5 60 15 120 30"}   # non-monotonic on purpose
+SECS=${SECS:-6}
+OUT=${OUT:-/tmp/devourer-offtime-sweep}
+
+mkdir -p "$OUT"
+RXLOG="$OUT/ground.rx.jsonl"
+: > "$OUT/results.tsv"
+
+RXPID=""
+cleanup() {
+  [ -n "$RXPID" ] && kill "$RXPID" 2>/dev/null
+  pkill -x txdemo 2>/dev/null
+  wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+hubport_for() { # $1=vid $2=pid -> "hub port"
+  local map=${REGRESS_VBUS_MAP:-} key entry
+  key=$(printf '%s:%s' "${1#0x}" "${2#0x}")
+  entry=$(tr ';' '\n' <<<"$map" | grep -i "^$key=" | head -1) || return 1
+  local hp=${entry#*=}
+  printf '%s %s' "${hp%,*}" "${hp#*,}"
+}
+
+read -r DUT_HUB DUT_PORT <<<"$(hubport_for "$DUT_VID" "$DUT_PID")" || {
+  echo "no VBUS map entry for DUT" >&2; exit 1; }
+
+# Power the DUT off, hold for $1 seconds, power on. The hold is the variable
+# under test; everything else about the cycle is identical every time.
+power_off_for() {
+  sudo uhubctl -l "$DUT_HUB" -p "$DUT_PORT" -a off >/dev/null 2>&1
+  sleep "$1"
+  sudo uhubctl -l "$DUT_HUB" -p "$DUT_PORT" -a on >/dev/null 2>&1
+  sleep 8   # enumeration; identical for every arm
+}
+
+probe() { # $1=rate $2=tag -> "delivered/sent thermal"
+  local rate="$1" tag="$2" off0 off1 sent delivered therm
+  off0=$(stat -c%s "$RXLOG")
+  sudo env DEVOURER_VID="$DUT_VID" DEVOURER_PID="$DUT_PID" \
+    DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$rate" \
+    DEVOURER_TX_GAP_US=2000 DEVOURER_THERMAL_POLL_MS=500 \
+    DEVOURER_LOG_LEVEL=warn \
+    timeout --signal=TERM $((SECS + 12)) "$TXDEMO" \
+    > "$OUT/tx_$tag.jsonl" 2>"$OUT/tx_$tag.err" &
+  local p=$!
+  sleep $((SECS + 6))
+  kill -TERM "$p" 2>/dev/null; wait "$p" 2>/dev/null
+  sleep 1
+  off1=$(stat -c%s "$RXLOG")
+  sent=$(grep -o '"submitted":[0-9]*' "$OUT/tx_$tag.jsonl" | tail -1 | cut -d: -f2)
+  # FIRST thermal sample of the session — the coldest point, i.e. what the die
+  # actually cooled to during the off-time, before this probe reheats it.
+  therm=$(grep -o '"raw":[0-9]*' "$OUT/tx_$tag.jsonl" | head -1 | cut -d: -f2)
+  delivered=$(python3 - "$RXLOG" "$off0" "$off1" <<'EOF'
+import sys
+sys.path.insert(0, "tests")
+from devourer_events import parse_event
+f = open(sys.argv[1], "rb"); f.seek(int(sys.argv[2]))
+blob = f.read(int(sys.argv[3]) - int(sys.argv[2])).decode(errors="replace")
+print(sum(int(ev.get("frames") or 0)
+          for ev in (parse_event(l, "rx.energy") for l in blob.splitlines()) if ev))
+EOF
+)
+  printf '%s/%s %s' "${delivered:-0}" "${sent:-0}" "${therm:-0}"
+}
+
+heat() {
+  sudo env DEVOURER_VID="$DUT_VID" DEVOURER_PID="$DUT_PID" \
+    DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$RATE" DEVOURER_TX_PWR=63 \
+    DEVOURER_TX_GAP_US=0 DEVOURER_TX_PAYLOAD_BYTES=1024 \
+    DEVOURER_LOG_LEVEL=warn \
+    timeout --signal=TERM $((HEAT_SECS + 10)) "$TXDEMO" >/dev/null 2>&1 &
+  local p=$!
+  sleep "$HEAT_SECS"
+  kill -TERM "$p" 2>/dev/null; wait "$p" 2>/dev/null
+}
+
+# Ground station up once for the whole sweep — the reference must not move.
+sudo uhubctl -l "$(hubport_for "$GND_VID" "$GND_PID" | cut -d' ' -f1)" \
+     -p "$(hubport_for "$GND_VID" "$GND_PID" | cut -d' ' -f2)" \
+     -a cycle -d 3 >/dev/null 2>&1
+sleep 12
+DEVOURER_VID="$GND_VID" DEVOURER_PID="$GND_PID" DEVOURER_CHANNEL="$CH" \
+DEVOURER_RX_AGG_SA=canon DEVOURER_RX_ENERGY_MS=500 DEVOURER_LOG_LEVEL=warn \
+"$RXDEMO" > "$RXLOG" 2>"$OUT/ground.rx.stderr" &
+RXPID=$!
+sleep 9
+kill -0 "$RXPID" 2>/dev/null || { echo "ground RX died" >&2; exit 1; }
+
+echo "off-time sweep — identical reset every arm, only cooling time varies"
+echo "  DUT $DUT_VID:$DUT_PID  heat ${HEAT_SECS}s max-duty, then power off for N"
+echo
+printf '  %-10s %-10s %-10s %-8s\n' "off(s)" "$RATE" "$CTRL" "thermal"
+for N in $OFF_TIMES; do
+  heat
+  power_off_for "$N"
+  t=$(probe "$RATE" "off${N}")
+  c=$(probe "$CTRL" "off${N}_ctrl")
+  read -r t_ds t_th <<<"$t"
+  read -r c_ds _ <<<"$c"
+  pct=$(python3 -c "d,s='$t_ds'.split('/'); print('%.1f%%'%(100*int(d)/int(s)) if int(s) else 'n/a')")
+  cpct=$(python3 -c "d,s='$c_ds'.split('/'); print('%.1f%%'%(100*int(d)/int(s)) if int(s) else 'n/a')")
+  printf '  %-10s %-10s %-10s %-8s\n' "$N" "$pct" "$cpct" "$t_th"
+  printf '%s\t%s\t%s\n' "$N" "$t" "$c" >> "$OUT/results.tsv"
+done
+
+echo
+echo "read: delivery rising with off-time => cooling (thermal);"
+echo "      delivery flat across off-time => the reset, not the cooling."

--- a/tests/warm_tx_degradation_repro.sh
+++ b/tests/warm_tx_degradation_repro.sh
@@ -67,14 +67,25 @@ cold_cycle() { # $1=vid $2=pid
 }
 
 # One devourer TX session at $1, measured against the standing ground receiver.
-# Echoes "delivered/sent".
+# Echoes "delivered/sent thermal_raw rssi evm".
+#
+# The three extra channels are what separate the candidate mechanisms, and the
+# whole point of running this before changing any library code:
+#   thermal_raw  the chip's own RF 0x42 meter. The adapter is never powered
+#                down between sessions, so it never cools; a monotonic rise
+#                that falls after a VBUS cycle means heat, not latched state.
+#   rssi         falling RSSI means the transmitter is losing POWER; RSSI flat
+#                while the high rates die means it is losing signal QUALITY
+#                (EVM / phase noise) at unchanged power. Different fixes.
+#   evm          the receiver's own quality estimate, as a cross-check on rssi.
 probe() {
-  local rate=$1 tag=$2
-  local off0 off1 sent delivered
+  local rate="$1" tag="$2"
+  local off0 off1 sent delivered stats
   off0=$(stat -c%s "$RXLOG")
   sudo env DEVOURER_VID="$DUT_VID" DEVOURER_PID="$DUT_PID" \
     DEVOURER_CHANNEL="$CH" DEVOURER_TX_RATE="$rate" \
-    DEVOURER_TX_GAP_US=2000 DEVOURER_LOG_LEVEL=warn \
+    DEVOURER_TX_GAP_US=2000 DEVOURER_THERMAL_POLL_MS="${THERM_MS:-1000}" \
+    DEVOURER_LOG_LEVEL=warn \
     timeout --signal=TERM $((SECS + 12)) "$TXDEMO" \
     > "$OUT/tx_$tag.jsonl" 2>"$OUT/tx_$tag.err" &
   local p=$!
@@ -83,21 +94,38 @@ probe() {
   sleep 1
   off1=$(stat -c%s "$RXLOG")
   sent=$(grep -o '"submitted":[0-9]*' "$OUT/tx_$tag.jsonl" | tail -1 | cut -d: -f2)
-  delivered=$(python3 - "$RXLOG" "$off0" "$off1" <<'EOF'
+  # Last thermal reading of the session — the warmest point, i.e. the one that
+  # would matter if heat is the mechanism.
+  local therm
+  therm=$(grep -o '"raw":[0-9]*' "$OUT/tx_$tag.jsonl" | tail -1 | cut -d: -f2)
+  stats=$(python3 - "$RXLOG" "$off0" "$off1" <<'EOF'
 import sys
 sys.path.insert(0, "tests")
 from devourer_events import parse_event
 f = open(sys.argv[1], "rb"); f.seek(int(sys.argv[2]))
 blob = f.read(int(sys.argv[3]) - int(sys.argv[2])).decode(errors="replace")
-n = 0
+frames = 0
+rssi, evm = [], []
 for line in blob.splitlines():
     ev = parse_event(line, "rx.energy")
-    if ev:
-        n += int(ev.get("frames") or 0)
-print(n)
+    if not ev:
+        continue
+    n = int(ev.get("frames") or 0)
+    frames += n
+    # Average only over windows that actually carried frames — an empty window
+    # reports rssi/evm as 0 and would drag the mean toward zero.
+    if n:
+        if ev.get("rssi_mean"):
+            rssi.append(ev["rssi_mean"])
+        if ev.get("evm_mean"):
+            evm.append(ev["evm_mean"])
+mean = lambda a: (sum(a) / len(a)) if a else 0
+print("%d %.0f %.0f" % (frames, mean(rssi), mean(evm)))
 EOF
 )
-  printf '%s/%s' "${delivered:-0}" "${sent:-0}"
+  read -r delivered rssi evm <<<"$stats"
+  printf '%s/%s %s %s %s' "${delivered:-0}" "${sent:-0}" "${therm:-0}" \
+      "${rssi:-0}" "${evm:-0}"
 }
 
 # A warm session: full devourer bring-up + TX + teardown, no power cycle. This
@@ -117,17 +145,23 @@ warm_session() {
   sleep 1
 }
 
-report() { # $1=label $2=test-result $3=control-result
-  local pct
+# $1=label, $2/$3 = probe output for the test and control rate
+# ("delivered/sent thermal rssi evm").
+report() {
+  local label="$1" t="$2" c="$3"
+  local t_ds t_therm t_rssi t_evm c_ds
+  read -r t_ds t_therm t_rssi t_evm <<<"$t"
+  read -r c_ds _ _ _ <<<"$c"
+  local pct cpct
   pct=$(python3 -c "
-d,s='$2'.split('/')
+d,s='$t_ds'.split('/')
 print('%.1f%%' % (100*int(d)/int(s)) if int(s) else 'n/a')")
-  local cpct
   cpct=$(python3 -c "
-d,s='$3'.split('/')
+d,s='$c_ds'.split('/')
 print('%.1f%%' % (100*int(d)/int(s)) if int(s) else 'n/a')")
-  printf '  %-34s %s %-9s   %s %-9s\n' "$1" "$RATE" "$pct" "$CTRL_RATE" "$cpct"
-  printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$OUT/results.tsv"
+  printf '  %-32s %-8s %-8s  therm=%-3s rssi=%-3s evm=%s\n' \
+      "$label" "$pct" "$cpct" "$t_therm" "$t_rssi" "$t_evm"
+  printf '%s\t%s\t%s\n' "$label" "$t" "$c" >> "$OUT/results.tsv"
 }
 
 echo "warm-session TX degradation repro"
@@ -143,7 +177,7 @@ RXPID=$!
 sleep 9
 kill -0 "$RXPID" 2>/dev/null || { echo "ground RX died" >&2; exit 1; }
 
-printf '  %-34s %-14s   %s\n' "stage" "test rate" "control rate"
+printf '  %-32s %-8s %-8s  %s\n' "stage" "$RATE" "$CTRL_RATE" "chip/link sensors"
 cold_cycle "$DUT_VID" "$DUT_PID" || exit 1
 report "cold baseline" "$(probe "$RATE" cold)" "$(probe "$CTRL_RATE" cold_ctrl)"
 


### PR DESCRIPTION
Closes #348 (as unreproducible — see below). Corrects two measurements published
in #349.

## What #348 turned out to be

The reported bug — an RTL8812AU whose 64-QAM rates die across sessions while
robust rates stay perfect, recovering only on a power cycle — was **a
measurement artifact**. The ground station was a TP-Link Archer T3U, an
RTL8822BU with **internal** antennas, whose modulation cliff sits inside the
rates under test.

Two RTL8822BU adapters. Identical silicon, identical code path, same
transmitter, same channel, minutes apart. Only the antennas differ:

| ground station | MCS1 | MCS3 | MCS4 | MCS5 | MCS6 | MCS7 |
| --- | --- | --- | --- | --- | --- | --- |
| Archer T3U — **internal** | 98.1 | 97.8 | 98.3 | 79.1 | 49.0 | **2.9** |
| Comfast CF-924AC V2 — **two external** | 95.8 | 95.4 | 95.8 | 95.7 | 94.4 | **95.9** |

A receiver on its cliff swings between fine and zero on a few dB of ambient
while the rates below stay pinned — indistinguishable from a transmitter that
degrades and recovers. In one session that same T3U gave MCS7 68%, later 0.6%;
the cliff never moved, the ambient did.

**Four successive root causes were wrong, all from this one instrument:**
latched chip state (refuted by reading the registers — the BB swing is rewritten
every init), thermal (refuted by an off-time sweep varying *only* cooling time,
and by a within-session probe where the meter is pinned while delivery drifts),
a band-switching TX defect (a real 32-point collapse over the devourer link —
but an AR9271 sniffer showed the same stressor moving decoded MCS7 from 3721 to
3915, i.e. not at all), and a degraded adapter (the vendor driver failed
identically, which a link-budget shortfall predicts just as well).

## Corrections to #349

Both were measured through the T3U and are wrong:

- **"2SS above MCS2 reads zero — near-field spatial decorrelation, rig not
  chip"** → wrong. On a qualified receiver: VHT2SS MCS0 **95.3%**, MCS4
  **90.8%**, MCS7 15.5%, all modulation-verified. That was the receiver's cliff.
- **"VHT1SS_MCS8 (256-QAM) delivered 295/4675"** → understated 12×. Actually
  **77.1%**, 37/37 frames decoded as `vht1ss_mcs8`.

So the 256-QAM-on-2.4 GHz result is materially stronger than published and the
2SS ceiling is MCS7, not MCS2.

What did **not** change: `DEVOURER_BW=40` still delivers zero on a qualified
receiver, including the most robust 40 MHz rate. That gap survives the better
instrument, so it is real and now properly evidenced rather than merely repeated.

## The guard, so this cannot recur

`tests/ground_station_qualify.sh` sweeps the ladder on a candidate ground
station and **refuses the pairing (exit 1)** when the test rate is off the flat
part. Self-tested against the T3U: *NOT QUALIFIED for MCS7/20, 2.8% vs 98.1%
best on its own ladder.*

Plus the harnesses each wrong answer needed to kill it:

| script | question it answers |
| --- | --- |
| `probe_repeatability.sh` | how big must an effect be to be real? (sd 1.8, 5.7-pt spread → <4 pts is not a finding) |
| `rx_vendor_ab.sh` | bad receiver: our code, or the hardware? (vendor driver on the **receive** side — the control never run) |
| `band_stressor_sniffer.sh` | does a stressor hurt the transmitter, judged independently? |
| `ground_rx_degradation.sh` | which end of the link is losing? |
| `severe_form_hunt.sh` | which stressor reproduces the collapse? (now cold-cycles **both** ends per arm + a drift canary that fails the run if the reference moved) |
| `thermal_offtime_sweep.sh` | cooling, or state reset? |
| `thermal_causation_probe.sh` | does delivery track temperature with nothing else changing? |

## Code changes

- **`examples/chipstate`** — reads a chip's registers with no USB reset and no
  bring-up, the only way to inspect what a session left behind. It forces its
  own `teardown_power_down=0` or it destroys the state it just read (verified:
  two consecutive dumps byte-identical). Canary set extended with the TX IQ
  correction (`0xcc4/0xcc8/0xccc/0xcd4` + `0xec*`, on BB page C1 — a plain read
  returns the wrong bank) and RF `0x58` LOK; neither is rewritten by a bring-up
  and neither was visible before.
- **Jaguar1 teardown power-down** — `Stop()`/destructor run
  `HalModule::rtw_hal_deinit()` (halt MAC engines, then the die's card-disable
  sequence, using tables that sat unused in `hal/Hal88*PwrSeq.c` since the port
  began). Jaguar1 was the only generation leaving the chip in ACT with RF live
  after process exit. **No performance claim attached** — the delivery recovery
  an earlier revision cited came from the unqualified T3U. It also makes a
  stray hardware beacon stop at session end (a documented wart).
- **`tuning.teardown_power_down`** (`DEVOURER_TEARDOWN_POWER_DOWN=0|1`) — a
  powered-down chip reads back the CARDEMU fill, so post-mortems need it off.
- `PowerOff()` reads back `0x0005`/`REG_CR` instead of trusting a return code.

## Behaviour change

A beacon in the MAC reserved page now stops when a Jaguar1 session ends instead
of airing until re-enumeration. Matches Jaguar3 and the vendor driver.

## Testing

`ctest` 48/48. `teardown_gen_sanity.sh` 10/10. `tx_teardown_asan.sh` 6/6 under
ASan including max-duty kills (teardown now writes registers with URBs in
flight). 8812AU/8814AU/8821AU each re-init cleanly across consecutive sessions
after the power-down.

## On closing #348

Whether the original field report describes something real is **unknown** and
deliberately left open in the doc. Nothing measured is evidence either way — it
was all taken through an instrument that could not support the conclusion. A
re-report is worth taking seriously from a rig where the ground station passes
`ground_station_qualify.sh`, a second receiver corroborates, and the noise floor
is established first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
