### PR TITLE
CLAUDE.md: split hopset/chanmig into subtree files, cut header duplication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,17 @@
 # CLAUDE.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with
-code in this repository. Per-generation deep facts (registers, descriptors,
-per-chip mechanisms) live in `src/{jaguar1,jaguar2,jaguar3,kestrel}/CLAUDE.md`,
-auto-loaded when working in that subtree — add new per-generation facts there,
-cross-cutting facts here.
+code in this repository. It holds **cross-cutting** facts only. Deep subtree
+facts live in nested `CLAUDE.md` files, auto-loaded when working there:
+`src/{jaguar1,jaguar2,jaguar3,kestrel}/` for per-generation registers,
+descriptors and per-chip mechanisms; `src/hopset/` for keyed FHSS and the
+adaptive hopset; `src/chanmig/` for channel migration. Add new facts to the
+narrowest file that covers them.
+
+Two standing rules for this file: never duplicate what a header already
+doc-comments (point at `src/DeviceConfig.h`, `src/TxPower.h`,
+`src/AdapterCaps.h` instead), and never quote a favourable measurement without
+its adversarial counterpart in the same breath.
 
 ## What this is
 
@@ -41,13 +48,11 @@ construction from the `SYS_CFG2` chip-id (Kestrel: PID-first):
   the 0x00FC byte is not a chip-id on AX silicon. Blacklist rtw89 when
   testing: a kernel driver pre-initializing the chip masks the cold-boot
   path. On-air-validated: monitor RX (both dies, 2.4/5 GHz), TX injection
-  (legacy/HT/VHT/HE + HE ER SU/DCM extended range —
-  `docs/he-extended-range.md`), 5/10/20/40/80 MHz on both dies + 160 MHz on
-  the 8852C (the B die has no 160 MHz); 6 GHz TX tops out at 80 MHz (the
-  6G+160 TX-enable path is un-ported). TX power is a fixed BB dBm
-  (`DEVOURER_TX_PWR`, whole dBm on this family). The capstone is 11ax
-  trigger-based UL + TWT (issue #236); the 8852A-family (RTL8832AU) is
-  deliberately excluded. 8852C behavioural quirks: `docs/8852c-quirks.md`.
+  (legacy/HT/VHT/HE + HE ER SU/DCM — `docs/he-extended-range.md`),
+  5/10/20/40/80 MHz on both dies + 160 MHz on the 8852C only; 6 GHz TX tops
+  out at 80 MHz (the 6G+160 TX-enable path is un-ported). TX power is a fixed
+  BB dBm (`DEVOURER_TX_PWR`, whole dBm here). The 8852A-family (RTL8832AU) is
+  deliberately excluded. Quirks: `docs/8852c-quirks.md`.
 
 Naming traps: **RTL8821AU is Jaguar1** (not Jaguar2, despite the Jaguar2
 RTL8821C's similar name); RTL8822**B**U (Jaguar2) ≠ RTL8822**C**U (Jaguar3);
@@ -57,23 +62,20 @@ table: README **Supported hardware**.
 
 **PCIe** (`DEVOURER_PCIE=ON`, Linux-only, default OFF): the RTL8821CE — the
 PCIe sibling of the 8821CU — rides the same Jaguar2 HAL through a vfio-pci
-transport (`src/PcieTransport.{h,cpp}`): registers are BAR2 MMIO (the same
-0x0000..0xFFFF space the USB vendor-control path addresses), TX/RX are the
-88xx buffer-descriptor DMA rings (rtw88 pci.{c,h} layout; TX = the data/MGMT
-BD rings behind the unchanged `send_packet`), RX completion polled by default
-(MSI+eventfd wakeups when available). USB and PCIe are independent transports
-behind `devourer::IRtlTransport` (`src/RtlTransport.h`); the bus-neutral
-`RtlAdapter` value type the HALs hold forwards to whichever it was built
+transport (`src/PcieTransport.{h,cpp}`: BAR2 MMIO registers over the same
+0x0000..0xFFFF space the USB vendor-control path addresses, 88xx
+buffer-descriptor DMA rings for TX/RX). USB and PCIe are independent
+transports behind `devourer::IRtlTransport` (`src/RtlTransport.h`); the
+bus-neutral `RtlAdapter` the HALs hold forwards to whichever it was built
 with. The few genuinely bus-specific bring-up steps gate on `is_usb()` (PCIe
 power-seq rows, PQ map, no USB RX-agg, no DLFW 512-pad) or ride `hci_setup()`
 (pre-power TRX ring programming, no-op on USB). Factory:
 `WiFiDriver::CreateRtlDevicePcie(PcieTransport::Open(bdf, logger))` — the
 caller owns vfio like it owns libusb. Demos: `DEVOURER_PCIE_BDF=0000:01:00.0`
-on rxdemo and txdemo; `pcieprobe <bdf> [id|power|fw]` validates the layers
-bottom-up. Bind/restore: `tests/pcie_vfio_bind.sh` (driver_override, not
-new_id — the in-tree rtw88 auto-probe race). Validation: `sudo python3
-tests/pcie_rx_smoke.py` against a vfio-bound 8821CE (rig specifics: local
-`INVENTORY.md`) — ambient beacons CRC-clean on ch 6 + 36.
+on rxdemo and txdemo; `pcieprobe <bdf>` validates the layers bottom-up.
+Bind/restore: `tests/pcie_vfio_bind.sh` — driver_override, **not** new_id,
+because of the in-tree rtw88 auto-probe race. Validation: `sudo python3
+tests/pcie_rx_smoke.py` against a vfio-bound 8821CE.
 
 ## Build
 
@@ -91,16 +93,15 @@ before running `tools/extract_*.py` or the hardware-testing kernel cells.
 Per-chip options, all default ON: `DEVOURER_JAGUAR1`, `DEVOURER_8814` (requires
 JAGUAR1), `DEVOURER_JAGUAR2_8822B`, `DEVOURER_JAGUAR2_8821C`,
 `DEVOURER_JAGUAR3_8822C`, `DEVOURER_JAGUAR3_8822E`, `DEVOURER_KESTREL_8852B`,
-`DEVOURER_KESTREL_8852C`. `DEVOURER_PCIE` (default
-OFF, Linux-only, requires JAGUAR2_8821C) adds the vfio-pci transport +
-`pcieprobe`; OFF builds are byte-identical to before it existed. Turning groups off drops
-their firmware blobs + PHY tables (an 8812AU-only `rxdemo` is ~1.6 MB vs
-~6.3 MB all-on; ~4.2 MB with only the two Kestrel dies dropped — their
-verbatim-vendored halbb/halrf plane dominates). Configure fails on
-no-chip-selected or 8814-without-JAGUAR1. Each
-group exports a PUBLIC `DEVOURER_HAVE_*` define; sites referencing a dropped
-group sit behind `#if defined(DEVOURER_HAVE_*)`, and the factory returns
-`nullptr` (logs) for a chip whose support isn't built.
+`DEVOURER_KESTREL_8852C`. `DEVOURER_PCIE` (default OFF, Linux-only, requires
+JAGUAR2_8821C) adds the vfio-pci transport + `pcieprobe`; OFF builds are
+byte-identical to before it existed. Turning groups off drops their firmware
+blobs + PHY tables (an 8812AU-only `rxdemo` is ~1.6 MB vs ~6.3 MB all-on — the
+verbatim-vendored Kestrel halbb/halrf plane dominates the difference).
+Configure fails on no-chip-selected or 8814-without-JAGUAR1. Each group
+exports a PUBLIC `DEVOURER_HAVE_*` define; sites referencing a dropped group
+sit behind `#if defined(DEVOURER_HAVE_*)`, and the factory returns `nullptr`
+(logs) for a chip whose support isn't built.
 
 `DEVOURER_SANITIZE=address|address+undefined|thread` (default off) builds the
 library, demos and selftests instrumented; the vendored halbb/halrf C is
@@ -196,32 +197,34 @@ knobs are runtime setters on `IRtlDevice` (`SetTxMode`, `SetTxPowerOffsetQdb`,
 `SetTxPowerIndexOverride`, `SetRxPathMask`, `SetCcaMode`, `FastRetune`, ...).
 
 **Adapter capabilities**: `IRtlDevice::GetAdapterCaps()` (`src/AdapterCaps.h`)
-returns a static aggregate of chip identity (name / generation / variant /
-transport / chip-id), TX/RX chain counts, the composed `GetTxCaps` +
-`GetTxPowerCaps`, the supported channel-width set, per-band tunable +
-characterized frequency spans, and feature flags — resolved at construction,
-thread-safe, callable pre-`Init`; the demos emit it as the `adapter.caps`
-JSONL event. The `ldpc_rx_*` flags are the bench-derived LDPC RX truth table
-(deliberately NOT the vendor `HAL_DEF_RX_LDPC` interop-advertisement policy,
-which reads all-false on Jaguar1 while the 8812A demonstrably decodes LDPC):
-every supported chip decodes HT+VHT LDPC except the 8821A (VHT-LDPC RX
-broken, HT fine) and the 8814A reports no per-frame flag. LDPC TX is
-per-packet radiotap-driven on all generations (`TxCaps.ldpc_ok`);
-bench-measured coding gain ≈ +3 dB at the 10%-delivery crossing, MCS7/20 MHz
-(`tests/ldpc_waterfall.sh`) — prefer `/LDPC` on any link whose RX side can
-decode it. `GetActiveRxPaths()` is the live companion: a best-effort
-per-chain-RSSI estimate of which antennas actually carry signal (needs an RX
-loop + traffic). The 5 GHz synthesizer tunes past the UNII channels (extended
-range ~5080–6165 MHz, chan up to 253, `freq = 5000 + 5*chan`); out-of-band
-channels tune but their TX power / per-channel constants are extrapolated
-from the nearest characterized channel (one-shot `W` diagnostic). No
-regulatory enforcement — the caller owns compliance.
+aggregates chip identity, chain counts, the composed `GetTxCaps` +
+`GetTxPowerCaps`, channel widths, per-band tunable + characterized frequency
+spans, and feature flags — resolved at construction, thread-safe, callable
+pre-`Init`; the demos emit it as the `adapter.caps` JSONL event. Every flag is
+doc-commented at its declaration, including the bench-derived (not
+vendor-advertised) `ldpc_rx_*` and `vht_2g4_ok` truth tables and the three
+per-packet-TX-power hardware shapes — read the header, not a copy of it.
 
-**Env vars are the demos' interface**: `examples/common/env_config.{h,cpp}`
-maps every library-level `DEVOURER_*` var onto `DeviceConfig`, so the test
-scripts drive everything through env. For the per-var reference, read the
-`env:` tags in `DeviceConfig.h`; demo-local vars (device selection, timing)
-are parsed in each demo's own code. The ones needed daily:
+Two facts that live only here: LDPC TX is per-packet radiotap-driven on all
+generations (`TxCaps.ldpc_ok`) with bench-measured coding gain ≈ +3 dB at the
+10%-delivery crossing, MCS7/20 MHz (`tests/ldpc_waterfall.sh`) — prefer
+`/LDPC` on any link whose RX side can decode it. And `GetActiveRxPaths()` is
+the live companion to the static caps: a best-effort per-chain-RSSI estimate
+of which antennas actually carry signal (needs an RX loop + traffic).
+
+The 5 GHz synthesizer tunes past the UNII channels (extended range
+~5080–6165 MHz, chan up to 253, `freq = 5000 + 5*chan`); out-of-band channels
+tune but their TX power / per-channel constants are extrapolated from the
+nearest characterized channel (one-shot `W` diagnostic). No regulatory
+enforcement — the caller owns compliance.
+
+**Env vars are the demos' interface**: `examples/common/env_config.{h,cpp}` is
+the authoritative mapping of every library-level `DEVOURER_*` var onto
+`DeviceConfig`, so the test scripts drive everything through env. For the
+per-var reference read the `env:` tags in `DeviceConfig.h` — do not look for a
+second copy here. Demo-local vars (device selection, timing, telemetry
+cadence) have no `DeviceConfig` field and are parsed in each demo's own code;
+those are the ones listed below.
 
 - `DEVOURER_PID=0xNNNN` / `DEVOURER_VID=0xNNNN` — restrict the device-open
   loop (default VID `0x0bda`, all Realtek PIDs). `DEVOURER_USB_BUS=N` +
@@ -247,8 +250,20 @@ are parsed in each demo's own code. The ones needed daily:
   `0` = max duty for heating experiments).
 - `DEVOURER_USB_DEBUG=1` — libusb DEBUG log level (~7 MB / 15 s, has filled
   `/tmp` mid-capture; adds 0.5–0.8 s to init).
+- `DEVOURER_THERMAL_POLL_MS=N` — emit `thermal` events from the RF 0x42 meter.
+  `raw` is 0..63 thermal units (~1.5–2 °C each, **not** absolute °C); `delta`
+  = raw − EFUSE baseline, and a rising delta is the early TX-degradation
+  warning.
+- `DEVOURER_LINKHEALTH=1` (rxdemo, needs `DEVOURER_RX_ENERGY_MS=N`) — classify
+  the RX sensor tuple via `src/LinkHealth.h`. **EVM, not SNR, is the
+  saturation tell**: strong RSSI + poor EVM means back power OFF, which is the
+  opposite of the weak-link response (`docs/bench-testing-near-field.md`).
+- `DEVOURER_LA_CAPTURE=<trig>/<rate>M/dma0/port:0x880` (rxdemo) — one-shot
+  LA-mode IQ capture to a `DVLA` file, offline per-tone H(k) via
+  `tools/la_csi.py`. Not on the 8812A/8821A (no LA block). Packing, per-chip
+  windows, trigger semantics and wedge risks: `docs/la-capture.md`.
 
-Knob-specific facts that aren't obvious from the field docs:
+Behavioural traps the per-field docs can't carry:
 
 - `DEVOURER_TX_WITH_RX=thread` (concurrent TX+RX on one claimed handle:
   `InitWrite` once, then `StartRxLoop` on a thread) must be set **before**
@@ -264,15 +279,15 @@ Knob-specific facts that aren't obvious from the field docs:
   `tests/mrc_mobility.py`). `DEVOURER_RX_ALLPATHS=1` emits per-chain
   RSSI/SNR/EVM as a separate `rx.path` event (C/D nonzero only on the
   8814AU).
-- `DEVOURER_RX_CSI_MASK` / `DEVOURER_RX_NBI` (RX per-tone equalizer mask /
-  narrowband notch, `src/ToneMask.h`) apply at RX-loop start and revert on a
-  channel switch. Measured: inert against a *jammed* slice (that loss is
-  pre-FCS sync/AGC, upstream of the equalizer) — they target in-band spurs on
-  decodable frames (`docs/pseudo-preamble-puncturing.md`).
-- `DEVOURER_RX_KEEP_CORRUPTED=1` passes FCS/ICV-failed frames up with
-  `crc_err`/`icv_err` set — the entry point for the fused-FEC salvage layer
-  (`docs/fused-fec.md`). Opt-in: a body with a corrupt tail is the worst-case
-  input for an IP-stack consumer that didn't ask for it.
+- `DEVOURER_RX_KEEP_CORRUPTED=1` is the entry point for the fused-FEC salvage
+  layer (`docs/fused-fec.md`), and stays opt-in for a reason: a body with a
+  corrupt tail is the worst-case input for an IP-stack consumer that didn't
+  ask for it.
+- `DEVOURER_RX_CSI_MASK` / `DEVOURER_RX_NBI` apply at RX-loop start and
+  **revert on a channel switch**. Measured inert against a *jammed* slice —
+  that loss is pre-FCS sync/AGC, upstream of the equalizer. They target
+  in-band spurs on otherwise decodable frames
+  (`docs/pseudo-preamble-puncturing.md`).
 - `DEVOURER_DIS_CCA=1` (Jaguar2/3, runtime `SetCcaMode`) disables the MAC
   carrier-sense gate — **both** primary CCA (`0x520[14]`) and EDCCA (`[15]`).
   The primary-CCA bit is the one that matters: monitor injection is not
@@ -284,67 +299,36 @@ Knob-specific facts that aren't obvious from the field docs:
   `DEVOURER_DIS_CCA=0` forces standard carrier-sense back. Does NOT apply the
   vendor BB CCA-off writes (they deafen the RX). RX-decode side is a separate
   null (`tests/dis_cca_onair.sh`).
-- `DEVOURER_LA_CAPTURE=<trig>/<rate>M/dma0/port:0x880` (rxdemo) — one-shot
-  LA-mode IQ capture into the TX packet buffer (`src/LaCapture.h`): raw
-  complex baseband to a `DVLA` file, offline per-tone H(k) via
-  `tools/la_csi.py`. 8814A/8822B/8821C/8822C/8822E (+ 8821CE PCIe); the
-  8812A/8821A have no LA block. Sample packing, per-chip windows, trigger
-  semantics, validation scripts and wedge risks: `docs/la-capture.md`.
-- `DEVOURER_THERMAL_POLL_MS=N` emits `thermal` events from the RF 0x42 meter:
-  `raw` is 0..63 thermal units (~1.5–2 °C each, **not** absolute °C), `delta`
-  = raw − EFUSE baseline; a rising delta is the early TX-degradation warning.
-- `DEVOURER_LINKHEALTH=1` (rxdemo, needs `DEVOURER_RX_ENERGY_MS=N` — the RX
-  energy-window cadence in ms) classifies the RX sensor tuple into SATURATED
-  / INTERFERENCE / WEAK / MARGINAL / HEALTHY / NO_SIGNAL
-  (`src/LinkHealth.h`) — distinguishing near-field saturation (strong RSSI +
-  poor **EVM** — back OFF power) from a weak link (add power). EVM, not SNR,
-  is the saturation tell. `docs/bench-testing-near-field.md`.
 
-**Runtime TX power** (all generations — the adaptive-link power lever, see
-`src/TxPower.h`): `SetTxPowerOffsetQdb(qdb)` shifts power in quarter-dB
-relative to the efuse per-rate table (shape preserved until rates saturate at
-the rails; flags in `GetTxPowerState`); `SetTxPowerIndexOverride(idx)`
-forces/clears a flat index. Both apply live and stick across
-`SetMonitorChannel` (re-folded on the new channel) and `FastRetune` (never
-rewrites TXAGC). `GetTxPowerCaps` reports the family step: 0.5 dB Jaguar1/2,
-0.25 dB Jaguar3. The Jaguar2 TXAGC block and the 8814A's packed port are
-write-only, so their `GetTxPowerState` reports the software shadow
-(`hw_readback=false`). `SetTxPowerRateDiffs(optional<TxRateDiffsQdb>)` is the
-third knob, on every generation (check `GetTxPowerCaps().rate_diffs`): a
-caller-supplied per-rate table (cck, legacy, mcs0..7, signed qdB) that
-**replaces** the chip's calibrated per-rate shape — every rate's level =
-**anchor** + its diff (quantized to the family step) + the runtime offset,
-clamped to the hardware rail, where the anchor is the level the chip's own
-default walk produces for HT MCS7. So a zero table is a no-op at MCS7 and
-flattens every other rate onto it; rates the struct doesn't describe (MCS8+,
-VHT/HE, 2SS+) sit at the anchor. Diffs are not regulatory-clamped — the same
-operator's call the other two knobs make. It sticks across
-`SetMonitorChannel`, `FastRetune`, and an override set/clear round trip
-(the clear path re-walks the caller table); `std::nullopt` restores the
-calibrated shape. **Kestrel is the one software fold**
-(`rate_diffs_hw_table=false`): with no per-rate TXAGC table under its
-fixed-dBm model the diff for the frame's own rate goes into the BB target at
-send time, so a fixed-rate stream costs one extra write and a rate ladder
-pays one per change — and a hardware-timed beacon airing between host frames
-inherits the last frame's level. `txpower` (examples/txpower/) is the
-reference consumer — `--rate-diffs cck,legacy,m0..m7|clear` for this knob,
-`--offset-start`/`--offset-stop` and `--flat` for the other two; `txdemo`
-maps it as `DEVOURER_TX_RATE_DIFFS`. Validation: `tests/txpwr_offset_regcheck.sh`
-(offset/override), `tests/txpwr_rate_diffs_regcheck.sh` (diff table registers /
-shadow — state management, NOT radiated power on a write-only family) and
-`tests/txpwr_rate_diffs_onair.sh` (the antenna, per rate).
+**Runtime TX power** — the adaptive-link power lever, three knobs on every
+generation: `SetTxPowerOffsetQdb` (relative, shape-preserving),
+`SetTxPowerIndexOverride` (flat absolute), `SetTxPowerRateDiffs` (replace the
+calibrated per-rate shape). The contract — how they compose, the MCS7-anchor
+semantics, family step sizes, the write-only-family `hw_readback=false`
+shadow, and Kestrel's software send-time fold — is documented at the
+declarations in `src/TxPower.h`; the per-chip mechanics are in each
+`src/<gen>/CLAUDE.md`. All three apply live and stick across
+`SetMonitorChannel` and `FastRetune`. None is regulatory-clamped: the
+operator owns compliance.
 
-**Per-packet TX power** (a radiotap `DBM_TX_POWER` dB-delta per frame, zero
-USB cost once armed; see the `per_pkt_txpwr_*` caps): Jaguar2 and the 8814A
-use a 3-bit descriptor `TXPWR_OFSET` hardware LUT (session default
-`SetTxPacketPowerStep`); Jaguar3 selects programmable BB offset banks via
-`TXPWR_OFSET_TYPE` (inert until programmed); Kestrel rewrites its fixed-dBm
-BB target between frames; the 8812AU/8821AU have no descriptor field — their
-compensating fast lever is `FastSetTxPowerOffsetQdb` (BB-swing). Full
-mechanisms: each `src/<gen>/CLAUDE.md`. Sweep harnesses:
-`tests/txpkt_pwr_ofset_onair.sh` (TX_PID/TX_VID select the DUT; Kestrel DUTs
-need `TX_PWR=14`-style dBm bases), `tests/txpkt_fastswing_onair.sh`,
-`tests/txpkt_hop_persist.sh`.
+`txpower` (`examples/txpower/`) is the reference consumer —
+`--rate-diffs cck,legacy,m0..m7|clear`, `--offset-start`/`--offset-stop`,
+`--flat`; `txdemo` maps the third knob as `DEVOURER_TX_RATE_DIFFS`. What each
+validation script actually proves matters on a write-only family:
+`tests/txpwr_offset_regcheck.sh` and `tests/txpwr_rate_diffs_regcheck.sh`
+check **register/shadow state management**, not radiated power —
+`tests/txpwr_rate_diffs_onair.sh` is the one that measures the antenna, per
+rate.
+
+**Per-packet TX power** — a radiotap `DBM_TX_POWER` dB-delta per frame, zero
+USB cost once armed. The three hardware shapes (Jaguar2 + 8814A descriptor
+LUT, Jaguar3 programmable BB banks, Kestrel fixed-dBm BB rewrite) are
+documented with the `per_pkt_txpwr_*` caps in `src/AdapterCaps.h`, and in
+full in each `src/<gen>/CLAUDE.md`. The 8812AU/8821AU have no descriptor field
+at all — their compensating fast lever is `FastSetTxPowerOffsetQdb`
+(BB-swing). Sweep harnesses: `tests/txpkt_pwr_ofset_onair.sh` (TX_PID/TX_VID
+select the DUT; Kestrel DUTs need `TX_PWR=14`-style dBm bases),
+`tests/txpkt_fastswing_onair.sh`, `tests/txpkt_hop_persist.sh`.
 
 Per-packet unequal error protection: `svctx` classifies stdin HEVC NALs by
 temporal layer and injects each at its ladder's rate
@@ -372,85 +356,13 @@ timing. Validation:
 full-vs-fast). Implementation + per-generation ports:
 `docs/frequency-hopping.md`.
 
-**Keyed FHSS + lockstep RX** (`src/HopSchedule.h`): `DEVOURER_HOP_SLOT_MS`
-selects monotonic wall-clock slots; `DEVOURER_HOP_SEED` (≤32 hex, a 128-bit
-key) replaces the public round-robin with a stateless SipHash-2-4
-Fisher-Yates permutation per round, so a receiver joins without RNG state. In
-slot mode the TX demos (`txdemo` beacon; `streamtx` own frame every
-`DEVOURER_HOP_SYNC_EVERY`, FEC PSDU untouched) emit a sync marker, and
-`rxdemo` hops in lockstep when
-`DEVOURER_HOP_CHANNELS`+`_SLOT_MS` are set (seed optional →
-keyed/sequential), emitting `hop.rx` acquire/track/retune events. Jammer
-resilience: `tests/run_jammer_resilience.sh` + `tests/sdr_follower_jammer.py`
-(B210 follower, reactive vs predictive). Article + results: `docs/fhss.md`,
+Above that primitive sits the **keyed FHSS / adaptive hopset** subsystem
+(`src/hopset/`, header-only and pure): keyed slot schedules and lockstep RX
+(`DEVOURER_HOP_SLOT_MS` + `DEVOURER_HOP_SEED`), a receiver-driven channel
+exclusion policy, and TX-side quiet-window sensing with endpoint fusion. Knob
+reference, policy thresholds, measured sensing constants and the on-air
+harnesses: `src/hopset/CLAUDE.md`. Article + results: `docs/fhss.md`,
 `docs/jammer-resilience.md`.
-
-**Adaptive hopset** (`src/hopset/`, header-only, ctest-gated): the immutable
-base hopset carries a per-generation `active_mask`; TX is the schedule
-authority (RX proposes, TX commits an absolute future activation slot,
-repeated until it arrives) over SipHash-MAC'd Proposal/Commit/Status frames
-with schedule/control keys domain-separated from `DEVOURER_HOP_SEED`. Gen 0 ≡
-the legacy fixed schedule byte-for-byte; gen ≥ 1 re-keys the permutation from
-(subkey, generation, round, mask). Acquisition always scans the base hopset;
-the v2 sync marker advertises (generation, mask fp) so a follower that missed
-the commits recovers from the status beacon. Demos:
-`DEVOURER_HOP_ADAPTIVE=1` (keyed slot mode only) +
-`DEVOURER_HOP_ADAPTIVE_SCRIPT="slot:mask,..."` (an operator lever, exempt from
-the one-channel-per-update limit; `DEVOURER_HOP_MIN_ACTIVE` lowers the
-authority floor for protocol tests).
-
-`DEVOURER_HOP_POLICY=1` adds the **receiver-driven exclusion policy**
-(`src/hopset/HopsetPolicy.h`, pure): per-dwell delivery evidence (delivery is
-authoritative — energy/link verdicts only classify) drives conservative
-exclude/restore decisions — ≥8 scored rounds, one channel per update, <30%
-delivery for 5 visits *with* a healthy alternative, hard `max(3, configured)`
-active floor, ≥10 rounds between updates (a *refused* proposal spends the
-budget too, so bouncing proposals can't flood control), nothing under broad
-degradation, excluded-fraction cap. Proposals air from rxdemo's own claimed
-handle; txdemo hears them under `DEVOURER_TX_WITH_RX=thread`, and the authority
-enforces its own shape limits (`max_mask_delta`, `min_update_gap_rounds`).
-Excluded channels are revisited by **keyed recovery probes**
-(`DEVOURER_HOP_PROBE_ROUNDS`, default 8, must match both ends): every P rounds
-one data slot is replaced, round/position/channel all keyed so recovery isn't a
-periodic target; sync/control only, never caller FEC payload. `hopset.*` events
-(incl. `hopset.decision`, `hopset.probe`).
-
-**TX sensing + endpoint fusion** (`DEVOURER_TX_SENSE=1`; `src/hopset/HopsetSense.h`
-+ `HopsetFusion.h`, both pure): the transmitter opens quiet windows
-(retune → settle → discard barrier → window → read; `_WINDOW_US` / `_POSTBURST_US`
-/ `_SETTLE_US` / `_EVERY` / `_NHM`) and scores occupancy from CCA/FA/IGI/NHM.
-Refuses to arm beside `DEVOURER_TX_THREADS>1`, under a ~1.5 ms window, or while
-committing (a commit inside the window is self-jamming that would feed the
-veto). Saturation constants are **measured** (~3 events/ms = fully jammed, ~0.6
-clean); a railed IGI or NHM contributes nothing.
-`DEVOURER_HOP_FUSION=rx|veto|either|failsafe` — the veto may only argue "this
-move leaves ME worse off" (broad TX degradation → delay; every survivor worse →
-reject), never "I disagree about your target": that signature IS the hidden-node
-case where the RX is right. Autonomous changes go through
-`start_local_change` (structural limits apply; the scripted lever stays exempt);
-`DEVOURER_HOP_MUTE=1` on rxdemo injects a one-way outage. Two test levers (not
-production knobs): `DEVOURER_TX_SENSE_INJECT="<idx>:<occ>[,*:<occ>]"` fabricates
-the TX's per-channel view (bypasses the hardware read, keeps the window timing)
-— the only way to build the hidden-node case and its mirror on a bench where
-both adapters hear the same interferer; `DEVOURER_TX_STDIN=1` makes txdemo carry
-caller PSDU bodies from stdin (`streamtx` framing) so FEC delivery can be
-measured across an adaptation. The classifier needs `_POSTBURST_US` armed before
-it proposes anything of its own — without it the TX observes and holds, which
-looks like a TX that is not sensing.
-
-On-air: `tests/hopset_adaptive_onair.sh` (protocol) and
-`tests/hopset_adaptive_jammer.sh` (B210 interferer;
-`MODE=parked|herding|sense|failsafe|hidden|mirror|fusionmatrix|policycost|prepost|overhead`,
-every mode reporting FEC delivery beside the marker proxy over a window that
-opens only once the RX is tracking); `tests/tx_sense_probe.sh` checks the
-telemetry is live at all. **Pick adapters by band** — a 5 GHz-only PA part
-senses nothing and cannot answer on 2.4 GHz. Sensing costs ~8% of frames (25 ms
-window, 1-in-2 dwells) — a throughput cost, not a delivery-ratio one (FEC
-delivery is unchanged). **The marker proxy
-overstates adaptation**: against a parked jammer it reads 0.762 → 0.946 where
-payload reads 0.861 → 0.927 and the delivered packet rate does not move —
-carrier sense already keeps the TX out of the jammed dwells. Doc:
-`docs/fhss.md`.
 
 `IRtlDevice::FastSetBandwidth(bw)` is the bandwidth analogue — a lean
 same-channel toggle between 20 MHz and 5/10 MHz narrowband (baseband re-clock
@@ -466,46 +378,14 @@ recover a coarse per-bin H(f) — down to 5 MHz bins on Jaguar3
 ## Adaptive channel migration
 
 Slow, evidence-driven whole-link channel moves — the deliberate complement to
-per-slot FHSS. Pure caller-side logic under `src/chanmig/` (namespace
-`devourer::chanmig`, header-mostly, each ctest-covered; the library reads no
-env, the demos map it). Five composable layers:
-
-- **Scout** (`chanscout`): a second adapter passively surveys a candidate
-  plan (`DEVOURER_SCOUT_PLAN`) while the primary RX stays on the video
-  channel, emitting versioned `survey.dwell` records with a counter-hygiene
-  discard barrier (the FA/CCA counters are delta-on-read). Measures only;
-  retunes nothing but itself. Grid-legality
-  validation, **no regulatory DB** — the caller owns compliance.
-- **Scoring** (`ChannelScore`, `DEVOURER_SCOUT_ADVISE`): a pure two-leg
-  recommendation engine — the primary receiver's *delivery* is authoritative
-  on the active channel (scout energy there is confounded by wanted video),
-  the scout's occupancy on candidates — emitting explainable
-  `channel.recommend`/`hold`.
-- **Protocol** (`examples/chanmig --role ground|drone`): an authenticated
-  ground-proposes/drone-commits migration (SipHash-MAC'd wire codec
-  `MigWire.h`, pure `MigProposer`/`MigResponder` state machines, random
-  per-boot epochs). The drone arms
-  activation only after the ground echoes its nonce, and the ground follows
-  the drone's authoritative STATUS — every failure-matrix row converges
-  without split-brain. Control frames are their own canonical-SA 802.11
-  frames — video PSDUs are never touched.
-- **Automation** (`MigGate`, `DEVOURER_MIG_MODE=off|advisory|manual|automatic`,
-  default advisory): a pure, deterministic gate hedged with cooldown /
-  residency / per-channel backoff / move-cap / probation and an operator kill
-  switch.
-- **Drone-side validation**: legality/caps checks are the free product
-  default; the pre-commit probe (`DEVOURER_MIG_PROBE`) is opt-in research
-  (real outage cost); probation is the gate's.
-
-Validated headless (`chanmig_wire_kat`, `chanmig_proto_matrix` — a 14-row
-failure matrix + drop-every-message sweep, `chan_score_policy`,
-`chanmig_gate_policy`, `chanmig_clock_math`) and on-air
-(`tests/chanmig_endurance.sh`, `tests/chanscout_stress.sh`,
-`tests/chanmig_soak.sh`). Docs: `docs/adaptive-channel-migration.md`,
-`docs/channel-migration-protocol.md`, `docs/channel-migration-validation.md`.
-Near-field bench note: two adapters ~30 cm apart saturate the RX front end at
-full power (`link.health` SATURATED), so migration tests reduce TX power
-(`DEVOURER_TX_PWR=12`).
+per-slot FHSS. Pure caller-side logic under `src/chanmig/`: a passive scout on
+a second adapter (`chanscout`), a two-leg scoring engine, an authenticated
+ground-proposes / drone-commits protocol (`examples/chanmig --role
+ground|drone`), and a deterministic automation gate
+(`DEVOURER_MIG_MODE=off|advisory|manual|automatic`, default `advisory`).
+Control frames are their own 802.11 frames — video PSDUs are never touched,
+and there is no regulatory DB: the caller owns compliance. Layer detail,
+validation matrix and the near-field bench note: `src/chanmig/CLAUDE.md`.
 
 ## Hardware time, beacons, AP mode
 

--- a/src/chanmig/CLAUDE.md
+++ b/src/chanmig/CLAUDE.md
@@ -1,0 +1,49 @@
+# src/chanmig/ — adaptive channel migration
+
+Deep facts for this subtree, loaded alongside the root CLAUDE.md. Slow,
+evidence-driven whole-link channel moves — the deliberate complement to
+per-slot FHSS (`src/hopset/`). Namespace `devourer::chanmig`, header-mostly,
+each piece ctest-covered and pure: the library reads no env, the demos map it.
+Docs: `docs/adaptive-channel-migration.md`,
+`docs/channel-migration-protocol.md`, `docs/channel-migration-validation.md`.
+
+## Five composable layers
+
+- **Scout** (`chanscout`, `ScanPlan.h` / `SurveyRecord.h`): a second adapter
+  passively surveys a candidate plan (`DEVOURER_SCOUT_PLAN`) while the primary
+  RX stays on the video channel, emitting versioned `survey.dwell` records
+  with a counter-hygiene discard barrier — the FA/CCA counters are
+  delta-on-read. Measures only; retunes nothing but itself. Grid-legality
+  validation, **no regulatory DB** — the caller owns compliance.
+- **Scoring** (`ChannelScore`, `DEVOURER_SCOUT_ADVISE`): a pure two-leg
+  recommendation engine. The primary receiver's *delivery* is authoritative on
+  the active channel (scout energy there is confounded by the wanted video);
+  the scout's occupancy is authoritative on candidates. Emits explainable
+  `channel.recommend` / `channel.hold`.
+- **Protocol** (`examples/chanmig --role ground|drone`): an authenticated
+  ground-proposes / drone-commits migration — SipHash-MAC'd wire codec
+  (`MigWire.h`), pure `MigProposer` / `MigResponder` state machines, random
+  per-boot epochs. The drone arms activation only after the ground echoes its
+  nonce, and the ground follows the drone's authoritative STATUS; every
+  failure-matrix row converges without split-brain. Control frames are their
+  own canonical-SA 802.11 frames — video PSDUs are never touched.
+- **Automation** (`MigGate`, `DEVOURER_MIG_MODE=off|advisory|manual|automatic`,
+  default `advisory`): a pure, deterministic gate hedged with cooldown /
+  residency / per-channel backoff / move-cap / probation, plus an operator kill
+  switch.
+- **Drone-side validation**: legality and caps checks are the free product
+  default; the pre-commit probe (`DEVOURER_MIG_PROBE`) is opt-in research with
+  a real outage cost. Probation belongs to the gate.
+
+## Validation
+
+Headless: `chanmig_wire_kat`, `chanmig_proto_matrix` (a 14-row failure matrix +
+a drop-every-message sweep), `chan_score_policy`, `chanmig_gate_policy`,
+`chanmig_clock_math`.
+
+On-air: `tests/chanmig_endurance.sh`, `tests/chanscout_stress.sh`,
+`tests/chanmig_soak.sh`.
+
+**Near-field bench note**: two adapters ~30 cm apart saturate the RX front end
+at full power (`link.health` SATURATED), so migration tests reduce TX power
+(`DEVOURER_TX_PWR=12`). See `docs/bench-testing-near-field.md`.

--- a/src/hopset/CLAUDE.md
+++ b/src/hopset/CLAUDE.md
@@ -1,0 +1,126 @@
+# src/hopset/ — keyed FHSS, adaptive hopset, TX sensing
+
+Deep facts for this subtree, loaded alongside the root CLAUDE.md. Everything
+here is header-only and pure (no device access, no env reads) and ctest-gated;
+the demos map the env vars. The device-side primitives these build on
+(`FastRetune`, `FastSetBandwidth`, the radiotap `CHANNEL` field) live in the
+core and are described in the root file. Article-length treatment:
+`docs/fhss.md`, `docs/frequency-hopping.md`, `docs/jammer-resilience.md`.
+
+## Demo knobs
+
+Hop set and pacing: `DEVOURER_HOP_CHANNELS` (SweepSpec grammar: `1,6,11`,
+`36-48/4`, `5170-5250/5` MHz) + `DEVOURER_HOP_DWELL_FRAMES` / `_ROUNDS` /
+`_FAST` / `_RADIOTAP` / `_BW` / `_OFFSET`. `DEVOURER_HOP_PROF=1` emits
+per-stage `debug.hop_prof` timing.
+
+Keyed slot mode: `DEVOURER_HOP_SLOT_MS` (monotonic wall-clock slots) and
+`DEVOURER_HOP_SEED` (≤32 hex, a 128-bit key). `DEVOURER_HOP_SYNC_EVERY` is
+`streamtx`'s sync-marker cadence.
+
+Adaptive: `DEVOURER_HOP_ADAPTIVE=1` (keyed slot mode only),
+`DEVOURER_HOP_ADAPTIVE_SCRIPT="slot:mask,..."`, `DEVOURER_HOP_MIN_ACTIVE`,
+`DEVOURER_HOP_POLICY=1`, `DEVOURER_HOP_PROBE_ROUNDS` (default 8, **must match
+both ends**), `DEVOURER_HOP_FUSION=rx|veto|either|failsafe`.
+
+Sensing: `DEVOURER_TX_SENSE=1` + `_WINDOW_US` / `_POSTBURST_US` / `_SETTLE_US`
+/ `_EVERY` / `_NHM`.
+
+## Keyed FHSS + lockstep RX
+
+`src/HopSchedule.h`: the seed replaces the public round-robin with a stateless
+SipHash-2-4 Fisher-Yates permutation per round, so a receiver joins without RNG
+state. In slot mode the TX demos emit a sync marker (`txdemo` its beacon;
+`streamtx` its own frame every `DEVOURER_HOP_SYNC_EVERY`, FEC PSDU untouched),
+and `rxdemo` hops in lockstep when `DEVOURER_HOP_CHANNELS` + `_SLOT_MS` are set
+(seed optional → keyed/sequential), emitting `hop.rx` acquire/track/retune
+events.
+
+## Adaptive hopset
+
+The immutable base hopset carries a per-generation `active_mask`. **TX is the
+schedule authority**: RX proposes, TX commits an absolute future activation
+slot, repeated until it arrives, over SipHash-MAC'd Proposal/Commit/Status
+frames whose schedule and control keys are domain-separated from
+`DEVOURER_HOP_SEED`. Generation 0 ≡ the legacy fixed schedule byte-for-byte;
+gen ≥ 1 re-keys the permutation from (subkey, generation, round, mask).
+
+Acquisition always scans the base hopset; the v2 sync marker advertises
+(generation, mask fp) so a follower that missed the commits recovers from the
+status beacon.
+
+## Exclusion policy (`HopsetPolicy.h`)
+
+Per-dwell delivery evidence drives conservative exclude/restore decisions.
+**Delivery is authoritative** — energy and link verdicts only classify. The
+guards, all deliberate:
+
+- ≥8 scored rounds before anything is proposed
+- one channel per update
+- <30% delivery for 5 visits **with a healthy alternative**
+- hard `max(3, configured)` active floor
+- ≥10 rounds between updates — a *refused* proposal spends the budget too, so
+  bouncing proposals cannot flood control
+- nothing under broad degradation; excluded-fraction cap
+
+Proposals air from rxdemo's own claimed handle; txdemo hears them under
+`DEVOURER_TX_WITH_RX=thread`, and the authority enforces its own shape limits
+(`max_mask_delta`, `min_update_gap_rounds`).
+
+Excluded channels are revisited by **keyed recovery probes**: every P rounds
+one data slot is replaced, with round, position and channel all keyed so
+recovery is not a periodic target. Probes carry sync/control only, never caller
+FEC payload. Events: `hopset.*`, including `hopset.decision` and
+`hopset.probe`.
+
+## TX sensing + endpoint fusion (`HopsetSense.h`, `HopsetFusion.h`)
+
+The transmitter opens quiet windows (retune → settle → discard barrier →
+window → read) and scores occupancy from CCA/FA/IGI/NHM. It refuses to arm
+beside `DEVOURER_TX_THREADS>1`, under a ~1.5 ms window, or while committing (a
+commit inside the window is self-jamming that would feed the veto).
+
+Saturation constants are **measured**: ~3 events/ms = fully jammed, ~0.6 =
+clean. A railed IGI or NHM contributes nothing.
+
+The veto may only argue *"this move leaves ME worse off"* — broad TX
+degradation → delay; every survivor worse → reject. It may never argue "I
+disagree about your target": that signature IS the hidden-node case, where the
+RX is right. Autonomous changes go through `start_local_change` (structural
+limits apply; the scripted lever stays exempt).
+
+The classifier needs `_POSTBURST_US` armed before it proposes anything of its
+own — without it the TX observes and holds, which looks exactly like a TX that
+is not sensing.
+
+Test levers, **not production knobs**: `DEVOURER_TX_SENSE_INJECT="<idx>:<occ>[,*:<occ>]"`
+fabricates the TX's per-channel view (bypasses the hardware read, keeps the
+window timing) — the only way to build the hidden-node case and its mirror on a
+bench where both adapters hear the same interferer. `DEVOURER_TX_STDIN=1` makes
+txdemo carry caller PSDU bodies from stdin (`streamtx` framing) so FEC delivery
+can be measured across an adaptation. `DEVOURER_HOP_MUTE=1` on rxdemo injects a
+one-way outage.
+
+## Validation
+
+`tests/run_hop_validation.sh`, `tests/hop_parity_check.sh` (register parity
+full-vs-fast), `tests/run_jammer_resilience.sh` +
+`tests/sdr_follower_jammer.py` (B210 follower, reactive vs predictive),
+`tests/hopset_adaptive_onair.sh` (protocol), `tests/tx_sense_probe.sh` (is the
+telemetry live at all), and `tests/hopset_adaptive_jammer.sh` (B210 interferer;
+`MODE=parked|herding|sense|failsafe|hidden|mirror|fusionmatrix|policycost|prepost|overhead`,
+every mode reporting FEC delivery beside the marker proxy over a window that
+opens only once the RX is tracking).
+
+**Pick adapters by band** — a 5 GHz-only PA part senses nothing and cannot
+answer on 2.4 GHz.
+
+### What the measurements actually say
+
+Sensing costs ~8% of frames (25 ms window, 1-in-2 dwells) — a throughput cost,
+not a delivery-ratio one; FEC delivery is unchanged.
+
+**The marker proxy overstates adaptation.** Against a parked jammer it reads
+0.762 → 0.946, where payload reads 0.861 → 0.927 and the delivered packet rate
+does not move at all — carrier sense already keeps the TX out of the jammed
+dwells. Quote both numbers together or the feature reads better than it is.


### PR DESCRIPTION
The root `CLAUDE.md` had grown to 41,702 chars, past the 40k limit at which it stops loading reliably. This gets it to 33,050 (−21%) with real headroom, and the way it gets there is meant to keep it there.

## Two changes

**Extend the nested-CLAUDE.md pattern to non-generation subtrees.** The `## Frequency hopping` and `## Adaptive channel migration` sections move into `src/hopset/CLAUDE.md` (6.3k) and `src/chanmig/CLAUDE.md` (2.8k), auto-loaded when working in those subtrees — the same mechanism as `src/jaguar*/CLAUDE.md`. Root keeps the cross-cutting `IRtlDevice` primitives (`FastRetune`, `FastSetBandwidth`, the radiotap `CHANNEL` per-packet rule, all of which live in core `send_packet`) plus a stub naming each subsystem and its env-var family, so a session working from the repo root still has the entry point rather than a dead end.

**Delete prose that re-documents source.** This is the bulk of the saving. `src/TxPower.h`, `src/AdapterCaps.h` and `src/DeviceConfig.h` carry more precise doc-comments than the CLAUDE.md paragraphs summarising them — the bench-derived `ldpc_rx_*` and `vht_2g4_ok` truth tables, the three-knob TX-power contract with its MCS7-anchor semantics, the three per-packet-power hardware shapes, every `env:` tag. Those became pointers. Two copies of the same fact drift; one of them was going to end up wrong.

The preamble now states both as standing rules, so the next edit has somewhere to land.

## What is deliberately untouched

`## Hardware gotchas` stays whole, as do the teardown-order contract and the per-generation TX transfer-mode rule. That material has no other home in the tree, and it is the reason to read the file at all.

## Verification

- `ctest` 48/48 green
- Scripted check: every `src/`, `docs/`, `tests/`, `tools/` path referenced across all three files resolves
- Diff-audit: extracted every token removed from root (`tests/*.sh`, `DEVOURER_*`, ctest names) and asserted each still appears in a nested file or the header it now points at. This caught one genuine loss — `DEVOURER_RX_KEEP_CORRUPTED` as the fused-FEC salvage entry point, a cross-cutting link no header states — which is restored in the diff.

Docs-only, no code changes, so the two-adapter on-air matrix does not apply here; `ctest` is the appropriate guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)