### PR TITLE
Per-antenna RSSI/SNR/EVM on every generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,8 +277,11 @@ Behavioural traps the per-field docs can't carry:
   `0xAA:0xBB[:0xCC]@<ms>` cycles masks on a timer for mobility/MRC
   measurements (`docs/measuring-spatial-diversity.md`,
   `tests/mrc_mobility.py`). `DEVOURER_RX_ALLPATHS=1` emits per-chain
-  RSSI/SNR/EVM as a separate `rx.path` event (C/D nonzero only on the
-  8814AU).
+  RSSI/SNR/EVM as a separate `rx.path` event on every generation (Kestrel
+  parses its halbb physts path pages; C/D nonzero only on the 8814AU — the
+  other dies are ≤2 RX chains). Windowed per-antenna means ride
+  `GetActiveRxPaths()` / the `adapter.rxpaths` event (rssi/snr/evm per
+  chain).
 - `DEVOURER_RX_KEEP_CORRUPTED=1` is the entry point for the fused-FEC salvage
   layer (`docs/fused-fec.md`), and stays opt-in for a reason: a body with a
   corrupt tail is the worst-case input for an IP-stack consumer that didn't

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -99,7 +99,7 @@ Emitters: L = library, RX/TX/... = demo. Optional fields in [brackets];
 | `rx.energy` | RX (`DEVOURER_RX_ENERGY_MS` / sweep) | t, [ch], cca_ofdm\|null, cca_cck\|null, fa_ofdm\|null, fa_cck\|null, igi\|null, abs_noise_floor_dbm\|null, [retune_us], frames, frames_ldpc, frames_stbc, crc_err, icv_err, rssi_mean, rssi_max, snr_mean, snr_min, evm_mean — crc/icv nonzero only under `DEVOURER_RX_KEEP_CORRUPTED` (the parser drops failed frames otherwise) |
 | `rx.nhm` | RX | [ch], peak, busy, dur, hist[12] |
 | `rx.quality` | RX (`DEVOURER_RXQUALITY`) | verdict, frames, rssi_mean_dbm, rssi_max_dbm, snr_mean_db, snr_min_db, evm_db\|null, noise_floor_dbm\|null, abs_noise_floor_dbm\|null, igi |
-| `adapter.rxpaths` | RX (`DEVOURER_RXQUALITY`) | active_mask "0xNN", n_active, n_chains, frames, rssi_dbm[] — GetActiveRxPaths live per-chain activity (the caps rx_chains companion) |
+| `adapter.rxpaths` | RX (`DEVOURER_RXQUALITY`) | active_mask "0xNN", n_active, n_chains, frames, rssi_dbm[], snr_db[], evm_db[] — GetActiveRxPaths live per-chain activity (the caps rx_chains companion); snr_db/evm_db only when a chain carried the metric this window (EVM -128 no-stream rail excluded) |
 | `link.health` | RX (`DEVOURER_LINKHEALTH`) | verdict, rssi_dbm, snr_db, evm_db\|null, frames, fa_ofdm\|null, igi\|null, [igi_floor], [igi_ceil], cause, fix |
 | `fw.c2h` | RX, duplex (`DEVOURER_TX_STATUS`) | len, bytes hex |
 

--- a/examples/rx/main.cpp
+++ b/examples/rx/main.cpp
@@ -1061,8 +1061,9 @@ static void packetProcessor(const Packet &packet) {
       /* DEVOURER_RX_ALLPATHS=1: emit all four RX chains (A,B,C,D) of per-stream
        * RSSI / SNR / EVM on a distinct `rx.path` event. Opt-in and separate so
        * the canonical two-path `rx.frame`/`rx.body` events stay untouched.
-       * Paths C/D are non-zero only on the 8814AU (4T4R); on 8812/8821 they
-       * read 0. Consumed by tests/antenna_decorrelation.py to measure
+       * Populated on every generation (Kestrel from its halbb physts path
+       * pages); paths C/D are non-zero only on the 8814AU (4T4R) — the other
+       * dies are <=2 RX chains. Consumed by tests/antenna_decorrelation.py to measure
        * inter-chain envelope correlation and realised diversity gain
        * (spatial-diversity axis). */
       static const bool rxpath_out =
@@ -1598,6 +1599,18 @@ int main(int argc, char **argv) {
                 .f("n_chains", ap.n_chains)
                 .f("frames", ap.frames)
                 .arr("rssi_dbm", ap.rssi_mean_dbm, ap.n_chains);
+            /* Per-chain window-mean SNR / EVM (dB) — present only when at
+             * least one chain carried the metric this window (a CCK-only
+             * stream carries neither). Unsampled chains read 0. */
+            bool any_snr = false, any_evm = false;
+            for (uint8_t i = 0; i < ap.n_chains; i++) {
+              any_snr = any_snr || ap.snr_sampled[i];
+              any_evm = any_evm || ap.evm_sampled[i];
+            }
+            if (any_snr)
+              pev.arr("snr_db", ap.snr_mean_db, ap.n_chains);
+            if (any_evm)
+              pev.arr("evm_db", ap.evm_mean_db, ap.n_chains);
           }
         }
         nap(g_rx_energy_ms);

--- a/hal/halbb/g6/kestrel_halbb_glue.c
+++ b/hal/halbb/g6/kestrel_halbb_glue.c
@@ -40,6 +40,14 @@ struct kestrel_halbb_ctx *kestrel_halbb_create(struct kestrel_halbb_bridge *br,
     c->hal.chip_id = CHIP_WIFI6_8852C;
   }
   c->bb.rx_path = RF_PATH_AB;
+  /* Both supported dies are 2SS / 2 RF paths. The vendor derives these in
+   * halbb_cmn_info_self_init from ic_type; the minimal bring-up must set them
+   * itself — halbb_physts_parsing_init shifts a
+   * halbb_gen_mask_from_0(num_rf_path) into the physts IE04..07 bits, so a
+   * zero here silently disables the per-path IE pages (per-antenna SNR/EVM). */
+  c->bb.num_rf_path = 2;
+  c->bb.num_tx_path = 2;
+  c->bb.num_ss = 2;
   c->bb.cr_type = BB_CLIENT;     /* USB client CR bank; without it the env-monitor
                                   * CR-init switch falls through and the NHM
                                   * ready-bit address stays 0 (report never rdy) */

--- a/src/RxQuality.h
+++ b/src/RxQuality.h
@@ -232,6 +232,15 @@ struct ActiveRxPaths {
   uint8_t active_mask = 0;      /* bit i set = chain i active */
   int rssi_mean_dbm[4] = {0, 0, 0, 0}; /* per-chain window mean (raw - 110) */
   bool chain_sampled[4] = {false, false, false, false}; /* had any sample */
+  /* Per-chain window-mean SNR / EVM (dB), sampled only when the frame's
+   * phy-status carried a nonzero value for that chain (CCK and non-type1
+   * phy-status leave them 0, so a mixed stream doesn't bias toward zero —
+   * the RxQualityAccumulator convention, per chain). EVM follows the
+   * phy-status sign: negative, more negative = cleaner constellation. */
+  double snr_mean_db[4] = {0, 0, 0, 0};
+  bool snr_sampled[4] = {false, false, false, false};
+  double evm_mean_db[4] = {0, 0, 0, 0};
+  bool evm_sampled[4] = {false, false, false, false};
 };
 
 /* Classify which of `n_chains` are active: a chain is active if it was sampled
@@ -261,18 +270,22 @@ inline uint8_t classify_active_paths(const int *rssi_mean_dbm,
   return count;
 }
 
-/* Thread-safe per-chain RSSI accumulator — the ActiveRxPaths analogue of
- * RxQualityAccumulator. The device feeds add() the full rssi[0..3] tuple for
+/* Thread-safe per-chain RSSI/SNR/EVM accumulator — the ActiveRxPaths analogue
+ * of RxQualityAccumulator. The device feeds add() the full [0..3] tuples for
  * every decoded frame; snapshot() drains the window (delta semantics) and
  * classifies. `margin_db` default 20 dB: a chain more than 20 dB below the
  * strongest is a disconnected/masked antenna, not thermal spread across
  * connected chains. */
 class RxPathActivityAccumulator {
 public:
-  /* Feed the per-chain RSSI (raw devourer units) of one decoded frame; only the
-   * first `n_chains` are considered. A chain reading <= 0 (no phy-status power)
-   * is not a sample for that chain. */
-  void add(const uint8_t *rssi_raw, uint8_t n_chains) {
+  /* Feed the per-chain RSSI / SNR / EVM (raw devourer units: rssi = dBm+110,
+   * snr/evm = half-dB) of one decoded frame; only the first `n_chains` are
+   * considered. A chain reading 0 on a metric (no phy-status value) is not a
+   * sample for that chain+metric — RSSI gates the frame count, SNR/EVM are
+   * folded independently so CCK frames don't zero-bias their means. `snr_raw`
+   * / `evm_raw` may be null (RSSI-only callers). */
+  void add(const uint8_t *rssi_raw, const int8_t *snr_raw,
+           const int8_t *evm_raw, uint8_t n_chains) {
     std::lock_guard<std::mutex> lk(mu_);
     if (n_chains > 4)
       n_chains = 4;
@@ -284,6 +297,18 @@ public:
       sum_[i] += rssi_raw[i];
       ++cnt_[i];
       any = true;
+      if (snr_raw && snr_raw[i] != 0) {
+        snr_sum_[i] += snr_raw[i];
+        ++snr_cnt_[i];
+      }
+      /* -128 is the phy-status no-stream rail (a 1SS frame has no stream-2
+       * EVM; the 11ac reports pin the byte at -128) — a sentinel, not a
+       * measurement (on-air: J1/J2/J3 all rail chain 1 at -128 under 1SS
+       * traffic while chain-1 RSSI/SNR stay live). */
+      if (evm_raw && evm_raw[i] != 0 && evm_raw[i] != -128) {
+        evm_sum_[i] += evm_raw[i];
+        ++evm_cnt_[i];
+      }
     }
     if (any)
       ++frames_;
@@ -301,6 +326,14 @@ public:
             static_cast<int>(sum_[i] / cnt_[i]) - 110;
         s.chain_sampled[i] = true;
       }
+      if (snr_cnt_[i]) {
+        s.snr_mean_db[i] = snr_sum_[i] / (2.0 * snr_cnt_[i]);
+        s.snr_sampled[i] = true;
+      }
+      if (evm_cnt_[i]) {
+        s.evm_mean_db[i] = evm_sum_[i] / (2.0 * evm_cnt_[i]);
+        s.evm_sampled[i] = true;
+      }
     }
     s.n_active = classify_active_paths(s.rssi_mean_dbm, s.chain_sampled,
                                        s.n_chains, margin_db, &s.active_mask);
@@ -309,6 +342,10 @@ public:
     for (uint8_t i = 0; i < 4; i++) {
       sum_[i] = 0;
       cnt_[i] = 0;
+      snr_sum_[i] = 0;
+      snr_cnt_[i] = 0;
+      evm_sum_[i] = 0;
+      evm_cnt_[i] = 0;
     }
     return s;
   }
@@ -319,6 +356,10 @@ private:
   uint8_t n_chains_ = 0;
   uint64_t sum_[4] = {0, 0, 0, 0};
   uint32_t cnt_[4] = {0, 0, 0, 0};
+  int64_t snr_sum_[4] = {0, 0, 0, 0};
+  uint32_t snr_cnt_[4] = {0, 0, 0, 0};
+  int64_t evm_sum_[4] = {0, 0, 0, 0};
+  uint32_t evm_cnt_[4] = {0, 0, 0, 0};
 };
 
 } // namespace devourer

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -1433,7 +1433,8 @@ void RtlJaguarDevice::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
         break;
       if (!p.RxAtrib.crc_err) {
         _rxq.add(p.RxAtrib.rssi[0], p.RxAtrib.snr[0], p.RxAtrib.evm[0]);
-        _rxpaths.add(p.RxAtrib.rssi, _eepromManager->numTotalRfPath);
+        _rxpaths.add(p.RxAtrib.rssi, p.RxAtrib.snr, p.RxAtrib.evm,
+                     _eepromManager->numTotalRfPath);
         if (_cfg.tuning.cfo_track)
           _cfo.add(p.RxAtrib.cfo_tail); /* closed-loop CFO input (#217) */
       }

--- a/src/jaguar2/RtlJaguar2Device.cpp
+++ b/src/jaguar2/RtlJaguar2Device.cpp
@@ -586,7 +586,7 @@ void RtlJaguar2Device::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
             std::span<uint8_t>(const_cast<uint8_t *>(f.frame), f.frame_len);
         if (!p.RxAtrib.crc_err) {
           _rxq.add(p.RxAtrib.rssi[0], p.RxAtrib.snr[0], p.RxAtrib.evm[0]);
-          _rxpaths.add(p.RxAtrib.rssi,
+          _rxpaths.add(p.RxAtrib.rssi, p.RxAtrib.snr, p.RxAtrib.evm,
                        _variant == jaguar2::ChipVariant::C8821C ? 1 : 2);
           if (_cfg.tuning.cfo_track)
             _cfo.add(p.RxAtrib.cfo_tail); /* closed-loop CFO input (#217) */

--- a/src/jaguar3/RtlJaguar3Device.cpp
+++ b/src/jaguar3/RtlJaguar3Device.cpp
@@ -319,7 +319,8 @@ void RtlJaguar3Device::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
         p.Data = std::span<uint8_t>(const_cast<uint8_t *>(f.frame), f.frame_len);
         if (!p.RxAtrib.crc_err) {
           _rxq.add(p.RxAtrib.rssi[0], p.RxAtrib.snr[0], p.RxAtrib.evm[0]);
-          _rxpaths.add(p.RxAtrib.rssi, 2); /* 8822C/8822E are 2T2R */
+          _rxpaths.add(p.RxAtrib.rssi, p.RxAtrib.snr, p.RxAtrib.evm,
+                       2); /* 8822C/8822E are 2T2R */
           if (_cfg.tuning.cfo_track)
             _cfo.add(p.RxAtrib.cfo_tail); /* closed-loop CFO input (#217) */
         }

--- a/src/kestrel/CLAUDE.md
+++ b/src/kestrel/CLAUDE.md
@@ -78,6 +78,22 @@ injection/monitor-link mode. `ReadTsf` reads the per-port MAC TSF;
 FORMAT=EXT_SU or `DEVOURER_TX_RATE=.../ER[/DCM]`; RX classifies the format in
 `RxAtrib.ppdu_type` (7=HE_SU, 8=HE_ERSU) — `docs/he-extended-range.md`.
 
+**Per-antenna RSSI/SNR/EVM** (physts per-path pages): the RX loop parses the
+whole PPDU-status blob (`kestrel::parse_physts_8852` — 8-byte header rssi_td +
+IE01 avg SNR + IE04/05 path pages) into `RxAtrib.rssi/snr/evm[0..1]` and the
+`GetActiveRxPaths()` window. The IE04..07 pages only appear when
+`halbb_physts_parsing_init` shifts a `num_rf_path` mask into the physts IE
+bitmap — the glue must set `bb.num_rf_path`/`num_ss` itself (its bb_info is
+memset-zeroed; a zero mask silently drops the pages and per-path SNR falls
+back to the IE01-average+RSSI-distance derivation, which shadows the loss —
+the tell is per-path SNR exactly tracking the RSSI split). On-air-validated on
+the C8852C (direct snr_lgy + per-path EVM). The C8852B path is untested on
+air: its bring-up skips `halbb_physts_parsing_init` (physts fills from the BB
+table default), so whether its bitmap includes the path pages — and thus
+whether its per-path EVM is real or 0 — is unmeasured; its per-path SNR is the
+derivation either way (the 8852B BB does not drive snr_lgy — vendor
+`halbb_physts_ie_04_07` chip branch).
+
 Async packet-C2H (bulk-IN rpkt_type=10) delivery works — routed by
 `handle_c2h` on the C2H class/func — so the #236 C2H surface (TWT/F2P
 reports) is reachable. Not working: the fw's USR_TX_RPT TX-egress-timestamp

--- a/src/kestrel/FrameParserKestrel.h
+++ b/src/kestrel/FrameParserKestrel.h
@@ -111,6 +111,99 @@ inline bool parse_rx_8852b(const uint8_t *buf, size_t buflen,
   return true;
 }
 
+/* --- PPDU-status (halbb physts) parse: per-path RSSI / SNR / EVM ---
+ *
+ * A PPDU-status payload is the bare halbb physts blob (HalKestrel clears the
+ * MAC-info prepend bits so nothing precedes it): an 8-byte header followed by
+ * fixed-order IEs. Header (physts_hdr_info): byte0 [4:0] ie_bitmap_select /
+ * [7] is_valid, byte1 total length in 8-byte units, byte3 rssi_avg_td,
+ * bytes 4..7 rssi_td[0..3] — all RSSI U(8,1) (dBm+110 = raw>>1). IEs follow in
+ * ascending index order, each starting with its index in byte0 [4:0]; IE00..07
+ * have fixed lengths {2,4,3,3,1,1,1,1} 8-byte units (halbb physts_ie_len_tab),
+ * IE08+ are variable-length so the walk stops there (nothing we need lives
+ * past IE07).
+ *
+ *   IE01 (common OFDM): avg SNR over active paths, byte 8 [5:0], whole dB.
+ *   IE04..07 (extend path A..D): per-path page — byte3 [7:2] snr_lgy (whole
+ *   dB, populated by the BB on the 8852C only), byte4 evm_ss_y (U(8,2),
+ *   quarter-dB distance of the stream this path carries).
+ *
+ * Per-path SNR follows the vendor halbb per-chip split (halbb_physts_ie_04_07):
+ * on the 8852B the IE's snr_lgy field is not driven, and the per-path FD SNR is
+ * derived from the IE01 average plus this path's RSSI distance from the average
+ * (halbb_cmn_rpt: snr_fd[i] = ((snr_fd_avg << 1) - rssi_avg + rssi[i]) >> 1);
+ * on the 8852C snr_lgy is read directly. Units out are the devourer raw
+ * conventions of rx_pkt_attrib: rssi = dBm+110, snr = dB*2, evm = half-dB
+ * (negative — matches the 11ac generations' phy-status sign, more negative =
+ * cleaner constellation). 0 always means "not measured". */
+struct KestrelPhySts {
+  uint8_t rssi_avg = 0; /* dBm+110; 0 = no power measured */
+  uint8_t rssi[4] = {0, 0, 0, 0};
+  uint8_t snr_avg = 0;      /* raw dB*2 from IE01; 0 = IE01 absent (e.g. CCK) */
+  int8_t snr[4] = {0, 0, 0, 0}; /* raw dB*2 per path */
+  int8_t evm[4] = {0, 0, 0, 0}; /* raw half-dB per path (negative) */
+};
+
+inline bool parse_physts_8852(const uint8_t *p, size_t len, bool is_8852c,
+                              KestrelPhySts &out) {
+  if (p == nullptr || len < 8)
+    return false;
+  out.rssi_avg = static_cast<uint8_t>(p[3] >> 1);
+  for (int i = 0; i < 4; i++)
+    out.rssi[i] = static_cast<uint8_t>(p[4 + i] >> 1);
+
+  /* IE walk only on a valid report (header bit7; the BB emits is_valid=0
+   * stubs for e.g. broken PPDUs) — header RSSI above is kept regardless,
+   * matching the pre-IE-walk behaviour. */
+  if ((p[0] & 0x80) == 0)
+    return true;
+  size_t total = static_cast<size_t>(p[1]) << 3; /* header length field */
+  if (total > len)
+    total = len;
+
+  static constexpr uint8_t ie_len8[8] = {2, 4, 3, 3, 1, 1, 1, 1};
+  size_t off = 8;
+  while (off + 8 <= total) {
+    const uint8_t ie = p[off] & 0x1f;
+    if (ie >= 8)
+      break; /* IE08+ are variable-length — stop */
+    const size_t ie_len = static_cast<size_t>(ie_len8[ie]) << 3;
+    if (off + ie_len > total)
+      break;
+    if (ie == 1) {
+      out.snr_avg = static_cast<uint8_t>((p[off + 8] & 0x3f) * 2);
+    } else if (ie >= 4) {
+      const int path = ie - 4;
+      const uint8_t evm_q = p[off + 4]; /* evm_ss_y, quarter-dB */
+      if (evm_q)
+        out.evm[path] = static_cast<int8_t>(-(evm_q >> 1));
+      if (is_8852c) {
+        out.snr[path] = static_cast<int8_t>(((p[off + 3] >> 2) & 0x3f) * 2);
+      }
+    }
+    off += ie_len;
+  }
+  /* 8852B (and fallback when the C's path page is absent): derive per-path FD
+   * SNR from the IE01 average + this path's RSSI distance. rssi raw here is
+   * already dBm+110 (1 dB units) and snr raw is dB*2, so the vendor's U(8,1)
+   * expression collapses to snr[i] = snr_avg + 2*(rssi[i] - rssi_avg). */
+  if (out.snr_avg) {
+    for (int i = 0; i < 4; i++) {
+      if (out.snr[i] || out.rssi[i] == 0)
+        continue;
+      int v = static_cast<int>(out.snr_avg) +
+              2 * (static_cast<int>(out.rssi[i]) -
+                   static_cast<int>(out.rssi_avg));
+      if (v < -128)
+        v = -128;
+      if (v > 127)
+        v = 127;
+      out.snr[i] = static_cast<int8_t>(v);
+    }
+  }
+  return true;
+}
+
 } /* namespace kestrel */
 
 #endif /* FRAME_PARSER_KESTREL_H */

--- a/src/kestrel/RtlKestrelDevice.cpp
+++ b/src/kestrel/RtlKestrelDevice.cpp
@@ -293,26 +293,36 @@ void RtlKestrelDevice::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
           if (!kestrel::parse_rx_8852b(data + off, static_cast<size_t>(n) - off,
                                        f, drv_info_unit))
             break;
-          if (f.rpkt_type == kestrel::RPKT_TYPE_PPDU && f.payload_len >= 6) {
-            /* physts header (halbb physts_hdr_info): byte3 = rssi_avg_td, byte4+
-             * = per-path rssi_td, all U(8,1) (RSSI% = dBm+110 = raw>>1). Cache
-             * for the following WIFI frame(s). */
-            _last_rssi[0] = static_cast<uint8_t>(f.payload[4] >> 1);
-            _last_rssi[1] = static_cast<uint8_t>(f.payload[5] >> 1);
-            /* Per-frame SNR for the passive floor: the 8-byte header is followed
-             * by the IEs; IE_01 (OFDM/HE info, physts_ie_1_info) is
-             * the first for a decodable OFDM/HE PPDU. Self-validate on its ie_hdr
-             * (byte0 [4:0] == 1) before trusting the offset: avg_snr is IE byte 8
-             * [5:0] in dB. Store as raw = dB*2 (the RxQualityAccumulator
-             * convention snr_db = raw/2). 0 when IE_01 absent (e.g. CCK).
-             * On-air-validated on BOTH dies (passive floor cross-matches the
-             * NHM floor within ~1 dB): the C8852C physts is bit-identical to the
-             * C8852B once its measurement engine is brought up (the 8852C branch
-             * in kestrel_halbb_rx_bringup + the R_AX_PPDU_STAT no-APP-prepend
-             * config in bb_reset_all) — same header, same IE_01 offset. */
-            _last_snr = 0;
-            if (f.payload_len >= 8 + 9 && (f.payload[8] & 0x1f) == 1)
-              _last_snr = static_cast<uint8_t>((f.payload[16] & 0x3f) * 2);
+          if (f.rpkt_type == kestrel::RPKT_TYPE_PPDU && f.payload_len >= 8) {
+            /* Full physts parse (header per-path rssi_td + IE01 avg SNR +
+             * IE04..07 per-path SNR/EVM pages) — kestrel::parse_physts_8852.
+             * Cached for the following WIFI frame(s) in the aggregate.
+             * On-air-validated on BOTH dies for the header + IE_01 offsets
+             * (passive floor cross-matches the NHM floor within ~1 dB): the
+             * C8852C physts is bit-identical to the C8852B once its measurement
+             * engine is brought up (the 8852C branch in
+             * kestrel_halbb_rx_bringup + the R_AX_PPDU_STAT no-APP-prepend
+             * config in bb_reset_all) — same header, same IE walk. */
+            kestrel::KestrelPhySts ps;
+            if (kestrel::parse_physts_8852(
+                    f.payload, f.payload_len,
+                    _variant == kestrel::ChipVariant::C8852C, ps))
+              _last_physts = ps;
+            /* Trace: raw physts blobs (first few) — the IE-page ground truth
+             * when a per-path metric reads 0 (is the page absent, or zero?). */
+            static int physts_dumped = 0;
+            if (physts_dumped < 4) {
+              ++physts_dumped;
+              std::string hex;
+              const uint32_t n = f.payload_len < 96 ? f.payload_len : 96;
+              hex.reserve(n * 2);
+              for (uint32_t i = 0; i < n; i++) {
+                static const char d[] = "0123456789abcdef";
+                hex.push_back(d[f.payload[i] >> 4]);
+                hex.push_back(d[f.payload[i] & 0xf]);
+              }
+              _logger->trace("Kestrel physts[{}B]: {}", f.payload_len, hex);
+            }
           } else if (f.rpkt_type == kestrel::RPKT_TYPE_WIFI && packetProcessor) {
             Packet p{};
             p.RxAtrib.pkt_len = static_cast<uint16_t>(f.payload_len);
@@ -323,14 +333,21 @@ void RtlKestrelDevice::StartRxLoop(Action_ParsedRadioPacket packetProcessor) {
             p.RxAtrib.ppdu_type = f.ppdu_type; /* 7=HE_SU 8=HE_ERSU */
             p.RxAtrib.ppdu_cnt = f.ppdu_cnt;
             p.RxAtrib.tsfl = f.freerun_cnt;
-            p.RxAtrib.rssi[0] = _last_rssi[0];
-            p.RxAtrib.rssi[1] = _last_rssi[1];
-            p.RxAtrib.snr[0] = _last_snr;
+            for (int i = 0; i < 4; i++) {
+              p.RxAtrib.rssi[i] = _last_physts.rssi[i];
+              p.RxAtrib.snr[i] = _last_physts.snr[i];
+              p.RxAtrib.evm[i] = _last_physts.evm[i];
+            }
             /* Feed the windowed RX-quality aggregate (passive rssi-snr floor +
-             * LinkHealth). rssi_raw = dBm+110 (== _last_rssi), snr_raw = dB*2;
-             * a frame with no IE_01 SNR (snr=0) still counts toward RSSI. */
-            if (_last_rssi[0] > 0)
-              _rxq.add(_last_rssi[0], _last_snr, 0);
+             * LinkHealth) with path-A RSSI + the IE01 average SNR (the
+             * all-paths quantity the passive floor was validated against;
+             * per-path SNR goes to _rxpaths instead). A frame with no IE_01
+             * SNR (snr_avg=0) still counts toward RSSI. */
+            if (_last_physts.rssi[0] > 0)
+              _rxq.add(_last_physts.rssi[0], _last_physts.snr_avg, 0);
+            /* Per-antenna window means (GetActiveRxPaths). Both dies are 2 RX
+             * chains; C/D read 0 and are excluded by n_chains. */
+            _rxpaths.add(p.RxAtrib.rssi, p.RxAtrib.snr, p.RxAtrib.evm, 2);
             p.Data = std::span<uint8_t>(const_cast<uint8_t *>(f.payload),
                                         f.payload_len);
             packetProcessor(p);

--- a/src/kestrel/RtlKestrelDevice.h
+++ b/src/kestrel/RtlKestrelDevice.h
@@ -16,6 +16,7 @@
 #include "SelectedChannel.h"
 
 #include "ChipVariant.h"
+#include "FrameParserKestrel.h" /* KestrelPhySts (cached per-path phy-status) */
 #include "HalKestrel.h"
 
 namespace kestrel {
@@ -130,6 +131,11 @@ public:
   /* Windowed RX link-quality: the passive rssi-snr floor + LinkHealth verdict
    * (fed per frame via _rxq) fused with the active NHM floor from GetRxEnergy. */
   devourer::RxQuality GetRxQuality() override;
+  /* Live per-chain RX-path activity (fed via _rxpaths in the RX loop): per-
+   * antenna RSSI/SNR/EVM window means from the physts per-path pages. */
+  devourer::ActiveRxPaths GetActiveRxPaths() override {
+    return _rxpaths.snapshot();
+  }
 
   /* Arm the AX HW beacon engine (mac_send_bcn_h2c + AP port timing). Requires a
    * prior InitWrite. `beacon` is a full 802.11 beacon; the MAC airs it every
@@ -240,15 +246,17 @@ private:
    *     (a fixed-rate stream pays once and then nothing). */
   std::atomic<bool> _rate_diffs_on{false};
   std::atomic<int8_t> _rate_diff_qdb[10]{};
-  /* Per-chain RSSI (RSSI% = dBm+110) cached from the last PPDU-status physts
-   * header, attached to the following WIFI frame(s) in the aggregate. */
-  uint8_t _last_rssi[2] = {0, 0};
-  /* Per-frame SNR (raw U(8,1) = dB*2), cached from the physts header alongside
-   * RSSI for the passive noise floor (rssi_dbm - snr_db). 0 = unknown. */
-  uint8_t _last_snr = 0;
+  /* Per-path RSSI/SNR/EVM (rx_pkt_attrib raw conventions) parsed from the last
+   * PPDU-status physts blob (kestrel::parse_physts_8852), attached to the
+   * following WIFI frame(s) in the aggregate. snr_avg (raw dB*2, IE01) feeds
+   * the passive noise floor (rssi_dbm - snr_db). 0 = not measured. */
+  kestrel::KestrelPhySts _last_physts{};
   /* Windowed RX link-quality accumulator (passive noise floor + LinkHealth),
    * fed per decoded frame from the RX loop; drained by GetRxQuality. */
   devourer::RxQualityAccumulator _rxq;
+  /* Live per-chain RX-path activity (per-antenna RSSI/SNR/EVM window means),
+   * fed per decoded frame; drained by GetActiveRxPaths. */
+  devourer::RxPathActivityAccumulator _rxpaths;
 };
 
 #endif /* RTL_KESTREL_DEVICE_H */

--- a/tests/adapter_caps_selftest.cpp
+++ b/tests/adapter_caps_selftest.cpp
@@ -92,16 +92,44 @@ int main() {
   {
     RxPathActivityAccumulator acc;
     const uint8_t f1[4] = {70, 30, 0, 0}; /* raw; chain0 strong, chain1 weak */
-    acc.add(f1, 2);
-    acc.add(f1, 2);
+    const int8_t snr1[4] = {60, 20, 0, 0}; /* raw dB*2: 30 dB / 10 dB */
+    const int8_t evm1[4] = {-52, 0, 0, 0}; /* raw half-dB: -26 dB; chain1 none */
+    acc.add(f1, snr1, evm1, 2);
+    acc.add(f1, snr1, evm1, 2);
     ActiveRxPaths s = acc.snapshot(20);
     expect("acc valid after frames", s.valid && s.frames == 2);
     expect("acc chain0 active", (s.active_mask & 0x1) != 0);
     expect("acc chain1 inactive (40 raw below)",
            (s.active_mask & 0x2) == 0);
+    expect("acc per-chain snr means",
+           s.snr_sampled[0] && s.snr_mean_db[0] == 30.0 &&
+               s.snr_sampled[1] && s.snr_mean_db[1] == 10.0);
+    expect("acc evm chain0 sampled, chain1 not",
+           s.evm_sampled[0] && s.evm_mean_db[0] == -26.0 && !s.evm_sampled[1]);
     /* Second snapshot drains to empty (delta semantics). */
     ActiveRxPaths s2 = acc.snapshot(20);
     expect("acc drained on read", !s2.valid && s2.frames == 0);
+    expect("acc snr/evm drained", !s2.snr_sampled[0] && !s2.evm_sampled[0]);
+  }
+  {
+    /* EVM -128 is the phy-status no-stream rail — excluded from the mean. */
+    RxPathActivityAccumulator acc;
+    const uint8_t f1[4] = {70, 60, 0, 0};
+    const int8_t snr1[4] = {40, 40, 0, 0};
+    const int8_t evm1[4] = {-52, -128, 0, 0};
+    acc.add(f1, snr1, evm1, 2);
+    ActiveRxPaths s = acc.snapshot(20);
+    expect("evm -128 rail not a sample",
+           s.evm_sampled[0] && !s.evm_sampled[1]);
+  }
+  {
+    /* Null SNR/EVM pointers (RSSI-only caller) are accepted. */
+    RxPathActivityAccumulator acc;
+    const uint8_t f1[4] = {70, 60, 0, 0};
+    acc.add(f1, nullptr, nullptr, 2);
+    ActiveRxPaths s = acc.snapshot(20);
+    expect("acc rssi-only add works",
+           s.valid && !s.snr_sampled[0] && !s.evm_sampled[0]);
   }
 
   if (g_fail) {

--- a/tests/kestrel_rxparse_selftest.cpp
+++ b/tests/kestrel_rxparse_selftest.cpp
@@ -175,6 +175,73 @@ int main() {
     CHECK(!parse_rx_8852b(b.data(), 8, f));  /* shorter than a short desc */
   }
 
+  /* --- physts blob parse: header RSSI + IE01 avg SNR + IE04/05 path pages ---
+   * Synthetic blob in the halbb layout: 8B header, IE00 (CCK, 16B) skipped by
+   * construction, IE01 (32B), IE02 (24B), IE04 (8B), IE05 (8B). */
+  {
+    std::vector<uint8_t> b(8 + 32 + 24 + 8 + 8, 0);
+    const uint8_t total8 = static_cast<uint8_t>(b.size() >> 3);
+    b[0] = 0x80 | 0x01;     /* is_valid + ie_bitmap_select */
+    b[1] = total8;          /* total length, 8-byte units */
+    b[3] = 120;             /* rssi_avg_td U(8,1) -> raw 60 = -50 dBm */
+    b[4] = 130;             /* path A td -> raw 65 */
+    b[5] = 110;             /* path B td -> raw 55 */
+    size_t off = 8;
+    b[off] = 1;             /* IE01 */
+    b[off + 8] = 30 & 0x3f; /* avg_snr = 30 dB */
+    off += 32;
+    b[off] = 2;             /* IE02 (contents irrelevant) */
+    off += 24;
+    b[off] = 4;             /* IE04 = path A */
+    b[off + 3] = static_cast<uint8_t>(25u << 2); /* snr_lgy = 25 dB */
+    b[off + 4] = 100;       /* evm_ss_y U(8,2) = 25.0 dB -> raw -50 half-dB */
+    off += 8;
+    b[off] = 5;             /* IE05 = path B */
+    b[off + 3] = static_cast<uint8_t>(18u << 2);
+    b[off + 4] = 60;        /* 15.0 dB -> raw -30 */
+
+    KestrelPhySts ps;
+    CHECK(parse_physts_8852(b.data(), b.size(), /*is_8852c=*/true, ps));
+    CHECK(ps.rssi_avg == 60 && ps.rssi[0] == 65 && ps.rssi[1] == 55);
+    CHECK(ps.snr_avg == 60); /* raw dB*2 */
+    CHECK(ps.snr[0] == 50 && ps.snr[1] == 36); /* snr_lgy * 2 */
+    CHECK(ps.evm[0] == -50 && ps.evm[1] == -30);
+
+    /* 8852B: snr_lgy is not driven; per-path SNR derives from the IE01
+     * average + the path's RSSI distance (vendor halbb_cmn_rpt formula):
+     * snr[i] = snr_avg_raw + 2*(rssi[i]-rssi_avg) = 60 +/- 10. */
+    KestrelPhySts pb;
+    CHECK(parse_physts_8852(b.data(), b.size(), /*is_8852c=*/false, pb));
+    CHECK(pb.snr[0] == 70 && pb.snr[1] == 50);
+    CHECK(pb.evm[0] == -50 && pb.evm[1] == -30); /* EVM page read on both */
+  }
+
+  /* --- physts: is_valid=0 keeps header RSSI but skips the IE walk --- */
+  {
+    std::vector<uint8_t> b(8 + 32, 0);
+    b[0] = 0x01; /* no is_valid bit */
+    b[1] = static_cast<uint8_t>(b.size() >> 3);
+    b[4] = 130;
+    b[8] = 1;
+    b[16] = 30;
+    KestrelPhySts ps;
+    CHECK(parse_physts_8852(b.data(), b.size(), true, ps));
+    CHECK(ps.rssi[0] == 65 && ps.snr_avg == 0 && ps.snr[0] == 0);
+  }
+
+  /* --- physts: truncated / lying total-length is bounded by the buffer --- */
+  {
+    std::vector<uint8_t> b(8 + 4, 0); /* room for header + a torn IE */
+    b[0] = 0x80 | 0x01;
+    b[1] = 0x40; /* claims 512 bytes */
+    b[8] = 1;    /* IE01 header, but its 32-byte body is missing */
+    KestrelPhySts ps;
+    CHECK(parse_physts_8852(b.data(), b.size(), true, ps));
+    CHECK(ps.snr_avg == 0); /* torn IE not parsed */
+    KestrelPhySts p2;
+    CHECK(!parse_physts_8852(b.data(), 4, true, p2)); /* below header size */
+  }
+
   if (failures == 0)
     std::printf("kestrel_rxparse_selftest: all checks passed\n");
   return failures == 0 ? 0 : 1;

--- a/tests/rxpath_perantenna_onair.sh
+++ b/tests/rxpath_perantenna_onair.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Per-antenna RSSI/SNR/EVM on-air validation (rx.path + adapter.rxpaths).
+#
+# Two plugged adapters: TX airs the canonical beacon (default 6M legacy), RX
+# runs with DEVOURER_RX_ALLPATHS=1 + DEVOURER_RX_ENERGY_MS so both the
+# per-frame `rx.path` event and the windowed `adapter.rxpaths` event fire.
+# Passes when, on the RX side:
+#   - rx.path frames carry nonzero RSSI *and* SNR on every expected chain,
+#   - EVM is nonzero-negative on at least chain 0,
+#   - adapter.rxpaths carries the per-chain snr_db array.
+#
+# Usage (root — the demos claim USB interfaces):
+#   sudo tests/rxpath_perantenna_onair.sh \
+#     --tx-vid 0x0bda --tx-pid 0xb812 \
+#     --rx-vid 0x35bc --rx-pid 0x0101 --chains 2 [--channel 36] [--secs 12]
+set -u
+
+BUILD=${BUILD:-"$(dirname "$0")/../build"}
+TX_VID=0x0bda TX_PID="" RX_VID=0x0bda RX_PID="" CHANNEL=36 SECS=12 CHAINS=2
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --tx-vid) TX_VID=$2; shift 2;;
+    --tx-pid) TX_PID=$2; shift 2;;
+    --rx-vid) RX_VID=$2; shift 2;;
+    --rx-pid) RX_PID=$2; shift 2;;
+    --channel) CHANNEL=$2; shift 2;;
+    --secs) SECS=$2; shift 2;;
+    --chains) CHAINS=$2; shift 2;;
+    *) echo "unknown arg: $1" >&2; exit 2;;
+  esac
+done
+[ -n "$TX_PID" ] && [ -n "$RX_PID" ] || { echo "need --tx-pid and --rx-pid" >&2; exit 2; }
+[ -x "$BUILD/rxdemo" ] && [ -x "$BUILD/txdemo" ] || { echo "build demos first" >&2; exit 2; }
+
+LOGDIR=$(mktemp -d /tmp/rxpath-onair.XXXXXX)
+RXLOG="$LOGDIR/rx.jsonl"
+RX_PID_N="" TX_PID_N=""
+cleanup() {
+  [ -n "$TX_PID_N" ] && kill "$TX_PID_N" 2>/dev/null
+  [ -n "$RX_PID_N" ] && kill "$RX_PID_N" 2>/dev/null
+  wait 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+echo "logs: $LOGDIR (RX ${RX_VID}:${RX_PID}, TX ${TX_VID}:${TX_PID}, ch $CHANNEL)"
+
+DEVOURER_VID=$RX_VID DEVOURER_PID=$RX_PID DEVOURER_CHANNEL=$CHANNEL \
+  DEVOURER_RX_ALLPATHS=1 DEVOURER_RX_ENERGY_MS=2000 DEVOURER_RXQUALITY=1 \
+  DEVOURER_LOG_LEVEL=trace \
+  "$BUILD/rxdemo" >"$RXLOG" 2>"$LOGDIR/rx.err" &
+RX_PID_N=$!
+
+sleep 4  # RX bring-up
+kill -0 "$RX_PID_N" 2>/dev/null || { echo "FAIL: rxdemo died during bring-up"; tail -5 "$LOGDIR/rx.err"; exit 1; }
+
+DEVOURER_VID=$TX_VID DEVOURER_PID=$TX_PID DEVOURER_CHANNEL=$CHANNEL \
+  timeout "$SECS" "$BUILD/txdemo" >"$LOGDIR/tx.jsonl" 2>"$LOGDIR/tx.err" &
+TX_PID_N=$!
+
+# Fail-fast preflight: a hit must arrive within ~8 s or the pair is dead.
+for _ in $(seq 1 8); do
+  sleep 1
+  grep -qF '"ev":"rx.path"' "$RXLOG" && break
+done
+grep -qF '"ev":"rx.path"' "$RXLOG" || {
+  echo "FAIL: no rx.path events after 8 s (link dead or ALLPATHS not emitting)"
+  tail -5 "$LOGDIR/rx.err"; exit 1; }
+
+wait "$TX_PID_N" 2>/dev/null; TX_PID_N=""
+sleep 3  # let one more adapter.rxpaths window drain
+kill "$RX_PID_N" 2>/dev/null; wait "$RX_PID_N" 2>/dev/null; RX_PID_N=""
+
+python3 - "$RXLOG" "$CHAINS" <<'EOF'
+import json, sys
+log, chains = sys.argv[1], int(sys.argv[2])
+paths, winds = [], []
+for line in open(log):
+    if not line.startswith('{"ev":"'):
+        continue
+    try:
+        e = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    if e.get("ev") == "rx.path":
+        paths.append(e)
+    elif e.get("ev") == "adapter.rxpaths":
+        winds.append(e)
+fail = []
+if not paths:
+    fail.append("no rx.path events")
+else:
+    n = len(paths)
+    for c in range(chains):
+        rssi_ok = sum(1 for e in paths if e["rssi"][c] > 0)
+        snr_ok = sum(1 for e in paths if e["snr"][c] != 0)
+        print(f"chain {c}: rssi nonzero {rssi_ok}/{n}, snr nonzero {snr_ok}/{n}")
+        if rssi_ok < n * 0.5:
+            fail.append(f"chain {c} rssi mostly zero")
+        if snr_ok < n * 0.5:
+            fail.append(f"chain {c} snr mostly zero")
+    evm0 = sum(1 for e in paths if e["evm"][0] < 0)
+    print(f"chain 0: evm negative {evm0}/{n}")
+    if evm0 < n * 0.5:
+        fail.append("chain 0 evm not populated")
+    ex = paths[len(paths)//2]
+    print("sample rx.path:", json.dumps({k: ex[k] for k in ("rssi","snr","evm")}))
+snr_w = [e for e in winds if "snr_db" in e]
+if not snr_w:
+    fail.append("no adapter.rxpaths window carried snr_db")
+else:
+    print("sample adapter.rxpaths:", json.dumps(snr_w[-1]))
+if fail:
+    print("FAIL:", "; ".join(fail)); sys.exit(1)
+print("PASS")
+EOF
+rc=$?
+exit $rc


### PR DESCRIPTION
## What

Per-antenna (per-RX-chain) RSSI/SNR/EVM as a first-class feature on all four generations. Jaguar1/2/3 already parsed per-chain values into `RxAtrib`; this PR closes the two real gaps:

- **Kestrel**: full PPDU-status (halbb physts) parse — header per-path `rssi_td`, IE01 avg SNR, IE04/05 per-path pages — into `RxAtrib.rssi/snr/evm[0..1]`, plus a `GetActiveRxPaths()` override. Per-path SNR follows the vendor per-chip split: `snr_lgy` read directly on the 8852C, the IE01-average + RSSI-distance derivation on the 8852B (its BB does not drive the field).
- **Windowed API**: `ActiveRxPaths` gains per-chain SNR/EVM window means (+ sampled flags); `adapter.rxpaths` gains `snr_db[]`/`evm_db[]`.

## Root cause the feature exposed

The halbb glue memset-zeroes its `bb_info` and never set `num_rf_path`, so `halbb_physts_parsing_init`'s IE04..07 enable mask (`halbb_gen_mask_from_0(num_rf_path) << IE04`) was **0** — the per-path pages were silently absent. The failure is shadowed by the derivation fallback; the tell is per-path SNR exactly tracking the RSSI split. Fixed by setting `num_rf_path/num_tx_path/num_ss = 2` (both dies are 2SS).

Also: EVM raw **-128 is the phy-status no-stream rail** — on 1SS traffic every 11ac generation rails chain-1 EVM at -128 while chain-1 RSSI/SNR stay live — so the accumulator excludes it from window means.

## Validation

- 48/48 `ctest` (new physts-parser + accumulator selftests: IE walk, 8852B vs C SNR split, is_valid=0 stub, torn-IE bounds, -128 exclusion, drain semantics).
- On-air (`tests/rxpath_perantenna_onair.sh`, 8822BU TX → each RX, ch36, ~4.3–4.7k `rx.path` frames per pair, all PASS):

| RX | chains | result |
|---|---|---|
| 8852C (TX50UH) | 2 | rssi+snr 100%; independent per-path SNR (`[84,84]` at rssi `[88,69]` — the direct field, not the derivation); EVM negative per chain |
| 8814AU | 4 | all 4 chains live, `active_mask 0x0f` |
| 8812BU (T3U) | 2 | PASS |
| 8812CU | 2 | PASS |

**Unmeasured**: the 8852B die was not on the bench. Its bring-up skips `halbb_physts_parsing_init` (physts bitmap comes from the BB table default), so whether its per-path EVM is real or 0 there is unmeasured; its per-path SNR is the derivation either way. Stated in `src/kestrel/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)