### PR TITLE
CI: qodo-gate — block merge until the Qodo review lands and its threads are resolved

### DIFF
--- a/.github/workflows/qodo-gate.yml
+++ b/.github/workflows/qodo-gate.yml
@@ -50,14 +50,10 @@ jobs:
                 repository(owner: $owner, name: $name) {
                   pullRequest(number: $pr) {
                     headRefOid
-                    commits(last: 1) {
-                      nodes { commit { committedDate } }
-                    }
                     labels(first: 100) { nodes { name } }
                     reviews(last: 100) {
                       nodes {
                         author { login }
-                        submittedAt
                         commit { oid }
                       }
                     }
@@ -72,24 +68,23 @@ jobs:
             exit 0
           fi
 
-          # A review counts only if it saw the current head: same commit oid,
-          # or submitted after the head commit landed (Qodo associates some
-          # incremental reviews with an earlier oid). Stale reviews of a
-          # previous push do NOT count — otherwise any follow-up commit could
-          # merge unreviewed, the same race one push later.
+          # A review counts only if it is tied to the current head oid. No
+          # timestamp fallback: submittedAt >= committedDate is spoofable by a
+          # rebase/cherry-pick whose head commit carries an old committedDate,
+          # and observed Qodo reviews associate with the exact head they
+          # reviewed. Stale reviews of a previous push do NOT count —
+          # otherwise any follow-up commit could merge unreviewed, the same
+          # race one push later. Summon a re-review with a `/review` comment.
           head_oid=$(echo "$json" | jq -r '.data.repository.pullRequest.headRefOid')
-          head_date=$(echo "$json" | jq -r \
-            '.data.repository.pullRequest.commits.nodes[0].commit.committedDate')
           current=$(echo "$json" | jq --arg b "$BOT" --arg oid "$head_oid" \
-              --arg d "$head_date" \
             '[.data.repository.pullRequest.reviews.nodes[]
               | select(.author.login == $b)
-              | select(.commit.oid == $oid or .submittedAt >= $d)] | length')
+              | select(.commit.oid == $oid)] | length')
           if [ "$current" -eq 0 ]; then
-            echo "FAIL: no Qodo review of the current head ($head_oid) — the"
-            echo "agent usually posts within a few minutes of a push; this"
-            echo "check re-runs on review submission. (Outage? Apply the"
-            echo "skip-qodo-gate label.)"
+            echo "FAIL: no Qodo review of the current head ($head_oid) —"
+            echo "comment /review on the PR to summon one; this check re-runs"
+            echo "on review submission. (Outage? Apply the skip-qodo-gate"
+            echo "label.)"
             exit 1
           fi
 
@@ -109,16 +104,20 @@ jobs:
                         pageInfo { hasNextPage endCursor }
                         nodes {
                           isResolved
-                          comments(first: 1) { nodes { author { login } } }
+                          comments(first: 10) { nodes { author { login } } }
                         }
                       }
                     }
                   }
                 }')
+            # A thread is Qodo's if ANY of its first comments is by the bot —
+            # first-comment-only attribution loses the thread when the bot's
+            # opening comment is deleted while replies remain (and deletion
+            # re-triggers this check, so that would be a false pass).
             n=$(echo "$page" | jq --arg b "$BOT" \
               '[.data.repository.pullRequest.reviewThreads.nodes[]
                 | select(.isResolved | not)
-                | select(.comments.nodes[0].author.login == $b)] | length')
+                | select([.comments.nodes[].author.login] | index($b))] | length')
             unresolved=$((unresolved + n))
             more=$(echo "$page" | jq -r \
               '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')

--- a/.github/workflows/qodo-gate.yml
+++ b/.github/workflows/qodo-gate.yml
@@ -9,16 +9,21 @@
 # be looked at before merge.
 #
 # Event-driven: re-evaluates when the PR updates, when a review is submitted,
-# and when a review thread is resolved/unresolved. Escape hatch for a Qodo
-# outage: the `skip-qodo-gate` label passes the check (label changes
-# re-trigger it).
+# and when someone replies in a review thread. GitHub's workflow parser
+# rejects the documented `pull_request_review_thread` trigger ("Unexpected
+# value"), so plain thread resolution does not auto-retrigger — after
+# resolving the last thread, either leave a reply (retriggers) or Re-run the
+# failed qodo-gate check from the PR's Checks tab; the check reads the live
+# resolution state each run. Escape hatch for a Qodo outage: the
+# `skip-qodo-gate` label passes the check (label changes re-trigger it).
 name: qodo-gate
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
   pull_request_review:
     types: [submitted]
-  pull_request_review_thread:
+  pull_request_review_comment:
+    types: [created, deleted]
 
 permissions:
   contents: read
@@ -80,7 +85,9 @@ jobs:
           if [ "$unresolved" -gt 0 ]; then
             echo "FAIL: $unresolved unresolved Qodo review thread(s) — address"
             echo "or explicitly dismiss each finding, then mark the thread"
-            echo "resolved; this check re-runs on thread resolution."
+            echo "resolved. Plain resolution does not auto-retrigger this"
+            echo "check: leave a reply in a thread (retriggers) or Re-run the"
+            echo "check from the PR's Checks tab after resolving."
             exit 1
           fi
 

--- a/.github/workflows/qodo-gate.yml
+++ b/.github/workflows/qodo-gate.yml
@@ -1,0 +1,88 @@
+# Merge gate for the Qodo code-review agent.
+#
+# Why: branch protection's "require conversation resolution" only blocks
+# unresolved threads that EXIST at merge time. Qodo posts its review a minute
+# or two after the PR opens, so a "merge when CI is green" flow can race past
+# it (PR #355 merged 64 s before the review landed). This required check stays
+# red until (a) a Qodo review has been submitted at all, and (b) every review
+# thread Qodo opened is resolved — so the race is closed and the findings must
+# be looked at before merge.
+#
+# Event-driven: re-evaluates when the PR updates, when a review is submitted,
+# and when a review thread is resolved/unresolved. Escape hatch for a Qodo
+# outage: the `skip-qodo-gate` label passes the check (label changes
+# re-trigger it).
+name: qodo-gate
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  qodo-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a Qodo review with all its threads resolved
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+          BOT='qodo-free-for-open-source-projects'
+
+          json=$(gh api graphql \
+            -F owner="$REPO_OWNER" -F name="$REPO_NAME" -F pr="$PR" \
+            -f query='
+              query($owner: String!, $name: String!, $pr: Int!) {
+                repository(owner: $owner, name: $name) {
+                  pullRequest(number: $pr) {
+                    labels(first: 50) { nodes { name } }
+                    reviews(first: 100) { nodes { author { login } } }
+                    reviewThreads(first: 100) {
+                      nodes {
+                        isResolved
+                        comments(first: 1) { nodes { author { login } } }
+                      }
+                    }
+                  }
+                }
+              }')
+
+          if echo "$json" | jq -e --arg l skip-qodo-gate \
+              '.data.repository.pullRequest.labels.nodes[] | select(.name == $l)' \
+              >/dev/null; then
+            echo "PASS: skip-qodo-gate label set (Qodo outage escape hatch)"
+            exit 0
+          fi
+
+          reviews=$(echo "$json" | jq --arg b "$BOT" \
+            '[.data.repository.pullRequest.reviews.nodes[]
+              | select(.author.login == $b)] | length')
+          if [ "$reviews" -eq 0 ]; then
+            echo "FAIL: no Qodo review submitted yet — the agent usually posts"
+            echo "within a few minutes of the PR opening; this check re-runs on"
+            echo "review submission. (Outage? Apply the skip-qodo-gate label.)"
+            exit 1
+          fi
+
+          unresolved=$(echo "$json" | jq --arg b "$BOT" \
+            '[.data.repository.pullRequest.reviewThreads.nodes[]
+              | select(.isResolved | not)
+              | select(.comments.nodes[0].author.login == $b)] | length')
+          if [ "$unresolved" -gt 0 ]; then
+            echo "FAIL: $unresolved unresolved Qodo review thread(s) — address"
+            echo "or explicitly dismiss each finding, then mark the thread"
+            echo "resolved; this check re-runs on thread resolution."
+            exit 1
+          fi
+
+          echo "PASS: Qodo reviewed ($reviews review(s)), all its threads resolved"

--- a/.github/workflows/qodo-gate.yml
+++ b/.github/workflows/qodo-gate.yml
@@ -4,9 +4,9 @@
 # unresolved threads that EXIST at merge time. Qodo posts its review a minute
 # or two after the PR opens, so a "merge when CI is green" flow can race past
 # it (PR #355 merged 64 s before the review landed). This required check stays
-# red until (a) a Qodo review has been submitted at all, and (b) every review
-# thread Qodo opened is resolved — so the race is closed and the findings must
-# be looked at before merge.
+# red until (a) a Qodo review of the CURRENT head exists — a stale review of
+# an earlier push does not count, or the race just moves to follow-up
+# commits — and (b) every review thread Qodo opened is resolved.
 #
 # Event-driven: re-evaluates when the PR updates, when a review is submitted,
 # and when someone replies in a review thread. GitHub's workflow parser
@@ -33,7 +33,7 @@ jobs:
   qodo-gate:
     runs-on: ubuntu-latest
     steps:
-      - name: Require a Qodo review with all its threads resolved
+      - name: Require a current-head Qodo review with all its threads resolved
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
@@ -49,12 +49,16 @@ jobs:
               query($owner: String!, $name: String!, $pr: Int!) {
                 repository(owner: $owner, name: $name) {
                   pullRequest(number: $pr) {
-                    labels(first: 50) { nodes { name } }
-                    reviews(first: 100) { nodes { author { login } } }
-                    reviewThreads(first: 100) {
+                    headRefOid
+                    commits(last: 1) {
+                      nodes { commit { committedDate } }
+                    }
+                    labels(first: 100) { nodes { name } }
+                    reviews(last: 100) {
                       nodes {
-                        isResolved
-                        comments(first: 1) { nodes { author { login } } }
+                        author { login }
+                        submittedAt
+                        commit { oid }
                       }
                     }
                   }
@@ -68,20 +72,61 @@ jobs:
             exit 0
           fi
 
-          reviews=$(echo "$json" | jq --arg b "$BOT" \
+          # A review counts only if it saw the current head: same commit oid,
+          # or submitted after the head commit landed (Qodo associates some
+          # incremental reviews with an earlier oid). Stale reviews of a
+          # previous push do NOT count — otherwise any follow-up commit could
+          # merge unreviewed, the same race one push later.
+          head_oid=$(echo "$json" | jq -r '.data.repository.pullRequest.headRefOid')
+          head_date=$(echo "$json" | jq -r \
+            '.data.repository.pullRequest.commits.nodes[0].commit.committedDate')
+          current=$(echo "$json" | jq --arg b "$BOT" --arg oid "$head_oid" \
+              --arg d "$head_date" \
             '[.data.repository.pullRequest.reviews.nodes[]
-              | select(.author.login == $b)] | length')
-          if [ "$reviews" -eq 0 ]; then
-            echo "FAIL: no Qodo review submitted yet — the agent usually posts"
-            echo "within a few minutes of the PR opening; this check re-runs on"
-            echo "review submission. (Outage? Apply the skip-qodo-gate label.)"
+              | select(.author.login == $b)
+              | select(.commit.oid == $oid or .submittedAt >= $d)] | length')
+          if [ "$current" -eq 0 ]; then
+            echo "FAIL: no Qodo review of the current head ($head_oid) — the"
+            echo "agent usually posts within a few minutes of a push; this"
+            echo "check re-runs on review submission. (Outage? Apply the"
+            echo "skip-qodo-gate label.)"
             exit 1
           fi
 
-          unresolved=$(echo "$json" | jq --arg b "$BOT" \
-            '[.data.repository.pullRequest.reviewThreads.nodes[]
-              | select(.isResolved | not)
-              | select(.comments.nodes[0].author.login == $b)] | length')
+          # Unresolved Qodo threads, paginated (a long-lived PR can exceed one
+          # 100-thread page; a truncated read must never produce a false pass).
+          unresolved=0
+          cursor=""
+          while :; do
+            args=( -F owner="$REPO_OWNER" -F name="$REPO_NAME" -F pr="$PR" )
+            [ -n "$cursor" ] && args+=( -F cursor="$cursor" )
+            page=$(gh api graphql "${args[@]}" \
+              -f query='
+                query($owner: String!, $name: String!, $pr: Int!, $cursor: String) {
+                  repository(owner: $owner, name: $name) {
+                    pullRequest(number: $pr) {
+                      reviewThreads(first: 100, after: $cursor) {
+                        pageInfo { hasNextPage endCursor }
+                        nodes {
+                          isResolved
+                          comments(first: 1) { nodes { author { login } } }
+                        }
+                      }
+                    }
+                  }
+                }')
+            n=$(echo "$page" | jq --arg b "$BOT" \
+              '[.data.repository.pullRequest.reviewThreads.nodes[]
+                | select(.isResolved | not)
+                | select(.comments.nodes[0].author.login == $b)] | length')
+            unresolved=$((unresolved + n))
+            more=$(echo "$page" | jq -r \
+              '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
+            [ "$more" = "true" ] || break
+            cursor=$(echo "$page" | jq -r \
+              '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
+          done
+
           if [ "$unresolved" -gt 0 ]; then
             echo "FAIL: $unresolved unresolved Qodo review thread(s) — address"
             echo "or explicitly dismiss each finding, then mark the thread"
@@ -91,4 +136,4 @@ jobs:
             exit 1
           fi
 
-          echo "PASS: Qodo reviewed ($reviews review(s)), all its threads resolved"
+          echo "PASS: current-head Qodo review present, all its threads resolved"

--- a/.github/workflows/qodo-gate.yml
+++ b/.github/workflows/qodo-gate.yml
@@ -19,7 +19,6 @@ on:
   pull_request_review:
     types: [submitted]
   pull_request_review_thread:
-    types: [resolved, unresolved]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

#355 exposed a race the existing branch protection cannot close: `required_conversation_resolution` is already enabled on master, but it only blocks **threads that exist at merge time**. Qodo posted its #355 review at 09:36:28 — 64 s after the 09:35:24 merge — so a "merge when CI is green" flow sails past the review agent entirely.

## What

A `qodo-gate` required status check that stays **red** until:

1. a review by `qodo-free-for-open-source-projects[bot]` has been submitted at all (closes the race), and
2. every review thread that bot opened is resolved (mirrors conversation-resolution, scoped to the agent).

Event-driven re-evaluation: `pull_request` (open/sync/label), `pull_request_review` (submitted), `pull_request_review_thread` (resolved/unresolved) — no polling, the check flips as soon as the review lands or a thread is resolved.

Escape hatch: the `skip-qodo-gate` label passes the check (for a Qodo outage; label events re-trigger).

Bot login + GraphQL thread shape verified against #355's live data.

## Rollout

After this merges, `qodo-gate` gets added to the master required-status-check contexts. Open PRs need a rebase (or close/reopen) to pick the workflow up before they can merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)