### PR TITLE
qodo-gate: accept Qodo's update-in-place re-review as current-head evidence

### DIFF
--- a/.github/workflows/qodo-gate.yml
+++ b/.github/workflows/qodo-gate.yml
@@ -28,6 +28,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  issues: read # the marker-comment fallback reads issues/<pr>/comments
 
 jobs:
   qodo-gate:
@@ -92,11 +93,15 @@ jobs:
               | select(.author.login == $b)
               | select(.commit.oid == $oid)] | length')
           if [ "$current" -eq 0 ]; then
+            # --paginate applies --jq PER PAGE, so a `| length` there emits
+            # one count per page ("0\n1"), breaking the integer test below.
+            # Emit matching comment ids instead and count lines across pages.
             current=$(gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$PR/comments" \
-              --paginate --jq "[.[]
+              --paginate --jq ".[]
                 | select(.user.login == \"${BOT}[bot]\")
                 | select(.body | test(\"up to the latest commit\"))
-                | select(.body | contains(\"$head_oid\"))] | length")
+                | select(.body | contains(\"$head_oid\"))
+                | .id" | wc -l)
           fi
           if [ "$current" -eq 0 ]; then
             echo "FAIL: no Qodo review of the current head ($head_oid) —"

--- a/.github/workflows/qodo-gate.yml
+++ b/.github/workflows/qodo-gate.yml
@@ -75,16 +75,34 @@ jobs:
           # reviewed. Stale reviews of a previous push do NOT count —
           # otherwise any follow-up commit could merge unreviewed, the same
           # race one push later. Summon a re-review with a `/review` comment.
+          #
+          # Two evidence forms, because Qodo re-reviews two ways: a fresh
+          # review object tied to the head oid (observed on PR open), or an
+          # in-place UPDATE of its code-review comment plus a marker comment
+          # "updated up to the latest commit <sha>" (observed on /review after
+          # a push — no new review object is submitted). The fallback accepts
+          # only the bot's own comments naming the exact head oid. NB comment
+          # edits cannot retrigger this check against the PR head (an
+          # issue_comment-triggered run would attach to the default branch),
+          # so after a summoned re-review, retrigger via a thread reply or a
+          # Checks-tab re-run.
           head_oid=$(echo "$json" | jq -r '.data.repository.pullRequest.headRefOid')
           current=$(echo "$json" | jq --arg b "$BOT" --arg oid "$head_oid" \
             '[.data.repository.pullRequest.reviews.nodes[]
               | select(.author.login == $b)
               | select(.commit.oid == $oid)] | length')
           if [ "$current" -eq 0 ]; then
+            current=$(gh api "repos/$REPO_OWNER/$REPO_NAME/issues/$PR/comments" \
+              --paginate --jq "[.[]
+                | select(.user.login == \"${BOT}[bot]\")
+                | select(.body | test(\"up to the latest commit\"))
+                | select(.body | contains(\"$head_oid\"))] | length")
+          fi
+          if [ "$current" -eq 0 ]; then
             echo "FAIL: no Qodo review of the current head ($head_oid) —"
-            echo "comment /review on the PR to summon one; this check re-runs"
-            echo "on review submission. (Outage? Apply the skip-qodo-gate"
-            echo "label.)"
+            echo "comment /review on the PR to summon one, then re-run this"
+            echo "check (or reply in a thread) once it answers. (Outage?"
+            echo "Apply the skip-qodo-gate label.)"
             exit 1
           fi
 


### PR DESCRIPTION
Follow-up gap found while landing #356: a `/review` summon after a push does **not** submit a new review object — Qodo edits its code-review comment in place and posts a marker comment naming the head sha ("updated up to the latest commit `<oid>`"). The gate's strict review-object/head-oid match therefore blocks forever on the summon path (observed live on #356; #357's summons happened to produce review objects).

The gate now accepts either evidence form:
1. a review object tied to the current head oid (unchanged), or
2. a bot-authored comment matching "up to the latest commit" **and** containing the exact head oid (verified against #356's live data).

Only the bot's own comments count, so this is not spoofable by other users. Comment edits can't retrigger the check against the PR head (issue_comment runs attach to the default branch), so the retrigger paths stay: thread reply or Checks-tab re-run — documented in the failure message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)