### PR TITLE
ARQ × A-MPDU measured: contract holds, CCX telemetry and goodput do not

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,7 +419,10 @@ guard time, dynamic beacon grants, ACK/TxReport, per-UE RX attribution) are
 
 `SetAmpduMode` enables 802.11 A-MPDU on injected frames: ~+30% *goodput* at
 the PHY ceiling by amortizing per-frame overhead — an occupancy metric can't
-show it, count delivered payload. `SetAckResponder(mac)` arms the hardware
+show it, count delivered payload. That number is high-MCS broadcast; the
+unicast-ARQ shape measured **−8%** delivered at MCS3, and per-frame CCX
+accounting does not survive AGG_EN (docs/aggregation.md) — under A-MPDU the
+receipts tier is the delivery truth. `SetAckResponder(mac)` arms the hardware
 ACK/BlockAck responder; with a unicast TA on the soliciting frame this closes
 a hardware-ARQ loop (autonomous MAC retransmission until ACK). The ACK's
 horizon is chip-FIFO **admission** (bench: 8812EU responder,

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -146,7 +146,14 @@ airtime ground truth):
   226.7 k frames over the same span) — at low MCS the preamble amortization
   is small and the BA machinery costs more than it saves. The +30% above is
   a high-MCS, broadcast/no-ack, near-PHY-ceiling number; measure the
-  intended shape before enabling A-MPDU on an ARQ link.
+  intended shape before enabling A-MPDU on an ARQ link. The delivery
+  *contract* itself is unaffected: the instrumented three-ledger arm shows
+  `acked_undelivered = 0` under BA exactly as per-frame — with the same
+  ACK-loss duplicate asymmetry (the un-aggregated control redelivered +97
+  duplicates, ≈0.04%, at saturation). The BA arm's 1.1% saturation
+  shortfall cannot be decomposed into write-offs vs declines precisely
+  because of the next bullet — inside a BA link, only the receipts tier can
+  say where frames died.
 - **Per-frame CCX accounting does not survive aggregation** (measured,
   8812CU): with AGG_EN, ~60% of requested SPE_RPT reports are never emitted
   (suppressed in a per-aggregate pattern — tag deltas bunch at whole

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -139,6 +139,23 @@ airtime ground truth):
   payload gain on a near-saturated chip; measure goodput (delivered payload)
   to see it. The multiplier grows with PHY rate, since preamble overhead is a
   bigger fraction at high MCS.
+- **The gain does not generalize to the unicast-ARQ shape.** The same
+  aggregation at MCS3/512 B unicast with hardware ACK + retry 8 (the FPV
+  ARQ configuration, `tests/arq_e2e_delivery.sh`, batch-8 feed at 4 k fps
+  demand) delivered **−8%** vs the identical un-aggregated feed (208.8 k vs
+  226.7 k frames over the same span) — at low MCS the preamble amortization
+  is small and the BA machinery costs more than it saves. The +30% above is
+  a high-MCS, broadcast/no-ack, near-PHY-ceiling number; measure the
+  intended shape before enabling A-MPDU on an ARQ link.
+- **Per-frame CCX accounting does not survive aggregation** (measured,
+  8812CU): with AGG_EN, ~60% of requested SPE_RPT reports are never emitted
+  (suppressed in a per-aggregate pattern — tag deltas bunch at whole
+  multiples of the sampling divisor), every emitted report says retries=0
+  (BlockAck retransmission cycles are invisible to CCX), and no frame ever
+  carries multiple reports. The SW_DEFINE tag-gap drop signal is therefore
+  accounting-grade only for un-aggregated frames; under A-MPDU, use the
+  windowed RX receipts (`src/cell/RxReceipt.h`) as the delivery truth — the
+  receiver-side ledger is unaffected by TX aggregation.
 - `ppdu_cnt` reads 0 on the 8812CU RX used for the bench; `paggr` + `tsfl`
   clustering are the working RX markers.
 

--- a/examples/common/env_config.cpp
+++ b/examples/common/env_config.cpp
@@ -110,8 +110,16 @@ devourer::DeviceConfig devourer_config_from_env() {
     cfg.tx.report = static_cast<int>(v < 0 ? 0 : v > 255 ? 255 : v);
   if (const char *e = env_str("DEVOURER_TX_AMPDU_MODE")) {
     devourer::AmpduMode m;
-    if (devourer::parse_ampdu_mode(e, m))
+    if (devourer::parse_ampdu_mode(e, m)) {
       cfg.tx.ampdu = m;
+    } else {
+      /* A silently-ignored spec means a bench that thinks it measured
+       * aggregation and didn't — fail loudly like RETRY_FALLBACK below. */
+      std::fprintf(stderr,
+                   "devourer [W] DEVOURER_TX_AMPDU_MODE='%s' unparsable — "
+                   "A-MPDU stays off\n", e);
+      std::fflush(stderr);
+    }
   }
   if (env_long("DEVOURER_TX_RETRY_LIMIT", &v))
     cfg.tx.retry_limit = static_cast<int>(v < 0 ? 0 : (v > 63 ? 63 : v));

--- a/tests/arq_e2e_analyze.py
+++ b/tests/arq_e2e_analyze.py
@@ -352,10 +352,16 @@ def main():
     # stdout — this is an offline report generator (the harness tees it into
     # report.txt), same contract as rxq_analyze.py / pp109_starve_analyze.py,
     # not a demo's runtime event plane.
+    # Self-describing counts: "reports"/"ok_reports" are raw tx.report events,
+    # "ok_frames" is the per-tag reconciled frame count the identity uses —
+    # equal at one report per frame, divergent once BA multi-reports exist.
     print(json.dumps({"ev": "arqe2e.verdict", "verdict": verdict,
                       "acked_undelivered": total_au,
                       "tail_suspect": tot_tail,
-                      "reports": len(reports), "ok": ok_frames,
+                      "reports": len(reports),
+                      "ok_reports": sum(1 for rp in reports if rp["ok"]),
+                      "ok_frames": ok_frames,
+                      "multi_report_frames": multi,
                       "dut_pctrs": len(dut), "wit_pctrs": len(wit),
                       "base": base}, separators=(",", ":")), flush=True)
     return 3 if verdict == "INCONCLUSIVE-SHORT-RUN" else 0

--- a/tests/arq_e2e_analyze.py
+++ b/tests/arq_e2e_analyze.py
@@ -241,10 +241,31 @@ def main():
         print(f"# WARNING: run spans only {max_index + 1} frame indices "
               f"(< 2x TAIL_GUARD={TAIL_GUARD}) — verdict will be "
               f"INCONCLUSIVE-SHORT-RUN")
-    per = defaultdict(lambda: defaultdict(int))
-    detail = []
+    # Per-frame reconciliation: under BlockAck a retransmitted MPDU can emit
+    # MULTIPLE reports for the same tag (data_tx_cnt incrementing per attempt
+    # — vendor-confirmed per-MPDU semantics). The frame's verdict is its LAST
+    # report's state, its retries the maximum seen; a per-frame-ACK run has
+    # exactly one report per frame, so this reduces to the identity there.
+    frames = {}
     for j, rp in enumerate(reports):
         k = base + rel[j]
+        f = frames.get(k)
+        if f is None:
+            frames[k] = {"ok": rp["ok"], "retries": rp["retries"],
+                         "reports": 1}
+        else:
+            f["ok"] = rp["ok"]  # last report wins
+            f["retries"] = max(f["retries"], rp["retries"])
+            f["reports"] += 1
+    multi = sum(1 for f in frames.values() if f["reports"] > 1)
+    if multi:
+        print(f"# BA reconciliation: {multi} frames carried multiple reports "
+              f"(last-state-wins, max-retries)")
+
+    per = defaultdict(lambda: defaultdict(int))
+    detail = []
+    for k in sorted(frames):
+        rp = frames[k]
         in_dut = k in dut
         in_wit = k in wit
         p = k_phase.get(k) if in_dut else attribute(k)
@@ -306,7 +327,10 @@ def main():
     # both the base alignment and the ledgers themselves.
     tot_dd = sum(st["dropped_but_delivered"] for st in per.values())
     tot_tail = sum(st["tail_suspect"] for st in per.values())
-    ident = n_ok - total_au - tot_tail + tot_dd
+    # Reconciled-frame ok, not raw report ok: under BA one frame can carry
+    # several reports and the identity is a per-FRAME conservation law.
+    ok_frames = sum(1 for f in frames.values() if f["ok"])
+    ident = ok_frames - total_au - tot_tail + tot_dd
     print(f"ledger identity: ok - acked_undelivered - tail_suspect "
           f"+ dropped_but_delivered = {ident} vs dut_pctrs = {len(dut)} "
           f"(delta {len(dut) - ident})")
@@ -331,7 +355,7 @@ def main():
     print(json.dumps({"ev": "arqe2e.verdict", "verdict": verdict,
                       "acked_undelivered": total_au,
                       "tail_suspect": tot_tail,
-                      "reports": len(reports), "ok": n_ok,
+                      "reports": len(reports), "ok": ok_frames,
                       "dut_pctrs": len(dut), "wit_pctrs": len(wit),
                       "base": base}, separators=(",", ":")), flush=True)
     return 3 if verdict == "INCONCLUSIVE-SHORT-RUN" else 0

--- a/tests/arq_e2e_delivery.sh
+++ b/tests/arq_e2e_delivery.sh
@@ -45,6 +45,10 @@ TX_SA=${TX_SA:-02:aa:bb:cc:dd:01}      # drone TA (unicast — the I/G footgun)
 RETRY_LIMIT=${RETRY_LIMIT:-3}          # field report used 3
 DRONE_REPORT_N=${DRONE_REPORT_N:-1}    # CCX sampling divisor (1 = every frame)
 DRONE_FALLBACK=${DRONE_FALLBACK:-}     # retry rate fallback: off | "" (=fw ladder)
+DRONE_AMPDU=${DRONE_AMPDU:-}           # A-MPDU mode spec "tid/max[...]" (off="")
+DRONE_BATCH=${DRONE_BATCH:-}           # send_packets batch depth (queue feed —
+                                       # aggregation only forms with frames
+                                       # queued back-to-back; rate = batch/gap)
 RECEIPT_MS=${RECEIPT_MS:-}             # windowed RX receipts cadence (off="")
 DRONE_RATE=${DRONE_RATE:-MCS3}
 DRONE_PAYLOAD=${DRONE_PAYLOAD:-512}    # >= 30 so the pctr stamp fits
@@ -169,6 +173,8 @@ env DEVOURER_VID="$DRONE_VID" DEVOURER_PID="$DRONE_PID" DEVOURER_CHANNEL="$CH" \
     DEVOURER_TX_GAP_US="$DRONE_GAP_US" \
     DEVOURER_TX_REPORT="$DRONE_REPORT_N" DEVOURER_TX_RETRY_LIMIT="$RETRY_LIMIT" \
     ${DRONE_FALLBACK:+DEVOURER_TX_RETRY_FALLBACK="$DRONE_FALLBACK"} \
+    ${DRONE_AMPDU:+DEVOURER_TX_AMPDU_MODE="$DRONE_AMPDU"} \
+    ${DRONE_BATCH:+DEVOURER_TX_BATCH="$DRONE_BATCH"} \
     ${RECEIPT_MS:+DEVOURER_TX_RECEIPTS=1 DEVOURER_TX_WITH_RX=thread} \
     DEVOURER_DIS_CCA="$DRONE_DIS_CCA" \
     DEVOURER_TX_PWR_OFFSET_QDB="$PWR_QDB" \


### PR DESCRIPTION
Executes the #364 measurement plan end-to-end on the bench rig (8812CU drone → 8812EU DUT duplex, 8814AU witness; MCS3/512 B unicast, hardware ACK, retry 8, batch-8 feed via `send_packets`).

## Findings

**1. The delivery contract survives aggregation.** `acked_undelivered = 0` in every BA arm (A-MPDU `0/31`) exactly as in every per-frame-ACK arm — the ACK-horizon law is unchanged: admission-gated, declines under congestion, no phantom ACKs introduced by the BA session.

**2. Per-frame CCX accounting does NOT survive AGG_EN** (the new negative result, now in `docs/aggregation.md`):

| metric | control (no agg) | BA arm |
|---|---|---|
| SPE_RPT reports (N=2 sampling, same span) | 49,636 | 19,516 (−61%) |
| tag-delta distribution | uniform ×2 | patterned 2×4537 / 4×6022 / 6×3912 / 8×5044 |
| reports with retries>0 | healthy tail {1:633, 2:239, …} | **zero** |
| frames with multiple reports | 0 | 0 |

Reports are suppressed in whole-aggregate bunches, retransmission cycles are invisible (BA retries happen below CCX), and the multi-report-per-MPDU model never materializes. The SW_DEFINE tag-gap drop signal is therefore **accounting-grade only for un-aggregated frames**; under A-MPDU the windowed RX receipts (#363) are the only delivery truth.

**3. No goodput win at the ARQ shape — a measured loss.** At 4 k fps saturation demand, BA delivered **−8%** vs the identical un-aggregated feed (208,792 vs 226,691 frames). The docs' +30% is a high-MCS broadcast near-PHY-ceiling number; at MCS3 the preamble amortization is small and the BA machinery costs more than it saves. Both numbers now sit side by side in `docs/aggregation.md` + the `CLAUDE.md` pointer.

**Recommendation shipped in docs:** do not enable A-MPDU on the ARQ/FPV link as measured; if revisited (high-MCS, receipts-only accounting), the analyzer is ready — see below.

## Code

- `tests/arq_e2e_analyze.py`: per-tag frame reconciliation (last-state-wins, max-retries, multi-report counter) so a multi-report BA future stays measurable; reduces to the previous identity at one report per frame — parity-verified byte-identical on recorded per-frame-ACK runs (clean baseline delta-0/au=0 and spsc au=5739 both reproduce).
- `tests/arq_e2e_delivery.sh`: `DRONE_AMPDU` / `DRONE_BATCH` knobs (aggregation only forms with a back-to-back queue feed).
- `docs/aggregation.md`, `CLAUDE.md`: the two adversarial pairings above.

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)