### PR TITLE
8821AU hardware ACK responder works — the "broken" verdict was a harness artifact

### DIFF
--- a/docs/scheduled-mac.md
+++ b/docs/scheduled-mac.md
@@ -204,20 +204,29 @@ retry inflation), see the `RetryFallback` note in `src/DeviceConfig.h`.
 Responder-side capability (same setup, J3 TX as the reference soliciting
 station): **8814AU** closes the loop at retries ~0.1 (the bench responder of
 choice); **8812AU** works but degraded (97% delivery at ~7 mean retries —
-its SIFS ACKs only land intermittently); **8821AU never closed the loop**
-(TX retries stayed pinned with it armed); the 8812BU responder was
-separately proven (`tests/ack_responder_check.sh`).
+its SIFS ACKs only land intermittently); **8821AU works** (61–64% single-shot
+across three reps, **94% at retry 8** with a healthy retry histogram,
+disarm-proof-verified: 0% with the responder powered down); the 8812BU
+responder was separately proven (`tests/ack_responder_check.sh`).
+
+A cell whose responder never armed reads exactly like a broken chip — on=0%
+/ off=0% — which is how the 8821AU carried a false "broken" verdict through
+three runs (silently dead responder: stale advisory adapter lock / open
+failure; root-caused with concurrent register peeks off the live armed die,
+`chipstate --no-claim --peek`). The check script now verifies the arm line
+and aborts loudly instead; treat any historical on=0/off=0 row from a
+harness without arm-verification as unmeasured, not broken.
 
 The full responder matrix (six cells, ch36, MCS3 unicast; run with
 `DEVOURER_TX_RETRY_LIMIT` at its 0 default, so delivered% is the
 **single-shot** ACK rate and capability is the on-vs-off delta — pin a
-nonzero limit for absolute numbers):
+nonzero limit for absolute numbers; 8821AU row re-measured ch6):
 
 | responder | on | off | verdict |
 |---|---|---|---|
 | 8814AU | 79% | 0% | works |
 | 8812BU | 98% | 0% | works |
-| 8821AU | 0% | 0% | broken (third independent confirmation) |
+| 8821AU | 62% | 0% | works (94% closed-loop at retry 8) |
 | 8812EU | 98% | 0% | works |
 | 8812CU | 69% | 0% | works |
 | 8852CU (Kestrel) | 0% | 0% | not implemented (SetAckResponder is J1/2/3-only) |

--- a/examples/chipstate/main.cpp
+++ b/examples/chipstate/main.cpp
@@ -34,8 +34,11 @@
 #include <libusb-1.0/libusb.h>
 #endif
 
+#include <vector>
+
 #include "DeviceSession.h"
 #include "IRtlDevice.h"
+#include "RtlAdapter.h"
 #include "UsbOpen.h"
 #include "WiFiDriver.h"
 #include "logger.h"
@@ -48,20 +51,106 @@ const uint16_t kRealtekPids[] = {0x8812, 0x8813, 0x881a, 0x0811, 0xa811,
                                  0x0820, 0x0821, 0x8822, 0x0120, 0x012d,
                                  0xb82c, 0xc811, 0xc812, 0xa81a};
 
+/* One --peek/--poke, kept in argv order so a poke-then-peek verifies the
+ * write inside a single claim. */
+struct RegOp {
+  bool write = false;
+  uint16_t addr = 0;
+  uint16_t end = 0;   /* peek range: inclusive last addr (== addr if single) */
+  uint32_t val = 0;   /* poke */
+  int width = 1;      /* poke: 1/2/4 */
+};
+
 struct Args {
   uint16_t vid = 0x0bda;
   int pid = -1;
   int channel = 6;
   bool init = false;
+  bool no_claim = false;
+  std::vector<RegOp> ops;
 };
 
 void usage() {
   std::fprintf(stderr,
                "usage: chipstate [--vid 0xNNNN] [--pid 0xNNNN] [--init] "
                "[--channel N]\n"
+               "                 [--peek 0xA[-0xB]]... [--poke 0xA=0xV[:W]]...\n"
                "  default: attach read-only, no USB reset, no bring-up.\n"
                "  --init : run a full bring-up first (for a healthy reference\n"
-               "           dump on a freshly power-cycled adapter).\n");
+               "           dump on a freshly power-cycled adapter).\n"
+               "  --peek : dump register byte(s) over the vendor-control path\n"
+               "           (range inclusive, 16 bytes/row) instead of the\n"
+               "           canary set. Bypasses chip dispatch — any die.\n"
+               "  --poke : write a register (width W = 1/2/4, default from the\n"
+               "           value magnitude). The bench-bisection intervention\n"
+               "           lever; ops run in argv order, so a trailing --peek\n"
+               "           verifies the write in the same claim.\n"
+               "  --no-claim : (peek/poke only) skip the interface claim —\n"
+               "           vendor control rides EP0 with device recipient, so\n"
+               "           registers stay reachable while another process\n"
+               "           (e.g. an armed rxdemo) owns the interface.\n");
+}
+
+bool parse_peek(const char *s, RegOp &op) {
+  char *end = nullptr;
+  op.addr = static_cast<uint16_t>(std::strtoul(s, &end, 0));
+  op.end = op.addr;
+  if (*end == '-') {
+    op.end = static_cast<uint16_t>(std::strtoul(end + 1, &end, 0));
+    if (op.end < op.addr)
+      return false;
+  }
+  return *end == '\0';
+}
+
+bool parse_poke(const char *s, RegOp &op) {
+  char *end = nullptr;
+  op.write = true;
+  op.addr = static_cast<uint16_t>(std::strtoul(s, &end, 0));
+  if (*end != '=')
+    return false;
+  op.val = static_cast<uint32_t>(std::strtoul(end + 1, &end, 0));
+  if (*end == ':') {
+    op.width = static_cast<int>(std::strtoul(end + 1, &end, 0));
+    if (op.width != 1 && op.width != 2 && op.width != 4)
+      return false;
+  } else {
+    op.width = op.val <= 0xff ? 1 : op.val <= 0xffff ? 2 : 4;
+  }
+  return *end == '\0';
+}
+
+/* Raw register client over the transport layer — deliberately below
+ * CreateRtlDevice so it works on any die, configured or not. */
+int run_reg_ops(libusb_device_handle *handle, Logger_t logger,
+                libusb_context *ctx,
+                std::shared_ptr<devourer::UsbDeviceLock> lock,
+                const std::vector<RegOp> &ops) {
+  RtlAdapter adapter(handle, logger, ctx, lock);
+  for (const RegOp &op : ops) {
+    if (op.write) {
+      if (op.width == 4)
+        adapter.rtw_write32(op.addr, op.val);
+      else if (op.width == 2)
+        adapter.rtw_write16(op.addr, static_cast<uint16_t>(op.val));
+      else
+        adapter.rtw_write8(op.addr, static_cast<uint8_t>(op.val));
+      std::printf("poke 0x%04x = 0x%0*x\n", op.addr, op.width * 2, op.val);
+    } else {
+      for (uint32_t row = op.addr & ~0xfu; row <= op.end; row += 16) {
+        std::printf("0x%04x:", row);
+        for (uint32_t i = row; i < row + 16; ++i) {
+          if (i < op.addr || i > op.end)
+            std::printf("   ");
+          else
+            std::printf(" %02x", adapter.rtw_read8(static_cast<uint16_t>(i)));
+        }
+        std::printf("\n");
+      }
+    }
+  }
+  std::fflush(stdout);
+  return 0;
 }
 
 } // namespace
@@ -81,6 +170,24 @@ int main(int argc, char **argv) {
       ++i;
     } else if (!std::strcmp(argv[i], "--init")) {
       a.init = true;
+    } else if (!std::strcmp(argv[i], "--no-claim")) {
+      a.no_claim = true;
+    } else if (!std::strcmp(argv[i], "--peek") && v) {
+      RegOp op;
+      if (!parse_peek(v, op)) {
+        usage();
+        return 2;
+      }
+      a.ops.push_back(op);
+      ++i;
+    } else if (!std::strcmp(argv[i], "--poke") && v) {
+      RegOp op;
+      if (!parse_poke(v, op)) {
+        usage();
+        return 2;
+      }
+      a.ops.push_back(op);
+      ++i;
     } else {
       usage();
       return 2;
@@ -114,6 +221,20 @@ int main(int argc, char **argv) {
     return 3;
   }
 
+  /* --no-claim + reg ops: EP0 vendor control with device recipient does not
+   * need the interface, so peeks/pokes work while another process (a live
+   * armed rxdemo) owns it — the concurrent-intervention mode. */
+  if (a.no_claim) {
+    if (a.ops.empty()) {
+      logger->error("--no-claim is peek/poke-only (the canary dump needs the "
+                    "claimed device)");
+      session.adopt_handle(handle);
+      return 2;
+    }
+    session.adopt_handle(handle);
+    return run_reg_ops(handle, logger, ctx, nullptr, a.ops);
+  }
+
   /* do_reset=false is the whole point: a USB reset re-runs the chip's own boot
    * and would wipe the state we came to read. Only --init opts into disturbing
    * the chip, and even then the reset stays off so the bring-up starts from
@@ -127,6 +248,12 @@ int main(int argc, char **argv) {
   }
   session.adopt_handle(handle);
   session.adopt_lock(lock);
+
+  /* --peek/--poke: raw transport-level register access, no device
+   * construction at all — the chip is not even identified, let alone
+   * configured, so this works mid-experiment on any die. */
+  if (!a.ops.empty())
+    return run_reg_ops(handle, logger, ctx, lock, a.ops);
 
   devourer::DeviceConfig cfg;
   /* Leave the chip exactly as found. Without this the device destructor runs

--- a/examples/chipstate/main.cpp
+++ b/examples/chipstate/main.cpp
@@ -91,13 +91,24 @@ void usage() {
                "           (e.g. an armed rxdemo) owns the interface.\n");
 }
 
+/* Range-checked address parse: a silently-wrapped register (0x12345 ->
+ * 0x2345) on a poke tool is a corruption hazard, so out-of-range is a parse
+ * error, never a truncation. */
+bool parse_reg_addr(const char *s, char **end, uint16_t &out) {
+  unsigned long v = std::strtoul(s, end, 0);
+  if (*end == s || v > 0xffff)
+    return false;
+  out = static_cast<uint16_t>(v);
+  return true;
+}
+
 bool parse_peek(const char *s, RegOp &op) {
   char *end = nullptr;
-  op.addr = static_cast<uint16_t>(std::strtoul(s, &end, 0));
+  if (!parse_reg_addr(s, &end, op.addr))
+    return false;
   op.end = op.addr;
   if (*end == '-') {
-    op.end = static_cast<uint16_t>(std::strtoul(end + 1, &end, 0));
-    if (op.end < op.addr)
+    if (!parse_reg_addr(end + 1, &end, op.end) || op.end < op.addr)
       return false;
   }
   return *end == '\0';
@@ -106,13 +117,21 @@ bool parse_peek(const char *s, RegOp &op) {
 bool parse_poke(const char *s, RegOp &op) {
   char *end = nullptr;
   op.write = true;
-  op.addr = static_cast<uint16_t>(std::strtoul(s, &end, 0));
+  if (!parse_reg_addr(s, &end, op.addr))
+    return false;
   if (*end != '=')
     return false;
-  op.val = static_cast<uint32_t>(std::strtoul(end + 1, &end, 0));
+  const char *vs = end + 1;
+  unsigned long v = std::strtoul(vs, &end, 0);
+  if (end == vs || v > 0xfffffffful)
+    return false;
+  op.val = static_cast<uint32_t>(v);
   if (*end == ':') {
     op.width = static_cast<int>(std::strtoul(end + 1, &end, 0));
     if (op.width != 1 && op.width != 2 && op.width != 4)
+      return false;
+    /* An explicit width the value doesn't fit is a mistake, not a mask. */
+    if (op.width < 4 && (op.val >> (op.width * 8)) != 0)
       return false;
   } else {
     op.width = op.val <= 0xff ? 1 : op.val <= 0xffff ? 2 : 4;
@@ -127,27 +146,37 @@ int run_reg_ops(libusb_device_handle *handle, Logger_t logger,
                 std::shared_ptr<devourer::UsbDeviceLock> lock,
                 const std::vector<RegOp> &ops) {
   RtlAdapter adapter(handle, logger, ctx, lock);
-  for (const RegOp &op : ops) {
-    if (op.write) {
-      if (op.width == 4)
-        adapter.rtw_write32(op.addr, op.val);
-      else if (op.width == 2)
-        adapter.rtw_write16(op.addr, static_cast<uint16_t>(op.val));
-      else
-        adapter.rtw_write8(op.addr, static_cast<uint8_t>(op.val));
-      std::printf("poke 0x%04x = 0x%0*x\n", op.addr, op.width * 2, op.val);
-    } else {
-      for (uint32_t row = op.addr & ~0xfu; row <= op.end; row += 16) {
-        std::printf("0x%04x:", row);
-        for (uint32_t i = row; i < row + 16; ++i) {
-          if (i < op.addr || i > op.end)
-            std::printf("   ");
-          else
-            std::printf(" %02x", adapter.rtw_read8(static_cast<uint16_t>(i)));
+  /* A failed vendor-control read throws (UsbTransport::ctrl_read) — on a
+   * powered-down or wedged chip that is a real answer about the chip, so
+   * report which op died and exit nonzero instead of terminating. */
+  try {
+    for (const RegOp &op : ops) {
+      if (op.write) {
+        if (op.width == 4)
+          adapter.rtw_write32(op.addr, op.val);
+        else if (op.width == 2)
+          adapter.rtw_write16(op.addr, static_cast<uint16_t>(op.val));
+        else
+          adapter.rtw_write8(op.addr, static_cast<uint8_t>(op.val));
+        std::printf("poke 0x%04x = 0x%0*x\n", op.addr, op.width * 2, op.val);
+      } else {
+        for (uint32_t row = op.addr & ~0xfu; row <= op.end; row += 16) {
+          std::printf("0x%04x:", row);
+          for (uint32_t i = row; i < row + 16; ++i) {
+            if (i < op.addr || i > op.end)
+              std::printf("   ");
+            else
+              std::printf(" %02x", adapter.rtw_read8(static_cast<uint16_t>(i)));
+          }
+          std::printf("\n");
         }
-        std::printf("\n");
       }
     }
+  } catch (const std::exception &e) {
+    std::fflush(stdout);
+    logger->error("register access failed ({}) — chip powered down / wedged? "
+                  "That is the finding, not a tool error.", e.what());
+    return 4;
   }
   std::fflush(stdout);
   return 0;

--- a/src/AdapterCaps.h
+++ b/src/AdapterCaps.h
@@ -164,9 +164,11 @@ struct AdapterCaps {
    * ack_responder_ok: SetAckResponder measurably closes a hardware-ARQ loop
    * as the RESPONDER (SIFS ACKs that a soliciting TX's CCX reports confirm).
    * Measured true: 8812A (works, degraded — intermittent SIFS ACKs), 8814A,
+   * 8821A (61–64% single-shot MCS3, 94% at retry 8, disarm-proof-verified —
+   * an earlier "broken" verdict was a harness artifact: the responder's arm
+   * was never verified, so a silently dead responder read as on=0/off=0),
    * 8822B, 8812C/8822C, 8812E/8822E (the 8811A rides the 8812 die path and
-   * inherits its row). Measured FALSE: the 8821A die — an armed 8821AU never
-   * closed the loop across three independent runs. False-as-unmeasured (the
+   * inherits its row). False-as-unmeasured (the
    * vht_2g4_ok reading: unmeasured, not incapable): the 8821C — it shares
    * the recipe but no 8821CU/CE cell has run. FALSE on Kestrel:
    * SetAckResponder is not implemented on the AX generation.

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -1728,7 +1728,7 @@ devourer::AdapterCaps RtlJaguarDevice::GetAdapterCaps() {
   /* Hardware ARQ (truth table at the AdapterCaps declarations): the 8821A
    * die never closes the responder loop; the 8814A die keeps the vendor
    * retry carve-out (knob inert). */
-  c.ack_responder_ok = _eepromManager->version_id.ICType != CHIP_8821;
+  c.ack_responder_ok = true; /* all four dies measured, 8821A included */
   c.tx_retry_limit_ok = _eepromManager->version_id.ICType != CHIP_8814A;
   /* Per-packet TX power: 8814A only — its dword5 [30:28] descriptor LUT (the
    * 8822B TXPWR_OFSET position; vendor-defined, vendor-unused). measured

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -1725,10 +1725,10 @@ devourer::AdapterCaps RtlJaguarDevice::GetAdapterCaps() {
     c.narrowband_ok = true;
   }
   c.fastretune_ok = true; /* phy_SwChnl8812_fast (8812/8821) + full-path fallback */
-  /* Hardware ARQ (truth table at the AdapterCaps declarations): the 8821A
-   * die never closes the responder loop; the 8814A die keeps the vendor
-   * retry carve-out (knob inert). */
-  c.ack_responder_ok = true; /* all four dies measured, 8821A included */
+  /* Hardware ARQ (truth table at the AdapterCaps declarations): responder
+   * measured working on all four dies — 8821A included; the 8814A die keeps
+   * the vendor retry carve-out (knob inert). */
+  c.ack_responder_ok = true;
   c.tx_retry_limit_ok = _eepromManager->version_id.ICType != CHIP_8814A;
   /* Per-packet TX power: 8814A only — its dword5 [30:28] descriptor LUT (the
    * 8822B TXPWR_OFSET position; vendor-defined, vendor-unused). measured

--- a/tests/ack_responder_check.sh
+++ b/tests/ack_responder_check.sh
@@ -22,6 +22,7 @@ BUILD="$ROOT/build"
 TX_PID=${TX_PID:-0xc812};  TX_VID=${TX_VID:-0x0bda}
 RESP_PID=${RESP_PID:-0x012d}; RESP_VID=${RESP_VID:-0x2357}
 CH=${CH:-6}; SECS=${SECS:-8}
+RETRY_LIMIT=${RETRY_LIMIT:-0}          # 0 = single-shot ACK rate; >0 = closed loop
 MAC=${MAC:-02:12:34:56:78:9a}
 # The TX's TA must be UNICAST — an ACK's RA is the soliciting frame's addr2,
 # and the canonical TX SA (57:42:..) is a group address. Third appearance of
@@ -29,7 +30,9 @@ MAC=${MAC:-02:12:34:56:78:9a}
 TX_SA=${TX_SA:-02:aa:bb:cc:dd:01}
 OUT=${OUT:-/tmp/ack_responder}
 
-KILL(){ pkill -9 -x rxdemo 2>/dev/null; pkill -9 -x txdemo 2>/dev/null; return 0; }
+# sudo: the cells run as root, so an unprivileged pkill silently fails and a
+# leftover responder poisons the next run (holds the adapter AND stays armed).
+KILL(){ sudo pkill -9 -x rxdemo 2>/dev/null; sudo pkill -9 -x txdemo 2>/dev/null; return 0; }
 trap KILL EXIT
 mkdir -p "$OUT"
 
@@ -40,12 +43,27 @@ run_cell() { # $1 = cell name, $2 = responder env ("" = off)
   sudo env DEVOURER_VID=$RESP_VID DEVOURER_PID=$RESP_PID DEVOURER_CHANNEL=$CH \
        $resp_env DEVOURER_LOG_LEVEL=info \
        "$BUILD/rxdemo" >"$OUT/resp_$name.jsonl" 2>"$OUT/resp_$name.err" &
-  sleep 6 # responder bring-up
+  # Arm/bring-up verification — a cell whose responder never came up must
+  # ABORT, not read as "0% delivered": an unverified arm is exactly how the
+  # 8821AU got a false "broken" verdict (three runs of a silently dead
+  # responder — stale adapter lock, open failure — scored on=0/off=0).
+  local want="Listening air" waited=0
+  [ -n "$resp_env" ] && want="ACK responder armed"
+  until grep -q "$want" "$OUT/resp_$name.err"; do
+    sleep 1; waited=$((waited+1))
+    if [ "$waited" -ge 25 ]; then
+      echo "ABORT: cell $name responder never reached '$want' (${waited}s)" >&2
+      tail -5 "$OUT/resp_$name.err" >&2
+      exit 1
+    fi
+  done
+  sleep 2 # RX loop settle
   sudo env DEVOURER_VID=$TX_VID DEVOURER_PID=$TX_PID DEVOURER_CHANNEL=$CH \
        DEVOURER_TX_RATE=MCS3 DEVOURER_TX_QOS_DATA=1 DEVOURER_TX_RA=$MAC \
        DEVOURER_TX_SA=$TX_SA \
        DEVOURER_TX_PAYLOAD_BYTES=200 DEVOURER_TX_GAP_US=5000 \
-       DEVOURER_TX_REPORT=1 DEVOURER_LOG_LEVEL=warn \
+       DEVOURER_TX_REPORT=1 DEVOURER_TX_RETRY_LIMIT=$RETRY_LIMIT \
+       DEVOURER_LOG_LEVEL=warn \
        timeout -s INT $SECS "$BUILD/txdemo" \
        >"$OUT/tx_$name.jsonl" 2>"$OUT/tx_$name.err" || true
   sleep 1


### PR DESCRIPTION
#365 step 3 (8821AU responder root-cause). The vendor 8821A-die source diff found no per-die gate in the response machinery — because there is nothing to gate: **the die was never broken.**

## Measurement (clean cells: unique responder MAC per die, power-down teardown, disarm-proof burst)

| cell | result |
|---|---|
| single-shot ACK rate, MCS3, 3 reps | 61.7% / 62.1% / 63.9% |
| closed loop, retry 8 | **94.0%**, healthy histogram {0:480, 1:111, 2:55, 3:23, 4:25, 5:7, 6:7, 7:6, 8:57} |
| responder powered down (disarm proof) | 0/772 |
| shipped harness re-run on 8821AU | on=66% / off=0% |

The autonomous MAC ARQ loop closes against 8821AU hardware ACKs.

## The artifact

`ack_responder_check.sh` never verified the responder **armed** — a silently dead responder (stale advisory adapter lock left by an unprivileged `pkill` of a root cell; any open failure) scores on=0/off=0, indistinguishable from a broken chip. All three "independent confirmations" shared the hole. The matrix's on=0/off=0 signature is now documented as *unmeasured, not broken* when it comes from an arm-unverified harness.

## Changes

- **tests/ack_responder_check.sh** — poll the arm/RX-start log line, ABORT loudly on timeout instead of scoring; `sudo` kills; `RETRY_LIMIT` knob for closed-loop cells.
- **chipstate `--peek` / `--poke` `[--no-claim]`** — raw transport-level register access (argv-ordered, poke-then-peek verifies in one claim); `--no-claim` rides EP0 vendor control with device recipient so registers stay reachable while a live armed rxdemo owns the interface. This is the instrument that produced the armed-8814AU-vs-armed-8821AU register diff and killed the register-level hypotheses (both dies e.g. read ACKTO=0x80 live, refuting the static-table theory).
- **AdapterCaps** — J1 `ack_responder_ok` true on all four dies (was falsed for CHIP_8821); truth-table doc carries the numbers. Live-verified: `adapter.caps` on the 8821AU emits `ack_responder:1`.
- **docs/scheduled-mac.md** — corrected matrix row + the trap note.

Part of #365 (steps 4–5 — Kestrel retry H2C, 8814A carve-out audit — remain open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)