### PR TITLE
Kestrel per-frame retry limit: WD DATA_TXCNT_LMT, attempts-semantics measured on the 8832CU

### DIFF
--- a/docs/scheduled-mac.md
+++ b/docs/scheduled-mac.md
@@ -176,7 +176,15 @@ scheduled MAC runs TX+RX anyway, so this is the relevant session shape.
 The OFF-phase pin is set by `DEVOURER_TX_RETRY_LIMIT` (the matrix runs 12,
 the value the descriptors used to hardcode) — the knob, not a descriptor
 constant, is now the single source of truth for the retry limit on
-jaguar1/2/3 (inert on Kestrel and the 8814A die).
+jaguar1/2/3 **and Kestrel** (inert on the 8814A die only). On Kestrel it
+rides the AX WD `DATA_TXCNT_LMT` per-frame field, which counts **attempts**
+— devourer folds +1 so N means N retries on every generation. Witness-
+measured on the 8832CU (`tests/kestrel_retry_witness.sh`: on-air copies of
+an unACKable unicast per stamped payload counter): limits {0,2} → modal
+copies {1,3} exactly; limit 8 → an 8/9 near-tie consistent with ~90%
+witness capture of a 9-copy truth. Kestrel has no CCX `tx.report` path, so
+the witness copy-count is the retry ground truth there — the fw-level
+delivery outcome stays invisible until a receipts-tier consumer counts it.
 
 Choosing the limit (`tests/arq_retry_sweep.sh`, collision regime: a ~1 k fps
 retrying unicast flood into an 8812EU duplex ground station airing

--- a/src/AdapterCaps.h
+++ b/src/AdapterCaps.h
@@ -173,10 +173,12 @@ struct AdapterCaps {
    * the recipe but no 8821CU/CE cell has run. FALSE on Kestrel:
    * SetAckResponder is not implemented on the AX generation.
    * tx_retry_limit_ok: DEVOURER_TX_RETRY_LIMIT drives hardware autonomous
-   * retransmission (measured 12/0/12 A/B: 8821AU, 8812BU, 8822CU). FALSE on
-   * the 8814A die (the vendor DATA_RETRY_LIMIT=0 carve-out is kept — knob
-   * inert), false-as-unmeasured on the 8821C, and FALSE on Kestrel (retry is
-   * firmware-level there). */
+   * retransmission (measured 12/0/12 A/B: 8821AU, 8812BU, 8822CU; Kestrel
+   * 8832CU witness-measured — the AX WD DATA_TXCNT_LMT field counts
+   * ATTEMPTS, folded +1 to the N-retries contract, limits {0,2,8} -> modal
+   * on-air copies {1,3,8-9}). FALSE on the 8814A die (the vendor
+   * DATA_RETRY_LIMIT=0 carve-out is kept — knob inert) and
+   * false-as-unmeasured on the 8821C. */
   bool ack_responder_ok = false;
   bool tx_retry_limit_ok = false;
 

--- a/src/kestrel/CLAUDE.md
+++ b/src/kestrel/CLAUDE.md
@@ -74,6 +74,18 @@ EDCCA/CCA gate disabled (`sch_tx_en`, TX path only) — the intended
 injection/monitor-link mode. `ReadTsf` reads the per-port MAC TSF;
 `StartBeacon` drives the AX HW beacon engine.
 
+**Per-frame retry limit** (`DEVOURER_TX_RETRY_LIMIT`): the AX WD wd_info
+dword1 `DATA_TXCNT_LMT[30:25]` + SEL(31) — NOT a mac_ax H2C (the per-MACID
+CCTRL twin exists but the WD field is the injection-path mechanism). The
+field counts **attempts** (witness-measured on the 8832CU, unACKable-unicast
+copy counts: limit-value 2 → modal 2 copies where the 11ac retries-field
+gives 3; value 0 hardware-clamps to one attempt), so `send_packet` folds +1
+to keep N-means-N-retries across generations. The neighbouring
+`DATA_RTY_LOWEST_RATE` floor field stays unwritten (the 11ac floor-form
+anomaly, `RetryFallback` note in `DeviceConfig.h`). No CCX `tx.report`
+exists on this family — `tests/kestrel_retry_witness.sh` (stamped-pctr copy
+counting on a witness monitor) is the retry ground truth.
+
 **HE ER SU + DCM extended range** (both dies): per-packet via radiotap-HE
 FORMAT=EXT_SU or `DEVOURER_TX_RATE=.../ER[/DCM]`; RX classifies the format in
 `RxAtrib.ppdu_type` (7=HE_SU, 8=HE_ERSU) — `docs/he-extended-range.md`.

--- a/src/kestrel/RtlKestrelDevice.cpp
+++ b/src/kestrel/RtlKestrelDevice.cpp
@@ -784,8 +784,13 @@ devourer::AdapterCaps RtlKestrelDevice::GetAdapterCaps() {
   c.rx_chains = 2;
   c.per_chain_rssi = true; /* per-path RSSI from the PPDU-status physts header */
   /* Hardware ARQ: SetAckResponder is not implemented on the AX generation
-   * (matrix-measured 0% closure) and retry is firmware-level here, so the
-   * DEVOURER_TX_RETRY_LIMIT knob is inert — both flags stay false. */
+   * (matrix-measured 0% closure) — that flag stays false. The retry knob IS
+   * wired (WD DATA_TXCNT_LMT per frame, attempts-semantics folded to the
+   * N-retries contract in send_packet; witness-measured on the 8832CU:
+   * limits {0,2} -> modal {1,3} on-air copies exactly, limit 8 -> an 8/9
+   * near-tie consistent with ~90% witness capture of a 9-copy truth —
+   * obedient, no wedge). */
+  c.tx_retry_limit_ok = true;
   c.bw_mask = devourer::bw_mask_for_generation(c.generation);
   if (_variant == kestrel::ChipVariant::C8852C)
     c.bw_mask |= devourer::kBw160; /* 8852C-only (vendor bw_sup BW_CAP_160M) */
@@ -1069,13 +1074,19 @@ bool RtlKestrelDevice::send_packet(const uint8_t *packet, size_t length) {
   /* Per-frame retry limit (DEVOURER_TX_RETRY_LIMIT, default 0 = single-shot,
    * same contract as the 11ac descriptor families): the AX WD carries it as
    * wd_info dword1 DATA_TXCNT_LMT with SEL, overriding the per-MACID CCTRL
-   * default. The vendor maps its rty_lmt verbatim into the field
-   * (hal_sta.c cctrl.data_tx_cnt_lmt = cap->rty_lmt), so the knob value goes
-   * in unmapped; tests/kestrel_retry_witness.sh is the on-air
-   * attempts-vs-retries semantics check. */
-  const int txcnt = _cfg.tx.retry_limit < 0    ? 0
-                    : _cfg.tx.retry_limit > 63 ? 63
-                                               : _cfg.tx.retry_limit;
+   * default. The field counts ATTEMPTS, not retries — measured on the
+   * 8832CU (tests/kestrel_retry_witness.sh: limit-value 2 -> modal 2 on-air
+   * copies, 8 -> 8, where the J3 retries-field gives N+1), so the knob folds
+   * +1 here to keep N-means-N-retries across generations. Value 0 is
+   * hardware-clamped to one attempt (336/336 frames aired exactly once), so
+   * the explicit 1 below is belt-and-braces, not a behavior change. NB the
+   * vendor's hal_sta.c writes its rty_lmt verbatim into the CCTRL twin of
+   * this field — its "retry limit" is off-by-one against 11ac by the same
+   * measurement. */
+  const int rl = _cfg.tx.retry_limit < 0    ? 0
+                 : _cfg.tx.retry_limit > 62 ? 62
+                                            : _cfg.tx.retry_limit;
+  const int txcnt = rl + 1;
   auto buf = is_data && _tx_data_ep
                  ? kestrel::build_data_txdesc(frame, flen, tr, 0,
                                               _tx_seq++ & 0xfff, wd_len, txcnt)

--- a/src/kestrel/RtlKestrelDevice.cpp
+++ b/src/kestrel/RtlKestrelDevice.cpp
@@ -74,6 +74,17 @@ RtlKestrelDevice::RtlKestrelDevice(RtlAdapter device, Logger_t logger,
    * from the Jaguar2 TXAGC-index meaning). Applied at every set_channel. */
   if (_cfg.tx.power_index.has_value())
     _hal.set_default_txpwr_dbm(*_cfg.tx.power_index);
+  /* The AX DATA_TXCNT_LMT field holds ATTEMPTS in 6 bits, so this family's
+   * retry ceiling is 62 (63 attempts) — one below the 11ac dies' 63. Clamp
+   * once here (send_packet reads the stored copy) and say so, rather than
+   * silently delivering 62 where the knob's 0..63 grammar promised 63. */
+  if (_cfg.tx.retry_limit > 62) {
+    _logger->warn("Kestrel: DEVOURER_TX_RETRY_LIMIT={} exceeds this family's "
+                  "ceiling of 62 retries (the AX field counts attempts, 6 "
+                  "bits) — clamped to 62",
+                  _cfg.tx.retry_limit);
+    _cfg.tx.retry_limit = 62;
+  }
 }
 
 RtlKestrelDevice::~RtlKestrelDevice() {

--- a/src/kestrel/RtlKestrelDevice.cpp
+++ b/src/kestrel/RtlKestrelDevice.cpp
@@ -1066,11 +1066,21 @@ bool RtlKestrelDevice::send_packet(const uint8_t *packet, size_t length) {
   const uint32_t wd_len = (_variant == kestrel::ChipVariant::C8852C)
                               ? kestrel::WD_BODY_LEN_V1
                               : kestrel::WD_BODY_LEN;
+  /* Per-frame retry limit (DEVOURER_TX_RETRY_LIMIT, default 0 = single-shot,
+   * same contract as the 11ac descriptor families): the AX WD carries it as
+   * wd_info dword1 DATA_TXCNT_LMT with SEL, overriding the per-MACID CCTRL
+   * default. The vendor maps its rty_lmt verbatim into the field
+   * (hal_sta.c cctrl.data_tx_cnt_lmt = cap->rty_lmt), so the knob value goes
+   * in unmapped; tests/kestrel_retry_witness.sh is the on-air
+   * attempts-vs-retries semantics check. */
+  const int txcnt = _cfg.tx.retry_limit < 0    ? 0
+                    : _cfg.tx.retry_limit > 63 ? 63
+                                               : _cfg.tx.retry_limit;
   auto buf = is_data && _tx_data_ep
                  ? kestrel::build_data_txdesc(frame, flen, tr, 0,
-                                              _tx_seq++ & 0xfff, wd_len)
+                                              _tx_seq++ & 0xfff, wd_len, txcnt)
                  : kestrel::build_mgnt_txdesc(frame, flen, tr, 0,
-                                              _tx_seq++ & 0xfff, wd_len);
+                                              _tx_seq++ & 0xfff, wd_len, txcnt);
   if (is_data && _tx_data_ep)
     ep = _tx_data_ep;
   int rc = _device.bulk_send_sync_ep(ep, buf.data(),

--- a/src/kestrel/TxDescKestrel.h
+++ b/src/kestrel/TxDescKestrel.h
@@ -165,9 +165,12 @@ inline uint32_t wd_info_dword1(const uint8_t *frame, uint32_t frame_len,
   uint32_t d1 = 0;
   if (frame_len >= 5 && (frame[4] & 0x01))
     d1 |= txd::BMC;
-  if (txcnt_lmt >= 0)
-    d1 |= txd::DATA_TXCNT_LMT_SEL |
-          (static_cast<uint32_t>(txcnt_lmt & 0x3f) << txd::DATA_TXCNT_LMT_SH);
+  if (txcnt_lmt >= 0) {
+    /* Clamp, never mask: 64 & 0x3f would silently program 0 attempts —
+     * the opposite of what an out-of-range caller wanted. */
+    const uint32_t lmt = txcnt_lmt > 63 ? 63u : static_cast<uint32_t>(txcnt_lmt);
+    d1 |= txd::DATA_TXCNT_LMT_SEL | (lmt << txd::DATA_TXCNT_LMT_SH);
+  }
   return d1;
 }
 

--- a/src/kestrel/TxDescKestrel.h
+++ b/src/kestrel/TxDescKestrel.h
@@ -44,6 +44,15 @@ constexpr uint32_t DATA_DCM_V1 = 1u << 30; /* wd_body dword7 (8852C) */
 constexpr uint32_t BMC = 1u << 11;         /* wd_info dword1: broadcast/multicast
                                             * — group-addressed, no ACK expected,
                                             * so the fw must not retry it */
+/* wd_info dword1 per-frame TX-count limit (vendor txdesc.h AX_TXD_DATA_
+ * TXCNT_LMT*, continuous-dword 7 on the 8852B / 9 on the V1 — the same
+ * wd_info-relative dword both dies): SEL selects this WD's limit over the
+ * per-MACID CCTRL value, the field is 6 bits. The neighbouring
+ * DATA_RTY_LOWEST_RATE [24:16] stays deliberately unwritten — the floor form
+ * was measured anomalous on 11ac (RetryFallback note in DeviceConfig.h) and
+ * is not ported here either. */
+constexpr uint32_t DATA_TXCNT_LMT_SEL = 1u << 31; /* wd_info dword1 */
+constexpr uint8_t DATA_TXCNT_LMT_SH = 25;         /* wd_info dword1 [30:25] */
 } /* namespace txd */
 
 /* Map a devourer MGN_* rate (RateDefinitions.h) to the AX_TXD_DATARATE encoding
@@ -147,11 +156,27 @@ inline void put_txdesc_rate(uint8_t *wd, uint32_t wd_body_len, const TxRate &r) 
   }
 }
 
+/* wd_info dword1 composer shared by the mgmt/data builders: BMC for a
+ * group-addressed RA (fw must not retry an unacked broadcast), plus the
+ * per-frame TX-count limit when the caller passes one (txcnt_lmt 0..63;
+ * -1 = leave SEL clear -> the per-MACID / firmware default governs). */
+inline uint32_t wd_info_dword1(const uint8_t *frame, uint32_t frame_len,
+                               int txcnt_lmt) {
+  uint32_t d1 = 0;
+  if (frame_len >= 5 && (frame[4] & 0x01))
+    d1 |= txd::BMC;
+  if (txcnt_lmt >= 0)
+    d1 |= txd::DATA_TXCNT_LMT_SEL |
+          (static_cast<uint32_t>(txcnt_lmt & 0x3f) << txd::DATA_TXCNT_LMT_SH);
+  return d1;
+}
+
 inline std::vector<uint8_t> build_mgnt_txdesc(const uint8_t *frame,
                                               uint32_t frame_len,
                                               const TxRate &r, uint8_t macid,
                                               uint16_t seq,
-                                              uint32_t wd_body_len = WD_BODY_LEN) {
+                                              uint32_t wd_body_len = WD_BODY_LEN,
+                                              int txcnt_lmt = -1) {
   /* The 8852C data/mgmt TX descriptor is the 32-byte wd_body_t_v1 (dwords 6/7
    * added, dword0-5 field layout identical); the 8852B is the 24-byte wd_body_t.
    * A short WD desyncs the MAC TX parser and the frame never airs (buffer still
@@ -174,12 +199,12 @@ inline std::vector<uint8_t> build_mgnt_txdesc(const uint8_t *frame,
   txd_put_le32(wd + 12, static_cast<uint32_t>(seq & 0xfff) << txd::WIFI_SEQ_SH);
   /* dword4,5 (+ v1 dword6,7) = 0 */
 
-  /* wd_info dword1: mark a group-addressed frame (RA bit0 set — e.g. an injected
-   * broadcast Trigger) as BMC. Without it the fw treats the unacked broadcast as
-   * a failed unicast and retransmits it to the retry limit (~45x the airtime).
-   * The 802.11 RA (addr1) is at frame offset 4 (after FC + Duration). */
-  if (frame_len >= 5 && (frame[4] & 0x01))
-    txd_put_le32(wd + wd_body_len + 4, txd::BMC);
+  /* wd_info dword1: BMC for a group-addressed RA (without it the fw treats
+   * the unacked broadcast as a failed unicast and retransmits it to the
+   * retry limit, ~45x the airtime; addr1 is at frame offset 4) + the
+   * per-frame TX-count limit. */
+  if (const uint32_t d1 = wd_info_dword1(frame, frame_len, txcnt_lmt))
+    txd_put_le32(wd + wd_body_len + 4, d1);
 
   /* Rate fields: force the rate (USERATE_SEL) + DATARATE + BW + GI/LTF +
    * LDPC/STBC + no fallback. On the 8852B (24-byte wd_body) these all live in
@@ -202,7 +227,8 @@ inline std::vector<uint8_t> build_data_txdesc(const uint8_t *frame,
                                               uint32_t frame_len,
                                               const TxRate &r, uint8_t macid,
                                               uint16_t seq,
-                                              uint32_t wd_body_len = WD_BODY_LEN) {
+                                              uint32_t wd_body_len = WD_BODY_LEN,
+                                              int txcnt_lmt = -1) {
   const uint32_t txd_len = wd_body_len + WD_INFO_LEN;
   std::vector<uint8_t> buf(txd_len + frame_len, 0);
   uint8_t *wd = buf.data();
@@ -217,6 +243,9 @@ inline std::vector<uint8_t> build_data_txdesc(const uint8_t *frame,
                    (static_cast<uint32_t>(macid & 0x7f) << txd::MACID_SH));
   /* dword3: WIFI_SEQ (no ampdu_en). */
   txd_put_le32(wd + 12, static_cast<uint32_t>(seq & 0xfff) << txd::WIFI_SEQ_SH);
+  /* wd_info dword1: BMC + per-frame TX-count limit (same as mgmt). */
+  if (const uint32_t d1 = wd_info_dword1(frame, frame_len, txcnt_lmt))
+    txd_put_le32(wd + wd_body_len + 4, d1);
   /* Rate fields: same split as mgmt (V1 -> wd_body dword7, else wd_info d0). */
   put_txdesc_rate(wd, wd_body_len, r);
   std::memcpy(wd + txd_len, frame, frame_len);

--- a/tests/kestrel_retry_witness.sh
+++ b/tests/kestrel_retry_witness.sh
@@ -42,7 +42,9 @@ for LIM in $LIMITS; do
   sudo env DEVOURER_VID=$WIT_VID DEVOURER_PID=$WIT_PID DEVOURER_CHANNEL=$CH \
        DEVOURER_RX_PCTR=1 DEVOURER_RX_AGG_SA=$TX_SA DEVOURER_LOG_LEVEL=info \
        "$BUILD/rxdemo" >"$OUT/wit_$LIM.jsonl" 2>"$OUT/wit_$LIM.err" &
-  w=0; until grep -q "Listening air" "$OUT/wit_$LIM.err"; do
+  # RX-start line differs per generation ("Listening air" J1, "entering RX
+  # loop" J3, ...) — the URB-ring submit line is the generation-neutral tell.
+  w=0; until grep -qE "async ring of .* URBs submitted|Listening air" "$OUT/wit_$LIM.err"; do
     sleep 1; w=$((w+1))
     [ $w -ge 25 ] && { echo "ABORT: witness never started" >&2; exit 1; }
   done; sleep 2

--- a/tests/kestrel_retry_witness.sh
+++ b/tests/kestrel_retry_witness.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Kestrel per-frame retry limit (#365 step 4): on-air semantics + efficacy
+# check for the AX WD DATA_TXCNT_LMT field, judged by a WITNESS monitor
+# counting on-air copies per frame. Kestrel has no CCX tx.report path, so the
+# copy count of an UNACKABLE unicast (RA = nonexistent station) is the only
+# per-frame retry ground truth. txdemo stamps a u32 payload counter at MPDU
+# offset 26; the witness runs DEVOURER_RX_PCTR + DEVOURER_RX_AGG_SA=<TX SA>
+# and its rx.seq ledger yields copies-per-pctr = attempts per frame:
+#
+#   limit N -> modal copies N+1 => the field counts RETRIES (11ac contract;
+#                                  DEVOURER_TX_RETRY_LIMIT goes in verbatim)
+#   limit N -> modal copies N   => the field counts ATTEMPTS (fold +1 in
+#                                  RtlKestrelDevice and update its comment)
+#   limit 0 -> zero witness hits while the control arm hears the TX
+#                               => ATTEMPTS with 0 = do-not-send; the default
+#                                  mapping MUST become +1 before this ships
+#
+# The witness restarts per arm, so each ledger belongs to exactly one limit.
+#
+#   sudo TX_PID=0xc832 bash tests/kestrel_retry_witness.sh
+#   (TX_PID: the plugged Kestrel adapter — 8832BU/8832CU/8852BU/8852CU PID)
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD="$ROOT/build"
+OUT=${OUT:-/tmp/kestrel-retry}
+CH=${CH:-6}
+TX_PID=${TX_PID:?set TX_PID to the Kestrel adapter PID}
+TX_VID=${TX_VID:-0x0bda}
+WIT_PID=${WIT_PID:-0x8813}; WIT_VID=${WIT_VID:-0x0bda}
+RA=${RA:-02:de:ad:be:ef:01}   # unicast, nobody home -> never ACKed
+TX_SA=${TX_SA:-02:aa:bb:cc:dd:01}
+LIMITS=${LIMITS:-0 2 8}
+SECS=${SECS:-6}
+
+KILL(){ sudo pkill -9 -x rxdemo 2>/dev/null; sudo pkill -9 -x txdemo 2>/dev/null; return 0; }
+trap KILL EXIT
+mkdir -p "$OUT"
+
+for LIM in $LIMITS; do
+  echo "=== limit $LIM"
+  KILL; sleep 1
+  sudo env DEVOURER_VID=$WIT_VID DEVOURER_PID=$WIT_PID DEVOURER_CHANNEL=$CH \
+       DEVOURER_RX_PCTR=1 DEVOURER_RX_AGG_SA=$TX_SA DEVOURER_LOG_LEVEL=info \
+       "$BUILD/rxdemo" >"$OUT/wit_$LIM.jsonl" 2>"$OUT/wit_$LIM.err" &
+  w=0; until grep -q "Listening air" "$OUT/wit_$LIM.err"; do
+    sleep 1; w=$((w+1))
+    [ $w -ge 25 ] && { echo "ABORT: witness never started" >&2; exit 1; }
+  done; sleep 2
+  sudo env DEVOURER_VID=$TX_VID DEVOURER_PID=$TX_PID DEVOURER_CHANNEL=$CH \
+       DEVOURER_TX_RATE=MCS3 DEVOURER_TX_QOS_DATA=1 DEVOURER_TX_RA=$RA \
+       DEVOURER_TX_SA=$TX_SA DEVOURER_TX_PAYLOAD_BYTES=200 \
+       DEVOURER_TX_GAP_US=20000 DEVOURER_TX_RETRY_LIMIT=$LIM \
+       DEVOURER_LOG_LEVEL=warn \
+       timeout -s INT $SECS "$BUILD/txdemo" \
+       >"$OUT/tx_$LIM.jsonl" 2>"$OUT/tx_$LIM.err" || true
+  sleep 1
+done
+KILL; sleep 1
+
+python3 - "$OUT" <<'PY'
+import collections, json, os, sys
+out = sys.argv[1]
+import glob
+for f in sorted(glob.glob(os.path.join(out, "wit_*.jsonl"))):
+    lim = os.path.basename(f)[4:-6]
+    per = collections.Counter()
+    for line in open(f, errors="replace"):
+        if not line.startswith('{"ev":"rx.seq"'):
+            continue
+        try:
+            r = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if r.get("crc"):
+            continue          # a corrupt copy still occupied air but isn't
+                              # attributable to a pctr — count clean only
+        per[r["pctr"]] += 1
+    if not per:
+        print(f"limit {lim:>2}: ZERO witness frames — either the TX never "
+              f"aired (the limit-0-as-attempts trap) or the witness is deaf; "
+              f"check tx_{lim}.err / wit_{lim}.err before concluding")
+        continue
+    dist = collections.Counter(per.values())
+    modal = dist.most_common(1)[0][0]
+    print(f"limit {lim:>2}: {len(per)} frames, copies dist "
+          f"{dict(sorted(dist.items()))} modal={modal}")
+PY
+echo "raw: $OUT"


### PR DESCRIPTION
#365 step 4, measured end-to-end on the real die.

## The mechanism (the issue's premise was wrong, usefully)

Retry on AX is **not a mac_ax H2C** — it is a WD descriptor field like every 11ac generation: `AX_TXD_DATA_TXCNT_LMT[30:25]` + SEL(31) in **wd_info dword1** on both dies (vendor continuous-dword 7 on the 8852B / 9 on the 8852C V1 — same wd_info-relative position, sharing the dword with BMC). The per-MACID CCTRL H2C twin exists; the per-frame WD field is the injection-path mechanism. The neighbouring `DATA_RTY_LOWEST_RATE` floor field stays deliberately unwritten (the 11ac floor-form anomaly).

## The measurement (TP-Link TX50UH = RTL8832CU, plugged under its `35bc:0101` OEM id; 8812CU witness counting on-air copies per stamped pctr)

| mapping | limit 0 | limit 2 | limit 8 |
|---|---|---|---|
| verbatim (vendor hal_sta.c style) | modal 1 (336/336) | **modal 2** | modal 8 |
| **+1 fold (shipped)** | modal 1 (369/369) | **modal 3** ✓ | 8/9 near-tie (67/65) |

The AX field counts **ATTEMPTS** where the 11ac descriptor counts retries — verbatim limit-2 gave 2 copies where J3's same harness run gives 3. `send_packet` folds +1 (clamp 62 retries) so `DEVOURER_TX_RETRY_LIMIT=N` means N retries on every generation. Value 0 hardware-clamps to one attempt; the 8/9 tie at limit 8 is consistent with ~90% per-copy witness capture of a 9-copy truth. Clean dose-response, no TX wedge.

Note the vendor's own `hal_sta.c` writes its `rty_lmt` verbatim into the CCTRL twin — off-by-one against 11ac semantics by this measurement.

## Harness

`tests/kestrel_retry_witness.sh` — Kestrel has no CCX `tx.report`, so semantics + efficacy are judged by witness copy-counts of an unACKable unicast (txdemo's stamped pctr + `DEVOURER_RX_PCTR`/`AGG_SA` rx.seq ledger, witness restarted per arm; self-diagnoses the limit-0-as-attempts trap). Methodology validated against the J3 8812CU before the Kestrel run (limit 0 → 143/143 single-copy, limit 2 → modal 3). Generation-neutral RX-start gate.

Caps: `tx_retry_limit_ok` true on Kestrel; truth tables updated in `AdapterCaps.h`, `docs/scheduled-mac.md`, `src/kestrel/CLAUDE.md`.

Part of #365 (step 5 — the 8814A carve-out audit — is implemented on `8814a-retry-audit` but bench-blocked: the rig 8814AU's 3081 MCU no longer boots across real VBUS colds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)