### PR TITLE
Carrier-sense/EDCCA: enabled by default on every generation, no silent no-ops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,17 +291,25 @@ Behavioural traps the per-field docs can't carry:
   that loss is pre-FCS sync/AGC, upstream of the equalizer. They target
   in-band spurs on otherwise decodable frames
   (`docs/pseudo-preamble-puncturing.md`).
-- `DEVOURER_DIS_CCA=1` (Jaguar2/3, runtime `SetCcaMode`) disables the MAC
-  carrier-sense gate — **both** primary CCA (`0x520[14]`) and EDCCA (`[15]`).
-  The primary-CCA bit is the one that matters: monitor injection is not
-  CCA-free, it defers ~40–60% to a co-channel 802.11 transmitter, and
-  clearing `[14]` recovers ~1.5–2.2× (on-air 8822EU/8812CU,
-  `tests/dis_cca_tx_onair.sh`); the energy bit `[15]` alone is null against a
-  decodable preamble. **On by default on the streamtx FPV downlink** (the
-  link owns the channel — CSMA backoff only stutters it);
-  `DEVOURER_DIS_CCA=0` forces standard carrier-sense back. Does NOT apply the
-  vendor BB CCA-off writes (they deafen the RX). RX-decode side is a separate
-  null (`tests/dis_cca_onair.sh`).
+- `DEVOURER_DIS_CCA=1` (every generation, runtime `SetCcaMode` — the
+  interface method is pure virtual so no generation can silently no-op it)
+  disables the MAC carrier-sense gate — **both** primary CCA (`0x520[14]`)
+  and EDCCA (`[15]`). The default is carrier-sense + EDCCA **enabled** on
+  Jaguar1/2/3; on Jaguar1 the enable is real work — its BB table parks the
+  EDCCA thresholds (`0x8a4`) at never-trigger, so bring-up programs the
+  vendor adaptivity operating point (IGI-coupled; the phydm watchdog
+  re-tracks it when running). The primary-CCA bit is the one that matters:
+  monitor injection is not CCA-free, it defers ~40–60% to a co-channel
+  802.11 transmitter, and clearing `[14]` recovers ~1.5–2.2× (on-air
+  8822EU/8812CU, `tests/dis_cca_tx_onair.sh`); the energy bit `[15]` alone
+  is null against a decodable preamble. **On by default on the streamtx FPV
+  downlink** (the link owns the channel — CSMA backoff only stutters it);
+  `DEVOURER_DIS_CCA=0` forces standard carrier-sense back. Kestrel's TX
+  bring-up is the one exception: it clears the gates regardless and WARNS —
+  carrier-sense TX 103-stalls there without the un-ported IQK/DPK cal
+  (perpetual-busy detectors); its RX-side CCA is untouched. Does NOT apply
+  the vendor BB CCA-off writes (they deafen the RX). RX-decode side is a
+  separate null (`tests/dis_cca_onair.sh`).
 
 **Runtime TX power** — the adaptive-link power lever, three knobs on every
 generation: `SetTxPowerOffsetQdb` (relative, shape-preserving),

--- a/src/DeviceConfig.h
+++ b/src/DeviceConfig.h
@@ -337,10 +337,17 @@ struct DeviceConfig {
      * follow-up: the fw replays cfg_param but lazily, and its rsvd-page download
      * stalls per batch. */
     int fw_table_offload = 0;
-    /* env: DEVOURER_DIS_CCA — Jaguar2/3 MAC carrier-sense disable at bring-up
-     * (primary CCA 0x520[14] + EDCCA [15]): injected/beacon TX stops deferring to
-     * a busy channel and punches through co-channel traffic. Runtime equivalent:
-     * SetCcaMode. Default-on on the streamtx FPV downlink. */
+    /* env: DEVOURER_DIS_CCA — MAC carrier-sense disable at bring-up, every
+     * generation (primary CCA 0x520[14] + EDCCA [15]; Jaguar1 additionally
+     * programs/parks its BB EDCCA thresholds 0x8a4 — its init table leaves
+     * them at never-trigger, and the explicit apply is what makes EDCCA
+     * real on that family): injected/beacon TX stops deferring to a
+     * busy channel and punches through co-channel traffic. Default false =
+     * carrier-sense + EDCCA ENABLED (the standards-compliant default) on
+     * Jaguar1/2/3. Kestrel's TX bring-up clears the gates regardless and
+     * warns — carrier-sense TX 103-stalls there without the un-ported
+     * IQK/DPK cal. Runtime equivalent: SetCcaMode. Default-on on the
+     * streamtx FPV downlink (the link owns the channel). */
     bool disable_cca = false;
     /* env: DEVOURER_TXPKT_STEP_QDB — Jaguar3 per-packet power-bank step size
      * in quarter-dB: the dB weight of one 0x1e70 offset-index step

--- a/src/IRtlDevice.h
+++ b/src/IRtlDevice.h
@@ -405,13 +405,16 @@ public:
    * against a decodable preamble — the primary-CCA bit [14] is what recovers the
    * inject path. This is the MAC-gate only; the vendor's BB CCA-off writes are
    * NOT applied (they deafen the RX). Also DEVOURER_DIS_CCA at construction.
-   * Implemented on Jaguar2/3 and Kestrel (the AX R_AX_CCA_CFG_0 all-CCA-EN field —
-   * on Kestrel injection is already CCA-off by default via sch_tx_en, so this is a
-   * runtime toggle rather than the deferral fix it is on Jaguar); a DELIBERATE
-   * no-op on Jaguar1, whose baseband EDCCA is already disabled by its init table
-   * (0x8A4 = 0x7F7F7F7F) and whose hardware-beacon downlink measures ~0.34 µs RMS
-   * on a crowded channel with no MAC-side gate. */
-  virtual void SetCcaMode(bool disabled) { (void)disabled; }
+   *
+   * Pure virtual: every generation implements or loudly refuses — a silent
+   * no-op here reads as "carrier-sense changed" to the caller. Default
+   * state on Jaguar1/2/3 is carrier-sense + EDCCA ENABLED (Jaguar1 programs
+   * its BB EDCCA thresholds at bring-up — its init table parks them at
+   * never-trigger); Kestrel's TX path keeps the gates cleared because
+   * carrier-sense TX 103-stalls without the un-ported IQK/DPK cal
+   * (perpetual-busy detectors) — it logs that loudly instead of
+   * pretending. */
+  virtual void SetCcaMode(bool disabled) = 0;
 
   /* Shift the next hardware beacon TBTT by `microseconds` (>0 = later/retard,
    * <0 = earlier/advance), quantized to whole TU (1 TU = 1024 µs). One-shot

--- a/src/jaguar1/HalModule.h
+++ b/src/jaguar1/HalModule.h
@@ -67,6 +67,10 @@ public:
             Logger_t logger, const devourer::DeviceConfig &cfg = {});
   bool rtw_hal_init(SelectedChannel selectedChannel);
   const devourer::FwBootStatus &GetFwBootStatus() const { return _fwBoot; }
+  /* Nullable — only exists when tuning.phydm_watchdog built it (the default
+   * config runs watchdog-less). SetCcaMode uses it to hand the EDCCA
+   * threshold re-track to the DIG tick. */
+  PhydmWatchdog *phydm_watchdog() { return _phydmWatchdog.get(); }
   /* Halt TRX and run the chip's card-disable power sequence, leaving it powered
    * down but re-enumerable — the counterpart to rtw_hal_init, and what every
    * other generation already does (HalJaguar2::power_off,

--- a/src/jaguar1/PhydmWatchdog.cpp
+++ b/src/jaguar1/PhydmWatchdog.cpp
@@ -98,6 +98,24 @@ void PhydmWatchdog::TickOnce() {
     _digInitialised = true;
   }
   DigTick(fa.cnt_all);
+
+  /* EDCCA threshold re-track (SetCcaMode enable + watchdog running): the
+   * vendor recomputes the 0x8a4 L2H/H2L from IGI every adaptivity cycle —
+   * with DIG walking IGI above, a static threshold would drift off the
+   * operating point. Write-on-change only. */
+  if (_edcca_track.load(std::memory_order_relaxed)) {
+    const int8_t th_ini =
+        _eepromManager->version_id.ICType == CHIP_8814A ? -14 : -17;
+    const int8_t l2h = jaguar1_edcca_l2h(th_ini, _cur_ig_value);
+    if (static_cast<uint8_t>(l2h) != _edcca_last_l2h) {
+      _device.phy_set_bb_reg(0x8a4, 0xFF, static_cast<uint8_t>(l2h));
+      _device.phy_set_bb_reg(0x8a4, 0xFF00, static_cast<uint8_t>(l2h - 7));
+      _edcca_last_l2h = static_cast<uint8_t>(l2h);
+      _logger->info("PhydmWatchdog: EDCCA L2H/H2L re-tracked to {}/{} "
+                    "(igi=0x{:02x})",
+                    l2h, l2h - 7, _cur_ig_value);
+    }
+  }
 }
 
 void PhydmWatchdog::ReadFaCountersAc(FaCnt &out) {

--- a/src/jaguar1/PhydmWatchdog.h
+++ b/src/jaguar1/PhydmWatchdog.h
@@ -53,6 +53,13 @@ public:
   /* Run one watchdog cycle synchronously on the calling thread. */
   void TickOnce();
 
+  /* EDCCA threshold tracking (the SetCcaMode enable path): when on, each
+   * tick re-derives the BB 0x8a4 L2H/H2L from the IGI DIG just wrote —
+   * the vendor couples the EDCCA threshold to IGI per watchdog cycle
+   * (phydm_adaptivity). Off = leave 0x8a4 alone (SetCcaMode owns the
+   * parked/static value). */
+  void SetEdccaTrack(bool on) { _edcca_track.store(on, std::memory_order_relaxed); }
+
   /* Most-recent FA counter snapshot — exposed for diagnostics /
    * future DIG integration. */
   struct FaCnt {
@@ -114,11 +121,25 @@ private:
    * just walk based on FA count). */
   bool _digInitialised = false;
   uint8_t _cur_ig_value = 0x20;
+  std::atomic<bool> _edcca_track{false};
+  uint8_t _edcca_last_l2h = 0x7f; /* parked sentinel — first tick writes */
   uint8_t _dm_dig_max = 0x26;       /* DIG_MAX_COVERAGR */
   uint8_t _dm_dig_min = 0x1c;       /* DIG_MIN_COVERAGE */
   uint8_t _dig_max_of_min = 0x2a;   /* DIG_MAX_OF_MIN_BALANCE_MODE */
   uint8_t _rx_gain_range_max = 0x2a;
   uint8_t _rx_gain_range_min = 0x1c;
 };
+
+/* Vendor adaptivity operating point for the 11AC dies (phydm_adaptivity.c
+ * phydm_adaptivity / phydm_set_l2h_th_ini): the BB EDCCA low-to-high
+ * threshold is IGI-coupled — L2H = th_l2h_ini + (igi_base 0x32 − IGI),
+ * upper-clamped to 10; H2L = L2H − 7. th_l2h_ini is −14 (0xf2) on the
+ * 8814A, −17 (0xef) on the 8812A/8811A/8821A. Shared by the one-shot
+ * SetCcaMode apply (static IGI, watchdog off — the default config) and the
+ * per-tick re-track (watchdog on). */
+inline int8_t jaguar1_edcca_l2h(int8_t th_l2h_ini, uint8_t igi) {
+  const int l2h = th_l2h_ini + (0x32 - static_cast<int>(igi));
+  return static_cast<int8_t>(l2h > 10 ? 10 : l2h);
+}
 
 #endif /* PHYDM_WATCHDOG_H */

--- a/src/jaguar1/RtlJaguarDevice.cpp
+++ b/src/jaguar1/RtlJaguarDevice.cpp
@@ -76,6 +76,11 @@ void RtlJaguarDevice::InitWrite(SelectedChannel channel) {
   if (_cfg.rx.ack_responder)
     SetAckResponder(*_cfg.rx.ack_responder); /* DEVOURER_ACK_RESPONDER */
 
+  /* Carrier-sense default: EDCCA + primary CCA enabled unless
+   * DEVOURER_DIS_CCA. Always applied — the enable path is what programs
+   * the BB EDCCA thresholds off their parked never-trigger table value. */
+  SetCcaMode(_cfg.tuning.disable_cca);
+
   /* DEVOURER_XTAL_CAP — crystal-cap trim (issue #217, narrowband CFO lever). */
   if (_cfg.tuning.xtal_cap)
     SetXtalCap(*_cfg.tuning.xtal_cap);
@@ -750,6 +755,51 @@ void RtlJaguarDevice::ClearAckResponder() {
   _logger->info("Jaguar1: hardware ACK responder disarmed (net_type=NoLink)");
 }
 
+void RtlJaguarDevice::SetCcaMode(bool disabled) {
+  /* MAC carrier-sense gate: the same REG_TX_PTCL_CTRL bits as the HalMAC
+   * generations — the vendor's phydm_mac_edcca_state drives 0x520[15] on
+   * this family too; [14] is the primary-CCA defer. */
+  uint32_t v520 = _device.rtw_read<uint32_t>(0x0520);
+  if (disabled)
+    v520 |= (1u << 15) | (1u << 14);
+  else
+    v520 &= ~((1u << 15) | (1u << 14));
+  _device.rtw_write<uint32_t>(0x0520, v520);
+
+  /* BB EDCCA thresholds (rEDCCA_Jaguar 0x8a4: L2H byte0 / H2L byte1). The
+   * BB init table parks them at 0x7f/0x7f = never-trigger — the vendor's
+   * adaptivity-off default (CONFIG_RTW_ADAPTIVITY_EN 0). Parked, the BB
+   * never raises the EDCCA signal, so the MAC gate [15] has nothing to
+   * honour — enable must program the vendor operating point from the live
+   * IGI for EDCCA to exist at all; disable re-parks. */
+  const auto ic = _eepromManager->version_id.ICType;
+  if (disabled) {
+    _device.phy_set_bb_reg(0x8a4, 0xFFFF, 0x7f7f);
+  } else {
+    const int8_t th_ini = ic == CHIP_8814A ? -14 : -17;
+    const uint8_t igi = static_cast<uint8_t>(
+        _radioManagement->phy_query_bb_reg_public(0xc50, 0x7f));
+    const int8_t l2h = jaguar1_edcca_l2h(th_ini, igi);
+    _device.phy_set_bb_reg(0x8a4, 0xFF, static_cast<uint8_t>(l2h));
+    _device.phy_set_bb_reg(0x8a4, 0xFF00, static_cast<uint8_t>(l2h - 7));
+    if (ic == CHIP_8812) {
+      /* Vendor 8812A enable-hang erratum ("fix AC series when enable EDCCA
+       * hang issue"): pulse the ADC mask once after programming. */
+      _device.phy_set_bb_reg(0x800, 1u << 10, 1);
+      _device.phy_set_bb_reg(0x800, 1u << 10, 0);
+    }
+    _logger->info("Jaguar1: EDCCA thresholds L2H/H2L = {}/{} (igi=0x{:02x})",
+                  l2h, l2h - 7, igi);
+  }
+  /* With the watchdog running, DIG walks IGI — hand it the re-track so the
+   * threshold follows (vendor couples them per adaptivity cycle). */
+  if (auto *wd = _halModule.phydm_watchdog())
+    wd->SetEdccaTrack(!disabled);
+  _logger->info("Jaguar1: MAC carrier-sense {}",
+                disabled ? "DISABLED (dis_cca: CCA+EDCCA)"
+                         : "enabled (default)");
+}
+
 bool RtlJaguarDevice::SetAmpduMode(const devourer::AmpduMode &mode) {
   /* A-MPDU TX mode (src/AmpduMode.h): record the descriptor state the TX path
    * reads and program the Jaguar1 MAC pacing registers. NB the aggregate-fill
@@ -1278,6 +1328,11 @@ void RtlJaguarDevice::Init(Action_ParsedRadioPacket packetProcessor,
 
   if (_cfg.rx.ack_responder)
     SetAckResponder(*_cfg.rx.ack_responder); /* DEVOURER_ACK_RESPONDER */
+
+  /* Carrier-sense default: EDCCA + primary CCA enabled unless
+   * DEVOURER_DIS_CCA. Always applied — the enable path is what programs
+   * the BB EDCCA thresholds off their parked never-trigger table value. */
+  SetCcaMode(_cfg.tuning.disable_cca);
 
   /* DEVOURER_XTAL_CAP — crystal-cap trim (issue #217, narrowband CFO lever). */
   if (_cfg.tuning.xtal_cap)

--- a/src/jaguar1/RtlJaguarDevice.h
+++ b/src/jaguar1/RtlJaguarDevice.h
@@ -256,6 +256,11 @@ public:
   /* Hardware ACK responder (IRtlDevice contract; src/AckResponder.h). */
   bool SetAckResponder(const devourer::MacAddr &mac) override;
   void ClearAckResponder() override;
+  /* Carrier-sense gate (IRtlDevice contract): MAC 0x520[14]/[15] like the
+   * HalMAC generations, plus this family's BB EDCCA thresholds (0x8a4) —
+   * parked at never-trigger by the BB table, programmed to the vendor
+   * operating point on enable (EDCCA only exists once they are set). */
+  void SetCcaMode(bool disabled) override;
   /* A-MPDU TX mode (IRtlDevice contract; src/AmpduMode.h). Programs the
    * Jaguar1 aggregate-fill timer (0x0456 — NOT the 0x0455 the HalMAC chips
    * use) + the 8814A burst-mode gate (0x04BC), and records the descriptor

--- a/src/kestrel/HalKestrel.cpp
+++ b/src/kestrel/HalKestrel.cpp
@@ -1210,7 +1210,15 @@ void HalKestrel::sch_tx_en() {
     return;
   }
   clr32(r::R_AX_CCA_CFG_0, r::B_AX_CCA_ALL_EN);
-  _logger->info("Kestrel TRX: CCA TX gates cleared (CCA_CFG_0=0x{:08x})",
+  /* Warn-level on purpose: this is a NON-STANDARD default (every other
+   * generation defaults to carrier-sense + EDCCA enabled). Carrier-sense TX
+   * on this family 103-stalls without the un-ported IQK/DPK cal — the
+   * detectors read perpetual-busy — so the TX path clears the gates to be
+   * able to transmit at all. RX-side CCA is unaffected (the pure-monitor
+   * bring-up leaves the gates on). */
+  _logger->warn("Kestrel TRX: CCA/EDCCA TX gates cleared (CCA_CFG_0=0x{:08x}) "
+                "— carrier-sense TX needs the un-ported IQK/DPK cal; this "
+                "generation cannot run the standards-compliant TX default yet",
                 _device.rtw_read32(r::R_AX_CCA_CFG_0));
 }
 

--- a/src/kestrel/RtlKestrelDevice.cpp
+++ b/src/kestrel/RtlKestrelDevice.cpp
@@ -402,6 +402,10 @@ void RtlKestrelDevice::SetCcaMode(bool disabled) {
   else
     v |= r::B_AX_CCA_ALL_EN;
   _device.rtw_write32(r::R_AX_CCA_CFG_0, v);
+  if (!disabled)
+    _logger->warn("Kestrel: carrier-sense ENABLED — injected TX is expected "
+                  "to stall (~103-frame PLE pin) until the IQK/DPK cal is "
+                  "ported; the detectors read perpetual-busy uncalibrated");
   _logger->info("Kestrel: MAC carrier-sense {} (CCA_CFG_0=0x{:08x})",
                 disabled ? "DISABLED (dis_cca)" : "enabled", v);
 }

--- a/tests/edcca_default_check.sh
+++ b/tests/edcca_default_check.sh
@@ -9,7 +9,7 @@
 #   sudo bash tests/edcca_default_check.sh
 set -u
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-BUILD="$ROOT/build" 
+BUILD="$ROOT/build"
 OUT=/tmp/edcca-val; mkdir -p "$OUT"
 CH=6
 J1_VID=0x2357 J1_PID=0x0120     # 8821AU DUT TX

--- a/tests/edcca_default_check.sh
+++ b/tests/edcca_default_check.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Carrier-sense/EDCCA default validation on Jaguar1: register proof (0x8a4
+# thresholds programmed vs parked, 0x520[15:14] clear vs set) + on-air
+# deferral A/B — the DUT TX counted by a witness while a co-channel flooder
+# holds the channel at max duty. Default (carrier-sense + EDCCA on) must
+# defer hard; DIS_CCA=1 must punch through (measured 48 vs 376 frames /
+# 10 s on the 8821AU at ch6).
+#
+#   sudo bash tests/edcca_default_check.sh
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD="$ROOT/build" 
+OUT=/tmp/edcca-val; mkdir -p "$OUT"
+CH=6
+J1_VID=0x2357 J1_PID=0x0120     # 8821AU DUT TX
+FLOOD_PID=0xc812                 # 8812CU co-channel flooder
+WIT_PID=0xb812                   # 8822BU witness
+TX_SA=02:aa:bb:cc:dd:01
+RA=02:de:ad:be:ef:01
+ESC=$(printf '%s' "$BUILD" | sed 's/[][\.*^$/]/\\&/g')
+KILL(){ sudo pkill -9 -f "^$ESC/rxdemo" 2>/dev/null; sudo pkill -9 -f "^$ESC/txdemo" 2>/dev/null; return 0; }
+trap KILL EXIT
+
+echo "=== 1) register proof: default (EDCCA on) ==="
+KILL; sleep 1
+sudo env DEVOURER_VID=$J1_VID DEVOURER_PID=$J1_PID DEVOURER_CHANNEL=$CH \
+     DEVOURER_LOG_LEVEL=info "$BUILD/rxdemo" >/dev/null 2>"$OUT/dflt.err" &
+w=0; until grep -q "MAC carrier-sense" "$OUT/dflt.err"; do
+  sleep 1; w=$((w+1)); [ $w -ge 25 ] && { echo ABORT-no-cca-log; exit 1; }
+done
+grep -E "EDCCA thresholds|carrier-sense" "$OUT/dflt.err" | head -2
+sudo "$BUILD/chipstate" --vid $J1_VID --pid $J1_PID --no-claim \
+     --peek 0x8a4-0x8a7 --peek 0x520-0x523 2>/dev/null
+KILL; sleep 1
+
+echo "=== 2) register proof: DIS_CCA=1 ==="
+sudo env DEVOURER_VID=$J1_VID DEVOURER_PID=$J1_PID DEVOURER_CHANNEL=$CH \
+     DEVOURER_DIS_CCA=1 DEVOURER_LOG_LEVEL=info \
+     "$BUILD/rxdemo" >/dev/null 2>"$OUT/dis.err" &
+w=0; until grep -q "MAC carrier-sense" "$OUT/dis.err"; do
+  sleep 1; w=$((w+1)); [ $w -ge 25 ] && { echo ABORT-no-cca-log; exit 1; }
+done
+grep -E "carrier-sense" "$OUT/dis.err" | head -1
+sudo "$BUILD/chipstate" --vid $J1_VID --pid $J1_PID --no-claim \
+     --peek 0x8a4-0x8a7 --peek 0x520-0x523 2>/dev/null
+KILL; sleep 1
+
+echo "=== 3) on-air deferral A/B under a co-channel flood ==="
+# witness hears the DUT SA; flooder screams broadcast at max duty
+sudo env DEVOURER_PID=$WIT_PID DEVOURER_CHANNEL=$CH \
+     DEVOURER_RX_PCTR=1 DEVOURER_RX_AGG_SA=$TX_SA DEVOURER_LOG_LEVEL=info \
+     "$BUILD/rxdemo" >"$OUT/wit.jsonl" 2>"$OUT/wit.err" &
+w=0; until grep -qE "async ring of .* URBs submitted|Listening air" "$OUT/wit.err"; do
+  sleep 1; w=$((w+1)); [ $w -ge 25 ] && { echo ABORT-wit; exit 1; }
+done
+sudo env DEVOURER_PID=$FLOOD_PID DEVOURER_CHANNEL=$CH DEVOURER_TX_RATE=MCS1 \
+     DEVOURER_TX_GAP_US=0 DEVOURER_DIS_CCA=1 DEVOURER_LOG_LEVEL=warn \
+     "$BUILD/txdemo" >/dev/null 2>"$OUT/flood.err" &
+sleep 8   # flooder bring-up + duty ramp
+for ARM in default discca; do
+  EXTRA=""; [ "$ARM" = discca ] && EXTRA="DEVOURER_DIS_CCA=1"
+  T0=$(date +%s%N)
+  sudo env DEVOURER_VID=$J1_VID DEVOURER_PID=$J1_PID DEVOURER_CHANNEL=$CH \
+       DEVOURER_TX_RATE=MCS3 DEVOURER_TX_QOS_DATA=1 DEVOURER_TX_RA=$RA \
+       DEVOURER_TX_SA=$TX_SA DEVOURER_TX_PAYLOAD_BYTES=200 \
+       DEVOURER_TX_GAP_US=5000 $EXTRA DEVOURER_LOG_LEVEL=warn \
+       timeout -s INT 10 "$BUILD/txdemo" >"$OUT/tx_$ARM.jsonl" 2>"$OUT/tx_$ARM.err" || true
+  T1=$(date +%s%N)
+  N=$(grep -c '"ev":"rx.seq"' "$OUT/wit.jsonl" || true)
+  echo "$ARM: witness total so far $N (wall $(( (T1-T0)/1000000 )) ms)"
+  echo "$N" > "$OUT/cum_$ARM"
+  sleep 1
+done
+KILL
+A=$(cat "$OUT/cum_default"); B=$(cat "$OUT/cum_discca")
+echo "witnessed DUT frames: default(EDCCA+CCA on)=$A  dis_cca=$((B-A))  (same 10 s window each)"
+echo "raw: $OUT"


### PR DESCRIPTION
Design change agreed with the PixelPilot dev: a silent no-op for "enable EDCCA" (Jaguar1) is a trap — a developer setting carrier-sense expects it to exist. New contract: **carrier-sense + EDCCA enabled by default everywhere, `DEVOURER_DIS_CCA=1` / `SetCcaMode(true)` the explicit override, and no generation can silently ignore the call.**

## What changed

- **`SetCcaMode` is pure virtual** on `IRtlDevice` — implement or loudly refuse; the compiler now bans the next silent no-op.
- **Jaguar1 gets the real implementation** (it had none). MAC gate = the same `0x520[14]/[15]` as the HalMAC generations (vendor `phydm_mac_edcca_state` drives `[15]` on this family too). The BB EDCCA thresholds (`0x8a4`) are parked at never-trigger by the BB init table — the vendor adaptivity-off default — so *enable programs the vendor operating point*: `L2H = th_l2h_ini + (0x32 − IGI)` clamped ≤10, `H2L = L2H − 7` (`th_l2h_ini` −14 8814A / −17 8812A/8811A/8821A), plus the vendor 8812A enable-hang erratum (ADC-mask pulse). With the phydm watchdog running, the DIG tick re-tracks the threshold as IGI walks. Bring-up applies `SetCcaMode(cfg.tuning.disable_cca)`.
- **Kestrel says the truth out loud**: carrier-sense TX 103-stalls there without the un-ported IQK/DPK cal (perpetual-busy detectors — measured previously), so its TX bring-up still clears the gates but now **WARNS** that this generation cannot run the standards-compliant TX default yet; `SetCcaMode(false)` warns about the expected stall. RX-side CCA untouched. Jaguar2/3 defaults were already enabled.
- **streamtx** keeps its explicit FPV default (gates off unless `DEVOURER_DIS_CCA` overrides) — that policy is now identical on every generation.

## Measured (8821AU, ch6 — `tests/edcca_default_check.sh`)

| | 0x8a4 (L2H/H2L) | 0x520[15:14] | DUT frames witnessed under max-duty co-channel flood (10 s) |
|---|---|---|---|
| default | **05/fe** (= formula at IGI 0x1c) | clear | **48** (defers) |
| `DIS_CCA=1` | 7f/7f (parked) | set | **376** (punches through, ~7.8×) |

Kestrel warn verified live on the 8832CU. ctest 49/49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)