### PR TITLE
Kestrel 8852C: standards-compliant carrier-sense TX default — the 103-stall is not reproducible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,10 +304,10 @@ Behavioural traps the per-field docs can't carry:
   8822EU/8812CU, `tests/dis_cca_tx_onair.sh`); the energy bit `[15]` alone
   is null against a decodable preamble. **On by default on the streamtx FPV
   downlink** (the link owns the channel — CSMA backoff only stutters it);
-  `DEVOURER_DIS_CCA=0` forces standard carrier-sense back. Kestrel's TX
-  bring-up is the one exception: it clears the gates regardless and WARNS —
-  carrier-sense TX 103-stalls there without the un-ported IQK/DPK cal
-  (perpetual-busy detectors); its RX-side CCA is untouched. Does NOT apply
+  `DEVOURER_DIS_CCA=0` forces standard carrier-sense back. On Kestrel the
+  8852C runs the same enabled default (measured: full-rate TX, 2.4x flood
+  deferral); the 8852B TX bring-up still clears the gates and WARNS pending
+  its measurement arm (`tests/kestrel_cca_default_check.sh`). Does NOT apply
   the vendor BB CCA-off writes (they deafen the RX). RX-decode side is a
   separate null (`tests/dis_cca_onair.sh`).
 

--- a/src/DeviceConfig.h
+++ b/src/DeviceConfig.h
@@ -344,10 +344,11 @@ struct DeviceConfig {
      * real on that family): injected/beacon TX stops deferring to a
      * busy channel and punches through co-channel traffic. Default false =
      * carrier-sense + EDCCA ENABLED (the standards-compliant default) on
-     * Jaguar1/2/3. Kestrel's TX bring-up clears the gates regardless and
-     * warns — carrier-sense TX 103-stalls there without the un-ported
-     * IQK/DPK cal. Runtime equivalent: SetCcaMode. Default-on on the
-     * streamtx FPV downlink (the link owns the channel). */
+     * Jaguar1/2/3 and the Kestrel 8852C; the Kestrel 8852B TX bring-up
+     * clears the gates and warns pending its measurement arm
+     * (tests/kestrel_cca_default_check.sh). Runtime equivalent: SetCcaMode.
+     * Default-on on the streamtx FPV downlink (the link owns the
+     * channel). */
     bool disable_cca = false;
     /* env: DEVOURER_TXPKT_STEP_QDB — Jaguar3 per-packet power-bank step size
      * in quarter-dB: the dB weight of one 0x1e70 offset-index step

--- a/src/kestrel/CLAUDE.md
+++ b/src/kestrel/CLAUDE.md
@@ -69,14 +69,11 @@ TX-enable path is un-ported — B210-confirmed 0% duty vs 45% at 6G-80 / 40% at
 5G-160; a MAC TXAGC-max / RF-TX-path gap, not a chip limit — the vendor
 drives it). 5/10 MHz narrowband is the BB "small BW" field with the RF left
 in 20 MHz mode (no ADC re-clock, unlike Jaguar). RX bulk-IN delivery requires
-the USB RXAGG engine enabled (`B_AX_RXAGG_EN`). TX on the 8852C runs
-carrier-sense + EDCCA enabled by default (R_AX_CCA_CFG_0 gates on;
-witness-measured: full-rate TX with all gates on from bring-up, 2.4x
-deferral vs `DEVOURER_DIS_CCA=1` under a co-channel flood —
-`tests/kestrel_cca_default_check.sh`); `DEVOURER_DIS_CCA=1` clears the
-gates for punch-through injection. The 8852B TX default still clears them
-(warn-logged) pending its arm of the same harness;
-`DEVOURER_KESTREL_CCA_ON=1` is the measurement lever. `ReadTsf` reads the per-port MAC TSF;
+the USB RXAGG engine enabled (`B_AX_RXAGG_EN`). TX carrier-sense
+defaults are per-die (8852C enabled / 8852B cleared-and-warned pending its
+measurement arm) — the numbers and knob interplay live at the bring-up
+comment in `RtlKestrelDevice.cpp` and the gate doc in `MacRegAx.h`;
+harness: `tests/kestrel_cca_default_check.sh`. `ReadTsf` reads the per-port MAC TSF;
 `StartBeacon` drives the AX HW beacon engine.
 
 **Per-frame retry limit** (`DEVOURER_TX_RETRY_LIMIT`): the AX WD wd_info

--- a/src/kestrel/CLAUDE.md
+++ b/src/kestrel/CLAUDE.md
@@ -69,9 +69,14 @@ TX-enable path is un-ported — B210-confirmed 0% duty vs 45% at 6G-80 / 40% at
 5G-160; a MAC TXAGC-max / RF-TX-path gap, not a chip limit — the vendor
 drives it). 5/10 MHz narrowband is the BB "small BW" field with the RF left
 in 20 MHz mode (no ADC re-clock, unlike Jaguar). RX bulk-IN delivery requires
-the USB RXAGG engine enabled (`B_AX_RXAGG_EN`). TX airs with the CMAC
-EDCCA/CCA gate disabled (`sch_tx_en`, TX path only) — the intended
-injection/monitor-link mode. `ReadTsf` reads the per-port MAC TSF;
+the USB RXAGG engine enabled (`B_AX_RXAGG_EN`). TX on the 8852C runs
+carrier-sense + EDCCA enabled by default (R_AX_CCA_CFG_0 gates on;
+witness-measured: full-rate TX with all gates on from bring-up, 2.4x
+deferral vs `DEVOURER_DIS_CCA=1` under a co-channel flood —
+`tests/kestrel_cca_default_check.sh`); `DEVOURER_DIS_CCA=1` clears the
+gates for punch-through injection. The 8852B TX default still clears them
+(warn-logged) pending its arm of the same harness;
+`DEVOURER_KESTREL_CCA_ON=1` is the measurement lever. `ReadTsf` reads the per-port MAC TSF;
 `StartBeacon` drives the AX HW beacon engine.
 
 **Per-frame retry limit** (`DEVOURER_TX_RETRY_LIMIT`): the AX WD wd_info

--- a/src/kestrel/HalKestrel.cpp
+++ b/src/kestrel/HalKestrel.cpp
@@ -1199,27 +1199,30 @@ void HalKestrel::sch_tx_en() {
    * disabling the gates lets frames air — the intended TX/monitor mode, on-air
    * validated (both the 8852BU and 8832CU radiate). */
   if (_cca_on) {
-    /* Experimental (DEVOURER_KESTREL_CCA_ON): leave the CCA gates ENABLED for a
-     * carrier-sense TX test. NB: measured NOT sufficient on its own — TX still
-     * 103-stalls even with RX-DCK + ADDCK + the EDCCA level threshold seeded to
-     * -62 dBm; carrier-sense TX needs deeper RF/BB config (IQK/DPK or a CCA
-     * state-machine bring-up). */
-    _logger->info("Kestrel TRX: CCA gates LEFT ON (CCA_CFG_0=0x{:08x}) — "
-                  "carrier-sense TX test",
+    /* Standards-compliant TX default (8852C-measured: full-rate TX with all
+     * gates on, real deferral under a co-channel flood —
+     * tests/kestrel_cca_default_check.sh). */
+    _logger->info("Kestrel TRX: carrier-sense + EDCCA enabled "
+                  "(CCA_CFG_0=0x{:08x})",
                   _device.rtw_read32(r::R_AX_CCA_CFG_0));
     return;
   }
   clr32(r::R_AX_CCA_CFG_0, r::B_AX_CCA_ALL_EN);
-  /* Warn-level on purpose: this is a NON-STANDARD default (every other
-   * generation defaults to carrier-sense + EDCCA enabled). Carrier-sense TX
-   * on this family 103-stalls without the un-ported IQK/DPK cal — the
-   * detectors read perpetual-busy — so the TX path clears the gates to be
-   * able to transmit at all. RX-side CCA is unaffected (the pure-monitor
+  /* Two reasons to be here: an explicit DEVOURER_DIS_CCA (intentional — the
+   * FPV punch-through mode, info-grade), or the 8852B die default, whose
+   * carrier-sense TX arm has not run — warn there so a non-standard default
+   * is never silent. RX-side CCA is unaffected either way (the pure-monitor
    * bring-up leaves the gates on). */
-  _logger->warn("Kestrel TRX: CCA/EDCCA TX gates cleared (CCA_CFG_0=0x{:08x}) "
-                "— carrier-sense TX needs the un-ported IQK/DPK cal; this "
-                "generation cannot run the standards-compliant TX default yet",
-                _device.rtw_read32(r::R_AX_CCA_CFG_0));
+  if (_cca_default_unmeasured)
+    _logger->warn("Kestrel TRX: CCA/EDCCA TX gates cleared "
+                  "(CCA_CFG_0=0x{:08x}) — the 8852B carrier-sense TX arm is "
+                  "unmeasured (tests/kestrel_cca_default_check.sh); "
+                  "DEVOURER_KESTREL_CCA_ON=1 runs it",
+                  _device.rtw_read32(r::R_AX_CCA_CFG_0));
+  else
+    _logger->info("Kestrel TRX: CCA/EDCCA TX gates cleared "
+                  "(CCA_CFG_0=0x{:08x}) — dis_cca",
+                  _device.rtw_read32(r::R_AX_CCA_CFG_0));
 }
 
 bool HalKestrel::start_beacon(const uint8_t *body, uint32_t len,

--- a/src/kestrel/HalKestrel.h
+++ b/src/kestrel/HalKestrel.h
@@ -491,7 +491,9 @@ public:
   KestrelFw _fw; /* persistent: owns the CH12 H2C transport + IO-offload */
   int16_t _txpwr_dbm_q2 = 20 * 4; /* fixed BB TX power, s(9,2); 20 dBm default */
   int16_t _txpwr_offset_qdb = 0;  /* runtime offset (quarter-dB), sticky */
-  bool _cca_on = false; /* DEVOURER_KESTREL_CCA_ON: keep CCA gates on (test) */
+  bool _cca_on = false; /* carrier-sense TX default (8852C) / forced on */
+  bool _cca_default_unmeasured = false; /* 8852B default-clear: warn, don't
+                                         * pretend it's a choice */
 
   /* Vendored halbb-G6 8852C RX bring-up (hal/halbb/g6/kestrel_halbb_glue).
    * The static callbacks route the vendor C's register/OS plane to this device
@@ -578,7 +580,10 @@ public:
 
 public:
   ~HalKestrel();
-  void set_cca_on(bool on) { _cca_on = on; }
+  void set_cca_on(bool on, bool default_unmeasured = false) {
+    _cca_on = on;
+    _cca_default_unmeasured = default_unmeasured;
+  }
   void set_kfr_ofld(bool on) { _kfr_ofld = on; }
 };
 

--- a/src/kestrel/MacRegAx.h
+++ b/src/kestrel/MacRegAx.h
@@ -1508,13 +1508,12 @@ constexpr uint16_t R_AX_SCH_EXT_CTRL = 0xC3FC;
 constexpr uint32_t B_AX_PORT_RST_TSF_ADV = 1u << 1;
 constexpr uint16_t R_AX_CCA_CFG_0 = 0xC340;
 constexpr uint32_t B_AX_BTCCA_EN = 1u << 5;
-/* CCA medium-busy enables (R_AX_CCA_CFG_0 bits 0-4). Cleared for injection TX:
- * without the RX-DCK/DACK BB calibration the carrier/energy detectors assert a
- * perpetual busy that freezes the CSMA backoff, so the scheduler never grants a
- * TX opportunity and injected frames stall in the CMAC MBH queue (~103-frame
- * mgmt-TX stall). Clearing CCA_EN + the secondary-channel + EDCCA gates lets the
- * frames air — the intended TX/monitor-link mode; carrier-sense returns with
- * the energy-detector calibration. On-air validated: the 8852BU radiates. */
+/* CCA medium-busy enables (R_AX_CCA_CFG_0 bits 0-4). The 8852C runs the
+ * standards-compliant default — all gates on (witness-measured: full-rate TX
+ * and real deferral under a co-channel flood; the bring-up cals suffice) —
+ * with DEVOURER_DIS_CCA clearing them for punch-through injection. The 8852B
+ * default clears them pending its measurement arm
+ * (tests/kestrel_cca_default_check.sh). */
 constexpr uint32_t B_AX_CCA_EN = 1u << 0;
 constexpr uint32_t B_AX_SEC20_EN = 1u << 1;
 constexpr uint32_t B_AX_SEC40_EN = 1u << 2;

--- a/src/kestrel/RtlKestrelDevice.cpp
+++ b/src/kestrel/RtlKestrelDevice.cpp
@@ -227,13 +227,28 @@ void RtlKestrelDevice::InitWrite(SelectedChannel channel) {
     _logger->error("Kestrel: TX bring-up failed");
     return;
   }
-  /* TX-only: enable the CMAC port + scheduler contention queues (this clears
-   * the CCA gates — see EnableTxScheduler). Kept out of BringUpMonitor so the
-   * pure-monitor RX path keeps CCA on and can actually hear frames. */
-  _hal.set_cca_on(_cfg.debug.kestrel_cca_on);
+  /* TX-only: enable the CMAC port + scheduler contention queues. Kept out
+   * of BringUpMonitor so the pure-monitor RX path keeps CCA on and can
+   * actually hear frames.
+   *
+   * Carrier-sense default: the 8852C die runs the standards-compliant
+   * default — gates STAY ON unless DEVOURER_DIS_CCA (witness-measured on
+   * the 8832CU: full-rate TX with all gates on from bring-up, 2106
+   * frames/12 s, and real deferral under a co-channel flood, 35 vs 83
+   * frames vs dis_cca — the same both-directions proof as the other
+   * generations; the bring-up's DACK/RX-DCK/ADDCK suffice, no IQK/DPK
+   * needed). The 8852B die keeps the gates cleared until its arm of
+   * tests/kestrel_cca_default_check.sh runs — unmeasured, not incapable.
+   * DEVOURER_KESTREL_CCA_ON forces gates-on on either die (the B-die
+   * measurement lever). */
+  const bool cca_on = _cfg.debug.kestrel_cca_on ||
+                      (_variant == kestrel::ChipVariant::C8852C &&
+                       !_cfg.tuning.disable_cca);
+  _hal.set_cca_on(cca_on, /*default_unmeasured=*/!cca_on &&
+                              !_cfg.tuning.disable_cca);
   EnableTxScheduler();
-  /* DEVOURER_DIS_CCA: EnableTxScheduler already cleared the CCA gates for TX;
-   * this just re-asserts it explicitly (idempotent) when the knob is set. */
+  /* DEVOURER_DIS_CCA: set_cca_on(false) already cleared the gates; this
+   * re-asserts explicitly (idempotent) when the knob is set. */
   if (_cfg.tuning.disable_cca)
     SetCcaMode(true);
   _tx_mgmt_ep = _device.nth_bulk_out_ep(0); /* B0MG -> BULKOUTID0 */
@@ -402,10 +417,6 @@ void RtlKestrelDevice::SetCcaMode(bool disabled) {
   else
     v |= r::B_AX_CCA_ALL_EN;
   _device.rtw_write32(r::R_AX_CCA_CFG_0, v);
-  if (!disabled)
-    _logger->warn("Kestrel: carrier-sense ENABLED — injected TX is expected "
-                  "to stall (~103-frame PLE pin) until the IQK/DPK cal is "
-                  "ported; the detectors read perpetual-busy uncalibrated");
   _logger->info("Kestrel: MAC carrier-sense {} (CCA_CFG_0=0x{:08x})",
                 disabled ? "DISABLED (dis_cca)" : "enabled", v);
 }

--- a/src/kestrel/RtlKestrelDevice.cpp
+++ b/src/kestrel/RtlKestrelDevice.cpp
@@ -241,9 +241,12 @@ void RtlKestrelDevice::InitWrite(SelectedChannel channel) {
    * tests/kestrel_cca_default_check.sh runs — unmeasured, not incapable.
    * DEVOURER_KESTREL_CCA_ON forces gates-on on either die (the B-die
    * measurement lever). */
-  const bool cca_on = _cfg.debug.kestrel_cca_on ||
-                      (_variant == kestrel::ChipVariant::C8852C &&
-                       !_cfg.tuning.disable_cca);
+  /* DEVOURER_DIS_CCA is the explicit override and beats everything,
+   * including the KESTREL_CCA_ON measurement lever — one knob, one final
+   * state, and the bring-up log matches it. */
+  const bool cca_on = !_cfg.tuning.disable_cca &&
+                      (_cfg.debug.kestrel_cca_on ||
+                       _variant == kestrel::ChipVariant::C8852C);
   _hal.set_cca_on(cca_on, /*default_unmeasured=*/!cca_on &&
                               !_cfg.tuning.disable_cca);
   EnableTxScheduler();

--- a/tests/kestrel_cca_default_check.sh
+++ b/tests/kestrel_cca_default_check.sh
@@ -40,7 +40,9 @@ wit_up(){
     [ $w -ge 25 ] && { echo "ABORT: witness never started" >&2; exit 1; }
   done; sleep 1
 }
-count(){ grep -c '"ev":"rx.seq"' "$OUT/wit.jsonl" 2>/dev/null || echo 0; }
+# grep -c prints the 0 itself (exiting 1) — || true keeps set -u-safe without
+# emitting a second zero line into $(count).
+count(){ grep -c '"ev":"rx.seq"' "$OUT/wit.jsonl" 2>/dev/null || true; }
 
 echo "=== 1) gates-on from bring-up ==="
 KILL; sleep 1; : >"$OUT/wit.jsonl"; wit_up

--- a/tests/kestrel_cca_default_check.sh
+++ b/tests/kestrel_cca_default_check.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Kestrel carrier-sense TX validation — the measurement behind the per-die
+# CCA default (RtlKestrelDevice bring-up). Three phases on one witness:
+#
+#  1) gates-on-from-bring-up TX (DEVOURER_KESTREL_CCA_ON=1): full-rate flow
+#     is the pass (the 8852C measured 2106 frames/12 s; a CSMA freeze reads
+#     as near-zero + a bulk-OUT stall in tx.err).
+#  2) live gate bisect: R_AX_CCA_CFG_0 low-byte poked per arm (none / CCA /
+#     CCA+SEC / EDCCA / ALL) via chipstate --no-claim — per-arm frame rates
+#     localize a misbehaving detector.
+#  3) deferral A/B under a co-channel flood: gates-on must defer, DIS_CCA=1
+#     must punch through (8852C: 35 vs 83 frames/10 s).
+#
+# Run with the die under test as TX (TX_VID/TX_PID); the 8852B arm is the
+# open one — a pass there flips its bring-up default too.
+#
+#   sudo TX_VID=0x35bc TX_PID=0x0101 bash tests/kestrel_cca_default_check.sh
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD="$ROOT/build"
+OUT=${OUT:-/tmp/kestrel-cca}
+CH=${CH:-6}
+TX_VID=${TX_VID:-0x35bc}; TX_PID=${TX_PID:-0x0101}
+FLOOD_PID=${FLOOD_PID:-0xc812}
+WIT_PID=${WIT_PID:-0xb812}
+TX_SA=02:aa:bb:cc:dd:01
+RA=02:de:ad:be:ef:01
+ESC=$(printf '%s' "$BUILD" | sed 's/[][\.*^$/]/\\&/g')
+KILL(){ sudo pkill -9 -f "^$ESC/rxdemo" 2>/dev/null; sudo pkill -9 -f "^$ESC/txdemo" 2>/dev/null; return 0; }
+trap KILL EXIT
+mkdir -p "$OUT"
+
+wit_up(){
+  sudo env DEVOURER_PID=$WIT_PID DEVOURER_CHANNEL=$CH \
+       DEVOURER_RX_PCTR=1 DEVOURER_RX_AGG_SA=$TX_SA DEVOURER_LOG_LEVEL=info \
+       "$BUILD/rxdemo" >"$OUT/wit.jsonl" 2>"$OUT/wit.err" &
+  local w=0
+  until grep -qE "async ring of .* URBs submitted|Listening air" "$OUT/wit.err"; do
+    sleep 1; w=$((w+1))
+    [ $w -ge 25 ] && { echo "ABORT: witness never started" >&2; exit 1; }
+  done; sleep 1
+}
+count(){ grep -c '"ev":"rx.seq"' "$OUT/wit.jsonl" 2>/dev/null || echo 0; }
+
+echo "=== 1) gates-on from bring-up ==="
+KILL; sleep 1; : >"$OUT/wit.jsonl"; wit_up
+sudo env DEVOURER_VID=$TX_VID DEVOURER_PID=$TX_PID DEVOURER_CHANNEL=$CH \
+     DEVOURER_KESTREL_CCA_ON=1 DEVOURER_TX_RATE=MCS3 DEVOURER_TX_QOS_DATA=1 \
+     DEVOURER_TX_RA=$RA DEVOURER_TX_SA=$TX_SA DEVOURER_TX_PAYLOAD_BYTES=200 \
+     DEVOURER_TX_GAP_US=5000 DEVOURER_LOG_LEVEL=info \
+     timeout -s INT 18 "$BUILD/txdemo" >/dev/null 2>"$OUT/tx1.err" || true
+echo "gates-on-from-bring-up: $(count) frames witnessed (~10 s steady TX)"
+KILL; sleep 1
+
+echo "=== 2) live gate bisect ==="
+: >"$OUT/wit.jsonl"; wit_up
+sudo env DEVOURER_VID=$TX_VID DEVOURER_PID=$TX_PID DEVOURER_CHANNEL=$CH \
+     DEVOURER_TX_RATE=MCS3 DEVOURER_TX_QOS_DATA=1 DEVOURER_TX_RA=$RA \
+     DEVOURER_TX_SA=$TX_SA DEVOURER_TX_PAYLOAD_BYTES=200 \
+     DEVOURER_TX_GAP_US=5000 DEVOURER_DIS_CCA=1 DEVOURER_LOG_LEVEL=warn \
+     "$BUILD/txdemo" >/dev/null 2>"$OUT/tx2.err" &
+sleep 8
+BASE_HI=$(sudo "$BUILD/chipstate" --vid $TX_VID --pid $TX_PID --no-claim \
+          --peek 0xc340-0xc343 2>/dev/null | tail -1 | awk '{print $3$4$5}')
+for A in c0 c1 cf d0 df c0; do
+  sudo "$BUILD/chipstate" --vid $TX_VID --pid $TX_PID --no-claim \
+       --poke "0xc341=0x${BASE_HI:0:2}" >/dev/null 2>&1 || true
+  sudo "$BUILD/chipstate" --vid $TX_VID --pid $TX_PID --no-claim \
+       --poke "0xc340=0x$A" >/dev/null 2>&1
+  C0=$(count); sleep 5; C1=$(count)
+  echo "gate byte 0x$A: $((C1-C0)) frames / 5 s"
+done
+KILL; sleep 1
+
+echo "=== 3) deferral A/B under co-channel flood ==="
+: >"$OUT/wit.jsonl"; wit_up
+sudo env DEVOURER_PID=$FLOOD_PID DEVOURER_CHANNEL=$CH DEVOURER_TX_RATE=MCS1 \
+     DEVOURER_TX_GAP_US=0 DEVOURER_DIS_CCA=1 DEVOURER_LOG_LEVEL=warn \
+     "$BUILD/txdemo" >/dev/null 2>"$OUT/flood.err" &
+sleep 8
+for ARM in ccaon discca; do
+  E="DEVOURER_KESTREL_CCA_ON=1"; [ "$ARM" = discca ] && E="DEVOURER_DIS_CCA=1"
+  sudo env DEVOURER_VID=$TX_VID DEVOURER_PID=$TX_PID DEVOURER_CHANNEL=$CH $E \
+       DEVOURER_TX_RATE=MCS3 DEVOURER_TX_QOS_DATA=1 DEVOURER_TX_RA=$RA \
+       DEVOURER_TX_SA=$TX_SA DEVOURER_TX_PAYLOAD_BYTES=200 \
+       DEVOURER_TX_GAP_US=5000 DEVOURER_LOG_LEVEL=warn \
+       timeout -s INT 10 "$BUILD/txdemo" >/dev/null 2>"$OUT/tx3_$ARM.err" || true
+  echo "$(count)" >"$OUT/c_$ARM"; sleep 1
+done
+KILL
+A=$(cat "$OUT/c_ccaon"); B=$(cat "$OUT/c_discca")
+echo "under flood: gates-ON=$A  dis_cca=$((B-A))  (10 s each; deferral = ON < dis_cca)"
+echo "raw: $OUT"


### PR DESCRIPTION
Follow-up to #378, which left Kestrel as the one generation that couldn't run the enabled default, per the in-tree claim that carrier-sense TX 103-stalls without the un-ported IQK/DPK cal. **That claim does not hold against the current bring-up** — measured on the 8832CU (`tests/kestrel_cca_default_check.sh`, witness-counted per stamped pctr):

| phase | result |
|---|---|
| all 5 gates on FROM bring-up | full-rate TX, **2106 frames/12 s** — no stall, no PLE pin (cals in the bring-up already: DACK/RX-DCK/ADDCK; no IQK/DPK) |
| live per-gate bisect (chipstate pokes mid-stream) | every combination flows: none 811 / CCA 648 / CCA+SEC 717 / EDCCA 780 / ALL 751 per 6 s |
| deferral A/B under max-duty co-channel flood | gates-ON **35** vs `DIS_CCA=1` **83** frames/10 s — defers 2.4×, override punches through (same both-directions proof as the other generations) |

So the 8852C TX bring-up now runs **gates-ON by default** with `DEVOURER_DIS_CCA` as the explicit punch-through override — the same contract as Jaguar1/2/3. Validated live: default bring-up logs `carrier-sense + EDCCA enabled (CCA_CFG_0=0x6a0306df)` and TX flows; `DIS_CCA=1` clears with an info-grade line (an explicit override is a choice, not a gap — no warn).

**The 8852B die keeps the cleared-gates default and the warn**: its arm of the harness is unmeasured (no B-die adapter on the rig) — unmeasured, not incapable. `DEVOURER_KESTREL_CCA_ON=1` is the measurement lever; a pass flips its default the same way.

Register/docs surfaces updated to current state (`MacRegAx.h` gate comment, `src/kestrel/CLAUDE.md`, root `CLAUDE.md`, `DeviceConfig.h`). ctest 49/49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)