### PR TITLE
ci: qodo-gate sweeps its own stale red runs off the head commit

### DIFF
--- a/.github/workflows/qodo-gate.yml
+++ b/.github/workflows/qodo-gate.yml
@@ -20,11 +20,20 @@
 # Event-driven: re-evaluates when the PR updates, when a review is submitted,
 # and when someone replies in a review thread. GitHub's workflow parser
 # rejects the documented `pull_request_review_thread` trigger ("Unexpected
-# value"), so plain thread resolution does not auto-retrigger — after
-# resolving the last thread, either leave a reply (retriggers) or Re-run the
-# failed qodo-gate check from the PR's Checks tab; the check reads the live
-# resolution state each run. Escape hatch for a Qodo outage: the
-# `skip-qodo-gate` label passes the check (label changes re-trigger it).
+# value" — re-verified empirically, zero-job "workflow file issue" run), so
+# plain thread resolution does not auto-retrigger — after resolving the last
+# thread, leave a reply (retriggers); the check reads the live resolution
+# state each run. Escape hatch for a Qodo outage: the `skip-qodo-gate` label
+# passes the check (label changes re-trigger it).
+#
+# A passing run also re-runs this workflow's earlier FAILED runs on the same
+# head commit. Each trigger event creates its own workflow run, and branch
+# protection's rollup counts every run of a required check on the commit — a
+# fresh green run sits beside the stale red ones rather than superseding
+# them, so the PR stays BLOCKED until each red run is re-run by hand (four
+# clicks on PR #396). Only a passing run re-runs others and a re-run that
+# passes finds nothing red left, so it converges; if threads are genuinely
+# unresolved the re-runs go red again and the gate still holds.
 name: qodo-gate
 on:
   pull_request:
@@ -37,6 +46,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  actions: write
 
 jobs:
   qodo-gate:
@@ -133,9 +143,29 @@ jobs:
             echo "FAIL: $unresolved unresolved Qodo review thread(s) — address"
             echo "or explicitly dismiss each finding in its thread, then mark"
             echo "it resolved. Plain resolution does not auto-retrigger this"
-            echo "check: leave a reply in a thread (retriggers) or Re-run the"
-            echo "check from the PR's Checks tab after resolving."
+            echo "check: leave a reply in a thread (retriggers) — the passing"
+            echo "run then sweeps this red run off the commit itself."
             exit 1
           fi
 
           echo "PASS: Qodo review present, all its threads resolved"
+
+      # Sweep stale red runs of this gate off the head commit, so the pass
+      # above is the one the branch-protection rollup sees. Best-effort: a
+      # failed re-run request must not turn a PASS into a FAIL.
+      - name: Re-run this gate's earlier failed runs on this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          THIS_RUN: ${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          gh run list --repo "$REPO" --workflow qodo-gate \
+              --commit "$HEAD_SHA" --json databaseId,conclusion \
+              --jq '.[] | select(.conclusion == "failure") | .databaseId' |
+          while read -r id; do
+            [ "$id" = "$THIS_RUN" ] && continue
+            echo "re-running failed qodo-gate run $id"
+            gh run rerun "$id" --repo "$REPO" --failed || true
+          done

--- a/.github/workflows/qodo-gate.yml
+++ b/.github/workflows/qodo-gate.yml
@@ -160,12 +160,19 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           THIS_RUN: ${{ github.run_id }}
         run: |
-          set -uo pipefail
-          gh run list --repo "$REPO" --workflow qodo-gate \
+          set -u
+          # The listing is guarded too, not just the reruns: with an unguarded
+          # pipeline a transient list failure would be the step's exit code —
+          # exactly the PASS-into-FAIL this step promises not to produce.
+          if ! ids=$(gh run list --repo "$REPO" --workflow qodo-gate \
               --commit "$HEAD_SHA" --json databaseId,conclusion \
-              --jq '.[] | select(.conclusion == "failure") | .databaseId' |
-          while read -r id; do
+              --jq '.[] | select(.conclusion == "failure") | .databaseId'); then
+            echo "sweep skipped: could not list this workflow's runs"
+            exit 0
+          fi
+          for id in $ids; do
             [ "$id" = "$THIS_RUN" ] && continue
             echo "re-running failed qodo-gate run $id"
             gh run rerun "$id" --repo "$REPO" --failed || true
           done
+          exit 0


### PR DESCRIPTION
## The friction this removes

Merging #396 surfaced a gap in the gate's unblock flow: after resolving the last Qodo thread, the reply-triggered green run lands **beside** the stale red runs rather than superseding them — each trigger event type creates its own workflow run, and the branch-protection rollup counts every run of a required check on the head commit. The PR stayed `BLOCKED` with a green latest run until all four red `pull_request`-event runs were re-run by hand from the Checks tab.

## The fix

A passing run now sweeps: it lists this workflow's `failure`-conclusion runs on the same head SHA and `gh run rerun --failed`s each (new `actions: write` permission). Properties:

- **Convergent**: only a PASS triggers sweeps, and a re-run that passes finds nothing red left to sweep.
- **Still a gate**: if threads are genuinely unresolved, the swept runs go red again and the check keeps blocking — the sweep can only align the rollup with the live resolution state, never bypass it.
- **Best-effort**: the sweep step tolerates individual `rerun` failures; it cannot turn a PASS into a FAIL.

The failure message now points at the one remaining manual step (reply in a thread to retrigger) instead of also asking for Checks-tab re-runs.

## The alternative, re-tested and still dead

Before adding machinery I re-verified the header's claim that GitHub rejects the documented `pull_request_review_thread` trigger — if that parsed, plain thread resolution would retrigger the gate and most of this would be unnecessary. It still doesn't: a scratch workflow carrying `pull_request_review_thread: {types: [resolved, unresolved]}` produced a zero-job "workflow file issue" run on push (run 31778980528). The header comment now records that this was re-verified empirically, not just inherited.

## What this does not change

The gate's semantics are untouched: not pinned to head (the anti-treadmill rationale stands), `skip-qodo-gate` label escape hatch, pagination, thread-attribution logic — all as before. One net-new permission (`actions: write`), scoped to the workflow's own runs by construction (`--workflow qodo-gate --commit <head>`).

Validation: YAML parses; the sweep's list/filter pipeline is the same query used to unblock #396 by hand. The self-referential part (a green qodo-gate re-running red qodo-gates) can only be observed on a PR that first goes red and then resolves — this PR itself will exercise the gate normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)