### PR TITLE
docs: sweep changelog framing out of current-state docs

### DIFF
--- a/docs/8822e-quirks.md
+++ b/docs/8822e-quirks.md
@@ -67,10 +67,10 @@ EU's RX, which would argue for a structural skip. The register is
 exonerated — a direct A/B with per-chain RSSI shows no RX effect from the
 write — but the observation points at something real: the static DPDT route
 disconnects RX path B's antenna outright (see the pin-mux section above),
-and a recheck counting TOTAL frames, which chain A dominates —
+and checks that count TOTAL frames, which chain A dominates —
 `tests/eu_41e8_desense_recheck.sh`'s −2% "noise" verdict and the 24k-frame
-full-duplex proof (`tests/eu_fullduplex_pathb_check.sh`) — is blind to a
-dead chain B. Per-chain RSSI is the only honest RX-health metric on a 2T2R
+full-duplex proof (`tests/eu_fullduplex_pathb_check.sh`) — are both blind to
+a dead chain B. Per-chain RSSI is the only honest RX-health metric on a 2T2R
 part.) Full-duplex holds under the eFEM pin-mux with path-B power applied.
 
 `DEVOURER_TX_WITH_RX=thread` must still be set **before** `InitWrite`

--- a/docs/8822e-quirks.md
+++ b/docs/8822e-quirks.md
@@ -62,14 +62,14 @@ at ch36 — MCS0/MCS4/MCS7/54M ≈ 5k frames / 12 s at EVM −26/−32/−48/−
 ## TX+RX mode and the path-B TXAGC reference (0x41e8)
 
 Path-B OFDM TXAGC (`0x41e8`) is written unconditionally in every mode,
-including TX+RX. (An earlier structural skip existed because any nonzero write
-appeared to near-deafen the EU's RX. The register is exonerated — a direct A/B
-with per-chain RSSI shows no RX effect from the write — but the historical
-observation was pointing at something real: the static DPDT route disconnects
-RX path B's antenna outright (see the pin-mux section above), and every
-recheck counted TOTAL frames, which chain A dominates —
+including TX+RX. (A nonzero write here can look like it near-deafens the
+EU's RX, which would argue for a structural skip. The register is
+exonerated — a direct A/B with per-chain RSSI shows no RX effect from the
+write — but the observation points at something real: the static DPDT route
+disconnects RX path B's antenna outright (see the pin-mux section above),
+and a recheck counting TOTAL frames, which chain A dominates —
 `tests/eu_41e8_desense_recheck.sh`'s −2% "noise" verdict and the 24k-frame
-full-duplex proof (`tests/eu_fullduplex_pathb_check.sh`) were both blind to a
+full-duplex proof (`tests/eu_fullduplex_pathb_check.sh`) — is blind to a
 dead chain B. Per-chain RSSI is the only honest RX-health metric on a 2T2R
 part.) Full-duplex holds under the eFEM pin-mux with path-B power applied.
 

--- a/docs/adaptive-link-validation.md
+++ b/docs/adaptive-link-validation.md
@@ -103,7 +103,7 @@ This is a clean **relative** confirmation. It is **not** an absolute SLA test:
 on a near-field bench the static baseline never reaches 0.99 (it tops out
 ≈ 0.89), because the adapters sit inches apart with tens of dB of margin, so
 the interferer is never in the "link holds at 0.99, then fades break it" regime. The residual loss
-is real end-to-end loss (on-air + processing), now measured honestly.
+is real end-to-end loss (on-air + processing).
 
 ## What this validation does not cover
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -27,7 +27,7 @@ Conventions:
 - Event names are lowercase dotted namespaces (`rx.frame`, `txpwr.state`).
 - Register addresses/values/masks are hex **strings** (`"addr":"0x0808"`).
 - Per-chain metrics are arrays (`"rssi":[-52,-60]`).
-- A field the chip can't provide is JSON `null` (the old text format used `-`).
+- A field the chip can't provide is JSON `null`.
 - `t` is monotonic **ms since process start**; periodic/marker events carry it,
   per-frame events rely on `seq`/`tsfl` instead.
 - Byte blobs (frame bodies, C2H payloads) are lowercase hex strings.

--- a/docs/pseudo-preamble-puncturing.md
+++ b/docs/pseudo-preamble-puncturing.md
@@ -26,7 +26,7 @@ Puncturing is **PHY signaling, not a driver trick**. Three independent walls:
 What the silicon *does* offer composes into a three-part approximation:
 per-tone **detection** (find the dirty slice), an RX-side **tone mask**
 (de-weight it in the equalizer), and TX-side **avoidance** (place a narrower
-transmission on the clean sub-channels). All three are now in devourer; the
+transmission on the clean sub-channels). All three are in devourer; the
 measurements below say which ones carry their weight.
 
 ## The RX tone mask (`DEVOURER_RX_CSI_MASK`, `DEVOURER_RX_NBI`)
@@ -144,7 +144,7 @@ Two detectors measured (`tests/pseudo_puncture_detect.sh`):
 |--------------------------------------|--------|------------------------------------------|
 | TX tone nulling / true puncturing    | no     | no silicon hook, no VHT signaling         |
 | RX CSI mask against a jammed slice   | no     | loss is pre-FCS (sync/AGC), mask is later |
-| RX CSI mask against in-band spurs    | yes    | the vendor's original use; knob now open  |
+| RX CSI mask against in-band spurs    | yes    | the vendor's original use; knob exposed   |
 | Sub-block salvage of jammed frames   | no     | nothing delivered to salvage              |
 | TX avoidance (narrower, clean half)  | yes    | 78% of clean delivery; per-packet capable |
 | Detection: self-sounding per-tone SNR| partly | senses the peer's channel, not the victim's |

--- a/docs/rtl8733b.md
+++ b/docs/rtl8733b.md
@@ -450,7 +450,7 @@ These results have **not** been claimed:
   cannot see per-frame delivery, so detecting a departed peer needs an
   application-level timeout
   (`src/rtl8733b/CLAUDE.md` "Hardware ARQ").
-- Fast retune is now ported and independently witnessed (intra-band,
+- Fast retune is ported and independently witnessed (intra-band,
   same-width; `src/rtl8733b/CLAUDE.md` has the measured contract and its
   counterparts): channel-state readback parity 7/7 hops, a 299/300 post-hop
   burst decoded by an RTL8812AU witness, ~55 ms call / ~10 ms p50 radio-live

--- a/docs/scheduled-mac.md
+++ b/docs/scheduled-mac.md
@@ -187,8 +187,8 @@ BlockAcks (`tests/rtl8733b_blockack_onair.sh`). All are one-RTL8733B bench
 results; details are in `docs/rtl8733b.md`.
 
 The OFF-phase pin is set by `DEVOURER_TX_RETRY_LIMIT` (the matrix runs 12,
-the value the descriptors used to hardcode) — the knob, not a descriptor
-constant, is now the single source of truth for the retry limit on
+the vendor descriptor default) — the knob, not a descriptor constant, is
+the single source of truth for the retry limit on
 jaguar1/2/3 **and Kestrel** (inert on the 8814A die only). On Kestrel it
 rides the AX WD `DATA_TXCNT_LMT` per-frame field, which counts **attempts**
 — devourer folds +1 so N means N retries on every generation. Witness-
@@ -228,8 +228,8 @@ on-air copy (`tests/retry_ladder_probe.sh`, ~99% capture, modal chains):
 | Jaguar3 8812CU @2.4 GHz | MCS3 ×4 → MCS2 → 5.5M → 1M ×3 (CCK floor) |
 | Jaguar3 8812CU, VHT | M7 ×4 → M4 → M1 → M0 → 6M (coarse −3 steps) |
 
-Why the ladder is MCS-native now, what a family-mismatched RA group did
-historically (the 8822C legacy chain, the 8822B VHT wander), the fallback
+Why the ladder is MCS-native, the family-mismatch failure modes it avoids
+(the 8822C legacy chain, the 8822B VHT wander), the fallback
 knob and the rejected floor form are documented at the source of truth:
 `rateid_for_mgn` in `src/RateDefinitions.h` and the `RetryFallback` note in
 `src/DeviceConfig.h` — read those, not a copy here. The closed ARQ loop
@@ -248,8 +248,8 @@ A cell whose responder never armed reads exactly like a broken chip — on=0%
 / off=0% — which is how the 8821AU carried a false "broken" verdict through
 three runs (silently dead responder: stale advisory adapter lock / open
 failure; root-caused with concurrent register peeks off the live armed die,
-`chipstate --no-claim --peek`). The check script now verifies the arm line
-and aborts loudly instead; treat any historical on=0/off=0 row from a
+`chipstate --no-claim --peek`). The check script verifies the arm line
+and aborts loudly; treat an on=0/off=0 row from a
 harness without arm-verification as unmeasured, not broken.
 
 The full responder matrix (six cells, ch36, MCS3 unicast; run with

--- a/src/rtl8733b/CLAUDE.md
+++ b/src/rtl8733b/CLAUDE.md
@@ -29,7 +29,7 @@ output.
 Chip-id first: `SYS_CFG2` must read `0x16`. The PID table exists for discovery
 and for one safety property — a device whose PID is a known 8733B identity but
 whose chip-id read fails is **refused**, not allowed to fall through to the
-historical Jaguar1 default. A wrong-HAL bring-up on this part writes an
+Jaguar1 default. A wrong-HAL bring-up on this part writes an
 unrelated register map.
 
 ## Chip facts
@@ -171,7 +171,7 @@ unrelated register map.
 The timing figures above (84 ms, ~11 fps, 2.51/2.71 ms) come from the original
 `f72b` validation unit and have no in-repo oracle. They are register-sequence
 and USB-transfer costs. Treat them as the order of magnitude to design
-against, not as constants. (RF-domain quantities are now measured on the
+against, not as constants. (RF-domain quantities are measured on the
 `b733` sample — see Validation status.)
 - **EFUSE**: physical packed map walked into a logical map. Running off the end
   of the readable span is address-space exhaustion, not corruption — a fully


### PR DESCRIPTION
Follow-up from the PR #407 review: the two pre-existing "is now" lines flagged there (`docs/rtl8733b.md` fast-retune, `src/rtl8733b/CLAUDE.md` RF-domain), plus a repo-wide sweep for the same pattern. 13 spots across 7 files rephrase transition-narration into current-state — "is now ported" → "is ported", "the value the descriptors used to hardcode" → "the vendor descriptor default", "did historically" → "failure modes it avoids", the `(the old text format used -)` aside in logging.md, and the "earlier structural skip" narration in 8822e-quirks.md. Every fact survives; only the history framing goes — git is the changelog.

Deliberately untouched: article-style lesson narratives whose past-tense content is measured evidence (docs/fhss.md's SDR-matcher pitfalls with their regression guard, the −64 qdB clamp story and "earlier cut cost ~9 dB" adversarial notes in the rtl8733b docs), vendor-lineage references ("the old trees" = vendor source trees), and protocol-time uses ("the old permutation").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcEcJciyf9zQ9GLZJ7jYXx