### PR TITLE
rx: make FCS presence a per-frame fact instead of an assumption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1245,6 +1245,17 @@ if(Python3_Interpreter_FOUND)
                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/rx_tone_localize.py --self-test
     )
 
+    # FCS-presence handling in tools/bf_report_decode.py. The C++ trim has the
+    # bf_report_decode cell; this covers the Python one, which is where both
+    # review-found regressions actually were - a dropped None guard that turned
+    # a skippable malformed event into an uncaught TypeError across three
+    # tools, and an unconditional trailing-byte reservation in parse_mu_snr.
+    add_test(
+        NAME bf_report_fcs
+        COMMAND ${Python3_EXECUTABLE}
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/bf_report_fcs_selftest.py
+    )
+
     # Headless guard for the LA-capture CSI math (tools/la_csi.py): synthetic
     # L-LTF through a known 2-tap channel + CFO + AWGN must locate, correct,
     # and recover |H(k)| with correlation > 0.99. Skips (77) without numpy.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -176,8 +176,8 @@ Emitters: L = library, RX/TX/... = demo. Optional fields in [brackets];
 |---|---|---|
 | `bf.report` | BfReportDetect.h | kind, n, sa, nc, nr, bw, ng, len |
 | `bf.any` | BfReportDetect.h | fc "0xNNNN", cat, act, crc, len |
-| `bf.report_raw` | BfReportDetect.h, sense (stderr) | frame hex |
-| `bf.csi` | BfReportDetect.h (mode 3) | len, csi hex |
+| `bf.report_raw` | BfReportDetect.h, sense (stderr) | fcs, frame hex |
+| `bf.csi` | BfReportDetect.h (mode 3) | fcs, len, csi hex |
 | `csi.hit` / `csi.wedged` | RX (`DEVOURER_RX_DUMP_CSI`) | hit, selector "0x…", value "0x…" / selector |
 
 ### Stream demos / misc

--- a/docs/mt7612u.md
+++ b/docs/mt7612u.md
@@ -165,9 +165,9 @@ control.
 ### This part does not deliver the FCS
 
 Measured, because it constrains integration rather than being a detail.
-`Packet::Data` in `src/RxPacket.h` is documented as the full 802.11 frame
-**including the trailing FCS**, and every Realtek parser here honours that.
-MT7612U cannot: the MAC strips it.
+`Packet::Data` carries the trailing FCS whenever `rx_pkt_attrib::fcs_present`
+is set, which every Realtek parser leaves at its default. MT7612U cannot: the
+MAC strips it, so this backend clears that flag.
 
 Four to seven bytes do sit past `MPDU_LEN` in every RX buffer — over 4263
 ambient frames the tail was 4 bytes on 3375 of them and 5-7 on the rest,
@@ -181,11 +181,13 @@ They are the FCE info trailer: mt76's `mt76u_get_rx_entry_len()` computes
 `min_len = MT_DMA_HDR_LEN + MT_RX_RXWI_LEN + MT_FCE_INFO_LEN`, and
 `dma.h:48` defines `MT_FCE_INFO_LEN 4`.
 
-A consumer that trims four bytes at its protocol boundary — which the
-`Packet::Data` contract invites, and which `tools/bf_report_decode.py`
-already does — would eat four bytes of payload off every frame. Whatever
-shape integration takes, this divergence has to be declared at the boundary,
-not smoothed over.
+A consumer that trims four bytes unconditionally would eat four bytes of
+payload off every frame. That divergence is now declared at the boundary
+rather than smoothed over: `rx_pkt_attrib::fcs_present` travels with each
+frame, and the consumers that trim — `devourer::bf::parse_report()`,
+`BfReportDetect`, `tools/bf_report_decode.py` — honour it. Airtime accounting
+adds the four bytes back, since they occupied the channel even though the MAC
+did not hand them over.
 
 ## USB bulk aggregation
 
@@ -344,8 +346,10 @@ Stated because the numbers above are uniformly favourable.
   no lifecycle soak of the kind the Realtek backends carry.
 - **80 MHz, VHT on air, and NSS=2 are unexercised.** The rate word encodes
   them and the RX path decodes them; neither has been transmitted.
-- **The RX path cannot satisfy `Packet::Data`'s FCS contract** (see above).
-  That is a measured hardware limit, not something the port can fix.
+- **The RX path delivers no FCS** (see above). That is a measured hardware
+  limit the port cannot fix, but it is no longer an integration blocker: the
+  backend clears `rx_pkt_attrib::fcs_present` and every consumer that trims
+  four bytes honours it.
 
 ## Open list
 

--- a/docs/mt7612u.md
+++ b/docs/mt7612u.md
@@ -167,7 +167,8 @@ control.
 Measured, because it constrains integration rather than being a detail.
 `Packet::Data` carries the trailing FCS whenever `rx_pkt_attrib::fcs_present`
 is set, which every Realtek parser leaves at its default. MT7612U cannot: the
-MAC strips it, so this backend clears that flag.
+MAC strips it, so this backend will clear that flag when it is wired in
+(nothing sets it today - see Open below).
 
 Four to seven bytes do sit past `MPDU_LEN` in every RX buffer — over 4263
 ambient frames the tail was 4 bytes on 3375 of them and 5-7 on the rest,
@@ -347,9 +348,9 @@ Stated because the numbers above are uniformly favourable.
 - **80 MHz, VHT on air, and NSS=2 are unexercised.** The rate word encodes
   them and the RX path decodes them; neither has been transmitted.
 - **The RX path delivers no FCS** (see above). That is a measured hardware
-  limit the port cannot fix, but it is no longer an integration blocker: the
-  backend clears `rx_pkt_attrib::fcs_present` and every consumer that trims
-  four bytes honours it.
+  limit the port cannot fix. It is no longer an integration *blocker* - the
+  metadata and every consumer that trims four bytes are in place - but the
+  adapter still has to USE it: see Open.
 
 ## Open list
 
@@ -357,6 +358,12 @@ Ordered, and honest about which are unknowns rather than typing:
 
 1. `IRadio` implementation, `WiFiDriver` dispatch, `DeviceConfig` plumbing,
    `CMakeLists.txt`, `ctest` cells. None of this exists.
+   Part of that adapter, called out because nothing will fail loudly if it is
+   forgotten: it MUST set `attrib.fcs_present = false` on every frame it
+   delivers. The field defaults to `true` - correct for every Realtek parser,
+   wrong for this part - so omitting the assignment silently feeds four bytes
+   of real payload to consumers that trim an FCS. There is no compile error,
+   no assert and no test that catches it.
 2. `mt76x2_phy_tssi_compensate()` — periodic temperature correction. Without
    it output power drifts with die temperature.
 3. Cold-boot verification on a host with switchable USB power.

--- a/examples/chanscout/main.cpp
+++ b/examples/chanscout/main.cpp
@@ -95,9 +95,13 @@ static void packetProcessor(const Packet &packet) {
     return;
   g_rx_count.fetch_add(1, std::memory_order_relaxed);
   const auto &a = packet.RxAtrib;
-  const uint32_t air = cm::frame_airtime_us(
-      a.data_rate, static_cast<uint32_t>(packet.Data.size()), a.bw,
-      a.sgi != 0);
+  /* Airtime is what occupied the channel, and the FCS was transmitted even
+   * where the MAC strips it before DMA - so add it back when the buffer does
+   * not carry it, or occupancy reads 4 bytes light on every frame. */
+  const uint32_t on_air_len =
+      static_cast<uint32_t>(packet.Data.size()) + (a.fcs_present ? 0u : 4u);
+  const uint32_t air =
+      cm::frame_airtime_us(a.data_rate, on_air_len, a.bw, a.sgi != 0);
   const bool ours = packet.Data.size() >= 16 &&
                     std::memcmp(packet.Data.data() + 10, kDvrSa, 6) == 0;
   std::lock_guard<std::mutex> lk(g_agg_mu);

--- a/examples/common/BfReportDetect.h
+++ b/examples/common/BfReportDetect.h
@@ -78,7 +78,10 @@ inline void detect_report(const Packet &packet) {
         .f("len", packet.Data.size());
     if (mode == '3' && rpt <= 6) {
       size_t off = 26 + 3; /* hdr(24)+cat+act+mimoctrl(3) */
-      size_t end = packet.Data.size() >= 4 ? packet.Data.size() - 4 : off;
+      /* Only the backends that append an FCS have four bytes to drop here;
+       * on MediaTek those bytes are CSI, not a checksum. */
+      const size_t fcs = packet.RxAtrib.fcs_present ? 4u : 0u;
+      size_t end = packet.Data.size() >= fcs ? packet.Data.size() - fcs : off;
       size_t n = end > off ? end - off : 0;
       devourer::Ev(*bf_events, "bf.csi")
           .f("len", n)
@@ -87,6 +90,7 @@ inline void detect_report(const Packet &packet) {
     if (mode == '4' && rpt <= 200) {
       /* Full-frame hex — consumed by tools/bf_report_decode.py. */
       devourer::Ev(*bf_events, "bf.report_raw")
+          .f("fcs", packet.RxAtrib.fcs_present ? 1 : 0)
           .hex("frame", d, packet.Data.size());
     }
   }

--- a/examples/common/BfReportDetect.h
+++ b/examples/common/BfReportDetect.h
@@ -38,7 +38,7 @@ inline devourer::EventSink *bf_events = nullptr;
 
 inline void detect_report(const Packet &packet) {
   const char *mode_s = std::getenv("DEVOURER_BF_DETECT_REPORT");
-  if (!mode_s || packet.Data.size() < 27 || bf_events == nullptr)
+  if (!mode_s || packet.Data.size() < 29 || bf_events == nullptr)
     return;
   const char mode = mode_s[0];
   const uint8_t *d = packet.Data.data();

--- a/examples/common/BfReportDetect.h
+++ b/examples/common/BfReportDetect.h
@@ -84,6 +84,7 @@ inline void detect_report(const Packet &packet) {
       size_t end = packet.Data.size() >= fcs ? packet.Data.size() - fcs : off;
       size_t n = end > off ? end - off : 0;
       devourer::Ev(*bf_events, "bf.csi")
+          .f("fcs", packet.RxAtrib.fcs_present ? 1 : 0)
           .f("len", n)
           .hex("csi", d + off, n < 40 ? n : 40);
     }

--- a/examples/sense/bf_report_decode_selftest.cpp
+++ b/examples/sense/bf_report_decode_selftest.cpp
@@ -93,8 +93,17 @@ int main() {
     CHECK(h2.angle_len == hdr.angle_len, "no-FCS angle_len identical");
 
     /* Exactly the angle block, nothing after it. */
+    /* CHECK only records a failure and returns, so this has to gate the
+     * slicing too - otherwise a shorter fixture walks the iterator past the
+     * end (UB) on exactly the path the check was meant to protect.
+     *
+     * The rejection below is MU-specific: it bites via the MU clamp
+     * (vbytes 65 > ab_len 61). An SU fixture would instead depend on
+     * (angle_len-4)*8 % ns, which is 0 for ns=16 - so this control would pass
+     * spuriously there. It requires an MU fixture, which this one is. */
     const size_t tight = 29u + (size_t)hdr.nc + (size_t)hdr.angle_len;
     CHECK(tight <= frame.size(), "fixture long enough to build the tight case");
+    if (tight <= frame.size()) {
     std::vector<uint8_t> snug(frame.begin(), frame.begin() + (long)tight);
 
     ReportHdr h4;
@@ -105,6 +114,7 @@ int main() {
     ReportHdr h5;
     CHECK(!parse_report(snug.data(), snug.size(), h5, /*fcs_present=*/true),
           "assuming an FCS that is not there must reject, not silently shorten");
+    }
   }
 
   /* 4. fixed-split decode vs offline reference. */

--- a/examples/sense/bf_report_decode_selftest.cpp
+++ b/examples/sense/bf_report_decode_selftest.cpp
@@ -71,6 +71,42 @@ int main() {
   CHECK(hdr.per_sc_bits == 10, "per_sc_bits=10 (MU)");
   CHECK(hdr.angle_len == 65, "angle_len=65 (52*10 bits)");
 
+  /* 3b. The same logical report delivered WITHOUT a trailing FCS - the
+   * MediaTek MT7612U shape, where the MAC strips it.
+   *
+   * With slack in the buffer the MU path clamps angle_len to vbytes, so the
+   * flag provably changes nothing there; that equivalence is the first check.
+   * To show the flag actually DOES something, the second half trims the frame
+   * to exactly (29 + nc) + vbytes - no slack at all - which is the shape a
+   * real FCS-less capture has. There, believing a non-existent FCS eats four
+   * angle bytes and the report must be REJECTED. A control that cannot fail is
+   * not a control. */
+  {
+    std::vector<uint8_t> nofcs(frame.begin(), frame.end() - 4);
+    ReportHdr h2;
+    CHECK(parse_report(nofcs.data(), nofcs.size(), h2, /*fcs_present=*/false),
+          "parse_report matches with no FCS");
+    CHECK(h2.nc == hdr.nc && h2.nr == hdr.nr && h2.bw == hdr.bw &&
+              h2.ng == hdr.ng && h2.mu == hdr.mu && h2.vht == hdr.vht &&
+              h2.ns == hdr.ns && h2.per_sc_bits == hdr.per_sc_bits,
+          "no-FCS header identical to FCS-present");
+    CHECK(h2.angle_len == hdr.angle_len, "no-FCS angle_len identical");
+
+    /* Exactly the angle block, nothing after it. */
+    const size_t tight = 29u + (size_t)hdr.nc + (size_t)hdr.angle_len;
+    CHECK(tight <= frame.size(), "fixture long enough to build the tight case");
+    std::vector<uint8_t> snug(frame.begin(), frame.begin() + (long)tight);
+
+    ReportHdr h4;
+    CHECK(parse_report(snug.data(), snug.size(), h4, /*fcs_present=*/false),
+          "tight FCS-less report still decodes");
+    CHECK(h4.angle_len == hdr.angle_len, "tight FCS-less angle_len intact");
+
+    ReportHdr h5;
+    CHECK(!parse_report(snug.data(), snug.size(), h5, /*fcs_present=*/true),
+          "assuming an FCS that is not there must reject, not silently shorten");
+  }
+
   /* 4. fixed-split decode vs offline reference. */
   std::vector<double> psi;
   CHECK(decode_psi(hdr, 8, 2, psi), "decode_psi ok");

--- a/examples/sense/main.cpp
+++ b/examples/sense/main.cpp
@@ -185,7 +185,9 @@ public:
       /* python-tool-compatible raw dump (events ride stderr in sense, so the
        * stdout display is untouched): capture with 2>file, analyse with
        * tools/bf_report_decode.py */
-      devourer::Ev(*g_ev, "bf.report_raw").hex("frame", frame, n);
+      devourer::Ev(*g_ev, "bf.report_raw")
+          .f("fcs", fcs_present ? 1 : 0)
+          .hex("frame", frame, n);
     }
     if (std::getenv("DEVOURER_SENSE_DEBUG")) {
       static int dbg = 0;
@@ -202,7 +204,7 @@ public:
     ++_total;
     if (!_meter) {
       /* calibration: copy full frames until we can pick a stable split */
-      _cal.emplace_back(frame, frame + n);
+      _cal.push_back({std::vector<uint8_t>(frame, frame + n), fcs_present});
       _ns = hdr.ns;
       _per = hdr.per_sc_bits;
       if ((int)_cal.size() >= kCalReports)
@@ -252,7 +254,10 @@ private:
     batch.reserve(_cal.size());
     for (auto &f : _cal) {
       ReportHdr h;
-      if (parse_report(f.data(), f.size(), h))
+      /* Reparse under the SAME rule the frame arrived with. Defaulting to
+       * fcs_present here would reject tight MU reports and mis-derive
+       * per_sc_bits for SU ones on any backend that strips the FCS. */
+      if (parse_report(f.first.data(), f.first.size(), h, f.second))
         batch.push_back(h);
     }
     int bphi = 0, bpsi = 0;
@@ -271,7 +276,8 @@ private:
   }
 
   std::mutex _mu;
-  std::vector<std::vector<uint8_t>> _cal;
+  /* frame bytes + whether they carry an FCS; calibrate() needs both. */
+  std::vector<std::pair<std::vector<uint8_t>, bool>> _cal;
   std::unique_ptr<MotionMeter> _meter;
   AdaptiveDetector _det;
   int _ns = 0, _per = 0, _bphi = 0, _bpsi = 0;

--- a/examples/sense/main.cpp
+++ b/examples/sense/main.cpp
@@ -177,7 +177,10 @@ class Sensor {
 public:
   explicit Sensor(double k) : _det(k) {}
 
-  void feed(const uint8_t *frame, size_t n, bool fcs_present = true) {
+  /* No default: the single call site has the Packet and must pass the
+   * frame's own flag. A default here would only let a future second
+   * caller compile while silently applying the Realtek rule. */
+  void feed(const uint8_t *frame, size_t n, bool fcs_present) {
     ReportHdr hdr;
     if (!parse_report(frame, n, hdr, fcs_present))
       return;

--- a/examples/sense/main.cpp
+++ b/examples/sense/main.cpp
@@ -177,9 +177,9 @@ class Sensor {
 public:
   explicit Sensor(double k) : _det(k) {}
 
-  void feed(const uint8_t *frame, size_t n) {
+  void feed(const uint8_t *frame, size_t n, bool fcs_present = true) {
     ReportHdr hdr;
-    if (!parse_report(frame, n, hdr))
+    if (!parse_report(frame, n, hdr, fcs_present))
       return;
     if (std::getenv("DEVOURER_SENSE_DUMP") && g_ev) {
       /* python-tool-compatible raw dump (events ride stderr in sense, so the
@@ -437,7 +437,7 @@ static int run_active(uint16_t snd_vid, uint16_t snd_pid, uint16_t bfe_vid,
   /* Self-capture the returned reports on the sounder's RX loop. */
   std::thread snd_rx([&snd, &sensor]() {
     snd.dev()->StartRxLoop(
-        [&sensor](const Packet &p) { sensor.feed(p.Data.data(), p.Data.size()); });
+        [&sensor](const Packet &p) { sensor.feed(p.Data.data(), p.Data.size(), p.RxAtrib.fcs_present); });
   });
   std::thread disp(run_display, std::ref(sensor));
 

--- a/src/BfReportDecode.h
+++ b/src/BfReportDecode.h
@@ -59,7 +59,12 @@ struct ReportHdr {
 
 /* True if `d`(n) is a VHT/HT Compressed Beamforming report; fills `hdr`. Mirrors
  * parse_frame() + the MU V-angle slice (ns*10 bits) in the Python tool. */
-inline bool parse_report(const uint8_t *d, size_t n, ReportHdr &hdr) {
+/* fcs_present: does `d` still carry the trailing 4-byte FCS?  Defaulted true
+ * because that is what every Realtek backend delivers and what the captured
+ * selftest fixture contains; pass RxAtrib.fcs_present when a Packet is in
+ * reach, so a MediaTek frame is not shortened by four bytes of real payload. */
+inline bool parse_report(const uint8_t *d, size_t n, ReportHdr &hdr,
+                         bool fcs_present = true) {
   if (d == nullptr || n < 30)
     return false;
   uint8_t sub = d[0] & 0xF0;
@@ -79,10 +84,14 @@ inline bool parse_report(const uint8_t *d, size_t n, ReportHdr &hdr) {
   hdr.mu = ((mc >> 11) & 0x1) != 0;
   hdr.vht = vht;
   hdr.ns = report_ns(hdr.bw, hdr.ng);
-  if (hdr.ns <= 0 || n < 30 + (size_t)hdr.nc + 4)
+  const size_t fcs = fcs_present ? 4u : 0u;
+  if (hdr.ns <= 0 || n < 30 + (size_t)hdr.nc + fcs)
     return false;
   const uint8_t *ab = d + 29 + hdr.nc;          /* after per-column avg SNR */
-  size_t ab_len = n - (29 + (size_t)hdr.nc) - 4; /* drop 4-byte FCS */
+  /* Drop the FCS only when the backend actually delivered one; the
+   * MediaTek MAC strips it, and taking four bytes off there removes
+   * real angle data (see rx_pkt_attrib::fcs_present). */
+  size_t ab_len = n - (29 + (size_t)hdr.nc) - fcs;
   if (hdr.mu) {
     /* MU report: the V-angles are the first ns*10 bits (the Realtek compact 2x1
      * codebook); the MU Exclusive per-tone SNR follows and is not decoded here. */

--- a/src/RxPacket.h
+++ b/src/RxPacket.h
@@ -106,18 +106,39 @@ struct rx_pkt_attrib
      * format. 0xff on pre-AX generations (their descriptors carry no such
      * field). */
     uint8_t ppdu_type = 0xff;
+    /* Whether Data still carries the trailing 4-byte FCS.
+     *
+     * True on every Realtek generation, because each sets the MAC's append-FCS
+     * bit at init (RCR_APPFCS on Jaguar1/2, bit 31 of RCR on Jaguar3 and
+     * 8733B, B_AX_APPEND_FCS on Kestrel), so the RX descriptor's PKT_LEN
+     * already counts those four bytes and the parser slices them in.
+     *
+     * False on MediaTek MT7612U: that MAC strips the FCS, and the four bytes
+     * following the MPDU are the FCE info trailer, not a checksum (CRC-32
+     * matched them on 0 of 4263 measured frames — docs/mt7612u.md). A consumer
+     * that removes four bytes there deletes real payload.
+     *
+     * Defaulted true so a parser that does not set it keeps the historical
+     * contract; adding this therefore changes nothing for existing backends.
+     * It is per-frame rather than an AdapterCaps entry because the consumers
+     * that need it — devourer::bf::parse_report() above all — are free
+     * functions handed a pointer and a length, with no device in reach. */
+    bool fcs_present = true;
     RX_PACKET_TYPE pkt_rpt_type;
 };
 
 struct Packet
 {
     rx_pkt_attrib RxAtrib;
-    /* Full 802.11 frame including the trailing FCS. Every Realtek RX parser
-     * follows this contract; consumers remove the FCS at their protocol
-     * boundary rather than making the frame length chip-specific. Retaining it
-     * also lets DEVOURER_RX_KEEP_CORRUPTED and fused-FEC salvage inspect a
-     * failed frame, while tools/bf_report_decode.py trims the trailing four
-     * bytes when decoding beamforming reports. */
+    /* The 802.11 frame. It carries the trailing FCS when
+     * RxAtrib.fcs_present is set, which is the case on every Realtek
+     * generation; a consumer that strips four bytes MUST check that flag
+     * rather than assume, because the MediaTek backend delivers no FCS.
+     * Keeping the FCS where the hardware supplies it lets
+     * DEVOURER_RX_KEEP_CORRUPTED and fused-FEC salvage inspect a failed frame,
+     * and tools/bf_report_decode.py trims those four bytes when decoding
+     * beamforming reports (it reads the `fcs` field of the bf.report_raw
+     * event to know whether to). */
     std::span<uint8_t> Data;
 
     /* The transmitter's hardware TX-egress TSF, when the frame carries one.

--- a/tests/bf_report_fcs_selftest.py
+++ b/tests/bf_report_fcs_selftest.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""FCS-presence handling in tools/bf_report_decode.py.
+
+The C++ half of the FCS-presence change is covered by the bf_report_decode
+ctest cell; this covers the Python half, where the real regressions have been.
+Both defects found in review lived here: report_hex()'s return type change
+silently dropped a None guard (turning a skippable malformed event into an
+uncaught TypeError across three tools), and parse_mu_snr() reserved trailing
+bytes unconditionally.
+
+No hardware, no network.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+import bf_report_decode as bf  # noqa: E402
+
+# A real VHT MU compressed beamforming report, FCS included (same capture the
+# C++ selftest uses).
+FRAME = (
+    "e000000056427505d60000e04c8822ce00000000000010001500088c04c2a98dad97b09fbe"
+    "addaadc7bfccbde1c9e5cfe8cdf3cdf1d1eacfe5cff0d5eed9f0d9e6e1ffd70cd820e017d2"
+    "25d61ef093f0b9daa1ec91e687dc83e093e058f417ecfbebf9ebe9e1f1db03dc08de0dda11"
+    "d814de0fd808d60dd219c815c605b811b01bac20b62ac40f01f00fef00100100ff00111110"
+    "01cbbf1bd5"
+)
+FRAME_NOFCS = FRAME[:-8]          # the same report as an FCS-less backend delivers
+
+fails = 0
+
+
+def check(cond, what):
+    global fails
+    if not cond:
+        print(f"  FAIL {what}")
+        fails += 1
+
+
+def ev(body):
+    return '{"ev":"bf.report_raw",' + body + "}"
+
+
+# --- report_hex: the contract is (hex, fcs_present) or None ---------------
+check(bf.report_hex('{"ev":"rx.pkt","n":1}') is None, "foreign event ignored")
+check(bf.report_hex(ev('"fcs":1,"frame":"%s"' % FRAME)) == (FRAME, True), "fcs:1")
+check(bf.report_hex(ev('"fcs":0,"frame":"%s"' % FRAME_NOFCS)) == (FRAME_NOFCS, False), "fcs:0")
+check(bf.report_hex(ev('"frame":"%s"' % FRAME)) == (FRAME, True), "legacy event has no fcs -> assumed present")
+check(bf.report_hex(FRAME) == (FRAME, True), "bare hex -> assumed present")
+
+# The regression: an event with no `frame` must stay skippable. Before the
+# guard was restored this returned (None, True), and bytes.fromhex(None) then
+# raised TypeError, which parse_frame's `except ValueError` does not catch.
+check(bf.report_hex(ev('"fcs":1')) is None, "event without a frame field is skippable")
+try:
+    got = bf.read_frames(iter([ev('"fcs":1'), '{"ev":"rx.pkt"}', ""]))
+    check(got == [], "read_frames survives malformed input")
+except Exception as exc:                                   # noqa: BLE001
+    check(False, f"read_frames raised {type(exc).__name__} on malformed input")
+
+# --- the equivalence the flag exists to produce ---------------------------
+with_fcs = bf.parse_frame(FRAME, True)
+no_fcs = bf.parse_frame(FRAME_NOFCS, False)
+check(with_fcs is not None and no_fcs is not None, "both shapes parse")
+if with_fcs and no_fcs:
+    check(len(no_fcs["angle_bytes"]) == len(with_fcs["angle_bytes"]),
+          "same logical report -> same angle block either way")
+    check(no_fcs["snr"] == with_fcs["snr"], "same per-column SNR")
+
+# Believing an FCS that is not there must cost exactly four bytes - that is
+# the corruption this whole change exists to prevent.
+wrong = bf.parse_frame(FRAME_NOFCS, True)
+if wrong and no_fcs:
+    check(len(wrong["angle_bytes"]) == len(no_fcs["angle_bytes"]) - 4,
+          "assuming an absent FCS loses four angle bytes")
+
+# --- parse_mu_snr: the FCS-present bound must not have moved --------------
+if with_fcs:
+    a = bf.parse_mu_snr(with_fcs, with_fcs["ns"] if "ns" in with_fcs else 52,
+                        len(with_fcs["angle_bytes"]))
+    legacy = dict(with_fcs)
+    legacy.pop("fcs_present", None)        # a dict from before the field existed
+    b = bf.parse_mu_snr(legacy, legacy["ns"] if "ns" in legacy else 52,
+                        len(legacy["angle_bytes"]))
+    check(a == b, "FCS-present MU-SNR identical with and without the new key")
+
+print("bf_report_fcs: " + ("FAIL" if fails else "PASS"))
+sys.exit(1 if fails else 0)

--- a/tools/bf_report_decode.py
+++ b/tools/bf_report_decode.py
@@ -112,7 +112,8 @@ def parse_frame(hexstr: str, fcs_present: bool = True):
     fcs = 4 if fcs_present else 0
     angle_bytes = d[29 + nc:len(d) - fcs]
     return dict(sa=sa, nc=nc, nr=nr, bw=bw, ng=ng, codebook=codebook,
-                feedback=feedback, snr=snr, angle_bytes=angle_bytes, raw=d)
+                feedback=feedback, snr=snr, angle_bytes=angle_bytes, raw=d,
+                fcs_present=fcs_present)
 
 
 def parse_mu_snr(frame, ns, vbytes):
@@ -126,8 +127,12 @@ def parse_mu_snr(frame, ns, vbytes):
     mu_start = 29 + frame["nc"] + vbytes
     if mu_start + 4 >= len(d):
         return None
+    # The FCS-present bound stays exactly what it always was (len - 2); only
+    # the FCS-less case extends, because there the trailing bytes are payload
+    # and stopping short of them drops the final SNR pair.
+    end = len(d) - 2 if frame.get("fcs_present", True) else len(d)
     vals, i, last = [], mu_start, None
-    while i + 1 < len(d) - 2:
+    while i + 1 < end:
         a = d[i]
         if a < 40 or (last is not None and abs(a - last) > 40):
             break                         # trailer/junk boundary

--- a/tools/bf_report_decode.py
+++ b/tools/bf_report_decode.py
@@ -80,7 +80,7 @@ def dequant_psi(q: int, b: int) -> float:
     return (2 * q + 1) * math.pi / (1 << (b + 2))
 
 
-def parse_frame(hexstr: str):
+def parse_frame(hexstr: str, fcs_present: bool = True):
     """Return dict with header fields + raw angle bytes, or None if not a
     VHT/HT compressed beamforming report."""
     try:
@@ -105,7 +105,12 @@ def parse_frame(hexstr: str):
     feedback = (mc >> 11) & 0x1           # 0 = SU, 1 = MU
     sa = ":".join(f"{b:02x}" for b in d[10:16])
     snr = list(d[29:29 + nc])             # avg SNR per column (signed 0.25 dB)
-    angle_bytes = d[29 + nc:len(d) - 4]   # drop 4-byte FCS
+    # Drop the FCS only when the capturing backend appended one. MediaTek
+    # MT7612U strips it, and its trailing bytes are the FCE info trailer, so
+    # taking four off there would discard real angle data. The bf.report_raw
+    # event carries "fcs"; bare-hex input predates it and is assumed Realtek.
+    fcs = 4 if fcs_present else 0
+    angle_bytes = d[29 + nc:len(d) - fcs]
     return dict(sa=sa, nc=nc, nr=nr, bw=bw, ng=ng, codebook=codebook,
                 feedback=feedback, snr=snr, angle_bytes=angle_bytes, raw=d)
 
@@ -185,8 +190,11 @@ def decode_angles(angle_bytes: bytes, ns: int, na: int, bphi: int, bpsi: int,
 
 def report_hex(line: str):
     """Hex payload of one input line: a `bf.report_raw` event's `frame` field,
-    or the line itself when it's bare hex. Returns None for any other event
-    line (other-event JSON must not fall through to the hex parser)."""
+    or the line itself when it's bare hex. Returns (hex, fcs_present) so the
+    caller knows whether those trailing four bytes are an FCS; bare hex has no
+    metadata and is assumed to carry one, which is what every Realtek capture
+    did before the field existed. Returns None for any other event line
+    (other-event JSON must not fall through to the hex parser)."""
     line = line.strip()
     if line.startswith('{"ev":"'):
         if not line.startswith('{"ev":"bf.report_raw"'):
@@ -197,18 +205,19 @@ def report_hex(line: str):
             return None
         if not isinstance(obj, dict) or obj.get("ev") != "bf.report_raw":
             return None
-        return obj.get("frame")
-    return line
+        return obj.get("frame"), bool(obj.get("fcs", 1))
+    return line, True
 
 
 def read_frames(src, max_frames=200):
     """Parse `bf.report_raw` event (or bare hex) lines into frame dicts."""
     frames = []
     for line in src:
-        h = report_hex(line)
-        if h is None:
+        hf = report_hex(line)
+        if hf is None:
             continue
-        f = parse_frame(h)
+        h, fcs_present = hf
+        f = parse_frame(h, fcs_present)
         if f:
             frames.append(f)
         if len(frames) >= max_frames:

--- a/tools/bf_report_decode.py
+++ b/tools/bf_report_decode.py
@@ -210,18 +210,27 @@ def report_hex(line: str):
             return None
         if not isinstance(obj, dict) or obj.get("ev") != "bf.report_raw":
             return None
-        return obj.get("frame"), bool(obj.get("fcs", 1))
+        frame = obj.get("frame")
+        if frame is None:
+            return None          # malformed event: skippable, as before
+        return frame, bool(obj.get("fcs", 1))
     return line, True
 
 
-def read_frames(src, max_frames=200):
-    """Parse `bf.report_raw` event (or bare hex) lines into frame dicts."""
+def read_frames(src, max_frames=200, bare_fcs=True):
+    """Parse `bf.report_raw` event (or bare hex) lines into frame dicts.
+
+    bare_fcs is the FCS assumption for BARE HEX input only; events carry their
+    own `fcs` field and always win. A hand-captured MediaTek dump has no
+    metadata channel, so --no-fcs is the only way to decode one correctly."""
     frames = []
     for line in src:
         hf = report_hex(line)
         if hf is None:
             continue
         h, fcs_present = hf
+        if line.strip() and not line.strip().startswith('{"ev":"'):
+            fcs_present = bare_fcs        # bare hex: no metadata, use the flag
         f = parse_frame(h, fcs_present)
         if f:
             frames.append(f)
@@ -362,6 +371,10 @@ def main() -> int:
     ap.add_argument("--csv", help="write per-subcarrier CSV here")
     ap.add_argument("--max-frames", type=int, default=200)
     ap.add_argument("--msb", action="store_true", help="MSB-first bit order")
+    ap.add_argument("--no-fcs", action="store_true",
+                    help="bare-hex input carries no trailing FCS (MediaTek "
+                         "MT7612U strips it). Events carry their own `fcs` "
+                         "field and are unaffected by this flag.")
     ap.add_argument("--operating-snr", type=float, default=None,
                     help="re-centre the MEASURED per-tone SNR shape so its mean "
                          "= this dB (models a weaker/longer-range link at the "
@@ -371,7 +384,7 @@ def main() -> int:
     global _MSB
     _MSB = args.msb
     src = open(args.infile) if args.infile else sys.stdin
-    frames = read_frames(src, args.max_frames)
+    frames = read_frames(src, args.max_frames, bare_fcs=not args.no_fcs)
     if not frames:
         print("no VHT/HT compressed-beamforming reports found", file=sys.stderr)
         return 1

--- a/tools/bf_waterfall.py
+++ b/tools/bf_waterfall.py
@@ -141,10 +141,11 @@ def main() -> int:
 
     try:
         for line in sys.stdin:
-            h = bf.report_hex(line)
-            if h is None:
+            hf = bf.report_hex(line)
+            if hf is None:
                 continue
-            f = bf.parse_frame(h)
+            h, fcs_present = hf
+            f = bf.parse_frame(h, fcs_present)
             if not f:
                 continue
             if ns is None:

--- a/tools/bf_waterfall_svg.py
+++ b/tools/bf_waterfall_svg.py
@@ -33,10 +33,11 @@ def main() -> int:
 
     frames = []
     for line in open(args.infile):
-        h = bf.report_hex(line)
-        if h is None:
+        hf = bf.report_hex(line)
+        if hf is None:
             continue
-        f = bf.parse_frame(h)
+        h, fcs_present = hf
+        f = bf.parse_frame(h, fcs_present)
         if f and f["feedback"]:
             frames.append(f)
     if not frames:


### PR DESCRIPTION
Prerequisite for #419 (MT7612U integration). No MediaTek code here — this only makes an existing assumption explicit, so a backend without an FCS can be wired in later without silently corrupting frames.

## The problem

`Packet::Data` promises a trailing 4-byte FCS. Every Realtek generation delivers one, because each sets the MAC's append-FCS bit at init — `RCR_APPFCS` (Jaguar1/2), bit 31 of RCR (Jaguar3, 8733B), `B_AX_APPEND_FCS` (Kestrel) — so the RX descriptor's `PKT_LEN` already counts those bytes and the parser slices them in.

MT7612U cannot honour it. That MAC strips the FCS, and the four bytes after the MPDU are the FCE info trailer, **not** a checksum — CRC-32 matched them on **0 of 4263** measured frames (`docs/mt7612u.md`). A consumer that removes four bytes there deletes real payload. `docs/mt7612u.md` already records this as a measured hardware limit rather than something the port can fix.

## The change

`rx_pkt_attrib::fcs_present`, **defaulted true**. No Realtek parser is touched and every parse site already value-initialises the struct, so this is a no-op for existing backends by construction.

Per-frame rather than an `AdapterCaps` entry for one concrete reason: the consumer that most needs it, `devourer::bf::parse_report()`, is a free function handed a pointer and a length with no device in reach.

## Consumers

A full sweep for trailing-4-byte trims across `src/`, `examples/`, `tests/` and `tools/` found exactly two C++ sites plus one offline tool:

- `src/BfReportDecode.h` — `parse_report()` gains a defaulted `fcs_present`, so its three callers and the captured selftest fixture are unaffected.
- `examples/common/BfReportDetect.h` — the CSI-hex path; also publishes `fcs` on the `bf.report_raw` event so the offline decoder can follow.
- `examples/sense/main.cpp` — threads the flag from the `Packet` into `feed()`.
- `tools/bf_report_decode.py` — honours that field; bare-hex input predates it and is still assumed to carry an FCS.

Two things the sweep settled that are worth stating, because they mean this PR is smaller than it looks:

- **Nothing reads those bytes as a CRC.** Every `crc_err`/`icv_err` in the tree is the chip's own descriptor bit, so no consumer will read garbage.
- **No pcap writer and no RX radiotap emission exist**, so there are no capture-file FCS-present semantics to change. (`IEEE80211_RADIOTAP_F_FCS` is defined and unused, if that's ever wanted.)

The wire parsers — `MigWire`, `HopsetWire`, `RxReceipt`, `TriggerParse`, chanmig — are prefix-parsers that already tolerate trailing bytes and stay correct either way; only their comments now name a flag instead of an assumption.

## One accounting bias fixed

`examples/chanscout` adds the FCS back before computing airtime. Those bytes occupied the channel even where the MAC strips them before DMA, so without this every occupancy estimate reads four bytes light. Easy to miss, hence calling it out.

## Verification

The selftest gains the FCS-less case. With slack in the buffer the MU path clamps `angle_len` to `vbytes`, so the flag provably changes nothing there — which also means a naive control there **cannot fail**. The frame is therefore also trimmed to exactly the angle block, where believing a non-existent FCS must reject the report rather than silently shorten it.

Mutation-checked in both directions: hardcoding the trim to `4`, and to `0`, each fail the test; the shipped code passes.

Build clean with **zero warnings**; all **57** ctest cells pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tba83kymS5W2v1vn2yRxrj
